### PR TITLE
Fixes #87: add ssh_sleep_closed argument and use only one ssh connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## upcoming release
 ENHANCEMENTS:
+* add ssh_sleep_closed argument in provider configuration (Fixes part of [#87](https://github.com/jeremmfr/terraform-provider-junos/issues/87))
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ ENHANCEMENTS:
 * add ssh_sleep_closed argument in provider configuration (Fixes part of [#87](https://github.com/jeremmfr/terraform-provider-junos/issues/87))
 
 BUG FIXES:
+* use only one ssh connection per action and per resource (Fixes part of #87(https://github.com/jeremmfr/terraform-provider-junos/issues/87))
+* add missing lock in data source to reduce netconf commands parallelism
+* use only one ssh connection per action and per resource (Fixes part of [#87](https://github.com/jeremmfr/terraform-provider-junos/issues/87))
 
 ## v1.11.0
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,8 @@
 ## upcoming release
 ENHANCEMENTS:
-* add ssh_sleep_closed argument in provider configuration (Fixes part of [#87](https://github.com/jeremmfr/terraform-provider-junos/issues/87))
+* add `ssh_sleep_closed` argument in provider configuration (Fixes part of [#87](https://github.com/jeremmfr/terraform-provider-junos/issues/87))
 
 BUG FIXES:
-* add missing lock in data source to reduce netconf commands parallelism
-* use only one ssh connection per action and per resource (Fixes part of #87(https://github.com/jeremmfr/terraform-provider-junos/issues/87))
 * add missing lock in data source to reduce netconf commands parallelism
 * use only one ssh connection per action and per resource (Fixes part of [#87](https://github.com/jeremmfr/terraform-provider-junos/issues/87))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ ENHANCEMENTS:
 * add ssh_sleep_closed argument in provider configuration (Fixes part of [#87](https://github.com/jeremmfr/terraform-provider-junos/issues/87))
 
 BUG FIXES:
+* add missing lock in data source to reduce netconf commands parallelism
 * use only one ssh connection per action and per resource (Fixes part of #87(https://github.com/jeremmfr/terraform-provider-junos/issues/87))
 * add missing lock in data source to reduce netconf commands parallelism
 * use only one ssh connection per action and per resource (Fixes part of [#87](https://github.com/jeremmfr/terraform-provider-junos/issues/87))

--- a/junos/config.go
+++ b/junos/config.go
@@ -9,6 +9,7 @@ type Config struct {
 	junosPort                int
 	junosCmdSleepShort       int
 	junosCmdSleepLock        int
+	junosSSHSleepClosed      int
 	junosIP                  string
 	junosUserName            string
 	junosPassword            string
@@ -22,17 +23,18 @@ type Config struct {
 // Session : read session information for Junos Device.
 func (c *Config) Session() (*Session, diag.Diagnostics) {
 	sess := &Session{
-		junosIP:          c.junosIP,
-		junosPort:        c.junosPort,
-		junosUserName:    c.junosUserName,
-		junosPassword:    c.junosPassword,
-		junosSSHKeyPEM:   c.junosSSHKeyPEM,
-		junosSSHKeyFile:  c.junosSSHKeyFile,
-		junosKeyPass:     c.junosKeyPass,
-		junosGroupIntDel: c.junosGroupIntDel,
-		junosLogFile:     c.junosDebugNetconfLogPath,
-		junosSleep:       c.junosCmdSleepLock,
-		junosSleepShort:  c.junosCmdSleepShort,
+		junosIP:             c.junosIP,
+		junosPort:           c.junosPort,
+		junosUserName:       c.junosUserName,
+		junosPassword:       c.junosPassword,
+		junosSSHKeyPEM:      c.junosSSHKeyPEM,
+		junosSSHKeyFile:     c.junosSSHKeyFile,
+		junosKeyPass:        c.junosKeyPass,
+		junosGroupIntDel:    c.junosGroupIntDel,
+		junosLogFile:        c.junosDebugNetconfLogPath,
+		junosSleepLock:      c.junosCmdSleepLock,
+		junosSleepShort:     c.junosCmdSleepShort,
+		junosSleepSSHClosed: c.junosSSHSleepClosed,
 	}
 
 	return sess, nil

--- a/junos/data_source_interface.go
+++ b/junos/data_source_interface.go
@@ -357,14 +357,20 @@ func dataSourceInterfaceRead(ctx context.Context, d *schema.ResourceData, m inte
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+	mutex.Lock()
 	nameFound, err := searchInterfaceID(d.Get("config_interface").(string), d.Get("match").(string), m, jnprSess)
 	if err != nil {
+		mutex.Unlock()
+
 		return diag.FromErr(err)
 	}
 	if nameFound == "" {
+		mutex.Unlock()
+
 		return diag.FromErr(fmt.Errorf("no interface found with arguments provided"))
 	}
 	interfaceOpt, err := readInterface(nameFound, m, jnprSess)
+	mutex.Unlock()
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/junos/data_source_interface_logical.go
+++ b/junos/data_source_interface_logical.go
@@ -331,14 +331,20 @@ func dataSourceInterfaceLogicalRead(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+	mutex.Lock()
 	nameFound, err := searchInterfaceLogicalID(d.Get("config_interface").(string), d.Get("match").(string), m, jnprSess)
 	if err != nil {
+		mutex.Unlock()
+
 		return diag.FromErr(err)
 	}
 	if nameFound == "" {
+		mutex.Unlock()
+
 		return diag.FromErr(fmt.Errorf("no logical interface found with arguments provided"))
 	}
 	interfaceOpt, err := readInterfaceLogical(nameFound, m, jnprSess)
+	mutex.Unlock()
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/junos/data_source_interface_physical.go
+++ b/junos/data_source_interface_physical.go
@@ -86,14 +86,20 @@ func dataSourceInterfacePhysicalRead(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+	mutex.Lock()
 	nameFound, err := searchInterfacePhysicalID(d.Get("config_interface").(string), d.Get("match").(string), m, jnprSess)
 	if err != nil {
+		mutex.Unlock()
+
 		return diag.FromErr(err)
 	}
 	if nameFound == "" {
+		mutex.Unlock()
+
 		return diag.FromErr(fmt.Errorf("no physical interface found with arguments provided"))
 	}
 	interfaceOpt, err := readInterfacePhysical(nameFound, m, jnprSess)
+	mutex.Unlock()
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/junos/netconf.go
+++ b/junos/netconf.go
@@ -301,12 +301,15 @@ func (j *NetconfObject) netconfCommit(logMessage string) error {
 }
 
 // Close disconnects our session to the device.
-func (j *NetconfObject) Close() error {
+func (j *NetconfObject) Close(sleepClosed int) error {
 	_, err := j.Session.Exec(netconf.RawMethod(rpcClose))
 	j.Session.Transport.Close()
 	if err != nil {
+		sleep(sleepClosed)
+
 		return fmt.Errorf("failed to netconf close : %w", err)
 	}
+	sleep(sleepClosed)
 
 	return nil
 }

--- a/junos/provider.go
+++ b/junos/provider.go
@@ -90,6 +90,11 @@ func Provider() *schema.Provider {
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("JUNOS_SLEEP_LOCK", 10),
 			},
+			"ssh_sleep_closed": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("JUNOS_SLEEP_SSH_CLOSED", 0),
+			},
 			"debug_netconf_log_path": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -168,6 +173,7 @@ func configureProvider(ctx context.Context, d *schema.ResourceData) (interface{}
 		junosGroupIntDel:         d.Get("group_interface_delete").(string),
 		junosCmdSleepShort:       d.Get("cmd_sleep_short").(int),
 		junosCmdSleepLock:        d.Get("cmd_sleep_lock").(int),
+		junosSSHSleepClosed:      d.Get("ssh_sleep_closed").(int),
 		junosDebugNetconfLogPath: d.Get("debug_netconf_log_path").(string),
 	}
 

--- a/junos/resource_aggregate_route.go
+++ b/junos/resource_aggregate_route.go
@@ -141,8 +141,6 @@ func resourceAggregateRouteCreate(ctx context.Context, d *schema.ResourceData, m
 	aggregateRouteExists, err = checkAggregateRouteExists(
 		d.Get("destination").(string), d.Get("routing_instance").(string), m, jnprSess)
 	if err != nil {
-		sess.configClear(jnprSess)
-
 		return diag.FromErr(err)
 	}
 	if aggregateRouteExists {

--- a/junos/resource_aggregate_route.go
+++ b/junos/resource_aggregate_route.go
@@ -152,18 +152,21 @@ func resourceAggregateRouteCreate(ctx context.Context, d *schema.ResourceData, m
 			"=> check your config", d.Get("destination").(string), d.Get("routing_instance").(string)))
 	}
 
-	return resourceAggregateRouteRead(ctx, d, m)
+	return resourceAggregateRouteReadWJnprSess(d, m, jnprSess)
 }
 func resourceAggregateRouteRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourceAggregateRouteReadWJnprSess(d, m, jnprSess)
+}
+func resourceAggregateRouteReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	aggregateRouteOptions, err := readAggregateRoute(d.Get("destination").(string), d.Get("routing_instance").(string),
 		m, jnprSess)
 	mutex.Unlock()
@@ -205,7 +208,7 @@ func resourceAggregateRouteUpdate(ctx context.Context, d *schema.ResourceData, m
 	}
 	d.Partial(false)
 
-	return resourceAggregateRouteRead(ctx, d, m)
+	return resourceAggregateRouteReadWJnprSess(d, m, jnprSess)
 }
 func resourceAggregateRouteDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)

--- a/junos/resource_application.go
+++ b/junos/resource_application.go
@@ -87,18 +87,20 @@ func resourceApplicationCreate(ctx context.Context, d *schema.ResourceData, m in
 		return diag.FromErr(fmt.Errorf("application %v not exists after commit => check your config", d.Get("name").(string)))
 	}
 
-	return resourceApplicationRead(ctx, d, m)
+	return resourceApplicationReadWJnprSess(d, m, jnprSess)
 }
 func resourceApplicationRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourceApplicationReadWJnprSess(d, m, jnprSess)
+}
+func resourceApplicationReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	applicationOptions, err := readApplication(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
 	if err != nil {
@@ -138,7 +140,7 @@ func resourceApplicationUpdate(ctx context.Context, d *schema.ResourceData, m in
 	}
 	d.Partial(false)
 
-	return resourceApplicationRead(ctx, d, m)
+	return resourceApplicationReadWJnprSess(d, m, jnprSess)
 }
 func resourceApplicationDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)

--- a/junos/resource_application_set.go
+++ b/junos/resource_application_set.go
@@ -80,18 +80,21 @@ func resourceApplicationSetCreate(ctx context.Context, d *schema.ResourceData, m
 			"=> check your config", d.Get("name").(string)))
 	}
 
-	return resourceApplicationSetRead(ctx, d, m)
+	return resourceApplicationSetReadWJnprSess(d, m, jnprSess)
 }
 func resourceApplicationSetRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourceApplicationSetReadWJnprSess(d, m, jnprSess)
+}
+func resourceApplicationSetReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	applicationSetOptions, err := readApplicationSet(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
 	if err != nil {
@@ -131,7 +134,7 @@ func resourceApplicationSetUpdate(ctx context.Context, d *schema.ResourceData, m
 	}
 	d.Partial(false)
 
-	return resourceApplicationSetRead(ctx, d, m)
+	return resourceApplicationSetReadWJnprSess(d, m, jnprSess)
 }
 func resourceApplicationSetDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)

--- a/junos/resource_bgp_group.go
+++ b/junos/resource_bgp_group.go
@@ -527,18 +527,20 @@ func resourceBgpGroupCreate(ctx context.Context, d *schema.ResourceData, m inter
 			"=> check your config", d.Get("name").(string), d.Get("routing_instance").(string)))
 	}
 
-	return resourceBgpGroupRead(ctx, d, m)
+	return resourceBgpGroupReadWJnprSess(d, m, jnprSess)
 }
 func resourceBgpGroupRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourceBgpGroupReadWJnprSess(d, m, jnprSess)
+}
+func resourceBgpGroupReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	bgpGroupOptions, err := readBgpGroup(d.Get("name").(string), d.Get("routing_instance").(string), m, jnprSess)
 	mutex.Unlock()
 	if err != nil {
@@ -578,7 +580,7 @@ func resourceBgpGroupUpdate(ctx context.Context, d *schema.ResourceData, m inter
 	}
 	d.Partial(false)
 
-	return resourceBgpGroupRead(ctx, d, m)
+	return resourceBgpGroupReadWJnprSess(d, m, jnprSess)
 }
 func resourceBgpGroupDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)

--- a/junos/resource_bgp_neighbor.go
+++ b/junos/resource_bgp_neighbor.go
@@ -536,18 +536,20 @@ func resourceBgpNeighborCreate(ctx context.Context, d *schema.ResourceData, m in
 			"=> check your config", d.Get("ip").(string), d.Get("group").(string), d.Get("routing_instance").(string)))
 	}
 
-	return resourceBgpNeighborRead(ctx, d, m)
+	return resourceBgpNeighborReadWJnprSess(d, m, jnprSess)
 }
 func resourceBgpNeighborRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourceBgpNeighborReadWJnprSess(d, m, jnprSess)
+}
+func resourceBgpNeighborReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	bgpNeighborOptions, err := readBgpNeighbor(d.Get("ip").(string),
 		d.Get("routing_instance").(string), d.Get("group").(string), m, jnprSess)
 	mutex.Unlock()
@@ -588,7 +590,7 @@ func resourceBgpNeighborUpdate(ctx context.Context, d *schema.ResourceData, m in
 	}
 	d.Partial(false)
 
-	return resourceBgpNeighborRead(ctx, d, m)
+	return resourceBgpNeighborReadWJnprSess(d, m, jnprSess)
 }
 func resourceBgpNeighborDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)

--- a/junos/resource_firewall_filter.go
+++ b/junos/resource_firewall_filter.go
@@ -309,18 +309,21 @@ func resourceFirewallFilterCreate(ctx context.Context, d *schema.ResourceData, m
 			"=> check your config", d.Get("name").(string)))
 	}
 
-	return resourceFirewallFilterRead(ctx, d, m)
+	return resourceFirewallFilterReadWJnprSess(d, m, jnprSess)
 }
 func resourceFirewallFilterRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourceFirewallFilterReadWJnprSess(d, m, jnprSess)
+}
+func resourceFirewallFilterReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	filterOptions, err := readFirewallFilter(d.Get("name").(string), d.Get("family").(string), m, jnprSess)
 	mutex.Unlock()
 	if err != nil {
@@ -360,7 +363,7 @@ func resourceFirewallFilterUpdate(ctx context.Context, d *schema.ResourceData, m
 	}
 	d.Partial(false)
 
-	return resourceFirewallFilterRead(ctx, d, m)
+	return resourceFirewallFilterReadWJnprSess(d, m, jnprSess)
 }
 func resourceFirewallFilterDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)

