### PR TITLE
Split junos_interface into seperate resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 ENHANCEMENTS:
 * deprecate `junos_interface` resource for two new resources (split physical and logical interface into separate resources)
 * deprecate `junos_interface` data source for two new data sources (split physical and logical interface into separate data sources)
+* add `junos_interface_physical` resource for replace the parts of physical interface in deprecated `junos_interface` resource
+* add `junos_interface_physical` data source for replace the parts of physical interface in deprecated `junos_interface` data source
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## upcoming release
 ENHANCEMENTS:
+* deprecate `junos_interface` resource for two new resources (split physical and logical interface into separate resources)
+* deprecate `junos_interface` data source for two new data sources (split physical and logical interface into separate data sources)
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ ENHANCEMENTS:
 * deprecate `junos_interface` data source for two new data sources (split physical and logical interface into separate data sources)
 * add `junos_interface_physical` resource for replace the parts of physical interface in deprecated `junos_interface` resource
 * add `junos_interface_physical` data source for replace the parts of physical interface in deprecated `junos_interface` data source
+* add `junos_interface_logical` resource for replace the parts of logical interface in deprecated `junos_interface` resource
+* add `junos_interface_logical` data source for replace the parts of logical interface in deprecated `junos_interface` data source
 
 BUG FIXES:
 

