### PR TITLE
Add interface support for qualified_next_hop

### DIFF
--- a/junos/resource_static_route.go
+++ b/junos/resource_static_route.go
@@ -79,6 +79,10 @@ func resourceStaticRoute() *schema.Resource {
 							Type:     schema.TypeInt,
 							Optional: true,
 						},
+						"interface": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 					},
 				},
 			},
@@ -339,6 +343,11 @@ func setStaticRoute(d *schema.ResourceData, m interface{}, jnprSess *NetconfObje
 				" qualified-next-hop "+qualifiedNextHopMap["next_hop"].(string)+
 				" metric "+strconv.Itoa(qualifiedNextHopMap["metric"].(int)))
 		}
+		if qualifiedNextHopMap["interface"] != "" {
+			configSet = append(configSet, setPrefix+
+				" qualified-next-hop "+qualifiedNextHopMap["next_hop"].(string)+
+				" interface "+qualifiedNextHopMap["interface"].(string))
+		}
 	}
 	if err := sess.configSet(configSet, jnprSess); err != nil {
 		return err
@@ -408,6 +417,7 @@ func readStaticRoute(destination string, instance string, m interface{},
 					"next_hop":   nextHopWords[0],
 					"metric":     0,
 					"preference": 0,
+					"interface":  "",
 				}
 				qualifiedNextHopOptions, confRead.qualifiedNextHop = copyAndRemoveItemMapList("next_hop",
 					false, qualifiedNextHopOptions, confRead.qualifiedNextHop)
@@ -425,6 +435,8 @@ func readStaticRoute(destination string, instance string, m interface{},
 					if err != nil {
 						return confRead, fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrimQnh, err)
 					}
+				case strings.HasPrefix(itemTrimQnh, "interface "):
+					qualifiedNextHopOptions["interface"] = strings.TrimPrefix(itemTrimQnh, "interface ")
 				}
 				confRead.qualifiedNextHop = append(confRead.qualifiedNextHop, qualifiedNextHopOptions)
 			}

--- a/junos/resource_static_route_test.go
+++ b/junos/resource_static_route_test.go
@@ -27,13 +27,17 @@ func TestAccJunosStaticRoute_basic(t *testing.T) {
 						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_instance",
 							"next_hop.0", "st0.0"),
 						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_instance",
-							"qualified_next_hop.#", "1"),
+							"qualified_next_hop.#", "2"),
 						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_instance",
 							"qualified_next_hop.0.next_hop", "st0.0"),
 						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_instance",
 							"qualified_next_hop.0.preference", "101"),
 						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_instance",
 							"qualified_next_hop.0.metric", "101"),
+						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_instance",
+							"qualified_next_hop.1.next_hop", "192.0.2.250"),
+						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_instance",
+							"qualified_next_hop.1.interface", "st0.0"),
 						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_instance",
 							"community.#", "1"),
 						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_instance",
@@ -69,13 +73,17 @@ func TestAccJunosStaticRoute_basic(t *testing.T) {
 						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_ipv6_instance",
 							"next_hop.0", "st0.0"),
 						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_ipv6_instance",
-							"qualified_next_hop.#", "1"),
+							"qualified_next_hop.#", "2"),
 						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_ipv6_instance",
 							"qualified_next_hop.0.next_hop", "st0.0"),
 						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_ipv6_instance",
 							"qualified_next_hop.0.preference", "101"),
 						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_ipv6_instance",
 							"qualified_next_hop.0.metric", "101"),
+						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_ipv6_instance",
+							"qualified_next_hop.1.next_hop", "2001:db8:85a4::1"),
+						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_ipv6_instance",
+							"qualified_next_hop.1.preference", "st0.0"),
 						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_ipv6_instance",
 							"community.#", "1"),
 						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_ipv6_instance",
@@ -149,6 +157,10 @@ resource junos_static_route testacc_staticRoute_instance {
     preference = 101
     metric     = 101
   }
+  qualified_next_hop {
+	next_hop   = "192.0.2.250"
+	interface  = "st0.0"
+  }
   community = ["no-advertise"]
 }
 resource junos_static_route testacc_staticRoute_default {
@@ -186,6 +198,10 @@ resource junos_static_route testacc_staticRoute_ipv6_instance {
     preference = 101
     metric = 101
   }
+  qualified_next_hop {
+  next_hop   = "2001:db8:85a4::1"
+  interface  = "st0.0"
+}
   community = ["no-advertise"]
 }
 `

--- a/website/docs/r/static_route.html.markdown
+++ b/website/docs/r/static_route.html.markdown
@@ -35,6 +35,7 @@ The following arguments are supported:
   * `next_hop` - (Required)(`String`) Target for qualified-next-hop
   * `preference` - (Optional)(`Int`) Preference of qualified next hop
   * `metric` - (Optional)(`Int`) Metric of qualified next hop
+  * `interface` - (Optional)(`String`) Interface of qualified next hop (Cannot be used with interface set as next-hop)
 
 ## Import
 


### PR DESCRIPTION
This allows specifying the interface for a qualified next hop in addition to metric, preference, and next_hop options on the static route resource


ENHANCEMENTS:

* add `interface` option to `qualified_next_hop` on `static_route` resource (Fixes #71)