--- a/junos/resource_firewall_policer.go
+++ b/junos/resource_firewall_policer.go
@@ -136,18 +136,21 @@ func resourceFirewallPolicerCreate(ctx context.Context, d *schema.ResourceData, 
 			"=> check your config", d.Get("name").(string)))
 	}
 
-	return resourceFirewallPolicerRead(ctx, d, m)
+	return resourceFirewallPolicerReadWJnprSess(d, m, jnprSess)
 }
 func resourceFirewallPolicerRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourceFirewallPolicerReadWJnprSess(d, m, jnprSess)
+}
+func resourceFirewallPolicerReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	policerOptions, err := readFirewallPolicer(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
 	if err != nil {
@@ -187,7 +190,7 @@ func resourceFirewallPolicerUpdate(ctx context.Context, d *schema.ResourceData, 
 	}
 	d.Partial(false)
 
-	return resourceFirewallPolicerRead(ctx, d, m)
+	return resourceFirewallPolicerReadWJnprSess(d, m, jnprSess)
 }
 func resourceFirewallPolicerDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)

--- a/junos/resource_interface.go
+++ b/junos/resource_interface.go
@@ -535,18 +535,20 @@ func resourceInterfaceCreate(ctx context.Context, d *schema.ResourceData, m inte
 		return diag.FromErr(fmt.Errorf("interface %v not exists after commit => check your config", d.Get("name").(string)))
 	}
 
-	return resourceInterfaceRead(ctx, d, m)
+	return resourceInterfaceReadWJnprSess(d, m, jnprSess)
 }
 func resourceInterfaceRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourceInterfaceReadWJnprSess(d, m, jnprSess)
+}
+func resourceInterfaceReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	intExists, err := checkInterfaceExistsOld(d.Get("name").(string), m, jnprSess)
 	if err != nil {
 		mutex.Unlock()
@@ -734,7 +736,7 @@ func resourceInterfaceUpdate(ctx context.Context, d *schema.ResourceData, m inte
 	}
 	d.Partial(false)
 
-	return resourceInterfaceRead(ctx, d, m)
+	return resourceInterfaceReadWJnprSess(d, m, jnprSess)
 }
 func resourceInterfaceDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)

