### PR TITLE
add multiple arguments in junos_static_route resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ENHANCEMENTS:
 * add `interface` option to `qualified_next_hop` on `static_route` resource (Fixes #71) Thanks [@tagur87](https://github.com/tagur87)
 * add `inet_rpf_check` and `inet6_rpf_check` arguments in `junos_interface` resource (Fixes [#72](https://github.com/jeremmfr/terraform-provider-junos/issues/72))
+* add `discard`, `receive`, `reject`, `next_table`, `active`, `passive`, `install`, `no_install`, `readvertise`, `no_readvertise`, `resolve`, `no_resolve`, `retain` and `no_retain` arguments in `junos_static_route` resource
 
 BUG FIXES:
 * fix missing compatibility argument checks when apply `junos_interface` resource (unit interface or not)

--- a/junos/resource_static_route_test.go
+++ b/junos/resource_static_route_test.go
@@ -42,6 +42,16 @@ func TestAccJunosStaticRoute_basic(t *testing.T) {
 							"community.#", "1"),
 						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_instance",
 							"community.0", "no-advertise"),
+						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_instance",
+							"active", "true"),
+						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_instance",
+							"install", "true"),
+						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_instance",
+							"readvertise", "true"),
+						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_instance",
+							"no_resolve", "true"),
+						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_instance",
+							"retain", "true"),
 						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_default",
 							"preference", "100"),
 						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_default",
@@ -62,6 +72,16 @@ func TestAccJunosStaticRoute_basic(t *testing.T) {
 							"community.#", "1"),
 						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_default",
 							"community.0", "no-advertise"),
+						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_default",
+							"active", "true"),
+						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_default",
+							"install", "true"),
+						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_default",
+							"readvertise", "true"),
+						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_default",
+							"no_resolve", "true"),
+						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_default",
+							"retain", "true"),
 						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_ipv6_instance",
 							"routing_instance", "testacc_staticRoute"),
 						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_ipv6_instance",
@@ -88,6 +108,16 @@ func TestAccJunosStaticRoute_basic(t *testing.T) {
 							"community.#", "1"),
 						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_ipv6_instance",
 							"community.0", "no-advertise"),
+						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_ipv6_instance",
+							"active", "true"),
+						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_ipv6_instance",
+							"install", "true"),
+						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_ipv6_instance",
+							"readvertise", "true"),
+						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_ipv6_instance",
+							"no_resolve", "true"),
+						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_ipv6_instance",
+							"retain", "true"),
 						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_ipv6_default",
 							"preference", "100"),
 						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_ipv6_default",
@@ -108,6 +138,16 @@ func TestAccJunosStaticRoute_basic(t *testing.T) {
 							"community.#", "1"),
 						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_ipv6_default",
 							"community.0", "no-advertise"),
+						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_ipv6_default",
+							"active", "true"),
+						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_ipv6_default",
+							"install", "true"),
+						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_ipv6_default",
+							"readvertise", "true"),
+						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_ipv6_default",
+							"no_resolve", "true"),
+						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_ipv6_default",
+							"retain", "true"),
 					),
 				},
 				{
@@ -121,6 +161,14 @@ func TestAccJunosStaticRoute_basic(t *testing.T) {
 							"qualified_next_hop.1.preference", "102"),
 						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_instance",
 							"qualified_next_hop.1.metric", "102"),
+						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_instance",
+							"passive", "true"),
+						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_instance",
+							"no_install", "true"),
+						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_instance",
+							"no_readvertise", "true"),
+						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_instance",
+							"no_retain", "true"),
 						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_ipv6_default",
 							"qualified_next_hop.#", "2"),
 						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_ipv6_default",
@@ -129,12 +177,45 @@ func TestAccJunosStaticRoute_basic(t *testing.T) {
 							"qualified_next_hop.1.preference", "102"),
 						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_ipv6_default",
 							"qualified_next_hop.1.metric", "102"),
+						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_ipv6_default",
+							"passive", "true"),
+						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_ipv6_default",
+							"no_install", "true"),
+						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_ipv6_default",
+							"no_readvertise", "true"),
+						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_ipv6_default",
+							"no_retain", "true"),
 					),
 				},
 				{
 					ResourceName:      "junos_static_route.testacc_staticRoute_instance",
 					ImportState:       true,
 					ImportStateVerify: true,
+				},
+				{
+					Config: testAccJunosStaticRouteConfigCreate2(),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_instance",
+							"receive", "true"),
+						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_instance",
+							"resolve", "true"),
+						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_ipv6_default",
+							"receive", "true"),
+						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_ipv6_default",
+							"resolve", "true"),
+						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_instance2",
+							"discard", "true"),
+						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_ipv6_default2",
+							"discard", "true"),
+						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_default",
+							"reject", "true"),
+						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_ipv6_instance",
+							"reject", "true"),
+						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_default2",
+							"next_table", "testacc_staticRoute2.inet.0"),
+						resource.TestCheckResourceAttr("junos_static_route.testacc_staticRoute_ipv6_instance2",
+							"next_table", "testacc_staticRoute2.inet6.0"),
+					),
 				},
 			},
 		})
