### PR TITLE
Add rpf-check attribute to interface resource

### DIFF
--- a/junos/resource_interface.go
+++ b/junos/resource_interface.go
@@ -827,7 +827,7 @@ func addInterfaceNC(interFace string, m interface{}, jnprSess *NetconfObject) er
 	case 1:
 		setName = intCut[0]
 	default:
-		return fmt.Errorf("the name %s contains too dot", interFace)
+		return fmt.Errorf("the name %s contains two dots", interFace)
 	}
 	if intCut[0] == st0Word || sess.junosGroupIntDel == "" {
 		err = sess.configSet([]string{"set interfaces " + setName + " disable description NC"}, jnprSess)
@@ -872,7 +872,7 @@ func setInterface(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject
 	case 1:
 		setName = intCut[0]
 	default:
-		return fmt.Errorf("the name %s contains too dot", d.Get("name").(string))
+		return fmt.Errorf("the name %s contains two dots", d.Get("name").(string))
 	}
 	if err := checkResourceInterfaceConfigAndName(len(intCut), d); err != nil {
 		return err
@@ -1158,7 +1158,7 @@ func delInterface(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject
 			return err
 		}
 	default:
-		return fmt.Errorf("the name %s contains too dot", d.Get("name").(string))
+		return fmt.Errorf("the name %s contains two dots", d.Get("name").(string))
 	}
 
 	if err := sess.configSet([]string{"delete interfaces " + setName}, jnprSess); err != nil {
@@ -1275,7 +1275,7 @@ func delInterfaceElement(element string, d *schema.ResourceData, m interface{}, 
 	case 1:
 		setName = intCut[0]
 	default:
-		return fmt.Errorf("the name %s contains too dot", d.Get("name").(string))
+		return fmt.Errorf("the name %s contains two dots", d.Get("name").(string))
 	}
 	configSet = append(configSet, "delete interfaces "+setName+" "+element)
 	if err := sess.configSet(configSet, jnprSess); err != nil {
@@ -1300,7 +1300,7 @@ func delInterfaceOpts(d *schema.ResourceData, m interface{}, jnprSess *NetconfOb
 	case 1:
 		setName = intCut[0]
 	default:
-		return fmt.Errorf("the name %s contains too dot", d.Get("name").(string))
+		return fmt.Errorf("the name %s contains two dots", d.Get("name").(string))
 	}
 	delPrefix := "delete interfaces " + setName + " "
 	configSet = append(configSet,

--- a/junos/resource_interface_test.go
+++ b/junos/resource_interface_test.go
@@ -96,7 +96,11 @@ func TestAccJunosInterface_basic(t *testing.T) {
 						resource.TestCheckResourceAttr("junos_interface.testacc_interfaceAEunit",
 							"inet", "true"),
 						resource.TestCheckResourceAttr("junos_interface.testacc_interfaceAEunit",
+							"inet_rpf", "true"),
+						resource.TestCheckResourceAttr("junos_interface.testacc_interfaceAEunit",
 							"inet6", "true"),
+						resource.TestCheckResourceAttr("junos_interface.testacc_interfaceAEunit",
+							"inet6_rpf", "true"),
 						resource.TestCheckResourceAttr("junos_interface.testacc_interfaceAEunit",
 							"inet_mtu", "1400"),
 						resource.TestCheckResourceAttr("junos_interface.testacc_interfaceAEunit",
@@ -200,6 +204,10 @@ func TestAccJunosInterface_basic(t *testing.T) {
 							"ae_minimum_links", "0"),
 						resource.TestCheckResourceAttr("junos_interface.testacc_interfaceAEunit",
 							"vlan_tagging_id", "101"),
+						resource.TestCheckResourceAttr("junos_interface.testacc_interfaceAEunit",
+							"inet_rpf", "false"),
+						resource.TestCheckResourceAttr("junos_interface.testacc_interfaceAEunit",
+							"inet6_rpf", "false"),
 						resource.TestCheckResourceAttr("junos_interface.testacc_interfaceAEunit",
 							"inet_mtu", "1500"),
 						resource.TestCheckResourceAttr("junos_interface.testacc_interfaceAEunit",
@@ -317,6 +325,7 @@ resource junos_interface testacc_interfaceAEunit {
   security_zone      = junos_security_zone.testacc_interface.name
   routing_instance   = junos_routing_instance.testacc_interface.name
   inet_mtu           = 1400
+  inet_rpf			 = true
   inet_filter_input  = junos_firewall_filter.testacc_interfaceInet.name
   inet_filter_output = junos_firewall_filter.testacc_interfaceInet.name
   inet_address {
@@ -343,6 +352,7 @@ resource junos_interface testacc_interfaceAEunit {
     }
   }
   inet6_mtu           = 1400
+  inet6_rpf			  = true
   inet6_filter_input  = junos_firewall_filter.testacc_interfaceInet6.name
   inet6_filter_output = junos_firewall_filter.testacc_interfaceInet6.name
   inet6_address {

--- a/website/docs/r/interface.html.markdown
+++ b/website/docs/r/interface.html.markdown
@@ -46,7 +46,9 @@ The following arguments are supported:
 * `vlan_tagging` - (Optional)(`Bool`) Add 802.1q VLAN tagging support.
 * `vlan_tagging_id` - (Optional,Computed)(`Int`) 802.1q VLAN ID for unit interface. If not set, computed with `name` of interface (ge-0/0/0.100 = 100)
 * `inet` - (Optional,Computed)(`Bool`) Enable family inet.
+* `inet_rpf` - (Optional)(`Bool`) Enable reverse-path-forwarding checks on this inet interface.
 * `inet6` - (Optional,Computed)(`Bool`) Enable family inet6.
+* `inet6_rpf` - (Optional)(`Bool`) Enable reverse-path-forwarding checks on this inet6 interface.
 * `inet_address` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified multiple times for each address to declare.
   * `address` - (Required)(`String`) Address IP/Mask v4.
   * `vrrp_group` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified multiple times for each vrrp group to declare. See the [`vrrp_group` arguments for inet_address](#vrrp_group-arguments-for-inet_address) block.


### PR DESCRIPTION
`rpf-check` was missing from the interface resource. Adds two new attributes that allow this to be set on inet and inet6 addresses.


ENHANCEMENTS
* add `inet_rpf` and `inet6_rpf` attributes to the interface resource(Fixes #72)

DOCUMENTATION
* spelling fixes