--- a/junos/resource_interface.go
+++ b/junos/resource_interface.go
@@ -522,8 +522,6 @@ func resourceInterfaceCreate(ctx context.Context, d *schema.ResourceData, m inte
 	if intExists {
 		ncInt, _, err := checkInterfaceNC(d.Get("name").(string), m, jnprSess)
 		if err != nil {
-			sess.configClear(jnprSess)
-
 			return diag.FromErr(err)
 		}
 		if ncInt {

--- a/junos/resource_interface_logical.go
+++ b/junos/resource_interface_logical.go
@@ -449,8 +449,6 @@ func resourceInterfaceLogicalCreate(ctx context.Context, d *schema.ResourceData,
 	if intExists {
 		ncInt, _, err := checkInterfaceLogicalNC(d.Get("name").(string), m, jnprSess)
 		if err != nil {
-			sess.configClear(jnprSess)
-
 			return diag.FromErr(err)
 		}
 		if ncInt {

--- a/junos/resource_interface_logical.go
+++ b/junos/resource_interface_logical.go
@@ -462,18 +462,21 @@ func resourceInterfaceLogicalCreate(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(fmt.Errorf("interface %v not exists after commit => check your config", d.Get("name").(string)))
 	}
 
-	return resourceInterfaceLogicalRead(ctx, d, m)
+	return resourceInterfaceLogicalReadWJnprSess(d, m, jnprSess)
 }
 func resourceInterfaceLogicalRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourceInterfaceLogicalReadWJnprSess(d, m, jnprSess)
+}
+func resourceInterfaceLogicalReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	intExists, err := checkInterfaceExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
 		mutex.Unlock()
@@ -587,7 +590,7 @@ func resourceInterfaceLogicalUpdate(ctx context.Context, d *schema.ResourceData,
 	}
 	d.Partial(false)
 
-	return resourceInterfaceLogicalRead(ctx, d, m)
+	return resourceInterfaceLogicalReadWJnprSess(d, m, jnprSess)
 }
 func resourceInterfaceLogicalDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)

--- a/junos/resource_interface_physical.go
+++ b/junos/resource_interface_physical.go
@@ -164,18 +164,21 @@ func resourceInterfacePhysicalCreate(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(fmt.Errorf("interface %v not exists after commit => check your config", d.Get("name").(string)))
 	}
 
-	return resourceInterfacePhysicalRead(ctx, d, m)
+	return resourceInterfacePhysicalReadWJnprSess(d, m, jnprSess)
 }
 func resourceInterfacePhysicalRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourceInterfacePhysicalReadWJnprSess(d, m, jnprSess)
+}
+func resourceInterfacePhysicalReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	intExists, err := checkInterfaceExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
 		mutex.Unlock()
@@ -309,7 +312,7 @@ func resourceInterfacePhysicalUpdate(ctx context.Context, d *schema.ResourceData
 	}
 	d.Partial(false)
 
-	return resourceInterfacePhysicalRead(ctx, d, m)
+	return resourceInterfacePhysicalReadWJnprSess(d, m, jnprSess)
 }
 func resourceInterfacePhysicalDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)

--- a/junos/resource_interface_physical.go
+++ b/junos/resource_interface_physical.go
@@ -151,8 +151,6 @@ func resourceInterfacePhysicalCreate(ctx context.Context, d *schema.ResourceData
 	if intExists {
 		ncInt, _, err := checkInterfacePhysicalNC(d.Get("name").(string), m, jnprSess)
 		if err != nil {
-			sess.configClear(jnprSess)
-
 			return diag.FromErr(err)
 		}
 		if ncInt {

--- a/junos/resource_interface_st0_unit.go
+++ b/junos/resource_interface_st0_unit.go
@@ -60,14 +60,12 @@ func resourceInterfaceSt0UnitCreate(ctx context.Context, d *schema.ResourceData,
 }
 func resourceInterfaceSt0UnitRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+	mutex.Lock()
 	intExists, err := checkInterfaceExists(d.Id(), m, jnprSess)
 	mutex.Unlock()
 	if err != nil {

--- a/junos/resource_ospf_area.go
+++ b/junos/resource_ospf_area.go
@@ -135,18 +135,20 @@ func resourceOspfAreaCreate(ctx context.Context, d *schema.ResourceData, m inter
 			d.Get("version").(string), d.Get("area_id").(string), d.Get("routing_instance").(string)))
 	}
 
-	return resourceOspfAreaRead(ctx, d, m)
+	return resourceOspfAreaReadWJnprSess(d, m, jnprSess)
 }
 func resourceOspfAreaRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourceOspfAreaReadWJnprSess(d, m, jnprSess)
+}
+func resourceOspfAreaReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	ospfAreaOptions, err := readOspfArea(d.Get("area_id").(string), d.Get("version").(string),
 		d.Get("routing_instance").(string), m, jnprSess)
 	mutex.Unlock()
@@ -187,7 +189,7 @@ func resourceOspfAreaUpdate(ctx context.Context, d *schema.ResourceData, m inter
 	}
 	d.Partial(false)
 
-	return resourceOspfAreaRead(ctx, d, m)
+	return resourceOspfAreaReadWJnprSess(d, m, jnprSess)
 }
 func resourceOspfAreaDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)

--- a/junos/resource_policyoptions_as_path.go
+++ b/junos/resource_policyoptions_as_path.go
@@ -84,18 +84,21 @@ func resourcePolicyoptionsAsPathCreate(ctx context.Context, d *schema.ResourceDa
 			"=> check your config", d.Get("name").(string)))
 	}
 
-	return resourcePolicyoptionsAsPathRead(ctx, d, m)
+	return resourcePolicyoptionsAsPathReadWJnprSess(d, m, jnprSess)
 }
 func resourcePolicyoptionsAsPathRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourcePolicyoptionsAsPathReadWJnprSess(d, m, jnprSess)
+}
+func resourcePolicyoptionsAsPathReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	asPathOptions, err := readPolicyoptionsAsPath(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
 	if err != nil {
@@ -135,7 +138,7 @@ func resourcePolicyoptionsAsPathUpdate(ctx context.Context, d *schema.ResourceDa
 	}
 	d.Partial(false)
 
-	return resourcePolicyoptionsAsPathRead(ctx, d, m)
+	return resourcePolicyoptionsAsPathReadWJnprSess(d, m, jnprSess)
 }
 func resourcePolicyoptionsAsPathDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)

--- a/junos/resource_policyoptions_as_path_group.go
+++ b/junos/resource_policyoptions_as_path_group.go
@@ -98,18 +98,21 @@ func resourcePolicyoptionsAsPathGroupCreate(
 			"=> check your config", d.Get("name").(string)))
 	}
 
-	return resourcePolicyoptionsAsPathGroupRead(ctx, d, m)
+	return resourcePolicyoptionsAsPathGroupReadWJnprSess(d, m, jnprSess)
 }
 func resourcePolicyoptionsAsPathGroupRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourcePolicyoptionsAsPathGroupReadWJnprSess(d, m, jnprSess)
+}
+func resourcePolicyoptionsAsPathGroupReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	asPathGroupOptions, err := readPolicyoptionsAsPathGroup(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
 	if err != nil {
@@ -150,7 +153,7 @@ func resourcePolicyoptionsAsPathGroupUpdate(
 	}
 	d.Partial(false)
 
-	return resourcePolicyoptionsAsPathGroupRead(ctx, d, m)
+	return resourcePolicyoptionsAsPathGroupReadWJnprSess(d, m, jnprSess)
 }
 func resourcePolicyoptionsAsPathGroupDelete(
 	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/junos/resource_policyoptions_community.go
+++ b/junos/resource_policyoptions_community.go
@@ -86,18 +86,21 @@ func resourcePolicyoptionsCommunityCreate(ctx context.Context, d *schema.Resourc
 			"=> check your config", d.Get("name").(string)))
 	}
 
-	return resourcePolicyoptionsCommunityRead(ctx, d, m)
+	return resourcePolicyoptionsCommunityReadWJnprSess(d, m, jnprSess)
 }
 func resourcePolicyoptionsCommunityRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourcePolicyoptionsCommunityReadWJnprSess(d, m, jnprSess)
+}
+func resourcePolicyoptionsCommunityReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	communityOptions, err := readPolicyoptionsCommunity(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
 	if err != nil {
@@ -137,7 +140,7 @@ func resourcePolicyoptionsCommunityUpdate(ctx context.Context, d *schema.Resourc
 	}
 	d.Partial(false)
 
-	return resourcePolicyoptionsCommunityRead(ctx, d, m)
+	return resourcePolicyoptionsCommunityReadWJnprSess(d, m, jnprSess)
 }
 func resourcePolicyoptionsCommunityDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)

--- a/junos/resource_policyoptions_policy_statement.go
+++ b/junos/resource_policyoptions_policy_statement.go
@@ -720,19 +720,22 @@ func resourcePolicyoptionsPolicyStatementCreate(
 			"=> check your config", d.Get("name").(string)))
 	}
 