@@ -152,6 +233,11 @@ resource junos_static_route testacc_staticRoute_instance {
   preference       = 100
   metric           = 100
   next_hop         = ["st0.0"]
+  active           = true
+  install          = true
+  readvertise      = true
+  no_resolve       = true
+  retain           = true
   qualified_next_hop {
     next_hop   = "st0.0"
     preference = 101
@@ -168,6 +254,11 @@ resource junos_static_route testacc_staticRoute_default {
   preference  = 100
   metric      = 100
   next_hop    = ["st0.0"]
+  active      = true
+  install     = true
+  readvertise = true
+  no_resolve  = true
+  retain      = true
   qualified_next_hop {
     next_hop   = "st0.0"
     preference = 101
@@ -180,10 +271,15 @@ resource junos_static_route testacc_staticRoute_ipv6_default {
   preference  = 100
   metric      = 100
   next_hop    = ["st0.0"]
+  active      = true
+  install     = true
+  readvertise = true
+  no_resolve  = true
+  retain      = true
   qualified_next_hop {
-    next_hop = "st0.0"
+    next_hop   = "st0.0"
     preference = 101
-    metric = 101
+    metric     = 101
   }
   community = ["no-advertise"]
 }
@@ -193,10 +289,15 @@ resource junos_static_route testacc_staticRoute_ipv6_instance {
   preference       = 100
   metric           = 100
   next_hop         = ["st0.0"]
+  active           = true
+  install          = true
+  readvertise      = true
+  no_resolve       = true
+  retain           = true
   qualified_next_hop {
-    next_hop = "st0.0"
+    next_hop   = "st0.0"
     preference = 101
-    metric = 101
+    metric     = 101
   }
   qualified_next_hop {
     next_hop   = "2001:db8:85a4::1"
@@ -212,38 +313,93 @@ resource junos_routing_instance testacc_staticRoute {
   name = "testacc_staticRoute"
 }
 resource junos_static_route testacc_staticRoute_instance {
-  destination = "192.0.2.0/24"
+  destination      = "192.0.2.0/24"
   routing_instance = junos_routing_instance.testacc_staticRoute.name
-  preference = 100
-  metric = 100
-  next_hop = [ "st0.0" ]
+  preference       = 100
+  metric           = 100
+  passive          = true
+  no_install       = true
+  no_readvertise   = true
+  no_retain        = true
   qualified_next_hop {
-    next_hop = "st0.0"
+    next_hop   = "st0.0"
     preference = 101
-    metric = 101
+    metric     = 101
   }
   qualified_next_hop {
-    next_hop = "dsc.0"
+    next_hop   = "dsc.0"
     preference = 102
-    metric = 102
+    metric     = 102
   }
 }
 resource junos_static_route testacc_staticRoute_ipv6_default {
-  destination = "2001:db8:85a3::/48"
-  preference  = 100
-  metric      = 100
-  next_hop    = ["st0.0"]
+  destination    = "2001:db8:85a3::/48"
+  preference     = 100
+  metric         = 100
+  passive        = true
+  no_install     = true
+  no_readvertise = true
+  no_retain      = true
   qualified_next_hop {
-    next_hop = "st0.0"
+    next_hop   = "st0.0"
     preference = 101
-    metric = 101
+    metric     = 101
   }
   qualified_next_hop {
-    next_hop = "dsc.0"
+    next_hop   = "dsc.0"
     preference = 102
-    metric = 102
+    metric     = 102
   }
   community = ["no-advertise"]
+}
+`
+}
+
+func testAccJunosStaticRouteConfigCreate2() string {
+	return `
+resource junos_routing_instance testacc_staticRoute {
+  name = "testacc_staticRoute"
+}
+resource junos_routing_instance testacc_staticRoute2 {
+  name = "testacc_staticRoute2"
+}
+resource junos_static_route testacc_staticRoute_instance {
+  destination      = "192.0.2.0/25"
+  routing_instance = junos_routing_instance.testacc_staticRoute.name
+  receive          = true
+  resolve          = true
+}
+resource junos_static_route testacc_staticRoute_ipv6_default {
+  destination = "2001:db8:85a3::/50"
+  receive     = true
+  resolve     = true
+}
+resource junos_static_route testacc_staticRoute_instance2 {
+  destination      = "192.0.2.0/26"
+  routing_instance = junos_routing_instance.testacc_staticRoute.name
+  discard          = true
+}
+resource junos_static_route testacc_staticRoute_ipv6_default2 {
+  destination = "2001:db8:85a3::/52"
+  discard          = true
+}
+resource junos_static_route testacc_staticRoute_default {
+  destination = "192.0.2.0/27"
+  reject      = true
+}
+resource junos_static_route testacc_staticRoute_ipv6_instance {
+  destination      = "2001:db8:85a3::/54"
+  routing_instance = junos_routing_instance.testacc_staticRoute.name
+  reject           = true
+}
+resource junos_static_route testacc_staticRoute_default2 {
+  destination = "192.0.2.0/28"
+  next_table  = "${junos_routing_instance.testacc_staticRoute2.name}.inet.0"
+}
+resource junos_static_route testacc_staticRoute_ipv6_instance2 {
+  destination      = "2001:db8:85a3::/56"
+  routing_instance = junos_routing_instance.testacc_staticRoute.name
+  next_table       = "${junos_routing_instance.testacc_staticRoute2.name}.inet6.0"
 }
 `
 }

--- a/website/docs/r/static_route.html.markdown
+++ b/website/docs/r/static_route.html.markdown
@@ -30,12 +30,26 @@ The following arguments are supported:
 * `preference` - (Optional)(`Int`) Preference for static route
 * `metric` - (Optional)(`Int`) Metric for static route
 * `community` - (Optional)(`ListOfString`) List of BGP community
-* `next_hop` - (Optional)(`ListOfString`) List of next-hop
-* `qualified_next_hop` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) List of qualified-next-hop with options. Can be specified multiple times for each qualified-next-hop.
+* `next_hop` - (Optional)(`ListOfString`) List of next-hop. Conflict with `next_table`, `discard`, `receive` and `reject`.
+* `next_table` - (Optional)(`String`) Next hop to another table. Conflict with `next_hop`, `qualified_next_hop`, `discard`, `receive` and `reject`.
+* `discard` - (Optional)(`Bool`) Drop packets to destination; send no ICMP unreachables. Conflict with `next_hop`, `next_table`, `qualified_next_hop`, `receive` and `reject`.
+* `receive` - (Optional)(`Bool`) Install a receive route for the destination. Conflict with `next_hop`, `next_table`, `qualified_next_hop`, `discard` and `reject`.
+* `reject` - (Optional)(`Bool`) Drop packets to destination; send ICMP unreachables. Conflict with `next_hop`, `next_table`, `qualified_next_hop`, `discard` and `receive`.
+* `qualified_next_hop` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) List of qualified-next-hop with options. Can be specified multiple times for each qualified-next-hop. Conflict with `next_table`, `discard`, `receive` and `reject`.
   * `next_hop` - (Required)(`String`) Target for qualified-next-hop
   * `preference` - (Optional)(`Int`) Preference of qualified next hop
   * `metric` - (Optional)(`Int`) Metric of qualified next hop
   * `interface` - (Optional)(`String`) Interface of qualified next hop (Cannot be used with interface set as next-hop)
+* `active` - (Optional)(`Bool`) Remove inactive route from forwarding table. Conflict with `passive`.
+* `passive` - (Optional)(`Bool`) Retain inactive route in forwarding table. Conflict with `active`.
+* `install` - (Optional)(`Bool`) Install route into forwarding table. Conflict with `no_install`.
+* `no_install` - (Optional)(`Bool`) Don't install route into forwarding table. Conflict with `install`.
+* `readvertise` - (Optional)(`Bool`) Mark route as eligible to be readvertised. Conflict with `no_readvertise`.
+* `no_readvertise` - (Optional)(`Bool`) Don't mark route as eligible to be readvertised. Conflict with `readvertise`.
+* `resolve` - (Optional)(`Bool`) Allow resolution of indirectly connected next hops. Conflict with `no_resolve`, `retain` and `no_retain`.
+* `no_resolve` - (Optional)(`Bool`) Don't allow resolution of indirectly connected next hops. Conflict with `resolve`.
+* `retain` - (Optional)(`Bool`) Always keep route in forwarding table. Conflict with `no_retain` and `resolve`.
+* `no_retain` - (Optional)(`Bool`) Don't always keep route in forwarding table. Conflict with `retain` and `resolve`.
 
 ## Import
 


### PR DESCRIPTION
ENHANCEMENTS:
* add `discard`, `receive`, `reject`, `next_table`, `active`, `passive`, `install`, `no_install`, `readvertise`, `no_readvertise`, `resolve`, `no_resolve`, `retain` and `no_retain` arguments in `junos_static_route` resource
