### PR TITLE
Fixes #53: add traffic_selector in resource security_ipsec_vpn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ ENHANCEMENTS:
 * add `traffic_selector` argument in resource `security_ipsec_vpn` (Fixes [#53](https://github.com/jeremmfr/terraform-provider-junos/issues/53))
 
 BUG FIXES:
+* remove useless ForceNew for `bind_interface_auto` argument in resource `security_ipsec_vpn`
 
 ## v1.7.0
 ENHANCEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## upcoming release
 ENHANCEMENTS:
 * add `traffic_selector` argument in resource `security_ipsec_vpn` (Fixes [#53](https://github.com/jeremmfr/terraform-provider-junos/issues/53))
+* add `complete_destroy` argument in resource `interface`
 
 BUG FIXES:
 * remove useless ForceNew for `bind_interface_auto` argument in resource `security_ipsec_vpn`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## upcoming release
 ENHANCEMENTS:
+* add `traffic_selector` argument in resource `security_ipsec_vpn` (Fixes [#53](https://github.com/jeremmfr/terraform-provider-junos/issues/53))
 
 BUG FIXES:
 

--- a/junos/resource_security_ike_ipsec_test.go
+++ b/junos/resource_security_ike_ipsec_test.go
@@ -129,7 +129,7 @@ func TestAccJunosSecurityIkeIpsec_basic(t *testing.T) {
 						resource.TestCheckResourceAttr("junos_security_policy.testacc_policyIpsecRemToLoc",
 							"policy.#", "1"),
 						resource.TestCheckResourceAttr("junos_security_policy.testacc_policyIpsecRemToLoc",
-							"policy.0.permit_tunnel_ipsec_vpn", "testacc_ipsecvpn"),
+							"policy.0.permit_tunnel_ipsec_vpn", "testacc_ipsecvpn2"),
 						resource.TestCheckResourceAttr("junos_security_policy_tunnel_pair_policy.testacc_vpn-in-out",
 							"policy_a_to_b", "testacc_vpn-out"),
 						resource.TestCheckResourceAttr("junos_security_policy_tunnel_pair_policy.testacc_vpn-in-out",
@@ -170,7 +170,7 @@ func TestAccJunosSecurityIkeIpsec_basic(t *testing.T) {
 					ImportStateVerify: true,
 				},
 				{
-					ResourceName:            "junos_security_ipsec_vpn.testacc_ipsecvpn",
+					ResourceName:            "junos_security_ipsec_vpn.testacc_ipsecvpn2",
 					ImportState:             true,
 					ImportStateVerify:       true,
 					ImportStateVerifyIgnore: []string{"bind_interface_auto"},
@@ -203,6 +203,14 @@ func TestAccJunosSecurityIkeIpsec_basic(t *testing.T) {
 					Check: resource.ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr("junos_security_ike_gateway.testacc_ikegateway",
 							"dynamic_remote.0.hostname", "host1.example.com"),
+						resource.TestCheckResourceAttr("junos_security_ipsec_vpn.testacc_ipsecvpn",
+							"traffic_selector.#", "2"),
+						resource.TestCheckResourceAttr("junos_security_ipsec_vpn.testacc_ipsecvpn",
+							"traffic_selector.0.name", "ts-1"),
+						resource.TestCheckResourceAttr("junos_security_ipsec_vpn.testacc_ipsecvpn",
+							"traffic_selector.0.local_ip", "192.0.2.0/26"),
+						resource.TestCheckResourceAttr("junos_security_ipsec_vpn.testacc_ipsecvpn",
+							"traffic_selector.0.remote_ip", "192.0.3.64/26"),
 					),
 				},
 				{
@@ -361,9 +369,8 @@ resource junos_security_ipsec_policy "testacc_ipsecpol" {
   proposals = [junos_security_ipsec_proposal.testacc_ipsecprop.name]
   pfs_keys  = "group1"
 }
-resource junos_security_ipsec_vpn "testacc_ipsecvpn" {
-  name                = "testacc_ipsecvpn"
-  bind_interface_auto = false
+resource junos_security_ipsec_vpn "testacc_ipsecvpn2" {
+  name = "testacc_ipsecvpn2"
   ike {
     gateway          = junos_security_ike_gateway.testacc_ikegateway.name
     policy           = junos_security_ipsec_policy.testacc_ipsecpol.name
@@ -396,7 +403,7 @@ resource junos_security_policy testacc_policyIpsecLocToRem {
       match_source_address      = [junos_security_zone.testacc_secIkeIpsec_local.address_book[0].name]
       match_destination_address = [junos_security_zone.testacc_secIkeIpsec_remote.address_book[0].name]
       match_application         = ["any"]
-      permit_tunnel_ipsec_vpn   = junos_security_ipsec_vpn.testacc_ipsecvpn.name
+      permit_tunnel_ipsec_vpn   = junos_security_ipsec_vpn.testacc_ipsecvpn2.name
   }
 }
 
@@ -408,7 +415,7 @@ resource junos_security_policy testacc_policyIpsecRemToLoc {
     match_source_address      = [junos_security_zone.testacc_secIkeIpsec_remote.address_book[0].name]
     match_destination_address = [junos_security_zone.testacc_secIkeIpsec_local.address_book[0].name]
     match_application         = ["any"]
-    permit_tunnel_ipsec_vpn   = junos_security_ipsec_vpn.testacc_ipsecvpn.name
+    permit_tunnel_ipsec_vpn   = junos_security_ipsec_vpn.testacc_ipsecvpn2.name
   }
 }
 
@@ -476,9 +483,8 @@ resource junos_security_ipsec_policy "testacc_ipsecpol" {
   proposals = [junos_security_ipsec_proposal.testacc_ipsecprop.name]
   pfs_keys  = "group1"
 }
-resource junos_security_ipsec_vpn "testacc_ipsecvpn" {
-  name                = "testacc_ipsecvpn"
-  bind_interface_auto = false
+resource junos_security_ipsec_vpn "testacc_ipsecvpn2" {
+  name = "testacc_ipsecvpn2"
   ike {
     gateway          = junos_security_ike_gateway.testacc_ikegateway.name
     policy           = junos_security_ipsec_policy.testacc_ipsecpol.name
@@ -511,7 +517,7 @@ resource junos_security_policy testacc_policyIpsecLocToRem {
       match_source_address      = [junos_security_zone.testacc_secIkeIpsec_local.address_book[0].name]
       match_destination_address = [junos_security_zone.testacc_secIkeIpsec_remote.address_book[0].name]
       match_application         = ["any"]
-      permit_tunnel_ipsec_vpn   = junos_security_ipsec_vpn.testacc_ipsecvpn.name
+      permit_tunnel_ipsec_vpn   = junos_security_ipsec_vpn.testacc_ipsecvpn2.name
   }
 }
 
@@ -523,7 +529,7 @@ resource junos_security_policy testacc_policyIpsecRemToLoc {
     match_source_address      = [junos_security_zone.testacc_secIkeIpsec_remote.address_book[0].name]
     match_destination_address = [junos_security_zone.testacc_secIkeIpsec_local.address_book[0].name]
     match_application         = ["any"]
-    permit_tunnel_ipsec_vpn   = junos_security_ipsec_vpn.testacc_ipsecvpn.name
+    permit_tunnel_ipsec_vpn   = junos_security_ipsec_vpn.testacc_ipsecvpn2.name
   }
 }
 
@@ -563,6 +569,41 @@ resource junos_security_ike_gateway "testacc_ikegateway" {
   }
   policy             = junos_security_ike_policy.testacc_ikepol.name
   external_interface = junos_interface.testacc_ikegateway.name
+}
+resource junos_security_ipsec_proposal "testacc_ipsecprop" {
+  name                     = "testacc_ipsecprop"
+  authentication_algorithm = "hmac-sha1-96"
+  protocol                 = "esp"
+  encryption_algorithm     = "aes-128-cbc"
+}
+resource junos_security_ipsec_policy "testacc_ipsecpol" {
+  name      = "testacc_ipsecpol"
+  proposals = [junos_security_ipsec_proposal.testacc_ipsecprop.name]
+  pfs_keys  = "group2"
+}
+resource junos_security_ipsec_vpn "testacc_ipsecvpn" {
+  name           = "testacc_ipsecvpn"
+  bind_interface = junos_interface.testacc_ipsecvpn_bind.name
+  ike {
+    gateway = junos_security_ike_gateway.testacc_ikegateway.name
+    policy  = junos_security_ipsec_policy.testacc_ipsecpol.name
+  }
+  establish_tunnels = "on-traffic"
+  traffic_selector {
+    name      = "ts-1"
+    local_ip  = "192.0.2.0/26"
+    remote_ip = "192.0.3.64/26"
+  }
+  traffic_selector {
+    name      = "ts-2"
+    local_ip  = "192.0.2.128/26"
+    remote_ip = "192.0.3.192/26"
+  }
+}
+resource junos_interface "testacc_ipsecvpn_bind" {
+  name             = "st0.1"
+  inet             = true
+  complete_destroy = true
 }
 `
 }

--- a/junos/resource_security_ipsec_vpn.go
+++ b/junos/resource_security_ipsec_vpn.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -48,9 +49,8 @@ func resourceIpsecVpn() *schema.Resource {
 				Computed: true,
 			},
 			"bind_interface_auto": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				ForceNew: true,
+				Type:          schema.TypeBool,
+				Optional:      true,
 				ConflictsWith: []string{"traffic_selector"},
 			},
 			"df_bit": {
@@ -238,32 +238,51 @@ func resourceIpsecVpnRead(ctx context.Context, d *schema.ResourceData, m interfa
 	return nil
 }
 func resourceIpsecVpnUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	var diagsReturn diag.Diagnostics
 	d.Partial(true)
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		return diag.FromErr(err)
+		return append(diagsReturn, diag.FromErr(err)...)
 	}
 	defer sess.closeSession(jnprSess)
 	sess.configLock(jnprSess)
 	if err := delIpsecVpnConf(d, m, jnprSess); err != nil {
 		sess.configClear(jnprSess)
 
-		return diag.FromErr(err)
+		return append(diagsReturn, diag.FromErr(err)...)
+	}
+	if d.HasChanges("bind_interface_auto") {
+		diagsReturn = append(diagsReturn, diag.Diagnostic{
+			Severity:      diag.Warning,
+			Summary:       "Modifying bind_interface_auto on resource already created has no effect",
+			AttributePath: cty.Path{cty.GetAttrStep{Name: "bind_interface_auto"}},
+		})
+	}
+	if d.HasChanges("bind_interface") {
+		oldInt, _ := d.GetChange("bind_interface")
+		empty := checkInterfaceNC(oldInt.(string), m, jnprSess)
+		if empty == nil {
+			if err := sess.configSet([]string{"delete interfaces " + oldInt.(string)}, jnprSess); err != nil {
+				sess.configClear(jnprSess)
+
+				return append(diagsReturn, diag.FromErr(err)...)
+			}
+		}
 	}
 	if err := setIpsecVpn(d, m, jnprSess); err != nil {
 		sess.configClear(jnprSess)
 
-		return diag.FromErr(err)
+		return append(diagsReturn, diag.FromErr(err)...)
 	}
 	if err := sess.commitConf("update resource junos_security_ipsec_vpn", jnprSess); err != nil {
 		sess.configClear(jnprSess)
 
-		return diag.FromErr(err)
+		return append(diagsReturn, diag.FromErr(err)...)
 	}
 	d.Partial(false)
 
-	return resourceIpsecVpnRead(ctx, d, m)
+	return append(diagsReturn, resourceIpsecVpnRead(ctx, d, m)...)
 }
 func resourceIpsecVpnDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
@@ -327,7 +346,7 @@ func setIpsecVpn(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject)
 	sess := m.(*Session)
 	configSet := make([]string, 0)
 
-	if d.Get("bind_interface_auto").(bool) {
+	if d.Get("bind_interface").(string) != "" {
 		configSet = append(configSet, "set interfaces "+d.Get("bind_interface").(string))
 	}
 	setPrefix := "set security ipsec vpn " + d.Get("name").(string)
@@ -503,9 +522,8 @@ func delIpsecVpn(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject)
 	sess := m.(*Session)
 	configSet := make([]string, 0, 1)
 	configSet = append(configSet, "delete security ipsec vpn "+d.Get("name").(string))
-	if d.Get("bind_interface_auto").(bool) {
-		empty := checkInterfaceNC(d.Get("bind_interface").(string), m, jnprSess)
-		if empty == nil {
+	if d.Get("bind_interface").(string) != "" {
+		if empty := checkInterfaceNC(d.Get("bind_interface").(string), m, jnprSess); empty == nil {
 			configSet = append(configSet, "delete interfaces "+d.Get("bind_interface").(string))
 		}
 	}

--- a/website/docs/r/interface.html.markdown
+++ b/website/docs/r/interface.html.markdown
@@ -41,6 +41,8 @@ The following arguments are supported:
 
 * `name` - (Required, Forces new resource)(`String`) Name of interface or unit interface (with dot).
 * `description` - (Optional)(`String`) Description for interface.
+* `complete_destroy` - (Optional)(`Bool`) When destroy this resource, delete all configurations => do not add `disable` + `descrition NC` or `apply-groups` with `group_interface_delete` provider argument on **physical** or **st0.x** interfaces.  
+(Usually, `st0.x` interfaces are completely deleted with `bind_interface` argument in `security_ipsec_vpn` resource because of the dependency, but only if st0.x interface is empty or disable.)
 * `vlan_tagging` - (Optional)(`Bool`) Add 802.1q VLAN tagging support.
 * `vlan_tagging_id` - (Optional,Computed)(`Int`) 802.1q VLAN ID for unit interface. If not set, computed with `name` of interface (ge-0/0/0.100 = 100)
 * `inet` - (Optional,Computed)(`Bool`) Enable family inet.

--- a/website/docs/r/security_ipsec_vpn.html.markdown
+++ b/website/docs/r/security_ipsec_vpn.html.markdown
@@ -45,6 +45,10 @@ The following arguments are supported:
   * `source_interface_auto` - (Optional)(`Bool`) Compute the source_interface to `bind_interface`
   * `destination_ip` - (Optional)(`String`) IP destination for monitor message
   * `optimized` - (Optional)(`Bool`) Optimize for scalability
+* `traffic_selector` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified multiple times for each traffic-selector to declare.
+  * `name` - (Required)(`String`) Name of traffic-selector.
+  * `local_ip` - (Required)(`String`) CIDR for IP addresses of local traffic-selector.
+  * `remote_ip` - (Required)(`String`) CIDR for IP addresses of remote traffic-selector.
 
 ## Import
 


### PR DESCRIPTION
ENHANCEMENTS:
* add `traffic_selector` argument in resource `security_ipsec_vpn` (Fixes [#53](https://github.com/jeremmfr/terraform-provider-junos/issues/53))
* add `complete_destroy` argument in resource `interface`

BUG FIXES:
* remove useless ForceNew for `bind_interface_auto` argument in resource `security_ipsec_vpn`