-	return resourcePolicyoptionsPolicyStatementRead(ctx, d, m)
+	return resourcePolicyoptionsPolicyStatementReadWJnprSess(d, m, jnprSess)
 }
 func resourcePolicyoptionsPolicyStatementRead(
 	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourcePolicyoptionsPolicyStatementReadWJnprSess(d, m, jnprSess)
+}
+func resourcePolicyoptionsPolicyStatementReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	policyStatementOptions, err := readPolicyStatement(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
 	if err != nil {
@@ -773,7 +776,7 @@ func resourcePolicyoptionsPolicyStatementUpdate(
 	}
 	d.Partial(false)
 
-	return resourcePolicyoptionsPolicyStatementRead(ctx, d, m)
+	return resourcePolicyoptionsPolicyStatementReadWJnprSess(d, m, jnprSess)
 }
 func resourcePolicyoptionsPolicyStatementDelete(
 	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/junos/resource_policyoptions_prefix_list.go
+++ b/junos/resource_policyoptions_prefix_list.go
@@ -91,18 +91,21 @@ func resourcePolicyoptionsPrefixListCreate(
 			"=> check your config", d.Get("name").(string)))
 	}
 
-	return resourcePolicyoptionsPrefixListRead(ctx, d, m)
+	return resourcePolicyoptionsPrefixListReadWJnprSess(d, m, jnprSess)
 }
 func resourcePolicyoptionsPrefixListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourcePolicyoptionsPrefixListReadWJnprSess(d, m, jnprSess)
+}
+func resourcePolicyoptionsPrefixListReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	prefixListOptions, err := readPolicyoptionsPrefixList(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
 	if err != nil {
@@ -144,7 +147,7 @@ func resourcePolicyoptionsPrefixListUpdate(
 	}
 	d.Partial(false)
 
-	return resourcePolicyoptionsPrefixListRead(ctx, d, m)
+	return resourcePolicyoptionsPrefixListReadWJnprSess(d, m, jnprSess)
 }
 func resourcePolicyoptionsPrefixListDelete(
 	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/junos/resource_routing_instance.go
+++ b/junos/resource_routing_instance.go
@@ -84,18 +84,21 @@ func resourceRoutingInstanceCreate(ctx context.Context, d *schema.ResourceData, 
 			"=> check your config", d.Get("name").(string)))
 	}
 
-	return resourceRoutingInstanceRead(ctx, d, m)
+	return resourceRoutingInstanceReadWJnprSess(d, m, jnprSess)
 }
 func resourceRoutingInstanceRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourceRoutingInstanceReadWJnprSess(d, m, jnprSess)
+}
+func resourceRoutingInstanceReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	instanceOptions, err := readRoutingInstance(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
 	if err != nil {
@@ -136,7 +139,7 @@ func resourceRoutingInstanceUpdate(ctx context.Context, d *schema.ResourceData, 
 	}
 	d.Partial(false)
 
-	return resourceRoutingInstanceRead(ctx, d, m)
+	return resourceRoutingInstanceReadWJnprSess(d, m, jnprSess)
 }
 func resourceRoutingInstanceDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)

--- a/junos/resource_routing_options.go
+++ b/junos/resource_routing_options.go
@@ -92,18 +92,21 @@ func resourceRoutingOptionsCreate(ctx context.Context, d *schema.ResourceData, m
 
 	d.SetId("routing_options")
 
-	return resourceRoutingOptionsRead(ctx, d, m)
+	return resourceRoutingOptionsReadWJnprSess(d, m, jnprSess)
 }
 func resourceRoutingOptionsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourceRoutingOptionsReadWJnprSess(d, m, jnprSess)
+}
+func resourceRoutingOptionsReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	routingOptionsOptions, err := readRoutingOptions(m, jnprSess)
 	mutex.Unlock()
 	if err != nil {
@@ -139,7 +142,7 @@ func resourceRoutingOptionsUpdate(ctx context.Context, d *schema.ResourceData, m
 	}
 	d.Partial(false)
 
-	return resourceRoutingOptionsRead(ctx, d, m)
+	return resourceRoutingOptionsReadWJnprSess(d, m, jnprSess)
 }
 func resourceRoutingOptionsDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	return nil

--- a/junos/resource_security.go
+++ b/junos/resource_security.go
@@ -589,18 +589,20 @@ func resourceSecurityCreate(ctx context.Context, d *schema.ResourceData, m inter
 
 	d.SetId("security")
 
-	return resourceSecurityRead(ctx, d, m)
+	return resourceSecurityReadWJnprSess(d, m, jnprSess)
 }
 func resourceSecurityRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourceSecurityReadWJnprSess(d, m, jnprSess)
+}
+func resourceSecurityReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	securityOptions, err := readSecurity(m, jnprSess)
 	mutex.Unlock()
 	if err != nil {
@@ -636,7 +638,7 @@ func resourceSecurityUpdate(ctx context.Context, d *schema.ResourceData, m inter
 	}
 	d.Partial(false)
 
-	return resourceSecurityRead(ctx, d, m)
+	return resourceSecurityReadWJnprSess(d, m, jnprSess)
 }
 func resourceSecurityDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	return nil

--- a/junos/resource_security_ike_gateway.go
+++ b/junos/resource_security_ike_gateway.go
@@ -314,18 +314,20 @@ func resourceIkeGatewayCreate(ctx context.Context, d *schema.ResourceData, m int
 			"=> check your config", d.Get("name").(string)))
 	}
 
-	return resourceIkeGatewayRead(ctx, d, m)
+	return resourceIkeGatewayReadWJnprSess(d, m, jnprSess)
 }
 func resourceIkeGatewayRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourceIkeGatewayReadWJnprSess(d, m, jnprSess)
+}
+func resourceIkeGatewayReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	ikeGatewayOptions, err := readIkeGateway(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
 	if err != nil {
@@ -365,7 +367,7 @@ func resourceIkeGatewayUpdate(ctx context.Context, d *schema.ResourceData, m int
 	}
 	d.Partial(false)
 
-	return resourceIkeGatewayRead(ctx, d, m)
+	return resourceIkeGatewayReadWJnprSess(d, m, jnprSess)
 }
 func resourceIkeGatewayDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)

--- a/junos/resource_security_ike_policy.go
+++ b/junos/resource_security_ike_policy.go
@@ -127,18 +127,20 @@ func resourceIkePolicyCreate(ctx context.Context, d *schema.ResourceData, m inte
 			"=> check your config", d.Get("name").(string)))
 	}
 
-	return resourceIkePolicyRead(ctx, d, m)
+	return resourceIkePolicyReadWJnprSess(d, m, jnprSess)
 }
 func resourceIkePolicyRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourceIkePolicyReadWJnprSess(d, m, jnprSess)
+}
+func resourceIkePolicyReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	ikePolicyOptions, err := readIkePolicy(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
 	if err != nil {
@@ -178,7 +180,7 @@ func resourceIkePolicyUpdate(ctx context.Context, d *schema.ResourceData, m inte
 	}
 	d.Partial(false)
 
-	return resourceIkePolicyRead(ctx, d, m)
+	return resourceIkePolicyReadWJnprSess(d, m, jnprSess)
 }
 func resourceIkePolicyDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)

--- a/junos/resource_security_ike_proposal.go
+++ b/junos/resource_security_ike_proposal.go
@@ -106,18 +106,20 @@ func resourceIkeProposalCreate(ctx context.Context, d *schema.ResourceData, m in
 			"=> check your config", d.Get("name").(string)))
 	}
 
-	return resourceIkeProposalRead(ctx, d, m)
+	return resourceIkeProposalReadWJnprSess(d, m, jnprSess)
 }
 func resourceIkeProposalRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourceIkeProposalReadWJnprSess(d, m, jnprSess)
+}
+func resourceIkeProposalReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	ikeProposalOptions, err := readIkeProposal(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
 	if err != nil {
@@ -157,7 +159,7 @@ func resourceIkeProposalUpdate(ctx context.Context, d *schema.ResourceData, m in
 	}
 	d.Partial(false)
 
-	return resourceIkeProposalRead(ctx, d, m)
+	return resourceIkeProposalReadWJnprSess(d, m, jnprSess)
 }
 func resourceIkeProposalDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)

--- a/junos/resource_security_ipsec_policy.go
+++ b/junos/resource_security_ipsec_policy.go
@@ -98,18 +98,20 @@ func resourceIpsecPolicyCreate(ctx context.Context, d *schema.ResourceData, m in
 			"=> check your config", d.Get("name").(string)))
 	}
 
-	return resourceIpsecPolicyRead(ctx, d, m)
+	return resourceIpsecPolicyReadWJnprSess(d, m, jnprSess)
 }
 func resourceIpsecPolicyRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourceIpsecPolicyReadWJnprSess(d, m, jnprSess)
+}
+func resourceIpsecPolicyReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	ipsecPolicyOptions, err := readIpsecPolicy(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
 	if err != nil {
@@ -149,7 +151,7 @@ func resourceIpsecPolicyUpdate(ctx context.Context, d *schema.ResourceData, m in
 	}
 	d.Partial(false)
 
-	return resourceIpsecPolicyRead(ctx, d, m)
+	return resourceIpsecPolicyReadWJnprSess(d, m, jnprSess)
 }
 func resourceIpsecPolicyDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)

