### PR TITLE
Fixes #64: add `junos_interface_st0_unit` resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ENHANCEMENTS:
 * Add `junos_system_information` data source for accessing system information i.e. - Serial Number, Hardware Type, etc (Fixes [#60](https://github.com/jeremmfr/terraform-provider-junos/issues/60)) Thanks [@tagur87](https://github.com/tagur87)
 * simplify gather system/software information when create new netconf session
+* add `junos_interface_st0_unit` resource (Fixes [#64](https://github.com/jeremmfr/terraform-provider-junos/issues/64))
 
 BUG FIXES:
 * fix inconsistent result after creating `junos_interface` resource with only `name` argument (Fixes [#65](https://github.com/jeremmfr/terraform-provider-junos/issues/65))

--- a/junos/provider.go
+++ b/junos/provider.go
@@ -104,6 +104,7 @@ func Provider() *schema.Provider {
 			"junos_bgp_neighbor":                                         resourceBgpNeighbor(),
 			"junos_firewall_filter":                                      resourceFirewallFilter(),
 			"junos_firewall_policer":                                     resourceFirewallPolicer(),
+			"junos_interface_st0_unit":                                   resourceInterfaceSt0Unit(),
 			"junos_interface":                                            resourceInterface(),
 			"junos_ospf_area":                                            resourceOspfArea(),
 			"junos_policyoptions_as_path_group":                          resourcePolicyoptionsAsPathGroup(),

--- a/junos/resource_interface.go
+++ b/junos/resource_interface.go
@@ -1166,7 +1166,7 @@ func delInterface(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject
 	}
 	if strings.Contains(d.Get("name").(string), "st0.") && !d.Get("complete_destroy").(bool) {
 		// interface totally delete by
-		// - junos_security_ipsec_vpn resource with bind_interface_auto argument (deprecated)
+		// - junos_security_ipsec_vpn resource with the bind_interface_auto argument (deprecated)
 		// or by
 		// - junos_interface_st0_unit resource
 		// else there is an interface st0.x empty

--- a/junos/resource_interface.go
+++ b/junos/resource_interface.go
@@ -1165,7 +1165,10 @@ func delInterface(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject
 		return err
 	}
 	if strings.Contains(d.Get("name").(string), "st0.") && !d.Get("complete_destroy").(bool) {
-		// interface totally delete by resource_security_ipsec_vpn with bind_interface
+		// interface totally delete by
+		// - junos_security_ipsec_vpn resource with bind_interface_auto argument (deprecated)
+		// or by
+		// - junos_interface_st0_unit resource
 		// else there is an interface st0.x empty
 		err := sess.configSet([]string{"set interfaces " + setName}, jnprSess)
 		if err != nil {

--- a/junos/resource_interface_st0_unit.go
+++ b/junos/resource_interface_st0_unit.go
@@ -75,8 +75,6 @@ func resourceInterfaceSt0UnitRead(ctx context.Context, d *schema.ResourceData, m
 	}
 	if !intExists {
 		d.SetId("")
-
-		return nil
 	}
 
 	return nil

--- a/junos/resource_interface_st0_unit.go
+++ b/junos/resource_interface_st0_unit.go
@@ -1,0 +1,162 @@
+package junos
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceInterfaceSt0Unit() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceInterfaceSt0UnitCreate,
+		ReadContext:   resourceInterfaceSt0UnitRead,
+		DeleteContext: resourceInterfaceSt0UnitDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceInterfaceSt0UnitImport,
+		},
+	}
+}
+
+func resourceInterfaceSt0UnitCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	sess.configLock(jnprSess)
+	newSt0, err := searchInterfaceSt0UnitToCreate(m, jnprSess)
+	if err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(fmt.Errorf("error for find new st0 unit interface: %w", err))
+	}
+	if err := sess.configSet([]string{"set interfaces " + newSt0}, jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	if err := sess.commitConf("create resource junos_interface_st0_unit", jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	intExists, err := checkInterfaceExists(newSt0, m, jnprSess)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if intExists {
+		d.SetId(newSt0)
+	} else {
+		return diag.FromErr(fmt.Errorf("create new st0 unit interface doesn't works, "+
+			"can't find the new interface %s after commit", newSt0))
+	}
+
+	return nil
+}
+func resourceInterfaceSt0UnitRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	mutex.Lock()
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		mutex.Unlock()
+
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	intExists, err := checkInterfaceExists(d.Id(), m, jnprSess)
+	mutex.Unlock()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if !intExists {
+		d.SetId("")
+
+		return nil
+	}
+
+	return nil
+}
+
+func resourceInterfaceSt0UnitDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	sess.configLock(jnprSess)
+	ncInt, emptyInt, err := checkInterfaceNC(d.Id(), m, jnprSess)
+	if err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	if !ncInt && !emptyInt {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(fmt.Errorf("interface %s not empty or disable", d.Id()))
+	}
+	if err := sess.configSet([]string{"delete interfaces " + d.Id()}, jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	if err := sess.commitConf("delete resource junos_interface_st0_unit", jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+func resourceInterfaceSt0UnitImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	sess := m.(*Session)
+	if !strings.HasPrefix(d.Id(), "st0.") {
+		return nil, fmt.Errorf("id must be start with 'st0.'")
+	}
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return nil, err
+	}
+	defer sess.closeSession(jnprSess)
+	result := make([]*schema.ResourceData, 1)
+	intExists, err := checkInterfaceExists(d.Id(), m, jnprSess)
+	if err != nil {
+		return nil, err
+	}
+	if !intExists {
+		return nil, fmt.Errorf("don't find interface with id '%v'"+
+			" (id must be the name of st0 unit interface <st0.?>)", d.Id())
+	}
+	result[0] = d
+
+	return result, nil
+}
+
+func searchInterfaceSt0UnitToCreate(m interface{}, jnprSess *NetconfObject) (string, error) {
+	sess := m.(*Session)
+	st0, err := sess.command("show interfaces st0 terse", jnprSess)
+	if err != nil {
+		return "", err
+	}
+	st0Line := strings.Split(st0, "\n")
+	st0int := make([]string, 0)
+	for _, line := range st0Line {
+		if strings.HasPrefix(line, "st0.") {
+			lineSplit := strings.Split(line, " ")
+			st0int = append(st0int, lineSplit[0])
+		}
+	}
+	for i := 0; i <= 1073741823; i++ {
+		if !stringInSlice("st0."+strconv.Itoa(i), st0int) {
+			return "st0." + strconv.Itoa(i), nil
+		}
+	}
+
+	return "", fmt.Errorf("error for find st0 unit to create")
+}

--- a/junos/resource_interface_st0_unit_test.go
+++ b/junos/resource_interface_st0_unit_test.go
@@ -1,0 +1,33 @@
+package junos_test
+
+import (
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccJunosInterfaceSt0Unit_basic(t *testing.T) {
+	regexpSt0 := regexp.MustCompile("st0.")
+	if os.Getenv("TESTACC_SWITCH") == "" {
+		resource.Test(t, resource.TestCase{
+			PreCheck:  func() { testAccPreCheck(t) },
+			Providers: testAccProviders,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccJunosInterfaceSt0UnitConfig(),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestMatchResourceAttr("resource.junos_interface_st0_unit.testacc", "id", regexpSt0),
+					),
+				},
+			},
+		})
+	}
+}
+
+func testAccJunosInterfaceSt0UnitConfig() string {
+	return `
+resource junos_interface_st0_unit testacc {}
+`
+}

--- a/junos/resource_security_ike_ipsec_test.go
+++ b/junos/resource_security_ike_ipsec_test.go
@@ -299,9 +299,10 @@ resource junos_security_ipsec_policy "testacc_ipsecpol" {
   proposals = [junos_security_ipsec_proposal.testacc_ipsecprop.name]
   pfs_keys  = "group2"
 }
+resource junos_interface_st0_unit testacc_ipsecvpn {}
 resource junos_security_ipsec_vpn "testacc_ipsecvpn" {
-  name                = "testacc_ipsecvpn"
-  bind_interface_auto = true
+  name           = "testacc_ipsecvpn"
+  bind_interface = junos_interface_st0_unit.testacc_ipsecvpn.id
   ike {
     gateway          = junos_security_ike_gateway.testacc_ikegateway.name
     policy           = junos_security_ipsec_policy.testacc_ipsecpol.name
@@ -605,10 +606,11 @@ resource junos_security_ipsec_vpn "testacc_ipsecvpn" {
   }
 }
 resource junos_interface "testacc_ipsecvpn_bind" {
-  name             = "st0.1"
+  name             = junos_interface_st0_unit.testacc_ipsec_vpn.id
   inet             = true
   complete_destroy = true
 }
+resource junos_interface_st0_unit testacc_ipsec_vpn {}
 `
 }
 func testAccJunosSecurityIkeIpsecConfigUpdate4(interFace string) string {

--- a/website/docs/r/interface.html.markdown
+++ b/website/docs/r/interface.html.markdown
@@ -42,7 +42,7 @@ The following arguments are supported:
 * `name` - (Required, Forces new resource)(`String`) Name of interface or unit interface (with dot).
 * `description` - (Optional)(`String`) Description for interface.
 * `complete_destroy` - (Optional)(`Bool`) When destroy this resource, delete all configurations => do not add `disable` + `descrition NC` or `apply-groups` with `group_interface_delete` provider argument on **physical** or **st0.x** interfaces.  
-(Usually, `st0.x` interfaces are completely deleted with `bind_interface` argument in `security_ipsec_vpn` resource because of the dependency, but only if st0.x interface is empty or disable.)
+(Usually, `st0.x` interfaces are completely deleted with `bind_interface_auto` argument in `junos_security_ipsec_vpn` resource or by `junos_interface_st0_unit` resource because of the dependency, but only if st0.x interface is empty or disable.)
 * `vlan_tagging` - (Optional)(`Bool`) Add 802.1q VLAN tagging support.
 * `vlan_tagging_id` - (Optional,Computed)(`Int`) 802.1q VLAN ID for unit interface. If not set, computed with `name` of interface (ge-0/0/0.100 = 100)
 * `inet` - (Optional,Computed)(`Bool`) Enable family inet.

--- a/website/docs/r/interface_st0_unit.html.markdown
+++ b/website/docs/r/interface_st0_unit.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Find st0 unit available and create interface.
 ---
 
-# junos_interface
+# junos_interface_st0_unit
 
 Find st0 unit available and create interface.
 

--- a/website/docs/r/interface_st0_unit.html.markdown
+++ b/website/docs/r/interface_st0_unit.html.markdown
@@ -1,0 +1,32 @@
+---
+layout: "junos"
+page_title: "Junos: junos_interface_st0_unit"
+sidebar_current: "docs-junos-resource-interface-st0-unit"
+description: |-
+  Find st0 unit available and create interface.
+---
+
+# junos_interface
+
+Find st0 unit available and create interface.
+
+It's useful for bind_interface in `junos_security_ipsec_vpn` resource.  
+New st0 unit interface can be configured with `junos_interface` resource.
+
+## Example Usage
+
+```hcl
+resource junos_interface_st0_unit "demo" {}
+```
+
+## Attributes Reference
+
+* `id` - Name of interface found and created.
+
+## Import
+
+Junos st0 unit interface can be imported using an id made up of the name of interface, e.g.
+
+```
+$ terraform import junos_interface_st0_unit.demo st0.0
+```

--- a/website/docs/r/security_ipsec_vpn.html.markdown
+++ b/website/docs/r/security_ipsec_vpn.html.markdown
@@ -17,12 +17,13 @@ Provides a security ipsec vpn resource.
 resource junos_security_ipsec_vpn "demo_vpn" {
   name                = "first-vpn"
   establish_tunnels   = "immediately"
-  bind_interface_auto = true
+  bind_interface      = junos_interface_st0_unit.demo.id
   ike {
     gateway = "ike-gateway"
     policy  = "ipsec-policy"
   }
 }
+resource junos_interface_st0_unit demo {}
 ```
 
 ## Argument Reference
@@ -32,7 +33,8 @@ The following arguments are supported:
 * `name` - (Required, Forces new resource)(`String`) The name of vpn.
 * `establish_tunnels` - (Optional)(`String`) When the VPN comes up. Need to be 'immediately' or 'on-traffic'
 * `bind_interface` - (Optional)(`String`) Interface st0 to bind vpn for route-based vpn. Computed when `bind_interface_auto` = true.
-* `bind_interface_auto` - (Optional)(`Bool`) Find st0 available for compute bind_interface automaticaly.
+* `bind_interface_auto` - (Optional,**DEPRECATED**)(`Bool`) Find st0 available for compute bind_interface automaticaly.  
+Deprecated argument, use the `junos_interface_st0_unit` resource to find st0 unit available instead.
 * `df_bit` - (Optional)(`String`) Specifies how to handle the Don't Fragment bit. Need to be 'clear', 'copy' or 'set'
 * `ike` - (Required)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once for declare ike configuration.
   * `gateway` - (Required)(`String`) The name of security ike gateway (phase-1)


### PR DESCRIPTION
to replace `bind_interface_auto` argument in `security_ipsec_vpn` resource
and therefore be able to create the st0 unit interface and configure before the ipsec vpn

ENHANCEMENTS:
* add `junos_interface_st0_unit` resource (Fixes #64)