### PR TITLE
Fixes #72: add rpf-check support in `junos_interface` resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## upcoming release
 ENHANCEMENTS:
+* add `inet_rpf_check` and `inet6_rpf_check` arguments in `junos_interface` resource (Fixes [#72](https://github.com/jeremmfr/terraform-provider-junos/issues/72))
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ ENHANCEMENTS:
 * add `inet_rpf_check` and `inet6_rpf_check` arguments in `junos_interface` resource (Fixes [#72](https://github.com/jeremmfr/terraform-provider-junos/issues/72))
 
 BUG FIXES:
+* fix missing compatibility argument checks when apply `junos_interface` resource (unit interface or not)
 
 ## v1.9.0
 FEATURES:

--- a/junos/data_source_interface.go
+++ b/junos/data_source_interface.go
@@ -273,6 +273,38 @@ func dataSourceInterface() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"inet_rpf_check": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"fail_filter": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"mode_loose": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"inet6_rpf_check": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"fail_filter": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"mode_loose": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
 			"ether802_3ad": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/junos/resource_interface.go
+++ b/junos/resource_interface.go
@@ -1822,6 +1822,24 @@ func checkResourceInterfaceConfigAndName(length int, d *schema.ResourceData) err
 		if d.Get("inet6_mtu").(int) > 0 {
 			return fmt.Errorf("inet6_mtu invalid for this interface")
 		}
+		if d.Get("inet_filter_input").(string) != "" {
+			return fmt.Errorf("inet_filter_input invalid for this interface")
+		}
+		if d.Get("inet_filter_output").(string) != "" {
+			return fmt.Errorf("inet_filter_output invalid for this interface")
+		}
+		if d.Get("inet6_filter_input").(string) != "" {
+			return fmt.Errorf("inet6_filter_input invalid for this interface")
+		}
+		if d.Get("inet6_filter_output").(string) != "" {
+			return fmt.Errorf("inet6_filter_output invalid for this interface")
+		}
+		if len(d.Get("inet_rpf_check").([]interface{})) > 0 {
+			return fmt.Errorf("inet_rpf_check invalid for this interface")
+		}
+		if len(d.Get("inet6_rpf_check").([]interface{})) > 0 {
+			return fmt.Errorf("inet6_rpf_check invalid for this interface")
+		}
 		if d.Get("security_zone").(string) != "" {
 			return fmt.Errorf("security_zone invalid for this interface")
 		}

--- a/junos/resource_interface.go
+++ b/junos/resource_interface.go
@@ -34,6 +34,8 @@ type interfaceOptions struct {
 	securityZones     string
 	routingInstances  string
 	vlanMembers       []string
+	inetRpfCheck      []map[string]interface{}
+	inet6RpfCheck     []map[string]interface{}
 	inetAddress       []map[string]interface{}
 	inet6Address      []map[string]interface{}
 }
@@ -330,6 +332,40 @@ func resourceInterface() *schema.Resource {
 				Type:             schema.TypeString,
 				Optional:         true,
 				ValidateDiagFunc: validateNameObjectJunos([]string{}),
+			},
+			"inet_rpf_check": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"fail_filter": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"mode_loose": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"inet6_rpf_check": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"fail_filter": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"mode_loose": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+					},
+				},
 			},
 			"ether802_3ad": {
 				Type:     schema.TypeString,
@@ -918,6 +954,32 @@ func setInterface(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject
 		configSet = append(configSet, setPrefix+"family inet6 mtu "+
 			strconv.Itoa(d.Get("inet6_mtu").(int)))
 	}
+	for _, v := range d.Get("inet_rpf_check").([]interface{}) {
+		configSet = append(configSet, setPrefix+"family inet rpf-check")
+		if v != nil {
+			rpfCheck := v.(map[string]interface{})
+			if rpfCheck["fail_filter"].(string) != "" {
+				configSet = append(configSet, setPrefix+"family inet rpf-check fail-filter "+
+					"\""+rpfCheck["fail_filter"].(string)+"\"")
+			}
+			if rpfCheck["mode_loose"].(bool) {
+				configSet = append(configSet, setPrefix+"family inet rpf-check mode loose ")
+			}
+		}
+	}
+	for _, v := range d.Get("inet6_rpf_check").([]interface{}) {
+		configSet = append(configSet, setPrefix+"family inet6 rpf-check")
+		if v != nil {
+			rpfCheck := v.(map[string]interface{})
+			if rpfCheck["fail_filter"].(string) != "" {
+				configSet = append(configSet, setPrefix+"family inet6 rpf-check fail-filter "+
+					"\""+rpfCheck["fail_filter"].(string)+"\"")
+			}
+			if rpfCheck["mode_loose"].(bool) {
+				configSet = append(configSet, setPrefix+"family inet6 rpf-check mode loose ")
+			}
+		}
+	}
 	if d.Get("inet_filter_input").(string) != "" {
 		configSet = append(configSet, setPrefix+"family inet filter input "+
 			d.Get("inet_filter_input").(string))
@@ -1054,6 +1116,20 @@ func readInterface(interFace string, m interface{}, jnprSess *NetconfObject) (in
 					confRead.inet6FilterInput = strings.TrimPrefix(itemTrim, "family inet6 filter input ")
 				case strings.HasPrefix(itemTrim, "family inet6 filter output "):
 					confRead.inet6FilterOutput = strings.TrimPrefix(itemTrim, "family inet6 filter output ")
+				case strings.HasPrefix(itemTrim, "family inet6 rpf-check"):
+					if len(confRead.inet6RpfCheck) == 0 {
+						confRead.inet6RpfCheck = append(confRead.inet6RpfCheck, map[string]interface{}{
+							"fail_filter": "",
+							"mode_loose":  false,
+						})
+					}
+					switch {
+					case strings.HasPrefix(itemTrim, "family inet6 rpf-check fail-filter "):
+						confRead.inet6RpfCheck[0]["fail_filter"] = strings.Trim(
+							strings.TrimPrefix(itemTrim, "family inet6 rpf-check fail-filter "), "\"")
+					case itemTrim == "family inet6 rpf-check mode loose":
+						confRead.inet6RpfCheck[0]["mode_loose"] = true
+					}
 				}
 			case strings.HasPrefix(itemTrim, "family inet"):
 				confRead.inet = true
@@ -1072,6 +1148,20 @@ func readInterface(interFace string, m interface{}, jnprSess *NetconfObject) (in
 					confRead.inetFilterInput = strings.TrimPrefix(itemTrim, "family inet filter input ")
 				case strings.HasPrefix(itemTrim, "family inet filter output "):
 					confRead.inetFilterOutput = strings.TrimPrefix(itemTrim, "family inet filter output ")
+				case strings.HasPrefix(itemTrim, "family inet rpf-check"):
+					if len(confRead.inetRpfCheck) == 0 {
+						confRead.inetRpfCheck = append(confRead.inetRpfCheck, map[string]interface{}{
+							"fail_filter": "",
+							"mode_loose":  false,
+						})
+					}
+					switch {
+					case strings.HasPrefix(itemTrim, "family inet rpf-check fail-filter "):
+						confRead.inetRpfCheck[0]["fail_filter"] = strings.Trim(
+							strings.TrimPrefix(itemTrim, "family inet rpf-check fail-filter "), "\"")
+					case itemTrim == "family inet rpf-check mode loose":
+						confRead.inetRpfCheck[0]["mode_loose"] = true
+					}
 				}
 			case strings.HasPrefix(itemTrim, "ether-options 802.3ad "):
 				confRead.v8023ad = strings.TrimPrefix(itemTrim, "ether-options 802.3ad ")
@@ -1379,6 +1469,12 @@ func fillInterfaceData(d *schema.ResourceData, interfaceOpt interfaceOptions) {
 		panic(tfErr)
 	}
 	if tfErr := d.Set("inet6_filter_output", interfaceOpt.inet6FilterOutput); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("inet_rpf_check", interfaceOpt.inetRpfCheck); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("inet6_rpf_check", interfaceOpt.inet6RpfCheck); tfErr != nil {
 		panic(tfErr)
 	}
 	if tfErr := d.Set("ether802_3ad", interfaceOpt.v8023ad); tfErr != nil {

--- a/junos/resource_interface_test.go
+++ b/junos/resource_interface_test.go
@@ -104,6 +104,8 @@ func TestAccJunosInterface_basic(t *testing.T) {
 						resource.TestCheckResourceAttr("junos_interface.testacc_interfaceAEunit",
 							"inet_filter_output", "testacc_interfaceInet"),
 						resource.TestCheckResourceAttr("junos_interface.testacc_interfaceAEunit",
+							"inet_rpf_check.#", "1"),
+						resource.TestCheckResourceAttr("junos_interface.testacc_interfaceAEunit",
 							"inet_address.#", "1"),
 						resource.TestCheckResourceAttr("junos_interface.testacc_interfaceAEunit",
 							"inet_address.0.address", "192.0.2.1/25"),
@@ -204,6 +206,10 @@ func TestAccJunosInterface_basic(t *testing.T) {
 							"inet_mtu", "1500"),
 						resource.TestCheckResourceAttr("junos_interface.testacc_interfaceAEunit",
 							"inet6_mtu", "1500"),
+						resource.TestCheckResourceAttr("junos_interface.testacc_interfaceAEunit",
+							"inet_rpf_check.#", "1"),
+						resource.TestCheckResourceAttr("junos_interface.testacc_interfaceAEunit",
+							"inet_rpf_check.0.mode_loose", "true"),
 						resource.TestCheckResourceAttr("junos_interface.testacc_interfaceAEunit",
 							"inet_address.#", "1"),
 						resource.TestCheckResourceAttr("junos_interface.testacc_interfaceAEunit",
@@ -319,6 +325,7 @@ resource junos_interface testacc_interfaceAEunit {
   inet_mtu           = 1400
   inet_filter_input  = junos_firewall_filter.testacc_interfaceInet.name
   inet_filter_output = junos_firewall_filter.testacc_interfaceInet.name
+  inet_rpf_check {}
   inet_address {
     address = "192.0.2.1/25"
     vrrp_group {
@@ -419,6 +426,9 @@ resource junos_interface testacc_interfaceAEunit {
   inet_mtu           = 1500
   inet_filter_input  = junos_firewall_filter.testacc_interfaceInet.name
   inet_filter_output = junos_firewall_filter.testacc_interfaceInet.name
+  inet_rpf_check {
+    mode_loose = true
+  }
   inet_address {
     address = "192.0.2.1/25"
     vrrp_group {

--- a/website/docs/r/interface.html.markdown
+++ b/website/docs/r/interface.html.markdown
@@ -60,6 +60,10 @@ The following arguments are supported:
 * `inet_filter_output` - (Optional)(`String`) Filter to be applied to transmitted packets for family inet.
 * `inet6_filter_input` - (Optional)(`String`) Filter to be applied to received packets for family inet6.
 * `inet6_filter_output` - (Optional)(`String`) Filter to be applied to transmitted packets for family inet6.
+* `inet_rpf_check` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once for enable reverse-path-forwarding checks with family inet on this interface with optional arguments.
+  * `fail_filter` - (Optional)(`String`) Name of filter applied to packets failing RPF check.
+  * `mode_loose` - (Optional)(`Bool`) Use reverse-path-forwarding loose mode instead the strict mode.
+* `inet6_rpf_check` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once for enable reverse-path-forwarding checks with family inet6 on this interface with optional arguments. Arguments is same as `inet_rpf_check`.
 * `ether802_3ad` - (Optional)(`String`) Name of aggregated device for add this interface to link of 802.3ad interface.
 * `trunk` - (Optional)(`Bool`) Interface mode is trunk.
 * `vlan_members` - (Optional)(`ListOfString`) List of vlan for membership for this interface.


### PR DESCRIPTION
ENHANCEMENTS:
* add `inet_rpf_check` and `inet6_rpf_check` arguments in `junos_interface` resource (Fixes [#72](https://github.com/jeremmfr/terraform-provider-junos/issues/72))

BUG FIXES:
* fix missing compatibility argument checks when apply `junos_interface` resource (unit interface or not)