--- a/junos/resource_security_ipsec_proposal.go
+++ b/junos/resource_security_ipsec_proposal.go
@@ -107,18 +107,21 @@ func resourceIpsecProposalCreate(ctx context.Context, d *schema.ResourceData, m 
 			"=> check your config", d.Get("name").(string)))
 	}
 
-	return resourceIpsecProposalRead(ctx, d, m)
+	return resourceIpsecProposalReadWJnprSess(d, m, jnprSess)
 }
 func resourceIpsecProposalRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourceIpsecProposalReadWJnprSess(d, m, jnprSess)
+}
+func resourceIpsecProposalReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	ipsecProposalOptions, err := readIpsecProposal(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
 	if err != nil {
@@ -158,7 +161,7 @@ func resourceIpsecProposalUpdate(ctx context.Context, d *schema.ResourceData, m 
 	}
 	d.Partial(false)
 
-	return resourceIpsecProposalRead(ctx, d, m)
+	return resourceIpsecProposalReadWJnprSess(d, m, jnprSess)
 }
 func resourceIpsecProposalDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)

--- a/junos/resource_security_log_stream.go
+++ b/junos/resource_security_log_stream.go
@@ -155,9 +155,7 @@ func resourceSecurityLogStreamCreate(ctx context.Context, d *schema.ResourceData
 
 		return diag.FromErr(err)
 	}
-	mutex.Lock()
 	securityLogStreamExists, err = checkSecurityLogStreamExists(d.Get("name").(string), m, jnprSess)
-	mutex.Unlock()
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/junos/resource_security_log_stream.go
+++ b/junos/resource_security_log_stream.go
@@ -168,18 +168,21 @@ func resourceSecurityLogStreamCreate(ctx context.Context, d *schema.ResourceData
 			"not exists after commit => check your config", d.Get("name").(string)))
 	}
 
-	return resourceSecurityLogStreamRead(ctx, d, m)
+	return resourceSecurityLogStreamReadWJnprSess(d, m, jnprSess)
 }
 func resourceSecurityLogStreamRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourceSecurityLogStreamReadWJnprSess(d, m, jnprSess)
+}
+func resourceSecurityLogStreamReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	securityLogStreamOptions, err := readSecurityLogStream(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
 	if err != nil {
@@ -219,7 +222,7 @@ func resourceSecurityLogStreamUpdate(ctx context.Context, d *schema.ResourceData
 	}
 	d.Partial(false)
 
-	return resourceSecurityLogStreamRead(ctx, d, m)
+	return resourceSecurityLogStreamReadWJnprSess(d, m, jnprSess)
 }
 func resourceSecurityLogStreamDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)

--- a/junos/resource_security_nat_destination.go
+++ b/junos/resource_security_nat_destination.go
@@ -138,18 +138,21 @@ func resourceSecurityNatDestinationCreate(ctx context.Context, d *schema.Resourc
 			"=> check your config", d.Get("name").(string)))
 	}
 
-	return resourceSecurityNatDestinationRead(ctx, d, m)
+	return resourceSecurityNatDestinationReadWJnprSess(d, m, jnprSess)
 }
 func resourceSecurityNatDestinationRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourceSecurityNatDestinationReadWJnprSess(d, m, jnprSess)
+}
+func resourceSecurityNatDestinationReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	natDestinationOptions, err := readSecurityNatDestination(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
 	if err != nil {
@@ -189,7 +192,7 @@ func resourceSecurityNatDestinationUpdate(ctx context.Context, d *schema.Resourc
 	}
 	d.Partial(false)
 
-	return resourceSecurityNatDestinationRead(ctx, d, m)
+	return resourceSecurityNatDestinationReadWJnprSess(d, m, jnprSess)
 }
 func resourceSecurityNatDestinationDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)

--- a/junos/resource_security_nat_destination_pool.go
+++ b/junos/resource_security_nat_destination_pool.go
@@ -107,19 +107,22 @@ func resourceSecurityNatDestinationPoolCreate(
 			"=> check your config", d.Get("name").(string)))
 	}
 
-	return resourceSecurityNatDestinationPoolRead(ctx, d, m)
+	return resourceSecurityNatDestinationPoolReadWJnprSess(d, m, jnprSess)
 }
 func resourceSecurityNatDestinationPoolRead(
 	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourceSecurityNatDestinationPoolReadWJnprSess(d, m, jnprSess)
+}
+func resourceSecurityNatDestinationPoolReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	natDestinationPoolOptions, err := readSecurityNatDestinationPool(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
 	if err != nil {
@@ -160,7 +163,7 @@ func resourceSecurityNatDestinationPoolUpdate(
 	}
 	d.Partial(false)
 
-	return resourceSecurityNatDestinationPoolRead(ctx, d, m)
+	return resourceSecurityNatDestinationPoolReadWJnprSess(d, m, jnprSess)
 }
 func resourceSecurityNatDestinationPoolDelete(
 	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/junos/resource_security_nat_source.go
+++ b/junos/resource_security_nat_source.go
@@ -178,18 +178,21 @@ func resourceSecurityNatSourceCreate(ctx context.Context, d *schema.ResourceData
 			"=> check your config", d.Get("name").(string)))
 	}
 
-	return resourceSecurityNatSourceRead(ctx, d, m)
+	return resourceSecurityNatSourceReadWJnprSess(d, m, jnprSess)
 }
 func resourceSecurityNatSourceRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourceSecurityNatSourceReadWJnprSess(d, m, jnprSess)
+}
+func resourceSecurityNatSourceReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	natSourceOptions, err := readSecurityNatSource(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
 	if err != nil {
@@ -229,7 +232,7 @@ func resourceSecurityNatSourceUpdate(ctx context.Context, d *schema.ResourceData
 	}
 	d.Partial(false)
 
-	return resourceSecurityNatSourceRead(ctx, d, m)
+	return resourceSecurityNatSourceReadWJnprSess(d, m, jnprSess)
 }
 func resourceSecurityNatSourceDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)

--- a/junos/resource_security_nat_source_pool.go
+++ b/junos/resource_security_nat_source_pool.go
@@ -114,18 +114,21 @@ func resourceSecurityNatSourcePoolCreate(ctx context.Context, d *schema.Resource
 			"=> check your config", d.Get("name").(string)))
 	}
 
-	return resourceSecurityNatSourcePoolRead(ctx, d, m)
+	return resourceSecurityNatSourcePoolReadWJnprSess(d, m, jnprSess)
 }
 func resourceSecurityNatSourcePoolRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourceSecurityNatSourcePoolReadWJnprSess(d, m, jnprSess)
+}
+func resourceSecurityNatSourcePoolReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	natSourcePoolOptions, err := readSecurityNatSourcePool(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
 	if err != nil {
@@ -165,7 +168,7 @@ func resourceSecurityNatSourcePoolUpdate(ctx context.Context, d *schema.Resource
 	}
 	d.Partial(false)
 
-	return resourceSecurityNatSourcePoolRead(ctx, d, m)
+	return resourceSecurityNatSourcePoolReadWJnprSess(d, m, jnprSess)
 }
 func resourceSecurityNatSourcePoolDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)

--- a/junos/resource_security_nat_static.go
+++ b/junos/resource_security_nat_static.go
@@ -142,18 +142,21 @@ func resourceSecurityNatStaticCreate(ctx context.Context, d *schema.ResourceData
 			"=> check your config", d.Get("name").(string)))
 	}
 
-	return resourceSecurityNatStaticRead(ctx, d, m)
+	return resourceSecurityNatStaticReadWJnprSess(d, m, jnprSess)
 }
 func resourceSecurityNatStaticRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourceSecurityNatStaticReadWJnprSess(d, m, jnprSess)
+}
+func resourceSecurityNatStaticReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	natStaticOptions, err := readSecurityNatStatic(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
 	if err != nil {
@@ -193,7 +196,7 @@ func resourceSecurityNatStaticUpdate(ctx context.Context, d *schema.ResourceData
 	}
 	d.Partial(false)
 
-	return resourceSecurityNatStaticRead(ctx, d, m)
+	return resourceSecurityNatStaticReadWJnprSess(d, m, jnprSess)
 }
 func resourceSecurityNatStaticDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)

--- a/junos/resource_security_policy.go
+++ b/junos/resource_security_policy.go
@@ -211,18 +211,21 @@ func resourceSecurityPolicyCreate(ctx context.Context, d *schema.ResourceData, m
 			"=> check your config", d.Get("from_zone").(string), d.Get("to_zone").(string)))
 	}
 
-	return resourceSecurityPolicyRead(ctx, d, m)
+	return resourceSecurityPolicyReadWJnprSess(d, m, jnprSess)
 }
 func resourceSecurityPolicyRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourceSecurityPolicyReadWJnprSess(d, m, jnprSess)
