### PR TITLE
fix advertisements_threshold argument missing for vrrp in family inet6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ ENHANCEMENTS:
 
 BUG FIXES:
 * fix missing compatibility argument checks when apply `junos_interface` resource (unit interface or not)
+* fix `advertisements_threshold` argument missing for vrrp in family inet6 address in `junos_interface` resource
 
 ## v1.9.0
 FEATURES:

--- a/junos/resource_interface.go
+++ b/junos/resource_interface.go
@@ -242,6 +242,11 @@ func resourceInterface() *schema.Resource {
 										Optional:     true,
 										ValidateFunc: validation.IntBetween(100, 40000),
 									},
+									"advertisements_threshold": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(1, 15),
+									},
 									"no_accept_data": {
 										Type:     schema.TypeBool,
 										Optional: true,
@@ -1648,10 +1653,6 @@ func setFamilyAddress(inetAddress interface{}, intCut []string, configSet []stri
 				configSet = append(configSet, setNameAddVrrp+" advertise-interval "+
 					strconv.Itoa(vrrpGroupMap["advertise_interval"].(int)))
 			}
-			if vrrpGroupMap["advertisements_threshold"].(int) != 0 {
-				configSet = append(configSet, setNameAddVrrp+" advertisements-threshold "+
-					strconv.Itoa(vrrpGroupMap["advertisements_threshold"].(int)))
-			}
 			if vrrpGroupMap["authentication_key"].(string) != "" {
 				configSet = append(configSet, setNameAddVrrp+" authentication-key \""+
 					vrrpGroupMap["authentication_key"].(string)+"\"")
@@ -1679,6 +1680,10 @@ func setFamilyAddress(inetAddress interface{}, intCut []string, configSet []stri
 		}
 		if vrrpGroupMap["accept_data"].(bool) {
 			configSet = append(configSet, setNameAddVrrp+" accept-data")
+		}
+		if vrrpGroupMap["advertisements_threshold"].(int) != 0 {
+			configSet = append(configSet, setNameAddVrrp+" advertisements-threshold "+
+				strconv.Itoa(vrrpGroupMap["advertisements_threshold"].(int)))
 		}
 		if vrrpGroupMap["no_accept_data"].(bool) {
 			configSet = append(configSet, setNameAddVrrp+" no-accept-data")
@@ -1777,19 +1782,19 @@ func genFamilyInetAddress(address string) map[string]interface{} {
 }
 func genVRRPGroup(family string) map[string]interface{} {
 	m := map[string]interface{}{
-		"identifier":         0,
-		"virtual_address":    make([]string, 0),
-		"accept_data":        false,
-		"advertise_interval": 0,
-		"no_accept_data":     false,
-		"no_preempt":         false,
-		"preempt":            false,
-		"priority":           0,
-		"track_interface":    make([]map[string]interface{}, 0),
-		"track_route":        make([]map[string]interface{}, 0),
+		"identifier":               0,
+		"virtual_address":          make([]string, 0),
+		"accept_data":              false,
+		"advertise_interval":       0,
+		"advertisements_threshold": 0,
+		"no_accept_data":           false,
+		"no_preempt":               false,
+		"preempt":                  false,
+		"priority":                 0,
+		"track_interface":          make([]map[string]interface{}, 0),
+		"track_route":              make([]map[string]interface{}, 0),
 	}
 	if family == inetWord {
-		m["advertisements_threshold"] = 0
 		m["authentication_key"] = ""
 		m["authentication_type"] = ""
 	}

--- a/junos/resource_interface_test.go
+++ b/junos/resource_interface_test.go
@@ -172,6 +172,8 @@ func TestAccJunosInterface_basic(t *testing.T) {
 						resource.TestCheckResourceAttr("junos_interface.testacc_interfaceAEunit",
 							"inet6_address.0.vrrp_group.0.advertise_interval", "100"),
 						resource.TestCheckResourceAttr("junos_interface.testacc_interfaceAEunit",
+							"inet6_address.0.vrrp_group.0.advertisements_threshold", "3"),
+						resource.TestCheckResourceAttr("junos_interface.testacc_interfaceAEunit",
 							"inet6_address.0.vrrp_group.0.preempt", "true"),
 						resource.TestCheckResourceAttr("junos_interface.testacc_interfaceAEunit",
 							"inet6_address.0.vrrp_group.0.priority", "100"),
@@ -359,7 +361,8 @@ resource junos_interface testacc_interfaceAEunit {
       virtual_address            = ["2001:db8::2"]
       virtual_link_local_address = "fe80::2"
       accept_data                = true
-      advertise_interval         = 100
+	  advertise_interval         = 100
+	  advertisements_threshold   = 3
       preempt                    = true
       priority                   = 100
       track_interface {


### PR DESCRIPTION
BUG FIXES:
* fix `advertisements_threshold` argument missing for vrrp in family inet6 address in `junos_interface` resource