--- a/junos/data_source_interface.go
+++ b/junos/data_source_interface.go
@@ -407,12 +407,10 @@ func searchInterfaceID(configInterface string, match string,
 		switch len(itemTrimSplit) {
 		case 0:
 			continue
-		case 1:
-			intConfigList = append(intConfigList, itemTrimSplit[0])
-		case 2:
+		case 1, 2:
 			intConfigList = append(intConfigList, itemTrimSplit[0])
 		default:
-			if itemTrimSplit[1] == "unit" { // nolint: goconst
+			if itemTrimSplit[1] == "unit" {
 				intConfigList = append(intConfigList, itemTrimSplit[0]+"."+itemTrimSplit[2])
 			} else {
 				intConfigList = append(intConfigList, itemTrimSplit[0])

--- a/junos/data_source_interface.go
+++ b/junos/data_source_interface.go
@@ -412,7 +412,7 @@ func searchInterfaceID(configInterface string, match string,
 		case 2:
 			intConfigList = append(intConfigList, itemTrimSplit[0])
 		default:
-			if itemTrimSplit[1] == "unit" {
+			if itemTrimSplit[1] == "unit" { // nolint: goconst
 				intConfigList = append(intConfigList, itemTrimSplit[0]+"."+itemTrimSplit[2])
 			} else {
 				intConfigList = append(intConfigList, itemTrimSplit[0])

--- a/junos/data_source_interface.go
+++ b/junos/data_source_interface.go
@@ -12,7 +12,8 @@ import (
 
 func dataSourceInterface() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceInterfaceRead,
+		ReadContext:        dataSourceInterfaceRead,
+		DeprecationMessage: "use junos_interface_physical or junos_interface_logical data source instead",
 		Schema: map[string]*schema.Schema{
 			"config_interface": {
 				Type:     schema.TypeString,

--- a/junos/data_source_interface_logical.go
+++ b/junos/data_source_interface_logical.go
@@ -336,7 +336,7 @@ func dataSourceInterfaceLogicalRead(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 	if nameFound == "" {
-		return diag.FromErr(fmt.Errorf("no interface found with arguments provided"))
+		return diag.FromErr(fmt.Errorf("no logical interface found with arguments provided"))
 	}
 	interfaceOpt, err := readInterfaceLogical(nameFound, m, jnprSess)
 	if err != nil {
@@ -379,34 +379,21 @@ func searchInterfaceLogicalID(configInterface string, match string,
 		}
 		itemTrimSplit := strings.Split(itemTrim, " ")
 		switch len(itemTrimSplit) {
-		case 0:
+		case 0, 1, 2:
 			continue
-		case 1:
-			intConfigList = append(intConfigList, itemTrimSplit[0])
-		case 2:
-			intConfigList = append(intConfigList, itemTrimSplit[0])
 		default:
-			if itemTrimSplit[1] == "unit" {
+			if itemTrimSplit[1] == "unit" && !stringInSlice("ethernet-switching", itemTrimSplit) {
 				intConfigList = append(intConfigList, itemTrimSplit[0]+"."+itemTrimSplit[2])
-			} else {
-				intConfigList = append(intConfigList, itemTrimSplit[0])
 			}
 		}
 	}
 	intConfigList = uniqueListString(intConfigList)
-	// remove physical
-	intLogicalList := make([]string, 0)
-	for _, intFace := range intConfigList {
-		if strings.Contains(intFace, ".") {
-			intLogicalList = append(intLogicalList, intFace)
-		}
-	}
-	if len(intLogicalList) == 0 {
+	if len(intConfigList) == 0 {
 		return "", nil
 	}
-	if len(intLogicalList) > 1 {
-		return "", fmt.Errorf("too many different interfaces found")
+	if len(intConfigList) > 1 {
+		return "", fmt.Errorf("too many different logical interfaces found")
 	}
 
-	return intLogicalList[0], nil
+	return intConfigList[0], nil
 }

--- a/junos/data_source_interface_logical.go
+++ b/junos/data_source_interface_logical.go
@@ -1,0 +1,412 @@
+package junos
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceInterfaceLogical() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceInterfaceLogicalRead,
+		Schema: map[string]*schema.Schema{
+			"config_interface": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"match": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(string)
+					if _, err := regexp.Compile(value); err != nil {
+						errors = append(errors, fmt.Errorf(
+							"%q for %q is not valid regexp", value, k))
+					}
+
+					return
+				},
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"vlan_id": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"family_inet": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"address": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"cidr_ip": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"vrrp_group": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"identifier": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+												"virtual_address": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+												"accept_data": {
+													Type:     schema.TypeBool,
+													Computed: true,
+												},
+												"advertise_interval": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+												"advertisements_threshold": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+												"authentication_key": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"authentication_type": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"no_accept_data": {
+													Type:     schema.TypeBool,
+													Computed: true,
+												},
+												"no_preempt": {
+													Type:     schema.TypeBool,
+													Computed: true,
+												},
+												"preempt": {
+													Type:     schema.TypeBool,
+													Computed: true,
+												},
+												"priority": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+												"track_interface": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"interface": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"priority_cost": {
+																Type:     schema.TypeInt,
+																Computed: true,
+															},
+														},
+													},
+												},
+												"track_route": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"route": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"routing_instance": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"priority_cost": {
+																Type:     schema.TypeInt,
+																Computed: true,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"mtu": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"filter_input": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"filter_output": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"rpf_check": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"fail_filter": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"mode_loose": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"family_inet6": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"address": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"cidr_ip": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"vrrp_group": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"identifier": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+												"virtual_address": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+												"virtual_link_local_address": {
+													Type:     schema.TypeString,
+													Computed: true,
+												},
+												"accept_data": {
+													Type:     schema.TypeBool,
+													Computed: true,
+												},
+												"advertise_interval": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+												"no_accept_data": {
+													Type:     schema.TypeBool,
+													Computed: true,
+												},
+												"no_preempt": {
+													Type:     schema.TypeBool,
+													Computed: true,
+												},
+												"preempt": {
+													Type:     schema.TypeBool,
+													Computed: true,
+												},
+												"priority": {
+													Type:     schema.TypeInt,
+													Computed: true,
+												},
+												"track_interface": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"interface": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"priority_cost": {
+																Type:     schema.TypeInt,
+																Computed: true,
+															},
+														},
+													},
+												},
+												"track_route": {
+													Type:     schema.TypeList,
+													Computed: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"route": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"routing_instance": {
+																Type:     schema.TypeString,
+																Computed: true,
+															},
+															"priority_cost": {
+																Type:     schema.TypeInt,
+																Computed: true,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"mtu": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"filter_input": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"filter_output": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"rpf_check": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"fail_filter": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"mode_loose": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"security_zone": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"routing_instance": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceInterfaceLogicalRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	if d.Get("config_interface").(string) == "" && d.Get("match").(string) == "" {
+		return diag.FromErr(fmt.Errorf("no arguments provided, 'config_interface' and 'match' empty"))
+	}
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	nameFound, err := searchInterfaceLogicalID(d.Get("config_interface").(string), d.Get("match").(string), m, jnprSess)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if nameFound == "" {
+		return diag.FromErr(fmt.Errorf("no interface found with arguments provided"))
+	}
+	interfaceOpt, err := readInterfaceLogical(nameFound, m, jnprSess)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(nameFound)
+	if tfErr := d.Set("name", nameFound); tfErr != nil {
+		panic(tfErr)
+	}
+	fillInterfaceLogicalData(d, interfaceOpt)
+
+	return nil
+}
+
+func searchInterfaceLogicalID(configInterface string, match string,
+	m interface{}, jnprSess *NetconfObject) (string, error) {
+	sess := m.(*Session)
+	intConfigList := make([]string, 0)
+	intConfig, err := sess.command("show configuration interfaces "+configInterface+" | display set", jnprSess)
+	if err != nil {
+		return "", err
+	}
+	for _, item := range strings.Split(intConfig, "\n") {
+		if strings.Contains(item, "<configuration-output>") {
+			continue
+		}
+		if strings.Contains(item, "</configuration-output>") {
+			break
+		}
+		if item == "" {
+			continue
+		}
+		itemTrim := strings.TrimPrefix(item, "set interfaces ")
+		matched, err := regexp.MatchString(match, itemTrim)
+		if err != nil {
+			return "", fmt.Errorf("failed to regexp with %s : %w", match, err)
+		}
+		if !matched {
+			continue
+		}
+		itemTrimSplit := strings.Split(itemTrim, " ")
+		switch len(itemTrimSplit) {
+		case 0:
+			continue
+		case 1:
+			intConfigList = append(intConfigList, itemTrimSplit[0])
+		case 2:
+			intConfigList = append(intConfigList, itemTrimSplit[0])
+		default:
+			if itemTrimSplit[1] == "unit" {
+				intConfigList = append(intConfigList, itemTrimSplit[0]+"."+itemTrimSplit[2])
+			} else {
+				intConfigList = append(intConfigList, itemTrimSplit[0])
+			}
+		}
+	}
+	intConfigList = uniqueListString(intConfigList)
+	// remove physical
+	intLogicalList := make([]string, 0)
+	for _, intFace := range intConfigList {
+		if strings.Contains(intFace, ".") {
+			intLogicalList = append(intLogicalList, intFace)
+		}
+	}
+	if len(intLogicalList) == 0 {
+		return "", nil
+	}
+	if len(intLogicalList) > 1 {
+		return "", fmt.Errorf("too many different interfaces found")
+	}
+
+	return intLogicalList[0], nil
+}

--- a/junos/data_source_interface_logical_test.go
+++ b/junos/data_source_interface_logical_test.go
@@ -1,0 +1,94 @@
+package junos_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// export TESTACC_INTERFACE=<inteface> for choose interface available else it's ge-0/0/3.
+func TestAccDataSourceInterfaceLogical_basic(t *testing.T) {
+	var testaccInterface string
+	if os.Getenv("TESTACC_INTERFACE") != "" {
+		testaccInterface = os.Getenv("TESTACC_INTERFACE")
+	} else {
+		testaccInterface = defaultInterfaceTestAcc
+	}
+	if os.Getenv("TESTACC_SWITCH") == "" {
+		resource.Test(t, resource.TestCase{
+			PreCheck:  func() { testAccPreCheck(t) },
+			Providers: testAccProviders,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccDataSourceInterfaceLogicalConfigCreate(testaccInterface),
+				},
+				{
+					Config: testAccDataSourceInterfaceLogicalConfigData(testaccInterface),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("data.junos_interface_logical.testacc_datainterfaceL",
+							"id", testaccInterface+".100"),
+						resource.TestCheckResourceAttr("data.junos_interface_logical.testacc_datainterfaceL",
+							"name", testaccInterface+".100"),
+						resource.TestCheckResourceAttr("data.junos_interface_logical.testacc_datainterfaceL",
+							"family_inet.#", "1"),
+						resource.TestCheckResourceAttr("data.junos_interface_logical.testacc_datainterfaceL",
+							"family_inet.0.address.#", "1"),
+						resource.TestCheckResourceAttr("data.junos_interface_logical.testacc_datainterfaceL",
+							"family_inet.0.address.0.cidr_ip", "192.0.2.1/25"),
+						resource.TestCheckResourceAttr("data.junos_interface_logical.testacc_datainterfaceL2",
+							"id", testaccInterface+".100"),
+					),
+				},
+			},
+			PreventPostDestroyRefresh: true,
+		})
+	}
+}
+
+func testAccDataSourceInterfaceLogicalConfigCreate(interFace string) string {
+	return `
+resource junos_interface_physical testacc_datainterfaceP {
+  name         = "` + interFace + `"
+  description  = "testacc_datainterfaceP"
+  vlan_tagging = true
+}
+resource junos_interface_logical testacc_datainterfaceL {
+  name        = "${junos_interface_physical.testacc_datainterfaceP.name}.100"
+  description = "testacc_datainterfaceL"
+  family_inet {
+    address {
+      cidr_ip = "192.0.2.1/25"
+    }
+  }
+}
+`
+}
+
+func testAccDataSourceInterfaceLogicalConfigData(interFace string) string {
+	return `
+resource junos_interface_physical testacc_datainterfaceP {
+  name         = "` + interFace + `"
+  description  = "testacc_datainterfaceP"
+  vlan_tagging = true
+}
+resource junos_interface_logical testacc_datainterfaceL {
+  name        = "${junos_interface_physical.testacc_datainterfaceP.name}.100"
+  description = "testacc_datainterfaceL"
+  family_inet {
+    address {
+      cidr_ip = "192.0.2.1/25"
+    }
+  }
+}
+
+data junos_interface_logical testacc_datainterfaceL {
+  config_interface = "` + interFace + `"
+  match            = "192.0.2.1/"
+}
+
+data junos_interface_logical testacc_datainterfaceL2 {
+  match = "192.0.2.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)"
+}
+`
+}

--- a/junos/data_source_interface_physical.go
+++ b/junos/data_source_interface_physical.go
@@ -1,0 +1,167 @@
+package junos
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceInterfacePhysical() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceInterfacePhysicalRead,
+		Schema: map[string]*schema.Schema{
+			"config_interface": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"match": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(string)
+					if _, err := regexp.Compile(value); err != nil {
+						errors = append(errors, fmt.Errorf(
+							"%q for %q is not valid regexp", value, k))
+					}
+
+					return
+				},
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"vlan_tagging": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"ether802_3ad": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"trunk": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"vlan_members": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"vlan_native": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"ae_lacp": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ae_link_speed": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ae_minimum_links": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceInterfacePhysicalRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	if d.Get("config_interface").(string) == "" && d.Get("match").(string) == "" {
+		return diag.FromErr(fmt.Errorf("no arguments provided, 'config_interface' and 'match' empty"))
+	}
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	nameFound, err := searchInterfacePhysicalID(d.Get("config_interface").(string), d.Get("match").(string), m, jnprSess)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if nameFound == "" {
+		return diag.FromErr(fmt.Errorf("no interface found with arguments provided"))
+	}
+	interfaceOpt, err := readInterfacePhysical(nameFound, m, jnprSess)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	d.SetId(nameFound)
+	if tfErr := d.Set("name", nameFound); tfErr != nil {
+		panic(tfErr)
+	}
+	fillInterfacePhysicalData(d, interfaceOpt)
+
+	return nil
+}
+
+func searchInterfacePhysicalID(configInterface string, match string,
+	m interface{}, jnprSess *NetconfObject) (string, error) {
+	sess := m.(*Session)
+	intConfigList := make([]string, 0)
+	intConfig, err := sess.command("show configuration interfaces "+configInterface+" | display set", jnprSess)
+	if err != nil {
+		return "", err
+	}
+	for _, item := range strings.Split(intConfig, "\n") {
+		if strings.Contains(item, "<configuration-output>") {
+			continue
+		}
+		if strings.Contains(item, "</configuration-output>") {
+			break
+		}
+		if item == "" {
+			continue
+		}
+		itemTrim := strings.TrimPrefix(item, "set interfaces ")
+		matched, err := regexp.MatchString(match, itemTrim)
+		if err != nil {
+			return "", fmt.Errorf("failed to regexp with %s : %w", match, err)
+		}
+		if !matched {
+			continue
+		}
+		itemTrimSplit := strings.Split(itemTrim, " ")
+		switch len(itemTrimSplit) {
+		case 0:
+			continue
+		case 1:
+			intConfigList = append(intConfigList, itemTrimSplit[0])
+		case 2:
+			intConfigList = append(intConfigList, itemTrimSplit[0])
+		default:
+			if itemTrimSplit[1] == "unit" {
+				intConfigList = append(intConfigList, itemTrimSplit[0]+"."+itemTrimSplit[2])
+			} else {
+				intConfigList = append(intConfigList, itemTrimSplit[0])
+			}
+		}
+	}
+	intConfigList = uniqueListString(intConfigList)
+	// remove logical
+	intPhysicalList := make([]string, 0)
+	for _, intFace := range intConfigList {
+		if !strings.Contains(intFace, ".") {
+			intPhysicalList = append(intPhysicalList, intFace)
+		}
+	}
+	if len(intPhysicalList) == 0 {
+		return "", nil
+	}
+	if len(intPhysicalList) > 1 {
+		return "", fmt.Errorf("too many different interfaces found")
+	}
+
+	return intPhysicalList[0], nil
+}

--- a/junos/data_source_interface_physical.go
+++ b/junos/data_source_interface_physical.go
@@ -91,7 +91,7 @@ func dataSourceInterfacePhysicalRead(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 	if nameFound == "" {
-		return diag.FromErr(fmt.Errorf("no interface found with arguments provided"))
+		return diag.FromErr(fmt.Errorf("no physical interface found with arguments provided"))
 	}
 	interfaceOpt, err := readInterfacePhysical(nameFound, m, jnprSess)
 	if err != nil {
@@ -133,35 +133,18 @@ func searchInterfacePhysicalID(configInterface string, match string,
 			continue
 		}
 		itemTrimSplit := strings.Split(itemTrim, " ")
-		switch len(itemTrimSplit) {
-		case 0:
+		if len(itemTrimSplit) == 0 {
 			continue
-		case 1:
-			intConfigList = append(intConfigList, itemTrimSplit[0])
-		case 2:
-			intConfigList = append(intConfigList, itemTrimSplit[0])
-		default:
-			if itemTrimSplit[1] == "unit" {
-				intConfigList = append(intConfigList, itemTrimSplit[0]+"."+itemTrimSplit[2])
-			} else {
-				intConfigList = append(intConfigList, itemTrimSplit[0])
-			}
 		}
+		intConfigList = append(intConfigList, itemTrimSplit[0])
 	}
 	intConfigList = uniqueListString(intConfigList)
-	// remove logical
-	intPhysicalList := make([]string, 0)
-	for _, intFace := range intConfigList {
-		if !strings.Contains(intFace, ".") {
-			intPhysicalList = append(intPhysicalList, intFace)
-		}
-	}
-	if len(intPhysicalList) == 0 {
+	if len(intConfigList) == 0 {
 		return "", nil
 	}
-	if len(intPhysicalList) > 1 {
-		return "", fmt.Errorf("too many different interfaces found")
+	if len(intConfigList) > 1 {
+		return "", fmt.Errorf("too many different physical interfaces found")
 	}
 
-	return intPhysicalList[0], nil
+	return intConfigList[0], nil
 }

--- a/junos/data_source_interface_physical_test.go
+++ b/junos/data_source_interface_physical_test.go
@@ -1,0 +1,63 @@
+package junos_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// export TESTACC_INTERFACE=<inteface> for choose interface available else it's ge-0/0/3.
+func TestAccDataSourceInterfacePhysical_basic(t *testing.T) {
+	var testaccInterface string
+	if os.Getenv("TESTACC_INTERFACE") != "" {
+		testaccInterface = os.Getenv("TESTACC_INTERFACE")
+	} else {
+		testaccInterface = defaultInterfaceTestAcc
+	}
+	if os.Getenv("TESTACC_SWITCH") == "" {
+		resource.Test(t, resource.TestCase{
+			PreCheck:  func() { testAccPreCheck(t) },
+			Providers: testAccProviders,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccDataSourceInterfacePhysicalConfigCreate(testaccInterface),
+				},
+				{
+					Config: testAccDataSourceInterfacePhysicalConfigData(testaccInterface),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("data.junos_interface_physical.testacc_datainterfaceP",
+							"id", testaccInterface),
+						resource.TestCheckResourceAttr("data.junos_interface_physical.testacc_datainterfaceP",
+							"vlan_tagging", "true"),
+					),
+				},
+			},
+			PreventPostDestroyRefresh: true,
+		})
+	}
+}
+
+func testAccDataSourceInterfacePhysicalConfigCreate(interFace string) string {
+	return `
+resource junos_interface_physical testacc_datainterfaceP {
+  name         = "` + interFace + `"
+  description  = "testacc_datainterfaceP"
+  vlan_tagging = true
+}
+`
+}
+
+func testAccDataSourceInterfacePhysicalConfigData(interFace string) string {
+	return `
+resource junos_interface_physical testacc_datainterfaceP {
+  name         = "` + interFace + `"
+  description  = "testacc_datainterfaceP"
+  vlan_tagging = true
+}
+
+data junos_interface_physical testacc_datainterfaceP {
+  config_interface = "` + interFace + `"
+}
+`
+}

--- a/junos/provider.go
+++ b/junos/provider.go
@@ -94,6 +94,7 @@ func Provider() *schema.Provider {
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"junos_interface":          dataSourceInterface(),
+			"junos_interface_logical":  dataSourceInterfaceLogical(),
 			"junos_interface_physical": dataSourceInterfacePhysical(),
 			"junos_system_information": dataSourceSystemInformation(),
 		},
@@ -106,6 +107,7 @@ func Provider() *schema.Provider {
 			"junos_firewall_filter":                                      resourceFirewallFilter(),
 			"junos_firewall_policer":                                     resourceFirewallPolicer(),
 			"junos_interface_physical":                                   resourceInterfacePhysical(),
+			"junos_interface_logical":                                    resourceInterfaceLogical(),
 			"junos_interface_st0_unit":                                   resourceInterfaceSt0Unit(),
 			"junos_interface":                                            resourceInterface(),
 			"junos_ospf_area":                                            resourceOspfArea(),

--- a/junos/provider.go
+++ b/junos/provider.go
@@ -94,6 +94,7 @@ func Provider() *schema.Provider {
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"junos_interface":          dataSourceInterface(),
+			"junos_interface_physical": dataSourceInterfacePhysical(),
 			"junos_system_information": dataSourceSystemInformation(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
@@ -104,6 +105,7 @@ func Provider() *schema.Provider {
 			"junos_bgp_neighbor":                                         resourceBgpNeighbor(),
 			"junos_firewall_filter":                                      resourceFirewallFilter(),
 			"junos_firewall_policer":                                     resourceFirewallPolicer(),
+			"junos_interface_physical":                                   resourceInterfacePhysical(),
 			"junos_interface_st0_unit":                                   resourceInterfaceSt0Unit(),
 			"junos_interface":                                            resourceInterface(),
 			"junos_ospf_area":                                            resourceOspfArea(),

--- a/junos/resource_interface.go
+++ b/junos/resource_interface.go
@@ -841,8 +841,8 @@ func checkInterfaceNC(interFace string, m interface{}, jnprSess *NetconfObject) 
 			return true, false, nil
 		}
 	}
-	if intConfig == "set description NC\nset disable" ||
-		intConfig == "set disable\nset description NC" {
+	if intConfig == "set description NC\nset disable" || // nolint: goconst
+		intConfig == "set disable\nset description NC" { // nolint: goconst
 		return true, false, nil
 	}
 	if intConfig == setLineStart ||
@@ -940,14 +940,14 @@ func setInterface(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject
 	}
 	for _, address := range d.Get("inet_address").([]interface{}) {
 		var err error
-		configSet, err = setFamilyAddress(address, intCut, configSet, setName, inetWord)
+		configSet, err = setFamilyAddressOld(address, intCut, configSet, setName, inetWord)
 		if err != nil {
 			return err
 		}
 	}
 	for _, address := range d.Get("inet6_address").([]interface{}) {
 		var err error
-		configSet, err = setFamilyAddress(address, intCut, configSet, setName, inet6Word)
+		configSet, err = setFamilyAddressOld(address, intCut, configSet, setName, inet6Word)
 		if err != nil {
 			return err
 		}
@@ -1109,7 +1109,7 @@ func readInterface(interFace string, m interface{}, jnprSess *NetconfObject) (in
 				confRead.inet6 = true
 				switch {
 				case strings.HasPrefix(itemTrim, "family inet6 address "):
-					inet6Address, err = fillFamilyInetAddress(itemTrim, inet6Address, inet6Word)
+					inet6Address, err = fillFamilyInetAddressOld(itemTrim, inet6Address, inet6Word)
 					if err != nil {
 						return confRead, err
 					}
@@ -1141,7 +1141,7 @@ func readInterface(interFace string, m interface{}, jnprSess *NetconfObject) (in
 				confRead.inet = true
 				switch {
 				case strings.HasPrefix(itemTrim, "family inet address "):
-					inetAddress, err = fillFamilyInetAddress(itemTrim, inetAddress, inetWord)
+					inetAddress, err = fillFamilyInetAddressOld(itemTrim, inetAddress, inetWord)
 					if err != nil {
 						return confRead, err
 					}
@@ -1511,7 +1511,7 @@ func fillInterfaceData(d *schema.ResourceData, interfaceOpt interfaceOptions) {
 		panic(tfErr)
 	}
 }
-func fillFamilyInetAddress(item string, inetAddress []map[string]interface{},
+func fillFamilyInetAddressOld(item string, inetAddress []map[string]interface{},
 	family string) ([]map[string]interface{}, error) {
 	var addressConfig []string
 	var itemTrim string
@@ -1524,11 +1524,11 @@ func fillFamilyInetAddress(item string, inetAddress []map[string]interface{},
 		itemTrim = strings.TrimPrefix(item, "family inet6 address "+addressConfig[0]+" ")
 	}
 
-	m := genFamilyInetAddress(addressConfig[0])
+	m := genFamilyInetAddressOld(addressConfig[0])
 	m, inetAddress = copyAndRemoveItemMapList("address", false, m, inetAddress)
 
 	if strings.HasPrefix(itemTrim, "vrrp-group ") || strings.HasPrefix(itemTrim, "vrrp-inet6-group ") {
-		vrrpGroup := genVRRPGroup(family)
+		vrrpGroup := genVRRPGroupOld(family)
 		vrrpID, err := strconv.Atoi(addressConfig[2])
 		if err != nil {
 			return inetAddress, nil
@@ -1619,10 +1619,10 @@ func fillFamilyInetAddress(item string, inetAddress []map[string]interface{},
 
 	return inetAddress, nil
 }
-func setFamilyAddress(inetAddress interface{}, intCut []string, configSet []string, setName string,
+func setFamilyAddressOld(inetAddress interface{}, intCut []string, configSet []string, setName string,
 	family string) ([]string, error) {
 	if family != inetWord && family != inet6Word {
-		return configSet, fmt.Errorf("setFamilyAddress() unknown family %v", family)
+		return configSet, fmt.Errorf("setFamilyAddressOld() unknown family %v", family)
 	}
 	inetAddressMap := inetAddress.(map[string]interface{})
 	configSet = append(configSet, "set interfaces "+setName+" family "+family+
@@ -1775,13 +1775,13 @@ func aggregatedCountSearchMax(newAE, oldAE, interFace string, m interface{}, jnp
 
 	return strconv.Itoa(newAENumInt + 1), nil
 }
-func genFamilyInetAddress(address string) map[string]interface{} {
+func genFamilyInetAddressOld(address string) map[string]interface{} {
 	return map[string]interface{}{
 		"address":    address,
 		"vrrp_group": make([]map[string]interface{}, 0),
 	}
 }
-func genVRRPGroup(family string) map[string]interface{} {
+func genVRRPGroupOld(family string) map[string]interface{} {
 	m := map[string]interface{}{
 		"identifier":               0,
 		"virtual_address":          make([]string, 0),

--- a/junos/resource_interface.go
+++ b/junos/resource_interface.go
@@ -1095,7 +1095,7 @@ func readInterface(interFace string, m interface{}, jnprSess *NetconfObject) (in
 			case strings.HasPrefix(itemTrim, "description "):
 				confRead.description = strings.Trim(strings.TrimPrefix(itemTrim, "description "), "\"")
 
-			case strings.HasPrefix(itemTrim, "vlan-tagging"):
+			case itemTrim == "vlan-tagging":
 				confRead.vlanTagging = true
 			case strings.HasPrefix(itemTrim, "vlan-id "):
 				var err error
@@ -1171,7 +1171,7 @@ func readInterface(interFace string, m interface{}, jnprSess *NetconfObject) (in
 				confRead.v8023ad = strings.TrimPrefix(itemTrim, "ether-options 802.3ad ")
 			case strings.HasPrefix(itemTrim, "gigether-options 802.3ad "):
 				confRead.v8023ad = strings.TrimPrefix(itemTrim, "gigether-options 802.3ad ")
-			case strings.HasPrefix(itemTrim, "unit 0 family ethernet-switching interface-mode trunk"):
+			case itemTrim == "unit 0 family ethernet-switching interface-mode trunk":
 				confRead.trunk = true
 			case strings.HasPrefix(itemTrim, "unit 0 family ethernet-switching vlan members"):
 				confRead.vlanMembers = append(confRead.vlanMembers, strings.TrimPrefix(itemTrim,
@@ -1548,7 +1548,7 @@ func fillFamilyInetAddressOld(item string, inetAddress []map[string]interface{},
 		case strings.HasPrefix(itemTrimVrrp, "virtual-link-local-address "):
 			vrrpGroup["virtual_link_local_address"] = strings.TrimPrefix(itemTrimVrrp,
 				"virtual-link-local-address ")
-		case strings.HasPrefix(itemTrimVrrp, "accept-data"):
+		case itemTrimVrrp == "accept-data":
 			vrrpGroup["accept_data"] = true
 		case strings.HasPrefix(itemTrimVrrp, "advertise-interval "):
 			vrrpGroup["advertise_interval"], err = strconv.Atoi(strings.TrimPrefix(itemTrimVrrp,
@@ -1576,11 +1576,11 @@ func fillFamilyInetAddressOld(item string, inetAddress []map[string]interface{},
 			}
 		case strings.HasPrefix(itemTrimVrrp, "authentication-type "):
 			vrrpGroup["authentication_type"] = strings.TrimPrefix(itemTrimVrrp, "authentication-type ")
-		case strings.HasPrefix(itemTrimVrrp, "no-accept-data"):
+		case itemTrimVrrp == "no-accept-data":
 			vrrpGroup["no_accept_data"] = true
-		case strings.HasPrefix(itemTrimVrrp, "no-preempt"):
+		case itemTrimVrrp == "no-preempt":
 			vrrpGroup["no_preempt"] = true
-		case strings.HasPrefix(itemTrimVrrp, "preempt"):
+		case itemTrimVrrp == "preempt":
 			vrrpGroup["preempt"] = true
 		case strings.HasPrefix(itemTrimVrrp, "priority"):
 			vrrpGroup["priority"], err = strconv.Atoi(strings.TrimPrefix(itemTrimVrrp, "priority "))

--- a/junos/resource_interface.go
+++ b/junos/resource_interface.go
@@ -1024,11 +1024,9 @@ func setInterface(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject
 	if d.Get("trunk").(bool) {
 		configSet = append(configSet, setPrefix+"unit 0 family ethernet-switching interface-mode trunk")
 	}
-	if len(d.Get("vlan_members").([]interface{})) > 0 {
-		for _, v := range d.Get("vlan_members").([]interface{}) {
-			configSet = append(configSet, setPrefix+
-				"unit 0 family ethernet-switching vlan members "+v.(string))
-		}
+	for _, v := range d.Get("vlan_members").([]interface{}) {
+		configSet = append(configSet, setPrefix+
+			"unit 0 family ethernet-switching vlan members "+v.(string))
 	}
 	if d.Get("vlan_native").(int) != 0 {
 		configSet = append(configSet, setPrefix+"native-vlan-id "+strconv.Itoa(d.Get("vlan_native").(int)))

--- a/junos/resource_interface.go
+++ b/junos/resource_interface.go
@@ -436,7 +436,7 @@ func resourceInterfaceCreate(ctx context.Context, d *schema.ResourceData, m inte
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	intExists, err := checkInterfaceExists(d.Get("name").(string), m, jnprSess)
+	intExists, err := checkInterfaceExistsOld(d.Get("name").(string), m, jnprSess)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -515,7 +515,7 @@ func resourceInterfaceCreate(ctx context.Context, d *schema.ResourceData, m inte
 
 		return diag.FromErr(err)
 	}
-	intExists, err = checkInterfaceExists(d.Get("name").(string), m, jnprSess)
+	intExists, err = checkInterfaceExistsOld(d.Get("name").(string), m, jnprSess)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -547,7 +547,7 @@ func resourceInterfaceRead(ctx context.Context, d *schema.ResourceData, m interf
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	intExists, err := checkInterfaceExists(d.Get("name").(string), m, jnprSess)
+	intExists, err := checkInterfaceExistsOld(d.Get("name").(string), m, jnprSess)
 	if err != nil {
 		mutex.Unlock()
 
@@ -597,7 +597,7 @@ func resourceInterfaceUpdate(ctx context.Context, d *schema.ResourceData, m inte
 	if d.HasChange("ether802_3ad") {
 		oAE, nAE := d.GetChange("ether802_3ad")
 		if oAE.(string) != "" {
-			newAE := "ae-1"
+			newAE := "ae-1" // nolint: goconst
 			if nAE.(string) != "" {
 				newAE = nAE.(string)
 			}
@@ -755,7 +755,7 @@ func resourceInterfaceDelete(ctx context.Context, d *schema.ResourceData, m inte
 		return diag.FromErr(err)
 	}
 	if !d.Get("complete_destroy").(bool) {
-		intExists, err := checkInterfaceExists(d.Get("name").(string), m, jnprSess)
+		intExists, err := checkInterfaceExistsOld(d.Get("name").(string), m, jnprSess)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -785,7 +785,7 @@ func resourceInterfaceImport(d *schema.ResourceData, m interface{}) ([]*schema.R
 	}
 	defer sess.closeSession(jnprSess)
 	result := make([]*schema.ResourceData, 1)
-	intExists, err := checkInterfaceExists(d.Id(), m, jnprSess)
+	intExists, err := checkInterfaceExistsOld(d.Id(), m, jnprSess)
 	if err != nil {
 		return nil, err
 	}
@@ -884,7 +884,7 @@ func addInterfaceNC(interFace string, m interface{}, jnprSess *NetconfObject) er
 	return nil
 }
 
-func checkInterfaceExists(interFace string, m interface{}, jnprSess *NetconfObject) (bool, error) {
+func checkInterfaceExistsOld(interFace string, m interface{}, jnprSess *NetconfObject) (bool, error) {
 	sess := m.(*Session)
 	rpcIntName := "<get-interface-information><interface-name>" + interFace +
 		"</interface-name></get-interface-information>"

--- a/junos/resource_interface.go
+++ b/junos/resource_interface.go
@@ -49,6 +49,7 @@ func resourceInterface() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: resourceInterfaceImport,
 		},
+		DeprecationMessage: "use junos_interface_physical or junos_interface_logical resource instead",
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,

--- a/junos/resource_interface_logical.go
+++ b/junos/resource_interface_logical.go
@@ -1078,7 +1078,7 @@ func fillFamilyInetAddress(item string, inetAddress []map[string]interface{},
 		case strings.HasPrefix(itemTrimVrrp, "virtual-link-local-address "):
 			vrrpGroup["virtual_link_local_address"] = strings.TrimPrefix(itemTrimVrrp,
 				"virtual-link-local-address ")
-		case strings.HasPrefix(itemTrimVrrp, "accept-data"):
+		case itemTrimVrrp == "accept-data":
 			vrrpGroup["accept_data"] = true
 		case strings.HasPrefix(itemTrimVrrp, "advertise-interval "):
 			vrrpGroup["advertise_interval"], err = strconv.Atoi(strings.TrimPrefix(itemTrimVrrp,
@@ -1106,11 +1106,11 @@ func fillFamilyInetAddress(item string, inetAddress []map[string]interface{},
 			}
 		case strings.HasPrefix(itemTrimVrrp, "authentication-type "):
 			vrrpGroup["authentication_type"] = strings.TrimPrefix(itemTrimVrrp, "authentication-type ")
-		case strings.HasPrefix(itemTrimVrrp, "no-accept-data"):
+		case itemTrimVrrp == "no-accept-data":
 			vrrpGroup["no_accept_data"] = true
-		case strings.HasPrefix(itemTrimVrrp, "no-preempt"):
+		case itemTrimVrrp == "no-preempt":
 			vrrpGroup["no_preempt"] = true
-		case strings.HasPrefix(itemTrimVrrp, "preempt"):
+		case itemTrimVrrp == "preempt":
 			vrrpGroup["preempt"] = true
 		case strings.HasPrefix(itemTrimVrrp, "priority"):
 			vrrpGroup["priority"], err = strconv.Atoi(strings.TrimPrefix(itemTrimVrrp, "priority "))

--- a/junos/resource_interface_logical.go
+++ b/junos/resource_interface_logical.go
@@ -1,0 +1,1271 @@
+package junos
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	jdecode "github.com/jeremmfr/junosdecode"
+)
+
+type interfaceLogicalOptions struct {
+	vlanID           int
+	description      string
+	securityZones    string
+	routingInstances string
+	familyInet       []map[string]interface{}
+	familyInet6      []map[string]interface{}
+}
+
+func resourceInterfaceLogical() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceInterfaceLogicalCreate,
+		ReadContext:   resourceInterfaceLogicalRead,
+		UpdateContext: resourceInterfaceLogicalUpdate,
+		DeleteContext: resourceInterfaceLogicalDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceInterfaceLogicalImport,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(string)
+					if strings.Count(value, ".") != 1 {
+						errors = append(errors, fmt.Errorf(
+							"%q in %q need to have 1 dot", value, k))
+					}
+
+					return
+				},
+			},
+			"st0_also_on_destroy": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"vlan_id": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IntBetween(1, 4094),
+			},
+			"family_inet": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"address": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"cidr_ip": {
+										Type:             schema.TypeString,
+										Required:         true,
+										ValidateDiagFunc: validateIPMaskFunc(),
+									},
+									"vrrp_group": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"identifier": {
+													Type:         schema.TypeInt,
+													Required:     true,
+													ValidateFunc: validation.IntBetween(1, 255),
+												},
+												"virtual_address": {
+													Type:     schema.TypeList,
+													Required: true,
+													MinItems: 1,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+												"accept_data": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"advertise_interval": {
+													Type:         schema.TypeInt,
+													Optional:     true,
+													ValidateFunc: validation.IntBetween(1, 255),
+												},
+												"advertisements_threshold": {
+													Type:         schema.TypeInt,
+													Optional:     true,
+													ValidateFunc: validation.IntBetween(1, 15),
+												},
+												"authentication_key": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"authentication_type": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: validation.StringInSlice([]string{"md5", "simple"}, false),
+												},
+												"no_accept_data": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"no_preempt": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"preempt": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"priority": {
+													Type:         schema.TypeInt,
+													Optional:     true,
+													ValidateFunc: validation.IntBetween(1, 255),
+												},
+												"track_interface": {
+													Type:     schema.TypeList,
+													Optional: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"interface": {
+																Type:     schema.TypeString,
+																Required: true,
+															},
+															"priority_cost": {
+																Type:         schema.TypeInt,
+																Required:     true,
+																ValidateFunc: validation.IntBetween(1, 254),
+															},
+														},
+													},
+												},
+												"track_route": {
+													Type:     schema.TypeList,
+													Optional: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"route": {
+																Type:     schema.TypeString,
+																Required: true,
+															},
+															"routing_instance": {
+																Type:     schema.TypeString,
+																Required: true,
+															},
+															"priority_cost": {
+																Type:         schema.TypeInt,
+																Required:     true,
+																ValidateFunc: validation.IntBetween(1, 254),
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"mtu": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(500, 9192),
+						},
+						"filter_input": {
+							Type:             schema.TypeString,
+							Optional:         true,
+							ValidateDiagFunc: validateNameObjectJunos([]string{}),
+						},
+						"filter_output": {
+							Type:             schema.TypeString,
+							Optional:         true,
+							ValidateDiagFunc: validateNameObjectJunos([]string{}),
+						},
+						"rpf_check": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"fail_filter": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"mode_loose": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"family_inet6": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"address": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"cidr_ip": {
+										Type:             schema.TypeString,
+										Required:         true,
+										ValidateDiagFunc: validateIPMaskFunc(),
+									},
+									"vrrp_group": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"identifier": {
+													Type:         schema.TypeInt,
+													Required:     true,
+													ValidateFunc: validation.IntBetween(1, 255),
+												},
+												"virtual_address": {
+													Type:     schema.TypeList,
+													Required: true,
+													MinItems: 1,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+												"virtual_link_local_address": {
+													Type:         schema.TypeString,
+													Required:     true,
+													ValidateFunc: validation.IsIPAddress,
+												},
+												"accept_data": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"advertise_interval": {
+													Type:         schema.TypeInt,
+													Optional:     true,
+													ValidateFunc: validation.IntBetween(100, 40000),
+												},
+												"advertisements_threshold": {
+													Type:         schema.TypeInt,
+													Optional:     true,
+													ValidateFunc: validation.IntBetween(1, 15),
+												},
+												"no_accept_data": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"no_preempt": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"preempt": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"priority": {
+													Type:         schema.TypeInt,
+													Optional:     true,
+													ValidateFunc: validation.IntBetween(1, 255),
+												},
+												"track_interface": {
+													Type:     schema.TypeList,
+													Optional: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"interface": {
+																Type:     schema.TypeString,
+																Required: true,
+															},
+															"priority_cost": {
+																Type:         schema.TypeInt,
+																Required:     true,
+																ValidateFunc: validation.IntBetween(1, 254),
+															},
+														},
+													},
+												},
+												"track_route": {
+													Type:     schema.TypeList,
+													Optional: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"route": {
+																Type:     schema.TypeString,
+																Required: true,
+															},
+															"routing_instance": {
+																Type:     schema.TypeString,
+																Required: true,
+															},
+															"priority_cost": {
+																Type:         schema.TypeInt,
+																Required:     true,
+																ValidateFunc: validation.IntBetween(1, 254),
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"mtu": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(500, 9192),
+						},
+						"filter_input": {
+							Type:             schema.TypeString,
+							Optional:         true,
+							ValidateDiagFunc: validateNameObjectJunos([]string{}),
+						},
+						"filter_output": {
+							Type:             schema.TypeString,
+							Optional:         true,
+							ValidateDiagFunc: validateNameObjectJunos([]string{}),
+						},
+						"rpf_check": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"fail_filter": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"mode_loose": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"security_zone": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateDiagFunc: validateNameObjectJunos([]string{}),
+			},
+			"routing_instance": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateDiagFunc: validateNameObjectJunos([]string{}),
+			},
+		},
+	}
+}
+
+func resourceInterfaceLogicalCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	intExists, err := checkInterfaceExists(d.Get("name").(string), m, jnprSess)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	sess.configLock(jnprSess)
+	if intExists {
+		ncInt, emptyInt, err := checkInterfaceLogicalNC(d.Get("name").(string), m, jnprSess)
+		if err != nil {
+			sess.configClear(jnprSess)
+
+			return diag.FromErr(err)
+		}
+		if !ncInt && !emptyInt {
+			return diag.FromErr(fmt.Errorf("interface %s already configured", d.Get("name").(string)))
+		}
+		if err := delInterfaceNC(d, m, jnprSess); err != nil {
+			sess.configClear(jnprSess)
+
+			return diag.FromErr(err)
+		}
+	}
+	if d.Get("security_zone").(string) != "" {
+		if !checkCompatibilitySecurity(jnprSess) {
+			sess.configClear(jnprSess)
+
+			return diag.FromErr(fmt.Errorf("security zone not compatible with Junos device %s",
+				jnprSess.SystemInformation.HardwareModel))
+		}
+		zonesExists, err := checkSecurityZonesExists(d.Get("security_zone").(string), m, jnprSess)
+		if err != nil {
+			sess.configClear(jnprSess)
+
+			return diag.FromErr(err)
+		}
+		if !zonesExists {
+			sess.configClear(jnprSess)
+
+			return diag.FromErr(fmt.Errorf("security zones %v doesn't exist", d.Get("security_zone").(string)))
+		}
+	}
+	if d.Get("routing_instance").(string) != "" {
+		instanceExists, err := checkRoutingInstanceExists(d.Get("routing_instance").(string), m, jnprSess)
+		if err != nil {
+			sess.configClear(jnprSess)
+
+			return diag.FromErr(err)
+		}
+		if !instanceExists {
+			sess.configClear(jnprSess)
+
+			return diag.FromErr(fmt.Errorf("routing instance %v doesn't exist", d.Get("routing_instance").(string)))
+		}
+	}
+	if err := setInterfaceLogical(d, m, jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	if err := sess.commitConf("create resource junos_interface_logical", jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	intExists, err = checkInterfaceExists(d.Get("name").(string), m, jnprSess)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if intExists {
+		ncInt, _, err := checkInterfaceLogicalNC(d.Get("name").(string), m, jnprSess)
+		if err != nil {
+			sess.configClear(jnprSess)
+
+			return diag.FromErr(err)
+		}
+		if ncInt {
+			return diag.FromErr(fmt.Errorf("interface %v exists but always disable after commit "+
+				"=> check your config", d.Get("name").(string)))
+		}
+		d.SetId(d.Get("name").(string))
+	} else {
+		return diag.FromErr(fmt.Errorf("interface %v not exists after commit => check your config", d.Get("name").(string)))
+	}
+
+	return resourceInterfaceLogicalRead(ctx, d, m)
+}
+func resourceInterfaceLogicalRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	mutex.Lock()
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		mutex.Unlock()
+
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	intExists, err := checkInterfaceExists(d.Get("name").(string), m, jnprSess)
+	if err != nil {
+		mutex.Unlock()
+
+		return diag.FromErr(err)
+	}
+	if !intExists {
+		d.SetId("")
+		mutex.Unlock()
+
+		return nil
+	}
+	ncInt, _, err := checkInterfaceLogicalNC(d.Get("name").(string), m, jnprSess)
+	if err != nil {
+		mutex.Unlock()
+
+		return diag.FromErr(err)
+	}
+	if ncInt {
+		d.SetId("")
+		mutex.Unlock()
+
+		return nil
+	}
+	interfaceLogicalOpt, err := readInterfaceLogical(d.Get("name").(string), m, jnprSess)
+	mutex.Unlock()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	fillInterfaceLogicalData(d, interfaceLogicalOpt)
+
+	return nil
+}
+func resourceInterfaceLogicalUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	d.Partial(true)
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	sess.configLock(jnprSess)
+	if err := delInterfaceLogicalOpts(d, m, jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	if d.HasChange("security_zone") {
+		oSecurityZone, nSecurityZone := d.GetChange("security_zone")
+		if nSecurityZone.(string) != "" {
+			if !checkCompatibilitySecurity(jnprSess) {
+				sess.configClear(jnprSess)
+
+				return diag.FromErr(fmt.Errorf("security zone not compatible with Junos device %s",
+					jnprSess.SystemInformation.HardwareModel))
+			}
+			zonesExists, err := checkSecurityZonesExists(nSecurityZone.(string), m, jnprSess)
+			if err != nil {
+				sess.configClear(jnprSess)
+
+				return diag.FromErr(err)
+			}
+			if !zonesExists {
+				sess.configClear(jnprSess)
+
+				return diag.FromErr(fmt.Errorf("security zones %v doesn't exist", nSecurityZone.(string)))
+			}
+		}
+		if oSecurityZone.(string) != "" {
+			err = delZoneInterfaceLogical(oSecurityZone.(string), d, m, jnprSess)
+			if err != nil {
+				sess.configClear(jnprSess)
+
+				return diag.FromErr(err)
+			}
+		}
+	}
+	if d.HasChange("routing_instance") {
+		oRoutingInstance, nRoutingInstance := d.GetChange("routing_instance")
+		if nRoutingInstance.(string) != "" {
+			instanceExists, err := checkRoutingInstanceExists(nRoutingInstance.(string), m, jnprSess)
+			if err != nil {
+				sess.configClear(jnprSess)
+
+				return diag.FromErr(err)
+			}
+			if !instanceExists {
+				sess.configClear(jnprSess)
+
+				return diag.FromErr(fmt.Errorf("routing instance %v doesn't exist", nRoutingInstance.(string)))
+			}
+		}
+		if oRoutingInstance.(string) != "" {
+			err = delRoutingInstanceInterfaceLogical(oRoutingInstance.(string), d, m, jnprSess)
+			if err != nil {
+				sess.configClear(jnprSess)
+
+				return diag.FromErr(err)
+			}
+		}
+	}
+	if err := setInterfaceLogical(d, m, jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	if err := sess.commitConf("update resource junos_interface_logical", jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	d.Partial(false)
+
+	return resourceInterfaceLogicalRead(ctx, d, m)
+}
+func resourceInterfaceLogicalDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	sess.configLock(jnprSess)
+	if err := delInterfaceLogical(d, m, jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	if err := sess.commitConf("delete resource junos_interface_logical", jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+func resourceInterfaceLogicalImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	if strings.Count(d.Id(), ".") != 1 {
+		return nil, fmt.Errorf("name of interface %s need to have 1 dot", d.Id())
+	}
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return nil, err
+	}
+	defer sess.closeSession(jnprSess)
+	result := make([]*schema.ResourceData, 1)
+	intExists, err := checkInterfaceExists(d.Id(), m, jnprSess)
+	if err != nil {
+		return nil, err
+	}
+	if !intExists {
+		return nil, fmt.Errorf("don't find interface with id '%v' (id must be <name>)", d.Id())
+	}
+	interfaceLogicalOpt, err := readInterfaceLogical(d.Id(), m, jnprSess)
+	if err != nil {
+		return nil, err
+	}
+	if tfErr := d.Set("name", d.Id()); tfErr != nil {
+		panic(tfErr)
+	}
+	fillInterfaceLogicalData(d, interfaceLogicalOpt)
+
+	result[0] = d
+
+	return result, nil
+}
+
+func checkInterfaceLogicalNC(interFace string, m interface{}, jnprSess *NetconfObject) (
+	ncInt bool, emtyInt bool, errFunc error) {
+	sess := m.(*Session)
+	intConfig, err := sess.command("show configuration interfaces "+interFace+" | display set relative", jnprSess)
+	if err != nil {
+		return false, false, err
+	}
+	intConfigLines := make([]string, 0)
+	// remove unused lines
+	for _, item := range strings.Split(intConfig, "\n") {
+		// exclude ethernet-switching (parameters in junos_interface_physical)
+		if strings.Contains(item, "ethernet-switching") {
+			continue
+		}
+		if strings.Contains(item, "<configuration-output>") {
+			continue
+		}
+		if strings.Contains(item, "</configuration-output>") {
+			break
+		}
+		if item == "" {
+			continue
+		}
+		intConfigLines = append(intConfigLines, item)
+	}
+	if len(intConfigLines) == 0 {
+		return false, true, nil
+	}
+	intConfig = strings.Join(intConfigLines, "\n")
+	if sess.junosGroupIntDel != "" {
+		if intConfig == "set apply-groups "+sess.junosGroupIntDel {
+			return true, false, nil
+		}
+	}
+	if intConfig == "set description NC\nset disable" ||
+		intConfig == "set disable\nset description NC" {
+		return true, false, nil
+	}
+	if intConfig == setLineStart ||
+		intConfig == emptyWord {
+		return false, true, nil
+	}
+
+	return false, false, nil
+}
+
+func setInterfaceLogical(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) error {
+	sess := m.(*Session)
+	intCut := strings.Split(d.Get("name").(string), ".")
+	if len(intCut) != 2 {
+		return fmt.Errorf("the name %s doesn't contain one dot", d.Get("name").(string))
+	}
+	configSet := make([]string, 0)
+	setPrefix := "set interfaces " + d.Get("name").(string) + " "
+	configSet = append(configSet, setPrefix)
+	if d.Get("description").(string) != "" {
+		configSet = append(configSet, setPrefix+"description \""+d.Get("description").(string)+"\"")
+	}
+	if d.Get("vlan_id").(int) != 0 {
+		configSet = append(configSet, setPrefix+"vlan-id "+strconv.Itoa(d.Get("vlan_id").(int)))
+	} else if intCut[0] != st0Word && intCut[1] != "0" {
+		configSet = append(configSet, setPrefix+"vlan-id "+intCut[1])
+	}
+	for _, v := range d.Get("family_inet").([]interface{}) {
+		configSet = append(configSet, setPrefix+"family inet")
+		if v != nil {
+			familyInet := v.(map[string]interface{})
+			for _, address := range familyInet["address"].([]interface{}) {
+				var err error
+				configSet, err = setFamilyAddress(address, configSet, setPrefix, inetWord)
+				if err != nil {
+					return err
+				}
+			}
+			if familyInet["mtu"].(int) > 0 {
+				configSet = append(configSet, setPrefix+"family inet mtu "+
+					strconv.Itoa(familyInet["mtu"].(int)))
+			}
+			for _, v2 := range familyInet["rpf_check"].([]interface{}) {
+				configSet = append(configSet, setPrefix+"family inet rpf-check")
+				if v2 != nil {
+					rpfCheck := v2.(map[string]interface{})
+					if rpfCheck["fail_filter"].(string) != "" {
+						configSet = append(configSet, setPrefix+"family inet rpf-check fail-filter "+
+							"\""+rpfCheck["fail_filter"].(string)+"\"")
+					}
+					if rpfCheck["mode_loose"].(bool) {
+						configSet = append(configSet, setPrefix+"family inet rpf-check mode loose ")
+					}
+				}
+			}
+			if familyInet["filter_input"].(string) != "" {
+				configSet = append(configSet, setPrefix+"family inet filter input "+
+					familyInet["filter_input"].(string))
+			}
+			if familyInet["filter_output"].(string) != "" {
+				configSet = append(configSet, setPrefix+"family inet filter output "+
+					familyInet["filter_output"].(string))
+			}
+		}
+	}
+	for _, v := range d.Get("family_inet6").([]interface{}) {
+		configSet = append(configSet, setPrefix+"family inet6")
+		if v != nil {
+			familyInet6 := v.(map[string]interface{})
+			for _, address := range familyInet6["address"].([]interface{}) {
+				var err error
+				configSet, err = setFamilyAddress(address, configSet, setPrefix, inet6Word)
+				if err != nil {
+					return err
+				}
+			}
+			if familyInet6["mtu"].(int) > 0 {
+				configSet = append(configSet, setPrefix+"family inet6 mtu "+
+					strconv.Itoa(familyInet6["mtu"].(int)))
+			}
+			for _, v2 := range familyInet6["rpf_check"].([]interface{}) {
+				configSet = append(configSet, setPrefix+"family inet6 rpf-check")
+				if v2 != nil {
+					rpfCheck := v2.(map[string]interface{})
+					if rpfCheck["fail_filter"].(string) != "" {
+						configSet = append(configSet, setPrefix+"family inet6 rpf-check fail-filter "+
+							"\""+rpfCheck["fail_filter"].(string)+"\"")
+					}
+					if rpfCheck["mode_loose"].(bool) {
+						configSet = append(configSet, setPrefix+"family inet6 rpf-check mode loose ")
+					}
+				}
+			}
+			if familyInet6["filter_input"].(string) != "" {
+				configSet = append(configSet, setPrefix+"family inet6 filter input "+
+					familyInet6["filter_input"].(string))
+			}
+			if familyInet6["filter_output"].(string) != "" {
+				configSet = append(configSet, setPrefix+"family inet6 filter output "+
+					familyInet6["filter_input"].(string))
+			}
+		}
+	}
+	if checkCompatibilitySecurity(jnprSess) && d.Get("security_zone").(string) != "" {
+		configSet = append(configSet, "set security zones security-zone "+
+			d.Get("security_zone").(string)+" interfaces "+d.Get("name").(string))
+	}
+	if d.Get("routing_instance").(string) != "" {
+		configSet = append(configSet, "set routing-instances "+d.Get("routing_instance").(string)+
+			" interface "+d.Get("name").(string))
+	}
+
+	if err := sess.configSet(configSet, jnprSess); err != nil {
+		return err
+	}
+
+	return nil
+}
+func readInterfaceLogical(interFace string, m interface{}, jnprSess *NetconfObject) (interfaceLogicalOptions, error) {
+	sess := m.(*Session)
+	var confRead interfaceLogicalOptions
+
+	intConfig, err := sess.command("show configuration interfaces "+interFace+" | display set relative", jnprSess)
+	if err != nil {
+		return confRead, err
+	}
+
+	if intConfig != emptyWord {
+		for _, item := range strings.Split(intConfig, "\n") {
+			// exclude ethernet-switching (parameters in junos_interface_physical)
+			if strings.Contains(item, "ethernet-switching") {
+				continue
+			}
+			if strings.Contains(item, "<configuration-output>") {
+				continue
+			}
+			if strings.Contains(item, "</configuration-output>") {
+				break
+			}
+			itemTrim := strings.TrimPrefix(item, setLineStart)
+			switch {
+			case strings.HasPrefix(itemTrim, "description "):
+				confRead.description = strings.Trim(strings.TrimPrefix(itemTrim, "description "), "\"")
+			case strings.HasPrefix(itemTrim, "vlan-id "):
+				var err error
+				confRead.vlanID, err = strconv.Atoi(strings.TrimPrefix(itemTrim, "vlan-id "))
+				if err != nil {
+					return confRead, fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+				}
+			case strings.HasPrefix(itemTrim, "family inet6"):
+				if len(confRead.familyInet6) == 0 {
+					confRead.familyInet6 = append(confRead.familyInet6, map[string]interface{}{
+						"address":       make([]map[string]interface{}, 0),
+						"mtu":           0,
+						"filter_input":  "",
+						"filter_output": "",
+						"rpf_check":     make([]map[string]interface{}, 0),
+					})
+				}
+				switch {
+				case strings.HasPrefix(itemTrim, "family inet6 address "):
+					var err error
+					confRead.familyInet6[0]["address"], err = fillFamilyInetAddress(
+						itemTrim, confRead.familyInet6[0]["address"].([]map[string]interface{}), inet6Word)
+					if err != nil {
+						return confRead, err
+					}
+				case strings.HasPrefix(itemTrim, "family inet6 mtu"):
+					var err error
+					confRead.familyInet6[0]["mtu"], err = strconv.Atoi(strings.TrimPrefix(itemTrim, "family inet6 mtu "))
+					if err != nil {
+						return confRead, fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+					}
+				case strings.HasPrefix(itemTrim, "family inet6 filter input "):
+					confRead.familyInet6[0]["filter_input"] = strings.TrimPrefix(itemTrim, "family inet6 filter input ")
+				case strings.HasPrefix(itemTrim, "family inet6 filter output "):
+					confRead.familyInet6[0]["filter_output"] = strings.TrimPrefix(itemTrim, "family inet6 filter output ")
+				case strings.HasPrefix(itemTrim, "family inet6 rpf-check"):
+					if len(confRead.familyInet6[0]["rpf_check"].([]map[string]interface{})) == 0 {
+						confRead.familyInet6[0]["rpf_check"] = append(
+							confRead.familyInet6[0]["rpf_check"].([]map[string]interface{}), map[string]interface{}{
+								"fail_filter": "",
+								"mode_loose":  false,
+							})
+					}
+					switch {
+					case strings.HasPrefix(itemTrim, "family inet6 rpf-check fail-filter "):
+						confRead.familyInet6[0]["rpf_check"].([]map[string]interface{})[0]["fail_filter"] = strings.Trim(
+							strings.TrimPrefix(itemTrim, "family inet6 rpf-check fail-filter "), "\"")
+					case itemTrim == "family inet6 rpf-check mode loose":
+						confRead.familyInet6[0]["rpf_check"].([]map[string]interface{})[0]["mode_loose"] = true
+					}
+				}
+			case strings.HasPrefix(itemTrim, "family inet"):
+				if len(confRead.familyInet) == 0 {
+					confRead.familyInet = append(confRead.familyInet, map[string]interface{}{
+						"address":       make([]map[string]interface{}, 0),
+						"mtu":           0,
+						"filter_input":  "",
+						"filter_output": "",
+						"rpf_check":     make([]map[string]interface{}, 0),
+					})
+				}
+				switch {
+				case strings.HasPrefix(itemTrim, "family inet address "):
+					var err error
+					confRead.familyInet[0]["address"], err = fillFamilyInetAddress(
+						itemTrim, confRead.familyInet[0]["address"].([]map[string]interface{}), inetWord)
+					if err != nil {
+						return confRead, err
+					}
+				case strings.HasPrefix(itemTrim, "family inet mtu"):
+					var err error
+					confRead.familyInet[0]["mtu"], err = strconv.Atoi(strings.TrimPrefix(itemTrim, "family inet mtu "))
+					if err != nil {
+						return confRead, fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+					}
+				case strings.HasPrefix(itemTrim, "family inet filter input "):
+					confRead.familyInet[0]["filter_input"] = strings.TrimPrefix(itemTrim, "family inet filter input ")
+				case strings.HasPrefix(itemTrim, "family inet filter output "):
+					confRead.familyInet[0]["filter_output"] = strings.TrimPrefix(itemTrim, "family inet filter output ")
+				case strings.HasPrefix(itemTrim, "family inet rpf-check"):
+					if len(confRead.familyInet[0]["rpf_check"].([]map[string]interface{})) == 0 {
+						confRead.familyInet[0]["rpf_check"] = append(
+							confRead.familyInet[0]["rpf_check"].([]map[string]interface{}), map[string]interface{}{
+								"fail_filter": "",
+								"mode_loose":  false,
+							})
+					}
+					switch {
+					case strings.HasPrefix(itemTrim, "family inet rpf-check fail-filter "):
+						confRead.familyInet[0]["rpf_check"].([]map[string]interface{})[0]["fail_filter"] = strings.Trim(
+							strings.TrimPrefix(itemTrim, "family inet rpf-check fail-filter "), "\"")
+					case itemTrim == "family inet rpf-check mode loose":
+						confRead.familyInet[0]["rpf_check"].([]map[string]interface{})[0]["mode_loose"] = true
+					}
+				}
+			default:
+				continue
+			}
+		}
+	}
+	if checkCompatibilitySecurity(jnprSess) {
+		zonesConfig, err := sess.command("show configuration security zones | display set relative", jnprSess)
+		if err != nil {
+			return confRead, err
+		}
+		regexpInts := regexp.MustCompile(`set security-zone .* interfaces ` + interFace + `$`)
+		for _, item := range strings.Split(zonesConfig, "\n") {
+			intMatch := regexpInts.MatchString(item)
+			if intMatch {
+				confRead.securityZones = strings.TrimPrefix(strings.TrimSuffix(item, " interfaces "+interFace),
+					"set security-zone ")
+
+				break
+			}
+		}
+	} else {
+		confRead.securityZones = ""
+	}
+	routingConfig, err := sess.command("show configuration routing-instances | display set relative", jnprSess)
+	if err != nil {
+		return confRead, err
+	}
+	regexpInt := regexp.MustCompile(`set .* interface ` + interFace + `$`)
+	for _, item := range strings.Split(routingConfig, "\n") {
+		intMatch := regexpInt.MatchString(item)
+		if intMatch {
+			confRead.routingInstances = strings.TrimPrefix(strings.TrimSuffix(item, " interface "+interFace),
+				"set ")
+
+			break
+		}
+	}
+
+	return confRead, nil
+}
+func delInterfaceLogical(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) error {
+	sess := m.(*Session)
+	if err := sess.configSet([]string{"delete interfaces " + d.Get("name").(string)}, jnprSess); err != nil {
+		return err
+	}
+	if strings.HasPrefix(d.Get("name").(string), "st0.") && !d.Get("st0_also_on_destroy").(bool) {
+		// interface totally delete by
+		// - junos_interface_st0_unit resource
+		// else there is an interface st0.x empty
+		err := sess.configSet([]string{"set interfaces " + d.Get("name").(string)}, jnprSess)
+		if err != nil {
+			return err
+		}
+	}
+	if checkCompatibilitySecurity(jnprSess) && d.Get("security_zone").(string) != "" {
+		if err := delZoneInterfaceLogical(d.Get("security_zone").(string), d, m, jnprSess); err != nil {
+			return err
+		}
+	}
+	if d.Get("routing_instance").(string) != "" {
+		if err := delRoutingInstanceInterfaceLogical(d.Get("routing_instance").(string), d, m, jnprSess); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func delInterfaceLogicalOpts(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) error {
+	sess := m.(*Session)
+	configSet := make([]string, 0, 1)
+	delPrefix := "delete interfaces " + d.Get("name").(string) + " "
+	configSet = append(configSet,
+		delPrefix+"family inet",
+		delPrefix+"family inet6")
+	if err := sess.configSet(configSet, jnprSess); err != nil {
+		return err
+	}
+
+	return nil
+}
+func delZoneInterfaceLogical(zone string, d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) error {
+	sess := m.(*Session)
+	configSet := make([]string, 0, 1)
+	configSet = append(configSet, "delete security zones security-zone "+zone+" interfaces "+d.Get("name").(string))
+	if err := sess.configSet(configSet, jnprSess); err != nil {
+		return err
+	}
+
+	return nil
+}
+func delRoutingInstanceInterfaceLogical(instance string, d *schema.ResourceData,
+	m interface{}, jnprSess *NetconfObject) error {
+	sess := m.(*Session)
+	configSet := make([]string, 0, 1)
+	configSet = append(configSet, "delete routing-instances "+instance+" interface "+d.Get("name").(string))
+	if err := sess.configSet(configSet, jnprSess); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func fillInterfaceLogicalData(d *schema.ResourceData, interfaceLogicalOpt interfaceLogicalOptions) {
+	if tfErr := d.Set("description", interfaceLogicalOpt.description); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("vlan_id", interfaceLogicalOpt.vlanID); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("family_inet", interfaceLogicalOpt.familyInet); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("family_inet6", interfaceLogicalOpt.familyInet6); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("security_zone", interfaceLogicalOpt.securityZones); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("routing_instance", interfaceLogicalOpt.routingInstances); tfErr != nil {
+		panic(tfErr)
+	}
+}
+
+func fillFamilyInetAddress(item string, inetAddress []map[string]interface{},
+	family string) ([]map[string]interface{}, error) {
+	var addressConfig []string
+	var itemTrim string
+	switch family {
+	case inetWord:
+		addressConfig = strings.Split(strings.TrimPrefix(item, "family inet address "), " ")
+		itemTrim = strings.TrimPrefix(item, "family inet address "+addressConfig[0]+" ")
+	case inet6Word:
+		addressConfig = strings.Split(strings.TrimPrefix(item, "family inet6 address "), " ")
+		itemTrim = strings.TrimPrefix(item, "family inet6 address "+addressConfig[0]+" ")
+	}
+
+	m := genFamilyInetAddress(addressConfig[0])
+	m, inetAddress = copyAndRemoveItemMapList("cidr_ip", false, m, inetAddress)
+
+	if strings.HasPrefix(itemTrim, "vrrp-group ") || strings.HasPrefix(itemTrim, "vrrp-inet6-group ") {
+		vrrpGroup := genVRRPGroup(family)
+		vrrpID, err := strconv.Atoi(addressConfig[2])
+		if err != nil {
+			return inetAddress, nil
+		}
+		itemTrimVrrp := strings.TrimPrefix(itemTrim, "vrrp-group "+strconv.Itoa(vrrpID)+" ")
+		if strings.HasPrefix(itemTrim, "vrrp-inet6-group ") {
+			itemTrimVrrp = strings.TrimPrefix(itemTrim, "vrrp-inet6-group "+strconv.Itoa(vrrpID)+" ")
+		}
+		vrrpGroup["identifier"] = vrrpID
+		vrrpGroup, m["vrrp_group"] = copyAndRemoveItemMapList("identifier", true, vrrpGroup,
+			m["vrrp_group"].([]map[string]interface{}))
+		switch {
+		case strings.HasPrefix(itemTrimVrrp, "virtual-address "):
+			vrrpGroup["virtual_address"] = append(vrrpGroup["virtual_address"].([]string),
+				strings.TrimPrefix(itemTrimVrrp, "virtual-address "))
+		case strings.HasPrefix(itemTrimVrrp, "virtual-inet6-address "):
+			vrrpGroup["virtual_address"] = append(vrrpGroup["virtual_address"].([]string),
+				strings.TrimPrefix(itemTrimVrrp, "virtual-inet6-address "))
+		case strings.HasPrefix(itemTrimVrrp, "virtual-link-local-address "):
+			vrrpGroup["virtual_link_local_address"] = strings.TrimPrefix(itemTrimVrrp,
+				"virtual-link-local-address ")
+		case strings.HasPrefix(itemTrimVrrp, "accept-data"):
+			vrrpGroup["accept_data"] = true
+		case strings.HasPrefix(itemTrimVrrp, "advertise-interval "):
+			vrrpGroup["advertise_interval"], err = strconv.Atoi(strings.TrimPrefix(itemTrimVrrp,
+				"advertise-interval "))
+			if err != nil {
+				return inetAddress, fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrimVrrp, err)
+			}
+		case strings.HasPrefix(itemTrimVrrp, "inet6-advertise-interval "):
+			vrrpGroup["advertise_interval"], err = strconv.Atoi(strings.TrimPrefix(itemTrimVrrp,
+				"inet6-advertise-interval "))
+			if err != nil {
+				return inetAddress, fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrimVrrp, err)
+			}
+		case strings.HasPrefix(itemTrimVrrp, "advertisements-threshold "):
+			vrrpGroup["advertisements_threshold"], err = strconv.Atoi(strings.TrimPrefix(itemTrimVrrp,
+				"advertisements-threshold "))
+			if err != nil {
+				return inetAddress, fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrimVrrp, err)
+			}
+		case strings.HasPrefix(itemTrimVrrp, "authentication-key "):
+			vrrpGroup["authentication_key"], err = jdecode.Decode(strings.Trim(strings.TrimPrefix(itemTrimVrrp,
+				"authentication-key "), "\""))
+			if err != nil {
+				return inetAddress, fmt.Errorf("failed to decode authentication-key : %w", err)
+			}
+		case strings.HasPrefix(itemTrimVrrp, "authentication-type "):
+			vrrpGroup["authentication_type"] = strings.TrimPrefix(itemTrimVrrp, "authentication-type ")
+		case strings.HasPrefix(itemTrimVrrp, "no-accept-data"):
+			vrrpGroup["no_accept_data"] = true
+		case strings.HasPrefix(itemTrimVrrp, "no-preempt"):
+			vrrpGroup["no_preempt"] = true
+		case strings.HasPrefix(itemTrimVrrp, "preempt"):
+			vrrpGroup["preempt"] = true
+		case strings.HasPrefix(itemTrimVrrp, "priority"):
+			vrrpGroup["priority"], err = strconv.Atoi(strings.TrimPrefix(itemTrimVrrp, "priority "))
+			if err != nil {
+				return inetAddress, fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrimVrrp, err)
+			}
+		case strings.HasPrefix(itemTrimVrrp, "track interface "):
+			vrrpSlit := strings.Split(itemTrimVrrp, " ")
+			cost, err := strconv.Atoi(vrrpSlit[len(vrrpSlit)-1])
+			if err != nil {
+				return inetAddress, fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrimVrrp, err)
+			}
+			trackInt := map[string]interface{}{
+				"interface":     vrrpSlit[2],
+				"priority_cost": cost,
+			}
+			vrrpGroup["track_interface"] = append(vrrpGroup["track_interface"].([]map[string]interface{}), trackInt)
+		case strings.HasPrefix(itemTrimVrrp, "track route "):
+			vrrpSlit := strings.Split(itemTrimVrrp, " ")
+			cost, err := strconv.Atoi(vrrpSlit[len(vrrpSlit)-1])
+			if err != nil {
+				return inetAddress, fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrimVrrp, err)
+			}
+			trackRoute := map[string]interface{}{
+				"route":            vrrpSlit[2],
+				"routing_instance": vrrpSlit[4],
+				"priority_cost":    cost,
+			}
+			vrrpGroup["track_route"] = append(vrrpGroup["track_route"].([]map[string]interface{}), trackRoute)
+		}
+		m["vrrp_group"] = append(m["vrrp_group"].([]map[string]interface{}), vrrpGroup)
+	}
+	inetAddress = append(inetAddress, m)
+
+	return inetAddress, nil
+}
+func setFamilyAddress(inetAddress interface{}, configSet []string, setPrefix string,
+	family string) ([]string, error) {
+	if family != inetWord && family != inet6Word {
+		return configSet, fmt.Errorf("setFamilyAddress() unknown family %v", family)
+	}
+	inetAddressMap := inetAddress.(map[string]interface{})
+	setPrefixAddress := setPrefix + "family " + family + " address " + inetAddressMap["cidr_ip"].(string)
+	configSet = append(configSet, setPrefixAddress)
+	for _, vrrpGroup := range inetAddressMap["vrrp_group"].([]interface{}) {
+		if strings.Contains(setPrefix, "set interfaces st0 unit") {
+			return configSet, fmt.Errorf("vrrp not available on st0")
+		}
+		vrrpGroupMap := vrrpGroup.(map[string]interface{})
+		if vrrpGroupMap["no_preempt"].(bool) && vrrpGroupMap["preempt"].(bool) {
+			return configSet, fmt.Errorf("ConflictsWith no_preempt and preempt")
+		}
+		if vrrpGroupMap["no_accept_data"].(bool) && vrrpGroupMap["accept_data"].(bool) {
+			return configSet, fmt.Errorf("ConflictsWith no_accept_data and accept_data")
+		}
+		var setNameAddVrrp string
+		switch family {
+		case inetWord:
+			setNameAddVrrp = setPrefixAddress + " vrrp-group " + strconv.Itoa(vrrpGroupMap["identifier"].(int))
+			for _, ip := range vrrpGroupMap["virtual_address"].([]interface{}) {
+				_, errs := validation.IsIPAddress(ip, "virtual_address")
+				if len(errs) > 0 {
+					return configSet, errs[0]
+				}
+				configSet = append(configSet, setNameAddVrrp+" virtual-address "+ip.(string))
+			}
+			if vrrpGroupMap["advertise_interval"].(int) != 0 {
+				configSet = append(configSet, setNameAddVrrp+" advertise-interval "+
+					strconv.Itoa(vrrpGroupMap["advertise_interval"].(int)))
+			}
+			if vrrpGroupMap["authentication_key"].(string) != "" {
+				configSet = append(configSet, setNameAddVrrp+" authentication-key \""+
+					vrrpGroupMap["authentication_key"].(string)+"\"")
+			}
+			if vrrpGroupMap["authentication_type"].(string) != "" {
+				configSet = append(configSet, setNameAddVrrp+" authentication-type "+
+					vrrpGroupMap["authentication_type"].(string))
+			}
+		case inet6Word:
+			setNameAddVrrp = setPrefixAddress + " vrrp-inet6-group " + strconv.Itoa(vrrpGroupMap["identifier"].(int))
+			for _, ip := range vrrpGroupMap["virtual_address"].([]interface{}) {
+				_, errs := validation.IsIPAddress(ip, "virtual_address")
+				if len(errs) > 0 {
+					return configSet, errs[0]
+				}
+				configSet = append(configSet, setNameAddVrrp+" virtual-inet6-address "+ip.(string))
+			}
+			configSet = append(configSet, setNameAddVrrp+" virtual-link-local-address "+
+				vrrpGroupMap["virtual_link_local_address"].(string))
+			if vrrpGroupMap["advertise_interval"].(int) != 0 {
+				configSet = append(configSet, setNameAddVrrp+" inet6-advertise-interval "+
+					strconv.Itoa(vrrpGroupMap["advertise_interval"].(int)))
+			}
+		}
+		if vrrpGroupMap["accept_data"].(bool) {
+			configSet = append(configSet, setNameAddVrrp+" accept-data")
+		}
+		if vrrpGroupMap["advertisements_threshold"].(int) != 0 {
+			configSet = append(configSet, setNameAddVrrp+" advertisements-threshold "+
+				strconv.Itoa(vrrpGroupMap["advertisements_threshold"].(int)))
+		}
+		if vrrpGroupMap["no_accept_data"].(bool) {
+			configSet = append(configSet, setNameAddVrrp+" no-accept-data")
+		}
+		if vrrpGroupMap["no_preempt"].(bool) {
+			configSet = append(configSet, setNameAddVrrp+" no-preempt")
+		}
+		if vrrpGroupMap["preempt"].(bool) {
+			configSet = append(configSet, setNameAddVrrp+" preempt")
+		}
+		if vrrpGroupMap["priority"].(int) != 0 {
+			configSet = append(configSet, setNameAddVrrp+" priority "+strconv.Itoa(vrrpGroupMap["priority"].(int)))
+		}
+		for _, trackInterface := range vrrpGroupMap["track_interface"].([]interface{}) {
+			trackInterfaceMap := trackInterface.(map[string]interface{})
+			configSet = append(configSet, setNameAddVrrp+" track interface "+trackInterfaceMap["interface"].(string)+
+				" priority-cost "+strconv.Itoa(trackInterfaceMap["priority_cost"].(int)))
+		}
+		for _, trackRoute := range vrrpGroupMap["track_route"].([]interface{}) {
+			trackRouteMap := trackRoute.(map[string]interface{})
+			configSet = append(configSet, setNameAddVrrp+" track route "+trackRouteMap["route"].(string)+
+				" routing-instance "+trackRouteMap["routing_instance"].(string)+
+				" priority-cost "+strconv.Itoa(trackRouteMap["priority_cost"].(int)))
+		}
+	}
+
+	return configSet, nil
+}
+func genFamilyInetAddress(address string) map[string]interface{} {
+	return map[string]interface{}{
+		"cidr_ip":    address,
+		"vrrp_group": make([]map[string]interface{}, 0),
+	}
+}
+func genVRRPGroup(family string) map[string]interface{} {
+	m := map[string]interface{}{
+		"identifier":               0,
+		"virtual_address":          make([]string, 0),
+		"accept_data":              false,
+		"advertise_interval":       0,
+		"advertisements_threshold": 0,
+		"no_accept_data":           false,
+		"no_preempt":               false,
+		"preempt":                  false,
+		"priority":                 0,
+		"track_interface":          make([]map[string]interface{}, 0),
+		"track_route":              make([]map[string]interface{}, 0),
+	}
+	if family == inetWord {
+		m["authentication_key"] = ""
+		m["authentication_type"] = ""
+	}
+	if family == inet6Word {
+		m["virtual_link_local_address"] = ""
+	}
+
+	return m
+}

--- a/junos/resource_interface_logical_test.go
+++ b/junos/resource_interface_logical_test.go
@@ -1,0 +1,370 @@
+package junos_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// export TESTACC_INTERFACE=<inteface> for choose interface available else it's ge-0/0/3.
+func TestAccJunosInterfaceLogical_basic(t *testing.T) {
+	var testaccInterface string
+	if os.Getenv("TESTACC_INTERFACE") != "" {
+		testaccInterface = os.Getenv("TESTACC_INTERFACE")
+	} else {
+		testaccInterface = defaultInterfaceTestAcc
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccJunosInterfaceLogicalConfigCreate(testaccInterface),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"description", "testacc_interface_"+testaccInterface+".100"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"name", testaccInterface+".100"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"vlan_id", "100"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"security_zone", "testacc_interface_logical"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"routing_instance", "testacc_interface_logical"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet.#", "1"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet6.#", "1"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet.0.mtu", "1400"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet.0.filter_input", "testacc_intlogicalInet"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet.0.filter_output", "testacc_intlogicalInet"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet.0.rpf_check.#", "1"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet.0.address.#", "1"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet.0.address.0.cidr_ip", "192.0.2.1/25"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet.0.address.0.vrrp_group.#", "1"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet.0.address.0.vrrp_group.0.identifier", "100"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet.0.address.0.vrrp_group.0.virtual_address.#", "1"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet.0.address.0.vrrp_group.0.virtual_address.0", "192.0.2.2"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet.0.address.0.vrrp_group.0.accept_data", "true"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet.0.address.0.vrrp_group.0.advertise_interval", "10"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet.0.address.0.vrrp_group.0.advertisements_threshold", "3"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet.0.address.0.vrrp_group.0.authentication_key", "thePassWord"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet.0.address.0.vrrp_group.0.authentication_type", "md5"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet.0.address.0.vrrp_group.0.preempt", "true"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet.0.address.0.vrrp_group.0.priority", "100"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet.0.address.0.vrrp_group.0.track_interface.#", "1"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet.0.address.0.vrrp_group.0.track_interface.0.interface", testaccInterface),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet.0.address.0.vrrp_group.0.track_interface.0.priority_cost", "20"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet.0.address.0.vrrp_group.0.track_route.#", "1"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet.0.address.0.vrrp_group.0.track_route.0.route", "192.0.2.128/25"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet.0.address.0.vrrp_group.0.track_route.0.routing_instance", "default"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet.0.address.0.vrrp_group.0.track_route.0.priority_cost", "20"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet6.0.mtu", "1400"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet6.0.filter_input", "testacc_intlogicalInet6"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet6.0.filter_output", "testacc_intlogicalInet6"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet6.0.address.#", "2"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet6.0.address.1.cidr_ip", "fe80::1/64"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet6.0.address.0.cidr_ip", "2001:db8::1/64"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet6.0.address.0.vrrp_group.#", "1"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet6.0.address.0.vrrp_group.0.identifier", "100"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet6.0.address.0.vrrp_group.0.virtual_address.#", "1"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet6.0.address.0.vrrp_group.0.virtual_address.0", "2001:db8::2"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet6.0.address.0.vrrp_group.0.virtual_link_local_address", "fe80::2"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet6.0.address.0.vrrp_group.0.accept_data", "true"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet6.0.address.0.vrrp_group.0.advertise_interval", "100"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet6.0.address.0.vrrp_group.0.advertisements_threshold", "3"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet6.0.address.0.vrrp_group.0.preempt", "true"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet6.0.address.0.vrrp_group.0.priority", "100"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet6.0.address.0.vrrp_group.0.track_interface.#", "1"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet6.0.address.0.vrrp_group.0.track_interface.0.interface", testaccInterface),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet6.0.address.0.vrrp_group.0.track_interface.0.priority_cost", "20"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet6.0.address.0.vrrp_group.0.track_route.#", "1"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet6.0.address.0.vrrp_group.0.track_route.0.route", "192.0.2.128/25"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet6.0.address.0.vrrp_group.0.track_route.0.routing_instance", "default"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet6.0.address.0.vrrp_group.0.track_route.0.priority_cost", "20"),
+				),
+			},
+			{
+				Config: testAccJunosInterfaceLogicalConfigUpdate(testaccInterface),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"vlan_id", "101"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet.#", "1"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet.0.mtu", "1500"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet6.#", "1"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet6.0.mtu", "1500"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet.0.rpf_check.#", "1"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet.0.rpf_check.0.mode_loose", "true"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet.0.address.#", "1"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet.0.address.0.vrrp_group.#", "1"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet.0.address.0.vrrp_group.0.no_accept_data", "true"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet.0.address.0.vrrp_group.0.no_preempt", "true"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet.0.address.0.vrrp_group.0.track_interface.#", "0"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet.0.address.0.vrrp_group.0.track_route.#", "0"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet6.0.address.#", "2"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet6.0.address.0.vrrp_group.#", "1"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet6.0.address.0.vrrp_group.0.no_accept_data", "true"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet6.0.address.0.vrrp_group.0.no_preempt", "true"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet6.0.address.0.vrrp_group.0.track_interface.#", "0"),
+					resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+						"family_inet6.0.address.0.vrrp_group.0.track_route.#", "0"),
+				),
+			},
+			{
+				ResourceName:      "junos_interface_logical.testacc_interface_logical",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccJunosInterfaceLogicalConfigCreate(interFace string) string {
+	return fmt.Sprintf(`
+resource junos_firewall_filter "testacc_intlogicalInet" {
+  name   = "testacc_intlogicalInet"
+  family = "inet"
+  term {
+    name = "testacc_intlogicalInetTerm"
+    then {
+      action = "accept"
+    }
+  }
+}
+resource junos_firewall_filter "testacc_intlogicalInet6" {
+  name   = "testacc_intlogicalInet6"
+  family = "inet6"
+  term {
+    name = "testacc_intlogicalInet6Term"
+    then {
+      action = "accept"
+    }
+  }
+}
+resource junos_security_zone "testacc_interface_logical" {
+  name = "testacc_interface_logical"
+}
+resource junos_routing_instance "testacc_interface_logical" {
+  name = "testacc_interface_logical"
+}
+resource junos_interface_physical testacc_interface_logical_phy {
+  name         = "` + interFace + `"
+  vlan_tagging = true
+}
+resource junos_interface_logical testacc_interface_logical {
+  name             = "${junos_interface_physical.testacc_interface_logical_phy.name}.100"
+  description      = "testacc_interface_${junos_interface_physical.testacc_interface_logical_phy.name}.100"
+  security_zone    = junos_security_zone.testacc_interface_logical.name
+  routing_instance = junos_routing_instance.testacc_interface_logical.name
+  family_inet {
+    mtu           = 1400
+    filter_input  = junos_firewall_filter.testacc_intlogicalInet.name
+    filter_output = junos_firewall_filter.testacc_intlogicalInet.name
+    rpf_check {}
+    address {
+      cidr_ip = "192.0.2.1/25"
+      vrrp_group {
+        identifier               = 100
+        virtual_address          = ["192.0.2.2"]
+        accept_data              = true
+        advertise_interval       = 10
+        advertisements_threshold = 3
+        authentication_key       = "thePassWord"
+        authentication_type      = "md5"
+        preempt                  = true
+        priority                 = 100
+        track_interface {
+          interface     = junos_interface_physical.testacc_interface_logical_phy.name
+          priority_cost = 20
+        }
+        track_route {
+          route            = "192.0.2.128/25"
+          routing_instance = "default"
+          priority_cost    = 20
+        }
+      }
+    }
+  }
+  family_inet6 {
+    mtu           = 1400
+    filter_input  = junos_firewall_filter.testacc_intlogicalInet6.name
+    filter_output = junos_firewall_filter.testacc_intlogicalInet6.name
+    address {
+      cidr_ip = "2001:db8::1/64"
+      vrrp_group {
+        identifier                 = 100
+        virtual_address            = ["2001:db8::2"]
+        virtual_link_local_address = "fe80::2"
+        accept_data                = true
+        advertise_interval         = 100
+        advertisements_threshold   = 3
+        preempt                    = true
+        priority                   = 100
+        track_interface {
+          interface     = junos_interface_physical.testacc_interface_logical_phy.name
+          priority_cost = 20
+        }
+        track_route {
+          route            = "192.0.2.128/25"
+          routing_instance = "default"
+          priority_cost    = 20
+        }
+      }
+    }
+    address {
+      cidr_ip = "fe80::1/64"
+    }
+  }
+}
+`)
+}
+func testAccJunosInterfaceLogicalConfigUpdate(interFace string) string {
+	return fmt.Sprintf(`
+resource junos_firewall_filter "testacc_intlogicalInet" {
+  name   = "testacc_intlogicalInet"
+  family = "inet"
+  term {
+    name = "testacc_intlogicalInetTerm"
+    then {
+      action = "accept"
+    }
+  }
+}
+resource junos_firewall_filter "testacc_intlogicalInet6" {
+  name   = "testacc_intlogicalInet6"
+  family = "inet6"
+  term {
+    name = "testacc_intlogicalInet6Term"
+    then {
+      action = "accept"
+    }
+  }
+}
+resource junos_security_zone "testacc_interface_logical" {
+  name = "testacc_interface"
+}
+resource junos_routing_instance "testacc_interface_logical" {
+  name = "testacc_interface"
+}
+resource junos_interface_physical testacc_interface_logical_phy {
+  name         = "` + interFace + `"
+  vlan_tagging = true
+}
+resource junos_interface_logical testacc_interface_logical {
+  name             = "${junos_interface_physical.testacc_interface_logical_phy.name}.100"
+  vlan_id          = 101
+  description      = "testacc_interface_${junos_interface_physical.testacc_interface_logical_phy.name}.100"
+  security_zone    = junos_security_zone.testacc_interface_logical.name
+  routing_instance = junos_routing_instance.testacc_interface_logical.name
+  family_inet {
+    mtu           = 1500
+    filter_input  = junos_firewall_filter.testacc_intlogicalInet.name
+    filter_output = junos_firewall_filter.testacc_intlogicalInet.name
+    rpf_check {
+      mode_loose = true
+    }
+    address {
+      cidr_ip = "192.0.2.1/25"
+      vrrp_group {
+        identifier               = 100
+        virtual_address          = ["192.0.2.2"]
+        no_accept_data           = true
+        advertise_interval       = 10
+        advertisements_threshold = 3
+        authentication_key       = "thePassWord"
+        authentication_type      = "md5"
+        no_preempt               = true
+        priority                 = 150
+      }
+    }
+  }
+  family_inet6 {
+    mtu           = 1500
+    filter_input  = junos_firewall_filter.testacc_intlogicalInet6.name
+    filter_output = junos_firewall_filter.testacc_intlogicalInet6.name
+    address {
+      cidr_ip = "2001:db8::1/64"
+      vrrp_group {
+        identifier                 = 100
+        virtual_address            = ["2001:db8::2"]
+        virtual_link_local_address = "fe80::2"
+        no_accept_data             = true
+        advertise_interval         = 100
+        no_preempt                 = true
+        priority                   = 150
+      }
+    }
+    address {
+      cidr_ip = "fe80::1/64"
+    }
+  }
+}
+`)
+}

--- a/junos/resource_interface_physical.go
+++ b/junos/resource_interface_physical.go
@@ -553,13 +553,13 @@ func readInterfacePhysical(interFace string, m interface{}, jnprSess *NetconfObj
 			case strings.HasPrefix(itemTrim, "description "):
 				confRead.description = strings.Trim(strings.TrimPrefix(itemTrim, "description "), "\"")
 
-			case strings.HasPrefix(itemTrim, "vlan-tagging"):
+			case itemTrim == "vlan-tagging":
 				confRead.vlanTagging = true
 			case strings.HasPrefix(itemTrim, "ether-options 802.3ad "):
 				confRead.v8023ad = strings.TrimPrefix(itemTrim, "ether-options 802.3ad ")
 			case strings.HasPrefix(itemTrim, "gigether-options 802.3ad "):
 				confRead.v8023ad = strings.TrimPrefix(itemTrim, "gigether-options 802.3ad ")
-			case strings.HasPrefix(itemTrim, "unit 0 family ethernet-switching interface-mode trunk"):
+			case itemTrim == "unit 0 family ethernet-switching interface-mode trunk":
 				confRead.trunk = true
 			case strings.HasPrefix(itemTrim, "unit 0 family ethernet-switching vlan members"):
 				confRead.vlanMembers = append(confRead.vlanMembers, strings.TrimPrefix(itemTrim,

--- a/junos/resource_interface_physical.go
+++ b/junos/resource_interface_physical.go
@@ -1,0 +1,799 @@
+package junos
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+type interfacePhysicalOptions struct {
+	vlanTagging bool
+	trunk       bool
+	vlanNative  int
+	aeMinLink   int
+	description string
+	v8023ad     string
+	aeLacp      string
+	aeLinkSpeed string
+	vlanMembers []string
+}
+
+func resourceInterfacePhysical() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceInterfacePhysicalCreate,
+		ReadContext:   resourceInterfacePhysicalRead,
+		UpdateContext: resourceInterfacePhysicalUpdate,
+		DeleteContext: resourceInterfacePhysicalDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceInterfacePhysicalImport,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(string)
+					if strings.Count(value, ".") > 0 {
+						errors = append(errors, fmt.Errorf(
+							"%q in %q cannot have a dot", value, k))
+					}
+
+					return
+				},
+			},
+			"no_disable_on_destroy": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"vlan_tagging": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"ether802_3ad": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(string)
+					if !strings.HasPrefix(value, "ae") {
+						errors = append(errors, fmt.Errorf(
+							"%q in %q isn't an ae interface", value, k))
+					}
+
+					return
+				},
+			},
+			"trunk": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"vlan_members": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"vlan_native": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(1, 4094),
+			},
+			"ae_lacp": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "",
+				ValidateFunc: validation.StringInSlice([]string{"active", "passive"}, false),
+			},
+			"ae_link_speed": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"100m", "1g", "8g", "10g", "40g", "50g", "80g", "100g"}, false),
+			},
+			"ae_minimum_links": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceInterfacePhysicalCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	intExists, err := checkInterfaceExists(d.Get("name").(string), m, jnprSess)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	sess.configLock(jnprSess)
+	if intExists {
+		ncInt, emptyInt, err := checkInterfacePhysicalNC(d.Get("name").(string), m, jnprSess)
+		if err != nil {
+			sess.configClear(jnprSess)
+
+			return diag.FromErr(err)
+		}
+		if !ncInt && !emptyInt {
+			return diag.FromErr(fmt.Errorf("interface %s already configured", d.Get("name").(string)))
+		}
+		if err := delInterfaceNC(d, m, jnprSess); err != nil {
+			sess.configClear(jnprSess)
+
+			return diag.FromErr(err)
+		}
+	}
+	if err := setInterfacePhysical(d, m, jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	if err := sess.commitConf("create resource junos_interface_physical", jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	intExists, err = checkInterfaceExists(d.Get("name").(string), m, jnprSess)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if intExists {
+		ncInt, _, err := checkInterfacePhysicalNC(d.Get("name").(string), m, jnprSess)
+		if err != nil {
+			sess.configClear(jnprSess)
+
+			return diag.FromErr(err)
+		}
+		if ncInt {
+			return diag.FromErr(fmt.Errorf("interface %v exists (because is a physical or internal default interface)"+
+				" but always disable after commit => check your config", d.Get("name").(string)))
+		}
+		d.SetId(d.Get("name").(string))
+	} else {
+		return diag.FromErr(fmt.Errorf("interface %v not exists after commit => check your config", d.Get("name").(string)))
+	}
+
+	return resourceInterfacePhysicalRead(ctx, d, m)
+}
+func resourceInterfacePhysicalRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	mutex.Lock()
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		mutex.Unlock()
+
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	intExists, err := checkInterfaceExists(d.Get("name").(string), m, jnprSess)
+	if err != nil {
+		mutex.Unlock()
+
+		return diag.FromErr(err)
+	}
+	if !intExists {
+		d.SetId("")
+		mutex.Unlock()
+
+		return nil
+	}
+	ncInt, _, err := checkInterfacePhysicalNC(d.Get("name").(string), m, jnprSess)
+	if err != nil {
+		mutex.Unlock()
+
+		return diag.FromErr(err)
+	}
+	if ncInt {
+		d.SetId("")
+		mutex.Unlock()
+
+		return nil
+	}
+	interfaceOpt, err := readInterfacePhysical(d.Get("name").(string), m, jnprSess)
+	mutex.Unlock()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	fillInterfacePhysicalData(d, interfaceOpt)
+
+	return nil
+}
+func resourceInterfacePhysicalUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	d.Partial(true)
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	sess.configLock(jnprSess)
+	if err := delInterfacePhysicalOpts(d, m, jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	if d.HasChange("ether802_3ad") {
+		oAE, nAE := d.GetChange("ether802_3ad")
+		if oAE.(string) != "" {
+			newAE := "ae-1"
+			if nAE.(string) != "" {
+				newAE = nAE.(string)
+			}
+			lastAEchild, err := interfaceAggregatedLastChild(oAE.(string), d.Get("name").(string), m, jnprSess)
+			if err != nil {
+				sess.configClear(jnprSess)
+
+				return diag.FromErr(err)
+			}
+			if lastAEchild {
+				aggregatedCount, err := interfaceAggregatedCountSearchMax(newAE, oAE.(string), d.Get("name").(string), m, jnprSess)
+				if err != nil {
+					sess.configClear(jnprSess)
+
+					return diag.FromErr(err)
+				}
+				if aggregatedCount == "0" {
+					err = sess.configSet([]string{"delete chassis aggregated-devices ethernet device-count"}, jnprSess)
+					if err != nil {
+						sess.configClear(jnprSess)
+
+						return diag.FromErr(err)
+					}
+					oAEintNC, oAEintEmpty, err := checkInterfacePhysicalNC(oAE.(string), m, jnprSess)
+					if err != nil {
+						sess.configClear(jnprSess)
+
+						return diag.FromErr(err)
+					}
+					if oAEintNC || oAEintEmpty {
+						err = sess.configSet([]string{"delete interfaces " + oAE.(string)}, jnprSess)
+						if err != nil {
+							sess.configClear(jnprSess)
+
+							return diag.FromErr(err)
+						}
+					}
+				} else {
+					oldAEInt, err := strconv.Atoi(strings.TrimPrefix(oAE.(string), "ae"))
+					if err != nil {
+						sess.configClear(jnprSess)
+
+						return diag.FromErr(err)
+					}
+					aggregatedCountInt, err := strconv.Atoi(aggregatedCount)
+					if err != nil {
+						sess.configClear(jnprSess)
+
+						return diag.FromErr(err)
+					}
+					if aggregatedCountInt < oldAEInt+1 {
+						oAEintNC, oAEintEmpty, err := checkInterfacePhysicalNC(oAE.(string), m, jnprSess)
+						if err != nil {
+							sess.configClear(jnprSess)
+
+							return diag.FromErr(err)
+						}
+						if oAEintNC || oAEintEmpty {
+							err = sess.configSet([]string{"delete interfaces " + oAE.(string)}, jnprSess)
+							if err != nil {
+								sess.configClear(jnprSess)
+
+								return diag.FromErr(err)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	if err := setInterfacePhysical(d, m, jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	if err := sess.commitConf("update resource junos_interface_physical", jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	d.Partial(false)
+
+	return resourceInterfacePhysicalRead(ctx, d, m)
+}
+func resourceInterfacePhysicalDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	sess.configLock(jnprSess)
+	if err := delInterfacePhysical(d, m, jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	if err := sess.commitConf("delete resource junos_interface_physical", jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	if !d.Get("no_disable_on_destroy").(bool) {
+		intExists, err := checkInterfaceExists(d.Get("name").(string), m, jnprSess)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		if intExists {
+			err = addInterfacePhysicalNC(d.Get("name").(string), m, jnprSess)
+			if err != nil {
+				sess.configClear(jnprSess)
+
+				return diag.FromErr(err)
+			}
+			err = sess.commitConf("disable(NC) resource junos_interface_physical", jnprSess)
+			if err != nil {
+				sess.configClear(jnprSess)
+
+				return diag.FromErr(err)
+			}
+		}
+	}
+
+	return nil
+}
+func resourceInterfacePhysicalImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	if strings.Count(d.Id(), ".") != 0 {
+		return nil, fmt.Errorf("name of interface %s need to doesn't have a dot", d.Id())
+	}
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return nil, err
+	}
+	defer sess.closeSession(jnprSess)
+	result := make([]*schema.ResourceData, 1)
+	intExists, err := checkInterfaceExists(d.Id(), m, jnprSess)
+	if err != nil {
+		return nil, err
+	}
+	if !intExists {
+		return nil, fmt.Errorf("don't find interface with id '%v' (id must be <name>)", d.Id())
+	}
+	interfaceOpt, err := readInterfacePhysical(d.Id(), m, jnprSess)
+	if err != nil {
+		return nil, err
+	}
+	if tfErr := d.Set("name", d.Id()); tfErr != nil {
+		panic(tfErr)
+	}
+	fillInterfacePhysicalData(d, interfaceOpt)
+
+	result[0] = d
+
+	return result, nil
+}
+
+func checkInterfacePhysicalNC(interFace string, m interface{}, jnprSess *NetconfObject) (
+	ncInt bool, emtyInt bool, errFunc error) {
+	sess := m.(*Session)
+	intConfig, err := sess.command("show configuration interfaces "+interFace+" | display set relative", jnprSess)
+	if err != nil {
+		return false, false, err
+	}
+	intConfigLines := make([]string, 0)
+	// remove unused lines
+	for _, item := range strings.Split(intConfig, "\n") {
+		// show parameters root on interface exclude unit parameters (except ethernet-switching)
+		if strings.HasPrefix(item, "set unit") && !strings.Contains(item, "ethernet-switching") {
+			continue
+		}
+		if strings.Contains(item, "<configuration-output>") {
+			continue
+		}
+		if strings.Contains(item, "</configuration-output>") {
+			break
+		}
+		if item == "" {
+			continue
+		}
+		intConfigLines = append(intConfigLines, item)
+	}
+	if len(intConfigLines) == 0 {
+		return false, true, nil
+	}
+	intConfig = strings.Join(intConfigLines, "\n")
+	if sess.junosGroupIntDel != "" {
+		if intConfig == "set apply-groups "+sess.junosGroupIntDel {
+			return true, false, nil
+		}
+	}
+	if intConfig == "set description NC\nset disable" ||
+		intConfig == "set disable\nset description NC" {
+		return true, false, nil
+	}
+	if intConfig == setLineStart ||
+		intConfig == emptyWord {
+		return false, true, nil
+	}
+
+	return false, false, nil
+}
+
+func addInterfacePhysicalNC(interFace string, m interface{}, jnprSess *NetconfObject) error {
+	sess := m.(*Session)
+	var err error
+	if sess.junosGroupIntDel == "" {
+		err = sess.configSet([]string{"set interfaces " + interFace + " disable description NC"}, jnprSess)
+	} else {
+		err = sess.configSet([]string{"set interfaces " + interFace +
+			" apply-groups " + sess.junosGroupIntDel}, jnprSess)
+	}
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func checkInterfaceExists(interFace string, m interface{}, jnprSess *NetconfObject) (bool, error) {
+	sess := m.(*Session)
+	rpcIntName := "<get-interface-information><interface-name>" + interFace +
+		"</interface-name></get-interface-information>"
+	reply, err := sess.commandXML(rpcIntName, jnprSess)
+	if err != nil {
+		return false, err
+	}
+	if strings.Contains(reply, " not found\n") {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func setInterfacePhysical(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) error {
+	sess := m.(*Session)
+	configSet := make([]string, 0)
+	setPrefix := "set interfaces " + d.Get("name").(string) + " "
+	configSet = append(configSet, setPrefix)
+	if d.Get("description").(string) != "" {
+		configSet = append(configSet, setPrefix+"description \""+d.Get("description").(string)+"\"")
+	}
+	if d.Get("vlan_tagging").(bool) {
+		configSet = append(configSet, setPrefix+"vlan-tagging")
+	}
+	if d.Get("ether802_3ad").(string) != "" {
+		configSet = append(configSet, setPrefix+"ether-options 802.3ad "+
+			d.Get("ether802_3ad").(string))
+		configSet = append(configSet, setPrefix+"gigether-options 802.3ad "+
+			d.Get("ether802_3ad").(string))
+		oldAE := "ae-1"
+		if d.HasChange("ether802_3ad") {
+			oldAEtf, _ := d.GetChange("ether802_3ad")
+			if oldAEtf.(string) != "" {
+				oldAE = oldAEtf.(string)
+			}
+		}
+		aggregatedCount, err := interfaceAggregatedCountSearchMax(d.Get("ether802_3ad").(string), oldAE,
+			d.Get("name").(string), m, jnprSess)
+		if err != nil {
+			return err
+		}
+		configSet = append(configSet, "set chassis aggregated-devices ethernet device-count "+aggregatedCount)
+	}
+	if d.Get("trunk").(bool) {
+		configSet = append(configSet, setPrefix+"unit 0 family ethernet-switching interface-mode trunk")
+	}
+	if len(d.Get("vlan_members").([]interface{})) > 0 {
+		for _, v := range d.Get("vlan_members").([]interface{}) {
+			configSet = append(configSet, setPrefix+
+				"unit 0 family ethernet-switching vlan members "+v.(string))
+		}
+	}
+	if d.Get("vlan_native").(int) != 0 {
+		configSet = append(configSet, setPrefix+"native-vlan-id "+strconv.Itoa(d.Get("vlan_native").(int)))
+	}
+	if d.Get("ae_lacp").(string) != "" {
+		if !strings.HasPrefix(d.Get("name").(string), "ae") {
+			return fmt.Errorf("ae_lacp invalid for this interface")
+		}
+		configSet = append(configSet, setPrefix+
+			"aggregated-ether-options lacp "+d.Get("ae_lacp").(string))
+	}
+	if d.Get("ae_link_speed").(string) != "" {
+		if !strings.HasPrefix(d.Get("name").(string), "ae") {
+			return fmt.Errorf("ae_link_speed invalid for this interface")
+		}
+		configSet = append(configSet, setPrefix+
+			"aggregated-ether-options link-speed "+d.Get("ae_link_speed").(string))
+	}
+	if d.Get("ae_minimum_links").(int) > 0 {
+		if !strings.HasPrefix(d.Get("name").(string), "ae") {
+			return fmt.Errorf("ae_minimum_links invalid for this interface")
+		}
+		configSet = append(configSet, setPrefix+
+			"aggregated-ether-options minimum-links "+strconv.Itoa(d.Get("ae_minimum_links").(int)))
+	}
+
+	if err := sess.configSet(configSet, jnprSess); err != nil {
+		return err
+	}
+
+	return nil
+}
+func readInterfacePhysical(interFace string, m interface{}, jnprSess *NetconfObject) (interfacePhysicalOptions, error) {
+	sess := m.(*Session)
+	var confRead interfacePhysicalOptions
+
+	intConfig, err := sess.command("show configuration interfaces "+interFace+" | display set relative", jnprSess)
+	if err != nil {
+		return confRead, err
+	}
+	if intConfig != emptyWord {
+		for _, item := range strings.Split(intConfig, "\n") {
+			if strings.Contains(item, " unit ") && !strings.Contains(item, "ethernet-switching") {
+				continue
+			}
+			if strings.Contains(item, "<configuration-output>") {
+				continue
+			}
+			if strings.Contains(item, "</configuration-output>") {
+				break
+			}
+			itemTrim := strings.TrimPrefix(item, setLineStart)
+			switch {
+			case strings.HasPrefix(itemTrim, "description "):
+				confRead.description = strings.Trim(strings.TrimPrefix(itemTrim, "description "), "\"")
+
+			case strings.HasPrefix(itemTrim, "vlan-tagging"):
+				confRead.vlanTagging = true
+			case strings.HasPrefix(itemTrim, "ether-options 802.3ad "):
+				confRead.v8023ad = strings.TrimPrefix(itemTrim, "ether-options 802.3ad ")
+			case strings.HasPrefix(itemTrim, "gigether-options 802.3ad "):
+				confRead.v8023ad = strings.TrimPrefix(itemTrim, "gigether-options 802.3ad ")
+			case strings.HasPrefix(itemTrim, "unit 0 family ethernet-switching interface-mode trunk"):
+				confRead.trunk = true
+			case strings.HasPrefix(itemTrim, "unit 0 family ethernet-switching vlan members"):
+				confRead.vlanMembers = append(confRead.vlanMembers, strings.TrimPrefix(itemTrim,
+					"unit 0 family ethernet-switching vlan members "))
+			case strings.HasPrefix(itemTrim, "native-vlan-id"):
+				confRead.vlanNative, err = strconv.Atoi(strings.TrimPrefix(itemTrim, "native-vlan-id "))
+				if err != nil {
+					return confRead, fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+				}
+			case strings.HasPrefix(itemTrim, "aggregated-ether-options lacp "):
+				confRead.aeLacp = strings.TrimPrefix(itemTrim, "aggregated-ether-options lacp ")
+			case strings.HasPrefix(itemTrim, "aggregated-ether-options link-speed "):
+				confRead.aeLinkSpeed = strings.TrimPrefix(itemTrim, "aggregated-ether-options link-speed ")
+			case strings.HasPrefix(itemTrim, "aggregated-ether-options minimum-links "):
+				confRead.aeMinLink, err = strconv.Atoi(strings.TrimPrefix(itemTrim,
+					"aggregated-ether-options minimum-links "))
+				if err != nil {
+					return confRead, fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+				}
+			default:
+				continue
+			}
+		}
+	}
+
+	return confRead, nil
+}
+func delInterfacePhysical(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) error {
+	sess := m.(*Session)
+	if err := checkInterfacePhysicalContainsUnit(d.Get("name").(string), m, jnprSess); err != nil {
+		return err
+	}
+	if err := sess.configSet([]string{"delete interfaces " + d.Get("name").(string)}, jnprSess); err != nil {
+		return err
+	}
+	if d.Get("ether802_3ad").(string) != "" {
+		lastAEchild, err := interfaceAggregatedLastChild(d.Get("ether802_3ad").(string), d.Get("name").(string), m, jnprSess)
+		if err != nil {
+			return err
+		}
+		if lastAEchild {
+			aggregatedCount, err := interfaceAggregatedCountSearchMax("ae-1", d.Get("ether802_3ad").(string),
+				d.Get("name").(string), m, jnprSess)
+			if err != nil {
+				return err
+			}
+			if aggregatedCount == "0" {
+				err = sess.configSet([]string{"delete chassis aggregated-devices ethernet device-count"}, jnprSess)
+				if err != nil {
+					return err
+				}
+			} else {
+				err = sess.configSet([]string{"set chassis aggregated-devices ethernet device-count " +
+					aggregatedCount}, jnprSess)
+				if err != nil {
+					return err
+				}
+			}
+			aeInt, err := strconv.Atoi(strings.TrimPrefix(d.Get("ether802_3ad").(string), "ae"))
+			if err != nil {
+				return fmt.Errorf("failed to convert AE id of ether802_3ad argument '%s' in integer : %w",
+					d.Get("ether802_3ad").(string), err)
+			}
+			aggregatedCountInt, err := strconv.Atoi(aggregatedCount)
+			if err != nil {
+				return fmt.Errorf("failed to convert internal variable aggregatedCountInt in integer : %w", err)
+			}
+			if aggregatedCountInt < aeInt+1 {
+				oAEintNC, oAEintEmpty, err := checkInterfacePhysicalNC(d.Get("ether802_3ad").(string), m, jnprSess)
+				if err != nil {
+					return err
+				}
+				if oAEintNC || oAEintEmpty {
+					err = sess.configSet([]string{"delete interfaces " + d.Get("ether802_3ad").(string)}, jnprSess)
+					if err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func checkInterfacePhysicalContainsUnit(interFace string, m interface{}, jnprSess *NetconfObject) error {
+	sess := m.(*Session)
+	intConfig, err := sess.command("show configuration interfaces "+interFace+" | display set relative", jnprSess)
+	if err != nil {
+		return err
+	}
+	for _, item := range strings.Split(intConfig, "\n") {
+		if strings.Contains(item, "<configuration-output>") {
+			continue
+		}
+		if strings.Contains(item, "</configuration-output>") {
+			break
+		}
+		if strings.HasPrefix(item, "set unit") {
+			if strings.Contains(item, "ethernet-switching") {
+				continue
+			}
+
+			return fmt.Errorf("interface %s is used for other son unit interface", interFace)
+		}
+	}
+
+	return nil
+}
+func delInterfaceNC(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) error {
+	sess := m.(*Session)
+	configSet := make([]string, 0, 1)
+	delPrefix := "delete interfaces " + d.Get("name").(string) + " "
+	if sess.junosGroupIntDel != "" {
+		configSet = append(configSet, delPrefix+"apply-groups "+sess.junosGroupIntDel)
+	}
+	configSet = append(configSet, delPrefix+"description")
+	configSet = append(configSet, delPrefix+"disable")
+	if err := sess.configSet(configSet, jnprSess); err != nil {
+		return err
+	}
+
+	return nil
+}
+func delInterfacePhysicalOpts(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) error {
+	sess := m.(*Session)
+	configSet := make([]string, 0, 1)
+	delPrefix := "delete interfaces " + d.Get("name").(string) + " "
+	configSet = append(configSet,
+		delPrefix+"vlan-tagging",
+		delPrefix+"ether-options 802.3ad",
+		delPrefix+"gigether-options 802.3ad",
+		delPrefix+"unit 0 family ethernet-switching interface-mode",
+		delPrefix+"unit 0 family ethernet-switching vlan members",
+		delPrefix+"native-vlan-id",
+		delPrefix+"aggregated-ether-options")
+	if err := sess.configSet(configSet, jnprSess); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func fillInterfacePhysicalData(d *schema.ResourceData, interfaceOpt interfacePhysicalOptions) {
+	if tfErr := d.Set("description", interfaceOpt.description); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("vlan_tagging", interfaceOpt.vlanTagging); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("ether802_3ad", interfaceOpt.v8023ad); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("trunk", interfaceOpt.trunk); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("vlan_members", interfaceOpt.vlanMembers); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("vlan_native", interfaceOpt.vlanNative); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("ae_lacp", interfaceOpt.aeLacp); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("ae_link_speed", interfaceOpt.aeLinkSpeed); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("ae_minimum_links", interfaceOpt.aeMinLink); tfErr != nil {
+		panic(tfErr)
+	}
+}
+
+func interfaceAggregatedLastChild(ae, interFace string, m interface{}, jnprSess *NetconfObject) (bool, error) {
+	sess := m.(*Session)
+	showConf, err := sess.command("show configuration interfaces | display set relative", jnprSess)
+	if err != nil {
+		return false, err
+	}
+	lastAE := true
+	for _, item := range strings.Split(showConf, "\n") {
+		if strings.HasSuffix(item, "ether-options 802.3ad "+ae) &&
+			!strings.HasPrefix(item, "set "+interFace+" ") {
+			lastAE = false
+		}
+	}
+
+	return lastAE, nil
+}
+func interfaceAggregatedCountSearchMax(
+	newAE, oldAE, interFace string, m interface{}, jnprSess *NetconfObject) (string, error) {
+	sess := m.(*Session)
+	newAENum := strings.TrimPrefix(newAE, "ae")
+	newAENumInt, err := strconv.Atoi(newAENum)
+	if err != nil {
+		return "", fmt.Errorf("failed to convert internal variable newAENum to integer : %w", err)
+	}
+	intShowInt, err := sess.command("show interfaces terse", jnprSess)
+	if err != nil {
+		return "", err
+	}
+
+	intShowIntLines := strings.Split(intShowInt, "\n")
+	intShowAE := make([]string, 0)
+	regexpAE := regexp.MustCompile(`ae\d*\s`)
+	for _, line := range intShowIntLines {
+		aematch := regexpAE.MatchString(line)
+		if aematch {
+			wordsLine := strings.Fields(line)
+			if wordsLine[0] != oldAE {
+				if (len(intShowAE) > 0 && intShowAE[len(intShowAE)-1] != wordsLine[0]) || len(intShowAE) == 0 {
+					intShowAE = append(intShowAE, wordsLine[0])
+				}
+			}
+		}
+	}
+	lastOldAE, err := interfaceAggregatedLastChild(oldAE, interFace, m, jnprSess)
+	if err != nil {
+		return "", err
+	}
+	if !lastOldAE {
+		intShowAE = append(intShowAE, oldAE)
+	}
+	if len(intShowAE) > 0 {
+		lastAeInt, err := strconv.Atoi(strings.TrimPrefix(intShowAE[len(intShowAE)-1], "ae"))
+		if err != nil {
+			return "", fmt.Errorf("failed to convert internal variable lastAeInt to integer : %w", err)
+		}
+		if lastAeInt > newAENumInt {
+			return strconv.Itoa(lastAeInt + 1), nil
+		}
+	}
+
+	return strconv.Itoa(newAENumInt + 1), nil
+}

--- a/junos/resource_interface_physical.go
+++ b/junos/resource_interface_physical.go
@@ -494,11 +494,9 @@ func setInterfacePhysical(d *schema.ResourceData, m interface{}, jnprSess *Netco
 	if d.Get("trunk").(bool) {
 		configSet = append(configSet, setPrefix+"unit 0 family ethernet-switching interface-mode trunk")
 	}
-	if len(d.Get("vlan_members").([]interface{})) > 0 {
-		for _, v := range d.Get("vlan_members").([]interface{}) {
-			configSet = append(configSet, setPrefix+
-				"unit 0 family ethernet-switching vlan members "+v.(string))
-		}
+	for _, v := range d.Get("vlan_members").([]interface{}) {
+		configSet = append(configSet, setPrefix+
+			"unit 0 family ethernet-switching vlan members "+v.(string))
 	}
 	if d.Get("vlan_native").(int) != 0 {
 		configSet = append(configSet, setPrefix+"native-vlan-id "+strconv.Itoa(d.Get("vlan_native").(int)))

--- a/junos/resource_interface_physical_test.go
+++ b/junos/resource_interface_physical_test.go
@@ -1,0 +1,166 @@
+package junos_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// export TESTACC_INTERFACE=<inteface> for choose interface available else it's ge-0/0/3.
+// export TESTACC_INTERFACE_AE=ae<num> for choose interface aggregate test else it's ae0.
+func TestAccJunosInterfacePhysical_basic(t *testing.T) {
+	var testaccInterface string
+	var testaccInterfaceAE string
+	if os.Getenv("TESTACC_INTERFACE") != "" {
+		testaccInterface = os.Getenv("TESTACC_INTERFACE")
+	} else {
+		testaccInterface = defaultInterfaceTestAcc
+	}
+	if os.Getenv("TESTACC_INTERFACE_AE") != "" {
+		testaccInterfaceAE = os.Getenv("TESTACC_INTERFACE_AE")
+	} else {
+		testaccInterfaceAE = "ae0"
+	}
+	if os.Getenv("TESTACC_SWITCH") != "" {
+		resource.Test(t, resource.TestCase{
+			PreCheck:  func() { testAccPreCheck(t) },
+			Providers: testAccProviders,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccJunosInterfacePhysicalConfigCreate(testaccInterface),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("junos_interface_physical.testacc_interface",
+							"description", "testacc_interface"),
+						resource.TestCheckResourceAttr("junos_interface_physical.testacc_interface",
+							"trunk", "true"),
+						resource.TestCheckResourceAttr("junos_interface_physical.testacc_interface",
+							"vlan_native", "100"),
+						resource.TestCheckResourceAttr("junos_interface_physical.testacc_interface",
+							"vlan_members.#", "1"),
+						resource.TestCheckResourceAttr("junos_interface_physical.testacc_interface",
+							"vlan_members.0", "100-110"),
+					),
+				},
+				{
+					Config: testAccJunosInterfacePhysicalConfigUpdate(testaccInterface),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("junos_interface_physical.testacc_interface",
+							"description", "testacc_interfaceU"),
+						resource.TestCheckResourceAttr("junos_interface_physical.testacc_interface",
+							"trunk", "false"),
+						resource.TestCheckResourceAttr("junos_interface_physical.testacc_interface",
+							"vlan_native", "0"),
+						resource.TestCheckResourceAttr("junos_interface_physical.testacc_interface",
+							"vlan_members.#", "1"),
+						resource.TestCheckResourceAttr("junos_interface_physical.testacc_interface",
+							"vlan_members.0", "100"),
+					),
+				},
+				{
+					ResourceName:      "junos_interface_physical.testacc_interface",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+			},
+		})
+	} else {
+		resource.Test(t, resource.TestCase{
+			PreCheck:  func() { testAccPreCheck(t) },
+			Providers: testAccProviders,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccJunosInterfacePhysicalFWConfigCreate(testaccInterface, testaccInterfaceAE),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("junos_interface_physical.testacc_interface",
+							"description", "testacc_interface"),
+						resource.TestCheckResourceAttr("junos_interface_physical.testacc_interface",
+							"ether802_3ad", testaccInterfaceAE),
+						resource.TestCheckResourceAttr("junos_interface_physical.testacc_interfaceAE",
+							"name", testaccInterfaceAE),
+						resource.TestCheckResourceAttr("junos_interface_physical.testacc_interfaceAE",
+							"ae_lacp", "active"),
+						resource.TestCheckResourceAttr("junos_interface_physical.testacc_interfaceAE",
+							"ae_minimum_links", "1"),
+						resource.TestCheckResourceAttr("junos_interface_physical.testacc_interfaceAE",
+							"vlan_tagging", "true"),
+					),
+				},
+				{
+					Config: testAccJunosInterfacePhysicalFWConfigUpdate(testaccInterface, testaccInterfaceAE),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("junos_interface_physical.testacc_interface",
+							"description", "testacc_interfaceU"),
+						resource.TestCheckResourceAttr("junos_interface_physical.testacc_interfaceAE",
+							"ae_lacp", ""),
+						resource.TestCheckResourceAttr("junos_interface_physical.testacc_interfaceAE",
+							"ae_minimum_links", "0"),
+					),
+				},
+				{
+					ResourceName:      "junos_interface_physical.testacc_interface",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+				{
+					ResourceName:      "junos_interface_physical.testacc_interfaceAE",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+			},
+		})
+	}
+}
+
+func testAccJunosInterfacePhysicalConfigCreate(interFace string) string {
+	return fmt.Sprintf(`
+resource junos_interface_physical testacc_interface {
+  name         = "` + interFace + `"
+  description  = "testacc_interface"
+  trunk        = true
+  vlan_native  = 100
+  vlan_members = ["100-110"]
+}
+`)
+}
+func testAccJunosInterfacePhysicalConfigUpdate(interFace string) string {
+	return fmt.Sprintf(`
+resource junos_interface_physical testacc_interface {
+  name         = "` + interFace + `"
+  description  = "testacc_interfaceU"
+  vlan_members = ["100"]
+}
+`)
+}
+
+func testAccJunosInterfacePhysicalFWConfigCreate(interFace, interfaceAE string) string {
+	return fmt.Sprintf(`
+resource junos_interface_physical testacc_interface {
+  name         = "` + interFace + `"
+  description  = "testacc_interface"
+  ether802_3ad = "` + interfaceAE + `"
+}
+resource junos_interface_physical testacc_interfaceAE {
+  name             = junos_interface_physical.testacc_interface.ether802_3ad
+  description      = "testacc_interfaceAE"
+  ae_lacp          = "active"
+  ae_minimum_links = 1
+  vlan_tagging     = true
+}
+`)
+}
+func testAccJunosInterfacePhysicalFWConfigUpdate(interFace, interfaceAE string) string {
+	return fmt.Sprintf(`
+resource junos_interface_physical testacc_interface {
+  name         = "` + interFace + `"
+  description  = "testacc_interfaceU"
+  ether802_3ad = "` + interfaceAE + `"
+}
+resource junos_interface_physical testacc_interfaceAE {
+  name         = junos_interface_physical.testacc_interface.ether802_3ad
+  description  = "testacc_interfaceAE"
+  vlan_tagging = true
+}
+`)
+}

--- a/junos/resource_interface_st0_unit.go
+++ b/junos/resource_interface_st0_unit.go
@@ -88,7 +88,7 @@ func resourceInterfaceSt0UnitDelete(ctx context.Context, d *schema.ResourceData,
 	}
 	defer sess.closeSession(jnprSess)
 	sess.configLock(jnprSess)
-	ncInt, emptyInt, err := checkInterfaceNC(d.Id(), m, jnprSess)
+	ncInt, emptyInt, err := checkInterfaceLogicalNC(d.Id(), m, jnprSess)
 	if err != nil {
 		sess.configClear(jnprSess)
 

--- a/junos/resource_ospf_area_test.go
+++ b/junos/resource_ospf_area_test.go
@@ -89,7 +89,7 @@ resource junos_ospf_area "testacc_ospfarea" {
 }
 func testAccJunosOspfAreaConfigUpdate(interFace string) string {
 	return `
-resource junos_interface "testacc_ospfarea" {
+resource junos_interface_logical "testacc_ospfarea" {
   name             = "` + interFace + `.0"
   description      = "testacc_ospfarea"
   routing_instance = junos_routing_instance.testacc_ospfarea.name
@@ -110,7 +110,7 @@ resource junos_ospf_area "testacc_ospfarea" {
     dead_interval = 10
   }
   interface {
-    name = junos_interface.testacc_ospfarea.name
+    name = junos_interface_logical.testacc_ospfarea.name
     disable = true
   }
 }

--- a/junos/resource_security_ike_ipsec_test.go
+++ b/junos/resource_security_ike_ipsec_test.go
@@ -249,10 +249,12 @@ func TestAccJunosSecurityIkeIpsec_basic(t *testing.T) {
 
 func testAccJunosSecurityIkeIpsecConfigCreate(interFace string) string {
 	return `
-resource junos_interface "testacc_ikegateway" {
+resource junos_interface_logical "testacc_ikegateway" {
   name = "` + interFace + `.0"
-  inet_address {
-    address = "192.0.2.4/25"
+  family_inet {
+    address {
+      cidr_ip = "192.0.2.4/25"
+    }
   }
 }
 resource junos_security_ike_proposal "testacc_ikeprop" {
@@ -272,7 +274,7 @@ resource junos_security_ike_gateway "testacc_ikegateway" {
   name               = "testacc_ikegateway"
   address            = ["192.0.2.3"]
   policy             = junos_security_ike_policy.testacc_ikepol.name
-  external_interface = junos_interface.testacc_ikegateway.name
+  external_interface = junos_interface_logical.testacc_ikegateway.name
   general_ike_id     = true
   no_nat_traversal   = true
   dead_peer_detection {
@@ -322,10 +324,12 @@ resource junos_security_ipsec_vpn "testacc_ipsecvpn" {
 }
 func testAccJunosSecurityIkeIpsecConfigUpdate(interFace string) string {
 	return `
-resource junos_interface "testacc_ikegateway" {
+resource junos_interface_logical "testacc_ikegateway" {
   name = "` + interFace + `.0"
-  inet_address {
-    address = "192.0.2.4/25"
+  family_inet {
+    address {
+      cidr_ip = "192.0.2.4/25"
+    }
   }
 }
 resource junos_security_ike_proposal "testacc_ikeprop" {
@@ -345,7 +349,7 @@ resource junos_security_ike_gateway "testacc_ikegateway" {
   name               = "testacc_ikegateway"
   address            = ["192.0.2.4"]
   policy             = junos_security_ike_policy.testacc_ikepol.name
-  external_interface = junos_interface.testacc_ikegateway.name
+  external_interface = junos_interface_logical.testacc_ikegateway.name
   no_nat_traversal   = true
   dead_peer_detection {
     interval  = 10
@@ -434,10 +438,12 @@ resource junos_security_policy_tunnel_pair_policy testacc_vpn-in-out {
 }
 func testAccJunosSecurityIkeIpsecConfigUpdate2(interFace string) string {
 	return `
-resource junos_interface "testacc_ikegateway" {
+resource junos_interface_logical "testacc_ikegateway" {
   name = "` + interFace + `.0"
-  inet_address {
-    address = "192.0.2.4/25"
+  family_inet {
+    address {
+      cidr_ip = "192.0.2.4/25"
+    }
   }
 }
 resource junos_security_ike_proposal "testacc_ikeprop" {
@@ -467,7 +473,7 @@ resource junos_security_ike_gateway "testacc_ikegateway" {
     client_password = "password"
   }
   policy             = junos_security_ike_policy.testacc_ikepol.name
-  external_interface = junos_interface.testacc_ikegateway.name
+  external_interface = junos_interface_logical.testacc_ikegateway.name
   no_nat_traversal   = true
   dead_peer_detection {
     interval  = 10
@@ -548,10 +554,12 @@ resource junos_security_policy_tunnel_pair_policy testacc_vpn-in-out {
 }
 func testAccJunosSecurityIkeIpsecConfigUpdate3(interFace string) string {
 	return `
-resource junos_interface "testacc_ikegateway" {
+resource junos_interface_logical "testacc_ikegateway" {
   name = "` + interFace + `.0"
-  inet_address {
-    address = "192.0.2.4/25"
+  family_inet {
+    address {
+      cidr_ip = "192.0.2.4/25"
+    }
   }
 }
 resource junos_security_ike_proposal "testacc_ikeprop" {
@@ -573,7 +581,7 @@ resource junos_security_ike_gateway "testacc_ikegateway" {
     hostname = "host1.example.com"
   }
   policy             = junos_security_ike_policy.testacc_ikepol.name
-  external_interface = junos_interface.testacc_ikegateway.name
+  external_interface = junos_interface_logical.testacc_ikegateway.name
 }
 resource junos_security_ipsec_proposal "testacc_ipsecprop" {
   name                     = "testacc_ipsecprop"
@@ -588,7 +596,7 @@ resource junos_security_ipsec_policy "testacc_ipsecpol" {
 }
 resource junos_security_ipsec_vpn "testacc_ipsecvpn" {
   name           = "testacc_ipsecvpn"
-  bind_interface = junos_interface.testacc_ipsecvpn_bind.name
+  bind_interface = junos_interface_logical.testacc_ipsecvpn_bind.name
   ike {
     gateway = junos_security_ike_gateway.testacc_ikegateway.name
     policy  = junos_security_ipsec_policy.testacc_ipsecpol.name
@@ -605,19 +613,21 @@ resource junos_security_ipsec_vpn "testacc_ipsecvpn" {
     remote_ip = "192.0.3.192/26"
   }
 }
-resource junos_interface "testacc_ipsecvpn_bind" {
-  name             = junos_interface_st0_unit.testacc_ipsec_vpn.id
-  inet             = true
+resource junos_interface_logical "testacc_ipsecvpn_bind" {
+  name = junos_interface_st0_unit.testacc_ipsec_vpn.id
+  family_inet {}
 }
 resource junos_interface_st0_unit testacc_ipsec_vpn {}
 `
 }
 func testAccJunosSecurityIkeIpsecConfigUpdate4(interFace string) string {
 	return `
-resource junos_interface "testacc_ikegateway" {
+resource junos_interface_logical "testacc_ikegateway" {
   name = "` + interFace + `.0"
-  inet_address {
-    address = "192.0.2.4/25"
+  family_inet {
+    address {
+      cidr_ip = "192.0.2.4/25"
+    }
   }
 }
 resource junos_security_ike_proposal "testacc_ikeprop" {
@@ -639,16 +649,18 @@ resource junos_security_ike_gateway "testacc_ikegateway" {
     inet = "192.168.0.4"
   }
   policy             = junos_security_ike_policy.testacc_ikepol.name
-  external_interface = junos_interface.testacc_ikegateway.name
+  external_interface = junos_interface_logical.testacc_ikegateway.name
 }
 `
 }
 func testAccJunosSecurityIkeIpsecConfigUpdate5(interFace string) string {
 	return `
-resource junos_interface "testacc_ikegateway" {
+resource junos_interface_logical "testacc_ikegateway" {
   name = "` + interFace + `.0"
-  inet_address {
-    address = "192.0.2.4/25"
+  family_inet {
+    address {
+      cidr_ip = "192.0.2.4/25"
+    }
   }
 }
 resource junos_security_ike_proposal "testacc_ikeprop" {
@@ -670,16 +682,18 @@ resource junos_security_ike_gateway "testacc_ikegateway" {
     inet6 = "2001:db8::1"
   }
   policy             = junos_security_ike_policy.testacc_ikepol.name
-  external_interface = junos_interface.testacc_ikegateway.name
+  external_interface = junos_interface_logical.testacc_ikegateway.name
 }
 `
 }
 func testAccJunosSecurityIkeIpsecConfigUpdate6(interFace string) string {
 	return `
-resource junos_interface "testacc_ikegateway" {
+resource junos_interface_logical "testacc_ikegateway" {
   name = "` + interFace + `.0"
-  inet_address {
-    address = "192.0.2.4/25"
+  family_inet {
+    address {
+      cidr_ip = "192.0.2.4/25"
+    }
   }
 }
 resource junos_security_ike_proposal "testacc_ikeprop" {
@@ -703,7 +717,7 @@ resource junos_security_ike_gateway "testacc_ikegateway" {
     user_at_hostname            = "user@example.com"
   }
   policy             = junos_security_ike_policy.testacc_ikepol.name
-  external_interface = junos_interface.testacc_ikegateway.name
+  external_interface = junos_interface_logical.testacc_ikegateway.name
 }
 `
 }

--- a/junos/resource_security_ipsec_vpn.go
+++ b/junos/resource_security_ipsec_vpn.go
@@ -262,7 +262,7 @@ func resourceIpsecVpnUpdate(ctx context.Context, d *schema.ResourceData, m inter
 	}
 	if d.HasChanges("bind_interface") && d.Get("bind_interfaces_auto").(bool) {
 		oldInt, _ := d.GetChange("bind_interface")
-		st0NC, st0Emtpy, err := checkInterfaceNC(oldInt.(string), m, jnprSess)
+		st0NC, st0Emtpy, err := checkInterfaceLogicalNC(oldInt.(string), m, jnprSess)
 		if err != nil {
 			sess.configClear(jnprSess)
 
@@ -529,7 +529,7 @@ func delIpsecVpn(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject)
 	configSet := make([]string, 0, 1)
 	configSet = append(configSet, "delete security ipsec vpn "+d.Get("name").(string))
 	if d.Get("bind_interface_auto").(bool) {
-		st0NC, st0Emtpy, err := checkInterfaceNC(d.Get("bind_interface").(string), m, jnprSess)
+		st0NC, st0Emtpy, err := checkInterfaceLogicalNC(d.Get("bind_interface").(string), m, jnprSess)
 		if err != nil {
 			return err
 		}

--- a/junos/resource_security_test.go
+++ b/junos/resource_security_test.go
@@ -268,7 +268,7 @@ resource junos_system "system" {
 
 func testAccJunosSecurityConfigCreate(interFace string) string {
 	return `
-resource junos_interface "testacc_security" {
+resource junos_interface_logical "testacc_security" {
   name        = "` + interFace + `.0"
   description = "testacc_security"
 }
@@ -354,7 +354,7 @@ resource junos_security "testacc_security" {
     format           = "syslog"
     mode             = "event"
 	report           = true
-	source_interface = junos_interface.testacc_security.name
+	source_interface = junos_interface_logical.testacc_security.name
     transport {
       protocol        = "tcp"
       tcp_connections = 5
@@ -372,7 +372,7 @@ resource junos_security "testacc_security" {
 }
 func testAccJunosSecurityConfigUpdate(interFace string) string {
 	return `
-resource junos_interface "testacc_security" {
+resource junos_interface_logical "testacc_security" {
   name        = "` + interFace + `.0"
   description = "testacc_security"
 }

--- a/website/docs/d/interface.html.markdown
+++ b/website/docs/d/interface.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Get information on an Interface
 
+!> **NOTE:** Since v1.11.0, this data soure is **deprecated**. For more consistency, functionalities of this data source have been splitted in two new data source `junos_interface_physical` and `junos_interface_logical`.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/d/interface_logical.html.markdown
+++ b/website/docs/d/interface_logical.html.markdown
@@ -1,0 +1,95 @@
+---
+layout: "junos"
+page_title: "Junos: junos_interface_logical"
+sidebar_current: "docs-junos-data-source-interface-logical"
+description: |-
+  Get information on a logical interface (as with an junos_interface_logical resource import)
+---
+
+# junos_interface_logical
+
+Get information on a logical interface
+
+## Example Usage
+
+```hcl
+# Search interface with IP
+data junos_interface_logical "demo_ip" {
+  match = "192.0.2.2/"
+}
+# Search interface with name
+data junos_interface_logical "interface_fw_demo" {
+  config_interface = "ge-0/0/3.0"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `config_interface` - (Optional)(`String`) Specifies the interface part for search. Command is 'show configuration interfaces <config_interface>'
+* `match` - (Optional)(`String`) Regex string to filter lines and find only one interface.
+
+~> **NOTE:** If more or less than a single match is returned by the search, Terraform will fail.
+
+## Attributes Reference
+
+* `id` - Like resource it's the `name` of interface
+* `name` - Name of unit interface (with dot).
+* `description` - Description for interface.
+* `vlan_id` - 802.1q VLAN ID for unit interface.
+* `family_inet` - Family inet enabled and possible configuration.
+  * `address` - List of address. See the [`address` attributes for family_inet](#address-attributes-for-family_inet) block.
+  * `mtu` - Maximum transmission unit.
+  * `filter_input` - Filter applied to received packets.
+  * `filter_output` - Filter applied to transmitted packets.
+  * `rpf_check` - Reverse-path-forwarding checks enabled and possible configuration. See the [`rpf_check` attributes](#rpf_check-attributes) block for attributes.
+* `family_inet6` - Family inet6 enabled and possible configuration.
+  * `address` - List of address. See the [`address` attributes for family_inet6](#address-attributes-for-family_inet6) block.
+  * `mtu` - Maximum transmission unit.
+  * `filter_input` - Filter applied to received packets.
+  * `filter_output` - Filter applied to transmitted packets.
+  * `rpf_check` - Reverse-path-forwarding checks enabled and possible configuration. See the [`rpf_check` attributes](#rpf_check-attributes) block for attributes.
+* `security_zone` - Security zone where the interface is.
+* `routing_instance` - Routing_instance where the interface is (if not default instance).
+
+---
+#### address attributes for family_inet
+* `cidr_ip` - Address IP/Mask v4.
+* `vrrp_group` - List of vrrp group configurations. See the [`vrrp_group` attributes for address in family_inet](#vrrp_group-attributes-for-address-in-family_inet) block.
+
+---
+#### vrrp_group attributes for address in family_inet
+* `identifier` - ID for vrrp.
+* `virtual_address` - List of address IP v4.
+* `accept_data` - Accept packets destined for virtual IP address.
+* `advertise_interval` - Advertisement interval (seconds).
+* `advertisements_threshold` - Number of vrrp advertisements missed before declaring master down.
+* `authentication_key` - Authentication key.
+* `authentication_type` - Authentication type.
+* `no_accept_data` - Don't accept packets destined for virtual IP address.
+* `no_preempt` - Preemption not allowed.
+* `preempt` - Preemption allowed.
+* `priority` - Virtual router election priority.
+* `track_interface` - List of track_interface.
+  * `interface` - Interface tracked.
+  * `priority_cost` - Value to subtract from priority when interface is down.
+* `track_route` - List of track_route.
+  * `route` - Route address tracked.
+  * `routing_instance` - Routing instance to which route belongs.
+  * `priority_cost` - Value to subtract from priority when route is down.
+
+---
+#### address attributes for family_inet6
+* `cidr_ip` - Address IP/Mask v6.
+* `vrrp_group` - List of vrrp group configurations. See the [`vrrp_group` attributes for address in family_inet6](#vrrp_group-attributes-for-address-in-family_inet6) block.
+
+---
+#### vrrp_group attributes for address in family_inet6
+Same as [`vrrp_group` attributes for address in family_inet](#vrrp_group-attributes-for-address-in-family_inet) block but without `authentication_key`, `authentication_type` and with  
+* `virtual_link_local_address` - Address IPv6 for Virtual link-local addresses.
+
+---
+### rpf_check attributes
+* `fail_filter` - Name of filter applied to packets failing RPF check.
+* `mode_loose` - Reverse-path-forwarding use loose mode instead the strict mode.

--- a/website/docs/d/interface_physical.html.markdown
+++ b/website/docs/d/interface_physical.html.markdown
@@ -1,0 +1,43 @@
+---
+layout: "junos"
+page_title: "Junos: junos_interface_physical"
+sidebar_current: "docs-junos-data-source-interface-physical"
+description: |-
+  Get information on a physical interface (as with an junos_interface_physcial resource import)
+---
+
+# junos_interface_physical
+
+Get information on a physical interface.
+
+## Example Usage
+
+```hcl
+# Search interface with name
+data junos_interface_physical "interface_physical_demo" {
+  config_interface = "ge-0/0/3"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `config_interface` - (Optional)(`String`) Specifies the interface part for search. Command is 'show configuration interfaces <config_interface>'
+* `match` - (Optional)(`String`) Regex string to filter lines and find only one interface.
+
+~> **NOTE:** If more or less than a single match is returned by the search, Terraform will fail.
+
+## Attributes Reference
+
+* `id` - Like resource it's the `name` of interface
+* `name` - Name of physical interface (without dot).
+* `description` - Description for interface.
+* `vlan_tagging` - 802.1q VLAN tagging support.
+* `ether802_3ad` - Link of 802.3ad interface.
+* `trunk` - Interface mode is trunk.
+* `vlan_members` - List of vlan membership for this interface.
+* `vlan_native` - Vlan for untagged frames.
+* `ae_lacp` - LACP option in aggregated-ether-options.
+* `ae_link_speed` - Link speed of individual interface that joins the AE.
+* `ae_minimum_links` - Minimum number of aggregated links (1..8).

--- a/website/docs/guides/interface-deprecated.html.markdown
+++ b/website/docs/guides/interface-deprecated.html.markdown
@@ -1,0 +1,101 @@
+---
+layout: "junos"
+page_title: "Junos: junos_interface resource deprecated"
+description: |-
+    Junos: Migrate to new interface resource guide
+
+---
+
+# junos_interface deprecated
+
+For more consistency, functionalities of `junos_interface` resource have been splitted in two new resource :
+`junos_interface_physical` and `junos_interface_logical`.  
+The `junos_interface` resource is **deprecated** since v1.11.0.
+
+## Rewrite resource for physical interface
+
+For physical interface (without dot in name) : 
+* rename the type of resource `junos_interface` to `junos_interface_physical`
+* rename `complete_destroy` argument to `no_disable_on_destroy`
+
+For example :
+```hcl
+# deprecated junos_interface
+resource junos_interface "interface_physical_demo" {
+  name         = "ge-0/0/0"
+  description  = "interfacePhysicalDemo"
+  trunk        = true
+  vlan_members = ["100"]
+}
+
+# new junos_interface_physical
+resource junos_interface_physical "interface_physical_demo" {
+  name         = "ge-0/0/0"
+  description  = "interfacePhysicalDemo"
+  trunk        = true
+  vlan_members = ["100"]
+}
+```
+
+## Rewrite resource for logical interface
+
+For logical interface (with dot in name) :
+* rename type of resource `junos_interface`to `junos_interface_logical`
+* rename `vlan_tagging_id` argument to `vlan_id`
+* rename `complete_destroy` argument to `st0_also_on_destroy`
+* move `inet_*` arguments in new `family_inet` block without prefix `inet_`
+* move `inet6_*` arguments in new `family_inet6` block without prefix `inet6_`
+* rename `address` in old `inet_address` argument to `cidr_ip`
+* rename `address` in old `inet6_address` argument to `cidr_ip`
+
+For example :
+```hcl
+# deprecated junos_interface 
+resource junos_interface "interface_logical_demo_100" {
+  name        = "ge-0/0/2.100"
+  description = "interfaceLogicalDemo100"
+  inet_address {
+    address = "192.0.2.1/25"
+  }
+  inet_filter_input = "filter_demo"
+}
+resource junos_interface "st0_100" {
+  name        = "st0.100"
+  description = "st0_100"
+  inet        = true
+}
+
+# new junos_interface_logical
+resource junos_interface_logical "interface_logical_demo_100" {
+  name        = "ge-0/0/2.100"
+  description = "interfaceLogicalDemo100"
+  family_inet {
+    address {
+      cidr_ip = "192.0.2.1/25"
+    }
+    filter_input = "filter_demo"
+  }
+}
+resource junos_interface_logical "st0_100" {
+  name        = "st0.100"
+  description = "st0_100"
+  family_inet {}
+}
+```
+
+## Upgrade without destroy and create new
+
+For upgrade to the new resource without destroy deprecated resource and recreate resource, you need to import the new resource and delete the old resource in Terraform state.
+
+After rewrite resource with new type, import each resources :
+```
+terraform import junos_interface_physical.interface_physical_demo ge-0/0/0
+terraform import junos_interface_logical.interface_logical_demo_100 ge-0/0/2.100
+terraform import junos_interface_logical.st0_100 st0.100
+```
+then now delete deprecated resource :
+```
+terraform state rm junos_interface.interface_physical_demo
+terraform state rm junos_interface.interface_logical_demo_100
+terraform state rm junos_interface.st0_100
+```

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -65,7 +65,7 @@ provider "junos" {
 }
 
 # Configure an interface
-resource "junos_interface" "server1" {
+resource junos_interface_physical "server1" {
   name = "ge-0/0/3"
   # ...
 }

--- a/website/docs/r/interface.html.markdown
+++ b/website/docs/r/interface.html.markdown
@@ -10,6 +10,9 @@ description: |-
 
 Provides a interface resource.
 
+!> **NOTE:** Since v1.11.0, this resource is **deprecated**. For more consistency, functionalities of this resource have been splitted in two new resource `junos_interface_physical` and `junos_interface_logical`.
+There is a guide for help migrating to the new resources.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/interface_logical.html.markdown
+++ b/website/docs/r/interface_logical.html.markdown
@@ -1,0 +1,98 @@
+---
+layout: "junos"
+page_title: "Junos: junos_interface_logical"
+sidebar_current: "docs-junos-resource-interface-logical"
+description: |-
+  Create/configure a logical interface
+---
+
+# junos_interface_logical
+
+Provides a logical interface resource.
+
+## Example Usage
+
+```hcl
+resource junos_interface_logical "interface_fw_demo_100" {
+  name        = "ae0.100"
+  description = "interfaceFwDemo100"
+  family_inet {
+    address {
+      cidr_ip = "192.0.2.1/25"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required, Forces new resource)(`String`) Name of unit interface (with dot).
+* `description` - (Optional)(`String`) Description for interface.
+* `st0_also_on_destroy` - (Optional)(`Bool`) When destroy this resource, if the name has prefix 'st0.', delete all configurations (not keep empty st0 interface).  
+(Usually, `st0.x` interfaces are completely deleted with `bind_interface_auto` argument in `junos_security_ipsec_vpn` resource or by `junos_interface_st0_unit` resource because of the dependency, but only if st0.x interface is empty or disable.)
+* `vlan_id` - (Optional,Computed)(`Int`) 802.1q VLAN ID for unit interface. If not set, computed with `name` of interface (ge-0/0/0.100 = 100) except if name has '.0' suffix or 'st0.' prefix.
+* `family_inet` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Enable family inet and add configurations if specified.
+  * `address` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified multiple times for each ip address to declare. See the [`address` arguments for family_inet](#address-arguments-for-family_inet) block.
+  * `mtu` - (Optional)(`Int`) Maximum transmission unit.
+  * `filter_input` - (Optional)(`String`) Filter to be applied to received packets.
+  * `filter_output` - (Optional)(`String`) Filter to be applied to transmitted packets.
+  * `rpf_check` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once for enable reverse-path-forwarding checks on this interface. See the [`rpf_check` arguments](#rpf_check-arguments) block for optional arguments.
+* `family_inet6` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Enable family inet6 and add configurations if specified.
+  * `address` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified multiple times for each ipv6 address to declare. See the [`address` arguments for family_inet6](#address-arguments-for-family_inet6) block.
+  * `mtu` - (Optional)(`Int`) Maximum transmission unit.
+  * `filter_input` - (Optional)(`String`) Filter to be applied to received packets.
+  * `filter_output` - (Optional)(`String`) Filter to be applied to transmitted packets.
+  * `rpf_check` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once for enable reverse-path-forwarding checks on this interface. See the [`rpf_check` arguments](#rpf_check-arguments) block for optional arguments. 
+* `security_zone` - (Optional)(`String`) Add this interface in security_zone. Need to be created before.
+* `routing_instance` - (Optional)(`String`) Add this interface in routing_instance. Need to be created before.
+
+---
+#### address arguments for family_inet
+* `cidr_ip` - (Required)(`String`) Address IP/Mask v4.
+* `vrrp_group` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified multiple times for each vrrp group to declare. See the [`vrrp_group` arguments for address in family_inet](#vrrp_group-arguments-for-address-in-family_inet) block.
+
+---
+#### vrrp_group arguments for address in family_inet
+* `identifier` - (Required)(`Int`) ID for vrrp
+* `virtual_address` - (Required)(`ListOfString`) List of address IP v4.
+* `accept_data` - (Optional)(`Bool`) Accept packets destined for virtual IP address. Conflict with `no_accept_data` when apply.
+* `advertise_interval` - (Optional)(`Int`) Advertisement interval (seconds)
+* `advertisements_threshold` - (Optional)(`Int`)  Number of vrrp advertisements missed before declaring master down.
+* `authentication_key` - (Optional)(`String`) Authentication key
+* `authentication_type` - (Optional)(`String`) Authentication type. Need to be 'md5' or 'simple'.
+* `no_accept_data` - (Optional)(`Bool`) Don't accept packets destined for virtual IP address. Conflict with `accept_data` when apply.
+* `no_preempt` - (Optional)(`Bool`) Don't allow preemption. Conflict with `preempt` when apply.
+* `preempt` - (Optional)(`Bool`) Allow preemption. Conflict with `no_preempt` when apply.
+* `priority` - (Optional)(`Int`) Virtual router election priority.
+* `track_interface` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified multiple times for each track_interface to declare.
+  * `interface` - (Required)(`String`) Name of interface.
+  * `priority_cost` - (Required)(`Int`) Value to subtract from priority when interface is down
+* `track_route` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified multiple times for each track_route to declare.
+  * `route` - (Required)(`String`) Route address.
+  * `routing_instance` - (Required)(`String`) Routing instance to which route belongs, or 'default'.
+  * `priority_cost` - (Required)(`Int`) Value to subtract from priority when route is down.
+
+---
+#### address arguments for family_inet6
+* `cidr_ip` - (Required)(`String`) Address IP/Mask v6.
+* `vrrp_group` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified multiple times for each vrrp group to declare. See the [`vrrp_group` arguments for address in family_inet6](#vrrp_group-arguments-for-address-in-family_inet6) block.
+
+---
+#### vrrp_group arguments for address in family_inet6
+Same as [`vrrp_group` arguments for address in family_inet](#vrrp_group-arguments-for-address-in-family_inet) block but without `authentication_key`, `authentication_type` and with
+* `virtual_link_local_address` - (Required)(`String`) Address IPv6 for Virtual link-local addresses.
+
+---
+#### rpf_check arguments
+* `fail_filter` - (Optional)(`String`) Name of filter applied to packets failing RPF check.
+* `mode_loose` - (Optional)(`Bool`) Use reverse-path-forwarding loose mode instead the strict mode.
+
+## Import
+
+Junos interface can be imported using an id made up of `<name>`, e.g.
+
+```
+$ terraform import junos_interface_logical.interface_fw_demo_100 ae.100
+```

--- a/website/docs/r/interface_physical.html.markdown
+++ b/website/docs/r/interface_physical.html.markdown
@@ -1,0 +1,54 @@
+---
+layout: "junos"
+page_title: "Junos: junos_interface_physical"
+sidebar_current: "docs-junos-resource-interface-physical"
+description: |-
+  Create/configure a physical interface
+---
+
+# junos_interface_physical
+
+Provides a physical interface resource.
+
+## Example Usage
+
+```hcl
+# Configure interface of switch
+resource junos_interface_physical "interface_switch_demo" {
+  name         = "ge-0/0/0"
+  description  = "interfaceSwitchDemo"
+  trunk        = true
+  vlan_members = ["100"]
+}
+# Configure interface for L3 logical interface on Junos Router or firewall
+resource junos_interface_physical "interface_fw_demo" {
+  name         = "ge-0/0/1"
+  description  = "interfaceFwDemo"
+  vlan_tagging = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required, Forces new resource)(`String`) Name of physical interface (without dot).
+* `description` - (Optional)(`String`) Description for interface.
+* `no_disable_on_destroy` - (Optional)(`Bool`) When destroy this resource, delete all configurations => do not add `disable` + `descrition NC` or `apply-groups` with `group_interface_delete` provider argument on interface.  
+* `vlan_tagging` - (Optional)(`Bool`) Add 802.1q VLAN tagging support.
+* `ether802_3ad` - (Optional)(`String`) Name of aggregated device for add this interface to link of 802.3ad interface.
+* `trunk` - (Optional)(`Bool`) Interface mode is trunk.
+* `vlan_members` - (Optional)(`ListOfString`) List of vlan for membership for this interface.
+* `vlan_native` - (Optional)(`Int`) Vlan for untagged frames
+* `ae_lacp` - (Optional)(`String`) Add lacp option in aggregated-ether-options. Need to be 'active' or 'passive' for initiate transmission or respond.
+* `ae_link_speed` - (Optional)(`String`) Link speed of individual interface that joins the AE.
+* `ae_minimum_links` - (Optional)(`Int`) Minimum number of aggregated links (1..8).
+
+## Import
+
+Junos interface can be imported using an id made up of `<name>`, e.g.
+
+```
+$ terraform import junos_interface_physical.interface_switch_demo ge-0/0/0
+$ terraform import junos_interface_physical.interface_fw_demo_100 ge-0/0/1
+```

--- a/website/docs/r/interface_st0_unit.html.markdown
+++ b/website/docs/r/interface_st0_unit.html.markdown
@@ -11,7 +11,7 @@ description: |-
 Find st0 unit available and create interface.
 
 It's useful for bind_interface in `junos_security_ipsec_vpn` resource.  
-New st0 unit interface can be configured with `junos_interface` resource.
+New st0 unit interface can be configured with `junos_interface_logical` resource.
 
 ## Example Usage
 

--- a/website/junos.erb
+++ b/website/junos.erb
@@ -6,6 +6,15 @@
           <a href="/docs/providers/junos/index.html">Junos Provider</a>
         </li>
 
+        <li<%= sidebar_current("docs-junos-guides") %>>
+        <a href="#">Guides</a>
+        <ul class="nav nav-visible">
+          <li>
+             <a href="/docs/providers/junos/guides/interface-deprecated.html">Junos: junos_interface deprecated</a>
+          </li>
+        </ul>
+        </li>
+
         <li<%= sidebar_current("docs-junos-data-source") %>>
         <a href="#">Data Sources</a>
         <ul class="nav nav-visible">

--- a/website/junos.erb
+++ b/website/junos.erb
@@ -12,6 +12,9 @@
           <li<%= sidebar_current("docs-junos-data-source-interface") %>>
             <a href="/docs/providers/junos/d/interface.html">junos_interface</a>
           </li>
+          <li<%= sidebar_current("docs-junos-data-source-interface-physical") %>>
+            <a href="/docs/providers/junos/d/interface_physical.html">junos_interface_physical</a>
+          </li>
           <li<%= sidebar_current("docs-junos-data-source-system-information") %>>
             <a href="/docs/providers/junos/d/system_information.html">junos_system_information</a>
           </li>
@@ -44,6 +47,9 @@
           </li>
           <li<%= sidebar_current("docs-junos-resource-interface") %>>
             <a href="/docs/providers/junos/r/interface.html">junos_interface</a>
+          </li>
+          <li<%= sidebar_current("docs-junos-resource-interface-physical") %>>
+            <a href="/docs/providers/junos/r/interface_physical.html">junos_interface_physical</a>
           </li>
           <li<%= sidebar_current("docs-junos-resource-interface-st0-unit") %>>
             <a href="/docs/providers/junos/r/interface_st0_unit.html">junos_interface_st0_unit</a>

--- a/website/junos.erb
+++ b/website/junos.erb
@@ -12,6 +12,9 @@
           <li<%= sidebar_current("docs-junos-data-source-interface") %>>
             <a href="/docs/providers/junos/d/interface.html">junos_interface</a>
           </li>
+          <li<%= sidebar_current("docs-junos-data-source-interface-logical") %>>
+            <a href="/docs/providers/junos/d/interface_logical.html">junos_interface_logical</a>
+          </li>
           <li<%= sidebar_current("docs-junos-data-source-interface-physical") %>>
             <a href="/docs/providers/junos/d/interface_physical.html">junos_interface_physical</a>
           </li>
@@ -47,6 +50,9 @@
           </li>
           <li<%= sidebar_current("docs-junos-resource-interface") %>>
             <a href="/docs/providers/junos/r/interface.html">junos_interface</a>
+          </li>
+          <li<%= sidebar_current("docs-junos-resource-interface-logical") %>>
+            <a href="/docs/providers/junos/r/interface_logical.html">junos_interface_logical</a>
           </li>
           <li<%= sidebar_current("docs-junos-resource-interface-physical") %>>
             <a href="/docs/providers/junos/r/interface_physical.html">junos_interface_physical</a>


### PR DESCRIPTION
ENHANCEMENTS:
* deprecate `junos_interface` resource for two new resources (split physical and logical interface into separate resources)
* deprecate `junos_interface` data source for two new data sources (split physical and logical interface into separate data sources)
* add `junos_interface_physical` resource for replace the parts of physical interface in deprecated `junos_interface` resource
* add `junos_interface_physical` data source for replace the parts of physical interface in deprecated `junos_interface` data source
* add `junos_interface_logical` resource for replace the parts of logical interface in deprecated `junos_interface` resource
* add `junos_interface_logical` data source for replace the parts of logical interface in deprecated `junos_interface` data source