+}
+func resourceSecurityPolicyReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	policyOptions, err := readSecurityPolicy(d.Get("from_zone").(string)+idSeparator+d.Get("to_zone").(string),
 		m, jnprSess)
 	mutex.Unlock()
@@ -265,7 +268,7 @@ func resourceSecurityPolicyUpdate(ctx context.Context, d *schema.ResourceData, m
 	}
 	d.Partial(false)
 
-	return resourceSecurityPolicyRead(ctx, d, m)
+	return resourceSecurityPolicyReadWJnprSess(d, m, jnprSess)
 }
 func resourceSecurityPolicyDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)

--- a/junos/resource_security_policy_tunnel_pair_policy.go
+++ b/junos/resource_security_policy_tunnel_pair_policy.go
@@ -126,19 +126,22 @@ func resourceSecurityPolicyTunnelPairPolicyCreate(
 		return diag.FromErr(fmt.Errorf("security policy pair policy not exists after commit => check your config"))
 	}
 
-	return resourceSecurityPolicyTunnelPairPolicyRead(ctx, d, m)
+	return resourceSecurityPolicyTunnelPairPolicyReadWJnprSess(d, m, jnprSess)
 }
 func resourceSecurityPolicyTunnelPairPolicyRead(
 	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourceSecurityPolicyTunnelPairPolicyReadWJnprSess(d, m, jnprSess)
+}
+func resourceSecurityPolicyTunnelPairPolicyReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	policyPairPolicyOptions, err := readSecurityPolicyTunnelPairPolicy(d.Get("zone_a").(string)+idSeparator+
 		d.Get("policy_a_to_b").(string)+idSeparator+
 		d.Get("zone_b").(string)+idSeparator+

--- a/junos/resource_security_utm_custom_url_pattern.go
+++ b/junos/resource_security_utm_custom_url_pattern.go
@@ -75,9 +75,7 @@ func resourceSecurityUtmCustomURLPatternCreate(
 
 		return diag.FromErr(err)
 	}
-	mutex.Lock()
 	utmCustomURLPatternExists, err = checkUtmCustomURLPatternsExists(d.Get("name").(string), m, jnprSess)
-	mutex.Unlock()
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/junos/resource_security_utm_custom_url_pattern.go
+++ b/junos/resource_security_utm_custom_url_pattern.go
@@ -88,19 +88,22 @@ func resourceSecurityUtmCustomURLPatternCreate(
 			"not exists after commit => check your config", d.Get("name").(string)))
 	}
 
-	return resourceSecurityUtmCustomURLPatternRead(ctx, d, m)
+	return resourceSecurityUtmCustomURLPatternReadWJnprSess(d, m, jnprSess)
 }
 func resourceSecurityUtmCustomURLPatternRead(
 	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourceSecurityUtmCustomURLPatternReadWJnprSess(d, m, jnprSess)
+}
+func resourceSecurityUtmCustomURLPatternReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	utmCustomURLPatternOptions, err := readUtmCustomURLPattern(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
 	if err != nil {
@@ -141,7 +144,7 @@ func resourceSecurityUtmCustomURLPatternUpdate(
 	}
 	d.Partial(false)
 
-	return resourceSecurityUtmCustomURLPatternRead(ctx, d, m)
+	return resourceSecurityUtmCustomURLPatternReadWJnprSess(d, m, jnprSess)
 }
 func resourceSecurityUtmCustomURLPatternDelete(
 	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/junos/resource_security_utm_policy.go
+++ b/junos/resource_security_utm_policy.go
@@ -180,18 +180,21 @@ func resourceSecurityUtmPolicyCreate(ctx context.Context, d *schema.ResourceData
 			"not exists after commit => check your config", d.Get("name").(string)))
 	}
 
-	return resourceSecurityUtmPolicyRead(ctx, d, m)
+	return resourceSecurityUtmPolicyReadWJnprSess(d, m, jnprSess)
 }
 func resourceSecurityUtmPolicyRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourceSecurityUtmPolicyReadWJnprSess(d, m, jnprSess)
+}
+func resourceSecurityUtmPolicyReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	utmPolicyOptions, err := readUtmPolicy(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
 	if err != nil {
@@ -231,7 +234,7 @@ func resourceSecurityUtmPolicyUpdate(ctx context.Context, d *schema.ResourceData
 	}
 	d.Partial(false)
 
-	return resourceSecurityUtmPolicyRead(ctx, d, m)
+	return resourceSecurityUtmPolicyReadWJnprSess(d, m, jnprSess)
 }
 func resourceSecurityUtmPolicyDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)

--- a/junos/resource_security_utm_policy.go
+++ b/junos/resource_security_utm_policy.go
@@ -167,9 +167,7 @@ func resourceSecurityUtmPolicyCreate(ctx context.Context, d *schema.ResourceData
 
 		return diag.FromErr(err)
 	}
-	mutex.Lock()
 	utmPolicyExists, err = checkUtmPolicysExists(d.Get("name").(string), m, jnprSess)
-	mutex.Unlock()
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/junos/resource_security_utm_profile_web_filtering_juniper_enhanced.go
+++ b/junos/resource_security_utm_profile_web_filtering_juniper_enhanced.go
@@ -222,9 +222,7 @@ func resourceSecurityUtmProfileWebFilteringEnhancedCreate(
 
 		return diag.FromErr(err)
 	}
-	mutex.Lock()
 	utmProfileWebFEnhancedExists, err = checkUtmProfileWebFEnhancedExists(d.Get("name").(string), m, jnprSess)
-	mutex.Unlock()
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/junos/resource_security_utm_profile_web_filtering_juniper_enhanced.go
+++ b/junos/resource_security_utm_profile_web_filtering_juniper_enhanced.go
@@ -235,19 +235,22 @@ func resourceSecurityUtmProfileWebFilteringEnhancedCreate(
 			"not exists after commit => check your config", d.Get("name").(string)))
 	}
 
-	return resourceSecurityUtmProfileWebFilteringEnhancedRead(ctx, d, m)
+	return resourceSecurityUtmProfileWebFilteringEnhancedReadWJnprSess(d, m, jnprSess)
 }
 func resourceSecurityUtmProfileWebFilteringEnhancedRead(
 	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourceSecurityUtmProfileWebFilteringEnhancedReadWJnprSess(d, m, jnprSess)
+}
+func resourceSecurityUtmProfileWebFilteringEnhancedReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	utmProfileWebFEnhancedOptions, err := readUtmProfileWebFEnhanced(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
 	if err != nil {
@@ -289,7 +292,7 @@ func resourceSecurityUtmProfileWebFilteringEnhancedUpdate(
 	}
 	d.Partial(false)
 
-	return resourceSecurityUtmProfileWebFilteringEnhancedRead(ctx, d, m)
+	return resourceSecurityUtmProfileWebFilteringEnhancedReadWJnprSess(d, m, jnprSess)
 }
 func resourceSecurityUtmProfileWebFilteringEnhancedDelete(
 	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/junos/resource_security_utm_profile_web_filtering_juniper_local.go
+++ b/junos/resource_security_utm_profile_web_filtering_juniper_local.go
@@ -118,9 +118,7 @@ func resourceSecurityUtmProfileWebFilteringLocalCreate(
 
 		return diag.FromErr(err)
 	}
-	mutex.Lock()
 	utmProfileWebFLocalExists, err = checkUtmProfileWebFLocalExists(d.Get("name").(string), m, jnprSess)
-	mutex.Unlock()
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/junos/resource_security_utm_profile_web_filtering_juniper_local.go
+++ b/junos/resource_security_utm_profile_web_filtering_juniper_local.go
@@ -131,19 +131,22 @@ func resourceSecurityUtmProfileWebFilteringLocalCreate(
 			"not exists after commit => check your config", d.Get("name").(string)))
 	}
 
-	return resourceSecurityUtmProfileWebFilteringLocalRead(ctx, d, m)
+	return resourceSecurityUtmProfileWebFilteringLocalReadWJnprSess(d, m, jnprSess)
 }
 func resourceSecurityUtmProfileWebFilteringLocalRead(
 	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourceSecurityUtmProfileWebFilteringLocalReadWJnprSess(d, m, jnprSess)
+}
+func resourceSecurityUtmProfileWebFilteringLocalReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	utmProfileWebFLocalOptions, err := readUtmProfileWebFLocal(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
 	if err != nil {
@@ -185,7 +188,7 @@ func resourceSecurityUtmProfileWebFilteringLocalUpdate(
 	}
 	d.Partial(false)
 
-	return resourceSecurityUtmProfileWebFilteringLocalRead(ctx, d, m)
+	return resourceSecurityUtmProfileWebFilteringLocalReadWJnprSess(d, m, jnprSess)
 }
 func resourceSecurityUtmProfileWebFilteringLocalDelete(
 	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/junos/resource_security_utm_profile_web_filtering_websense_redirect.go
+++ b/junos/resource_security_utm_profile_web_filtering_websense_redirect.go
@@ -142,9 +142,7 @@ func resourceSecurityUtmProfileWebFilteringWebsenseCreate(
 
 		return diag.FromErr(err)
 	}
-	mutex.Lock()
 	utmProfileWebFWebsenseExists, err = checkUtmProfileWebFWebsenseExists(d.Get("name").(string), m, jnprSess)
-	mutex.Unlock()
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/junos/resource_security_utm_profile_web_filtering_websense_redirect.go
+++ b/junos/resource_security_utm_profile_web_filtering_websense_redirect.go
@@ -155,19 +155,22 @@ func resourceSecurityUtmProfileWebFilteringWebsenseCreate(
 			"not exists after commit => check your config", d.Get("name").(string)))
 	}
 
