### PR TITLE
Fixes #41: add missing `password` field in provider configuration 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ENHANCEMENTS:
 
 BUG FIXES:
+* add missing `password` field in provider configuration for ssh authentication #41
 
 ## v1.5.0
 ENHANCEMENTS:

--- a/junos/config.go
+++ b/junos/config.go
@@ -7,6 +7,7 @@ type Config struct {
 	junosCmdSleepLock        int
 	junosIP                  string
 	junosUserName            string
+	junosPassword            string
 	junosSSHKeyFile          string
 	junosKeyPass             string
 	junosGroupIntDel         string
@@ -19,6 +20,7 @@ func (c *Config) Session() (*Session, error) {
 		junosIP:          c.junosIP,
 		junosPort:        c.junosPort,
 		junosUserName:    c.junosUserName,
+		junosPassword:    c.junosPassword,
 		junosSSHKeyFile:  c.junosSSHKeyFile,
 		junosKeyPass:     c.junosKeyPass,
 		junosGroupIntDel: c.junosGroupIntDel,

--- a/junos/provider.go
+++ b/junos/provider.go
@@ -50,9 +50,14 @@ func Provider() terraform.ResourceProvider {
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("JUNOS_USERNAME", "netconf"),
 			},
+			"password": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("JUNOS_PASSWORD", nil),
+			},
 			"sshkeyfile": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("JUNOS_KEYFILE", nil),
 			},
 			"keypass": {
@@ -136,6 +141,7 @@ func configureProvider(d *schema.ResourceData) (interface{}, error) {
 		junosIP:                  d.Get("ip").(string),
 		junosPort:                d.Get("port").(int),
 		junosUserName:            d.Get("username").(string),
+		junosPassword:            d.Get("password").(string),
 		junosSSHKeyFile:          d.Get("sshkeyfile").(string),
 		junosKeyPass:             d.Get("keypass").(string),
 		junosGroupIntDel:         d.Get("group_interface_delete").(string),

--- a/junos/session.go
+++ b/junos/session.go
@@ -15,6 +15,7 @@ type Session struct {
 	junosSleepShort  int
 	junosIP          string
 	junosUserName    string
+	junosPassword    string
 	junosSSHKeyFile  string
 	junosKeyPass     string
 	junosGroupIntDel string
@@ -24,16 +25,21 @@ type Session struct {
 func (sess *Session) startNewSession() (*NetconfObject, error) {
 	var auth netconfAuthMethod
 	auth.Username = sess.junosUserName
-	auth.PrivateKey = sess.junosSSHKeyFile
-	if strings.HasPrefix(sess.junosSSHKeyFile, "~") {
-		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			return nil, err
+	if sess.junosSSHKeyFile != "" {
+		auth.PrivateKey = sess.junosSSHKeyFile
+		if strings.HasPrefix(sess.junosSSHKeyFile, "~") {
+			homeDir, err := os.UserHomeDir()
+			if err != nil {
+				return nil, err
+			}
+			auth.PrivateKey = homeDir + sess.junosSSHKeyFile[1:]
 		}
-		auth.PrivateKey = homeDir + sess.junosSSHKeyFile[1:]
+		if sess.junosKeyPass != "" {
+			auth.Passphrase = sess.junosKeyPass
+		}
 	}
-	if sess.junosKeyPass != "" {
-		auth.Passphrase = sess.junosKeyPass
+	if sess.junosPassword != "" {
+		auth.Password = sess.junosPassword
 	}
 	jnpr, err := netconfNewSession(sess.junosIP+":"+strconv.Itoa(sess.junosPort), &auth)
 	if err != nil {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -41,8 +41,14 @@ and optionally a specific user for netconf:
 set system login user netconf uid 200?
 
 set system login user netconf class xxxx
-
+```
+with authentication method : ssh key or password
+```
 set system login user netconf authentication ssh-rsa "xxxx"
+```
+or
+```
+set system login user netconf authentication plain-text-password
 ```
 
 Use the navigation to the left to read about the available resources.
@@ -70,13 +76,15 @@ The following arguments are supported in the `provider` block:
 * `ip` - (Required) This is the target for Netconf session (ip or dns name).
   It can also be sourced from the `JUNOS_HOST` environment variable.
 
-* `sshkeyfile` - (Required) This is the path to ssh key for establish ssh
-  connection. It can also be sourced from the `JUNOS_KEYFILE` environment
-  variable.
-
 * `username` - (Optional) This is the username for ssh connection.
   It can also be sourced from the `JUNOS_USERNAME` environment variable.
   Defaults to `netconf`.
+
+* `sshkeyfile` - (Optional) This is the path to ssh key for establish ssh connection.
+  It can also be sourced from the `JUNOS_KEYFILE` environment variable.
+
+* `password` - (Optional) This is a password for ssh connection if `sshkeyfile` is not used.
+  It can also be sourced from the `JUNOS_PASSWORD` environment variable.
 
 * `port` - (Optional) This is the tcp port for ssh connection.
   It can also be sourced from the `JUNOS_PORT` environment variable.


### PR DESCRIPTION
BUG FIXES:
* add missing `password` field in provider configuration for ssh authentication