-	return resourceSecurityUtmProfileWebFilteringWebsenseRead(ctx, d, m)
+	return resourceSecurityUtmProfileWebFilteringWebsenseReadWJnprSess(d, m, jnprSess)
 }
 func resourceSecurityUtmProfileWebFilteringWebsenseRead(
 	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourceSecurityUtmProfileWebFilteringWebsenseReadWJnprSess(d, m, jnprSess)
+}
+func resourceSecurityUtmProfileWebFilteringWebsenseReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	utmProfileWebFWebsenseOptions, err := readUtmProfileWebFWebsense(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
 	if err != nil {
@@ -209,7 +212,7 @@ func resourceSecurityUtmProfileWebFilteringWebsenseUpdate(
 	}
 	d.Partial(false)
 
-	return resourceSecurityUtmProfileWebFilteringWebsenseRead(ctx, d, m)
+	return resourceSecurityUtmProfileWebFilteringWebsenseReadWJnprSess(d, m, jnprSess)
 }
 func resourceSecurityUtmProfileWebFilteringWebsenseDelete(
 	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/junos/resource_security_zone.go
+++ b/junos/resource_security_zone.go
@@ -119,9 +119,7 @@ func resourceSecurityZoneCreate(ctx context.Context, d *schema.ResourceData, m i
 
 		return diag.FromErr(err)
 	}
-	mutex.Lock()
 	securityZoneExists, err = checkSecurityZonesExists(d.Get("name").(string), m, jnprSess)
-	mutex.Unlock()
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/junos/resource_security_zone.go
+++ b/junos/resource_security_zone.go
@@ -132,18 +132,21 @@ func resourceSecurityZoneCreate(ctx context.Context, d *schema.ResourceData, m i
 			"=> check your config", d.Get("name").(string)))
 	}
 
-	return resourceSecurityZoneRead(ctx, d, m)
+	return resourceSecurityZoneReadWJnprSess(d, m, jnprSess)
 }
 func resourceSecurityZoneRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourceSecurityZoneReadWJnprSess(d, m, jnprSess)
+}
+func resourceSecurityZoneReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	zoneOptions, err := readSecurityZone(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
 	if err != nil {
@@ -202,7 +205,7 @@ func resourceSecurityZoneUpdate(ctx context.Context, d *schema.ResourceData, m i
 	}
 	d.Partial(false)
 
-	return resourceSecurityZoneRead(ctx, d, m)
+	return resourceSecurityZoneReadWJnprSess(d, m, jnprSess)
 }
 func resourceSecurityZoneDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)

--- a/junos/resource_static_route.go
+++ b/junos/resource_static_route.go
@@ -223,8 +223,6 @@ func resourceStaticRouteCreate(ctx context.Context, d *schema.ResourceData, m in
 	staticRouteExists, err = checkStaticRouteExists(d.Get("destination").(string), d.Get("routing_instance").(string),
 		m, jnprSess)
 	if err != nil {
-		sess.configClear(jnprSess)
-
 		return diag.FromErr(err)
 	}
 	if staticRouteExists {

--- a/junos/resource_static_route.go
+++ b/junos/resource_static_route.go
@@ -234,18 +234,20 @@ func resourceStaticRouteCreate(ctx context.Context, d *schema.ResourceData, m in
 			"=> check your config", d.Get("destination").(string), d.Get("routing_instance").(string)))
 	}
 
-	return resourceStaticRouteRead(ctx, d, m)
+	return resourceStaticRouteReadWJnprSess(d, m, jnprSess)
 }
 func resourceStaticRouteRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourceStaticRouteReadWJnprSess(d, m, jnprSess)
+}
+func resourceStaticRouteReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	staticRouteOptions, err := readStaticRoute(d.Get("destination").(string), d.Get("routing_instance").(string),
 		m, jnprSess)
 	mutex.Unlock()
@@ -287,7 +289,7 @@ func resourceStaticRouteUpdate(ctx context.Context, d *schema.ResourceData, m in
 	}
 	d.Partial(false)
 
-	return resourceStaticRouteRead(ctx, d, m)
+	return resourceStaticRouteReadWJnprSess(d, m, jnprSess)
 }
 func resourceStaticRouteDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)

--- a/junos/resource_system.go
+++ b/junos/resource_system.go
@@ -468,18 +468,20 @@ func resourceSystemCreate(ctx context.Context, d *schema.ResourceData, m interfa
 
 	d.SetId("system")
 
-	return resourceSystemRead(ctx, d, m)
+	return resourceSystemReadWJnprSess(d, m, jnprSess)
 }
 func resourceSystemRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourceSystemReadWJnprSess(d, m, jnprSess)
+}
+func resourceSystemReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	systemOptions, err := readSystem(m, jnprSess)
 	mutex.Unlock()
 	if err != nil {
@@ -515,7 +517,7 @@ func resourceSystemUpdate(ctx context.Context, d *schema.ResourceData, m interfa
 	}
 	d.Partial(false)
 
-	return resourceSystemRead(ctx, d, m)
+	return resourceSystemReadWJnprSess(d, m, jnprSess)
 }
 func resourceSystemDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	return nil

--- a/junos/resource_system_ntp_server.go
+++ b/junos/resource_system_ntp_server.go
@@ -99,18 +99,21 @@ func resourceSystemNtpServerCreate(ctx context.Context, d *schema.ResourceData, 
 			"=> check your config", d.Get("address").(string)))
 	}
 
-	return resourceSystemNtpServerRead(ctx, d, m)
+	return resourceSystemNtpServerReadWJnprSess(d, m, jnprSess)
 }
 func resourceSystemNtpServerRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourceSystemNtpServerReadWJnprSess(d, m, jnprSess)
+}
+func resourceSystemNtpServerReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	ntpServerOptions, err := readSystemNtpServer(d.Get("address").(string), m, jnprSess)
 	mutex.Unlock()
 	if err != nil {
@@ -150,7 +153,7 @@ func resourceSystemNtpServerUpdate(ctx context.Context, d *schema.ResourceData, 
 	}
 	d.Partial(false)
 
-	return resourceSystemNtpServerRead(ctx, d, m)
+	return resourceSystemNtpServerReadWJnprSess(d, m, jnprSess)
 }
 func resourceSystemNtpServerDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)

--- a/junos/resource_system_radius_server.go
+++ b/junos/resource_system_radius_server.go
@@ -158,18 +158,21 @@ func resourceSystemRadiusServerCreate(ctx context.Context, d *schema.ResourceDat
 			"=> check your config", d.Get("address").(string)))
 	}
 
-	return resourceSystemRadiusServerRead(ctx, d, m)
+	return resourceSystemRadiusServerReadWJnprSess(d, m, jnprSess)
 }
 func resourceSystemRadiusServerRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourceSystemRadiusServerReadWJnprSess(d, m, jnprSess)
+}
+func resourceSystemRadiusServerReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	radiusServerOptions, err := readSystemRadiusServer(d.Get("address").(string), m, jnprSess)
 	mutex.Unlock()
 	if err != nil {
@@ -209,7 +212,7 @@ func resourceSystemRadiusServerUpdate(ctx context.Context, d *schema.ResourceDat
 	}
 	d.Partial(false)
 
-	return resourceSystemRadiusServerRead(ctx, d, m)
+	return resourceSystemRadiusServerReadWJnprSess(d, m, jnprSess)
 }
 func resourceSystemRadiusServerDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)

--- a/junos/resource_system_syslog_file.go
+++ b/junos/resource_system_syslog_file.go
@@ -272,18 +272,21 @@ func resourceSystemSyslogFileCreate(ctx context.Context, d *schema.ResourceData,
 			"=> check your config", d.Get("filename").(string)))
 	}
 
-	return resourceSystemSyslogFileRead(ctx, d, m)
+	return resourceSystemSyslogFileReadWJnprSess(d, m, jnprSess)
 }
 func resourceSystemSyslogFileRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourceSystemSyslogFileReadWJnprSess(d, m, jnprSess)
+}
+func resourceSystemSyslogFileReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	syslogFileOptions, err := readSystemSyslogFile(d.Get("filename").(string), m, jnprSess)
 	mutex.Unlock()
 	if err != nil {
@@ -323,7 +326,7 @@ func resourceSystemSyslogFileUpdate(ctx context.Context, d *schema.ResourceData,
 	}
 	d.Partial(false)
 
-	return resourceSystemSyslogFileRead(ctx, d, m)
+	return resourceSystemSyslogFileReadWJnprSess(d, m, jnprSess)
 }
 func resourceSystemSyslogFileDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)

--- a/junos/resource_system_syslog_host.go
+++ b/junos/resource_system_syslog_host.go
@@ -230,18 +230,21 @@ func resourceSystemSyslogHostCreate(ctx context.Context, d *schema.ResourceData,
 			"=> check your config", d.Get("host").(string)))
 	}
 
-	return resourceSystemSyslogHostRead(ctx, d, m)
+	return resourceSystemSyslogHostReadWJnprSess(d, m, jnprSess)
 }
 func resourceSystemSyslogHostRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourceSystemSyslogHostReadWJnprSess(d, m, jnprSess)
+}
+func resourceSystemSyslogHostReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	syslogHostOptions, err := readSystemSyslogHost(d.Get("host").(string), m, jnprSess)
 	mutex.Unlock()
 	if err != nil {
@@ -281,7 +284,7 @@ func resourceSystemSyslogHostUpdate(ctx context.Context, d *schema.ResourceData,
 	}
 	d.Partial(false)
 
-	return resourceSystemSyslogHostRead(ctx, d, m)
+	return resourceSystemSyslogHostReadWJnprSess(d, m, jnprSess)
 }
 func resourceSystemSyslogHostDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)

--- a/junos/resource_vlan.go
+++ b/junos/resource_vlan.go
@@ -189,18 +189,20 @@ func resourceVlanCreate(ctx context.Context, d *schema.ResourceData, m interface
 		return diag.FromErr(fmt.Errorf("vlan %v not exists after commit => check your config", d.Get("name").(string)))
 	}
 
-	return resourceVlanRead(ctx, d, m)
+	return resourceVlanReadWJnprSess(d, m, jnprSess)
 }
 func resourceVlanRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	mutex.Lock()
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
-		mutex.Unlock()
-
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
+
+	return resourceVlanReadWJnprSess(d, m, jnprSess)
+}
+func resourceVlanReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
 	vlanOptions, err := readVlan(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
 	if err != nil {
@@ -240,7 +242,7 @@ func resourceVlanUpdate(ctx context.Context, d *schema.ResourceData, m interface
 	}
 	d.Partial(false)
 
-	return resourceVlanRead(ctx, d, m)
+	return resourceVlanReadWJnprSess(d, m, jnprSess)
 }
 func resourceVlanDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)

--- a/junos/resource_vlan.go
+++ b/junos/resource_vlan.go
@@ -177,9 +177,7 @@ func resourceVlanCreate(ctx context.Context, d *schema.ResourceData, m interface
 
 		return diag.FromErr(err)
 	}
-	mutex.Lock()
 	vlanExists, err = checkVlansExists(d.Get("name").(string), m, jnprSess)
-	mutex.Unlock()
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/junos/session.go
+++ b/junos/session.go
@@ -10,17 +10,18 @@ import (
 
 // Session information for connect to Junos Device.
 type Session struct {
-	junosPort        int
-	junosSleep       int
-	junosSleepShort  int
-	junosIP          string
-	junosUserName    string
-	junosPassword    string
-	junosSSHKeyPEM   string
-	junosSSHKeyFile  string
-	junosKeyPass     string
-	junosGroupIntDel string
-	junosLogFile     string
+	junosPort           int
+	junosSleepLock      int
+	junosSleepShort     int
+	junosSleepSSHClosed int
+	junosIP             string
+	junosUserName       string
+	junosPassword       string
+	junosSSHKeyPEM      string
+	junosSSHKeyFile     string
+	junosKeyPass        string
+	junosGroupIntDel    string
+	junosLogFile        string
 }
 
 func (sess *Session) startNewSession() (*NetconfObject, error) {
@@ -62,7 +63,7 @@ func (sess *Session) startNewSession() (*NetconfObject, error) {
 	return jnpr, nil
 }
 func (sess *Session) closeSession(jnpr *NetconfObject) {
-	err := jnpr.Close()
+	err := jnpr.Close(sess.junosSleepSSHClosed)
 	if sess.junosLogFile != "" {
 		if err != nil {
 			logFile(fmt.Sprintf("[closeSession] err: %q", err), sess.junosLogFile)
@@ -154,7 +155,7 @@ func (sess *Session) configLock(jnpr *NetconfObject) {
 			if sess.junosLogFile != "" {
 				logFile("[configLock] sleep for wait lock", sess.junosLogFile)
 			}
-			sleep(sess.junosSleep)
+			sleep(sess.junosSleepLock)
 		}
 	}
 }
@@ -165,7 +166,7 @@ func (sess *Session) configClear(jnpr *NetconfObject) {
 		logFile("[configClear] config clear", sess.junosLogFile)
 	}
 	if err != nil {
-		err := jnpr.Close()
+		err := jnpr.Close(sess.junosSleepSSHClosed)
 		if err != nil && sess.junosLogFile != "" {
 			logFile(fmt.Sprintf("[configClear] close err: %q", err), sess.junosLogFile)
 		}
@@ -177,7 +178,7 @@ func (sess *Session) configClear(jnpr *NetconfObject) {
 		logFile("[configClear] config unlock", sess.junosLogFile)
 	}
 	if err != nil {
-		err := jnpr.Close()
+		err := jnpr.Close(sess.junosSleepSSHClosed)
 		if err != nil && sess.junosLogFile != "" {
 			logFile(fmt.Sprintf("[configClear] close err: %q", err), sess.junosLogFile)
 		}

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -111,13 +111,19 @@ The following arguments are supported in the `provider` block:
 
 ---
 #### Command options
-* `cmd_sleep_short` - (Optional) Number of milliseconds to wait after Terraform executes an action on the Junos device.  
+* `cmd_sleep_short` - (Optional) Number of milliseconds to wait after Terraform provider executes an action on the Junos device.  
   It can also be sourced from the `JUNOS_SLEEP_SHORT` environment variable.  
   Defaults to `100`.
 
-* `cmd_sleep_lock` - (Optional) Number of seconds of standby while waiting for Terraform to lock candidate configuration on a Junos device.  
+* `cmd_sleep_lock` - (Optional) Number of seconds of standby while waiting for Terraform provider to lock candidate configuration on a Junos device.  
   It can also be sourced from the `JUNOS_SLEEP_LOCK` environment variable.  
   Defaults to `10`.
+
+---
+#### SSH options
+* `ssh_sleep_closed` - (Optional) Number of seconds to wait after Terraform provider closed a ssh connection.  
+  It can also be sourced from the `JUNOS_SLEEP_SSH_CLOSED` environment variable.  
+  Defaults to `0`.
 
 ---
 #### Debug options

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -154,3 +154,21 @@ ge-0/0/3 {
 ```
 
 and considers the interface available if the is this lines and only this lines on interface.
+
+## Number of ssh connections and netconf commands
+
+By default, terraform run with 10 parrallel actions, cf [walks the graph](https://www.terraform.io/docs/internals/graph.html#walking-the-graph).
+
+With N for terraform's [`-parallelism`](https://www.terraform.io/docs/commands/plan.html#parallelism-n) argument, this provider :
+
+* open N ssh connections.
+* reduce the parrallelism of netconf `show` commands parrallelism under N with a mutex lock.
+* lock the Junos configuration before adding `set` lines and execute `commit` so one `commit` at a time (other threads wait for locking).
+
+To reduce :
+
+* rate of parallel ssh connections, reduce parallelism with terraform's [`-parallelism`](https://www.terraform.io/docs/commands/plan.html#parallelism-n) argument.
+* rate of new ssh connections by second, increase the provider's [`ssh_sleep_closed`](#ssh_sleep_closed) argument.
+* rate of netconf commands by second on ssh connections, increase the provider's [`cmd_sleep_short`](#cmd_sleep_short) argument.
+
+To increase the speed of `commit` (if your Junos device is quick to commit), decrease the provider's [`cmd_sleep_lock`](#cmd_sleep_lock) argument (be safe, too small is counterproductive).


### PR DESCRIPTION
ENHANCEMENTS:
* add `ssh_sleep_closed` argument in provider configuration (Fixes part of [#87](https://github.com/jeremmfr/terraform-provider-junos/issues/87))

BUG FIXES:
* add missing lock in data source to reduce netconf commands parallelism
* use only one ssh connection per action and per resource (Fixes part of [#87](https://github.com/jeremmfr/terraform-provider-junos/issues/87))