### PR TITLE
Fixes #88: add support for system login options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## upcoming release
 ENHANCEMENTS:
+* add `login` argument in `junos_system` resource (Fixes parts of [#88](https://github.com/jeremmfr/terraform-provider-junos/issues/88))
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ENHANCEMENTS:
 * add `login` argument in `junos_system` resource (Fixes parts of [#88](https://github.com/jeremmfr/terraform-provider-junos/issues/88))
 * add `junos_system_login_class` resource (Fixes parts of [#88](https://github.com/jeremmfr/terraform-provider-junos/issues/88))
+* add `junos_system_login_user` resource (Fixes parts of [#88](https://github.com/jeremmfr/terraform-provider-junos/issues/88))
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## upcoming release
 ENHANCEMENTS:
 * add `login` argument in `junos_system` resource (Fixes parts of [#88](https://github.com/jeremmfr/terraform-provider-junos/issues/88))
+* add `junos_system_login_class` resource (Fixes parts of [#88](https://github.com/jeremmfr/terraform-provider-junos/issues/88))
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ ENHANCEMENTS:
 * add `login` argument in `junos_system` resource (Fixes parts of [#88](https://github.com/jeremmfr/terraform-provider-junos/issues/88))
 * add `junos_system_login_class` resource (Fixes parts of [#88](https://github.com/jeremmfr/terraform-provider-junos/issues/88))
 * add `junos_system_login_user` resource (Fixes parts of [#88](https://github.com/jeremmfr/terraform-provider-junos/issues/88))
+* add `junos_system_root_authentication` resource
 
 BUG FIXES:
 

--- a/junos/provider.go
+++ b/junos/provider.go
@@ -147,6 +147,7 @@ func Provider() *schema.Provider {
 			"junos_static_route":                                         resourceStaticRoute(),
 			"junos_system":                                               resourceSystem(),
 			"junos_system_login_class":                                   resourceSystemLoginClass(),
+			"junos_system_login_user":                                    resourceSystemLoginUser(),
 			"junos_system_ntp_server":                                    resourceSystemNtpServer(),
 			"junos_system_radius_server":                                 resourceSystemRadiusServer(),
 			"junos_system_syslog_host":                                   resourceSystemSyslogHost(),

--- a/junos/provider.go
+++ b/junos/provider.go
@@ -150,6 +150,7 @@ func Provider() *schema.Provider {
 			"junos_system_login_user":                                    resourceSystemLoginUser(),
 			"junos_system_ntp_server":                                    resourceSystemNtpServer(),
 			"junos_system_radius_server":                                 resourceSystemRadiusServer(),
+			"junos_system_root_authentication":                           resourceSystemRootAuthentication(),
 			"junos_system_syslog_host":                                   resourceSystemSyslogHost(),
 			"junos_system_syslog_file":                                   resourceSystemSyslogFile(),
 			"junos_vlan":                                                 resourceVlan(),

--- a/junos/provider.go
+++ b/junos/provider.go
@@ -146,6 +146,7 @@ func Provider() *schema.Provider {
 			"junos_security_zone":                                        resourceSecurityZone(),
 			"junos_static_route":                                         resourceStaticRoute(),
 			"junos_system":                                               resourceSystem(),
+			"junos_system_login_class":                                   resourceSystemLoginClass(),
 			"junos_system_ntp_server":                                    resourceSystemNtpServer(),
 			"junos_system_radius_server":                                 resourceSystemRadiusServer(),
 			"junos_system_syslog_host":                                   resourceSystemSyslogHost(),

--- a/junos/resource_system.go
+++ b/junos/resource_system.go
@@ -27,6 +27,7 @@ type systemOptions struct {
 	nameServer                           []string
 	inet6BackupRouter                    []map[string]interface{}
 	internetOptions                      []map[string]interface{}
+	login                                []map[string]interface{}
 	services                             []map[string]interface{}
 	syslog                               []map[string]interface{}
 }
@@ -223,6 +224,138 @@ func resourceSystem() *schema.Resource {
 							Type:         schema.TypeInt,
 							Optional:     true,
 							ValidateFunc: validation.IntBetween(64, 65535),
+						},
+					},
+				},
+			},
+			"login": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"announcement": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"deny_sources_address": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"idle_timeout": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(1, 60),
+						},
+						"message": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"password": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"change_type": {
+										Type:     schema.TypeString,
+										Optional: true,
+										ValidateFunc: validation.StringInSlice([]string{
+											"character-sets", "set-transitions"}, false),
+									},
+									"format": {
+										Type:     schema.TypeString,
+										Optional: true,
+										ValidateFunc: validation.StringInSlice([]string{
+											"sha1", "sha256", "sha512"}, false),
+									},
+									"maximum_length": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(20, 128),
+									},
+									"minimum_changes": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(1, 128),
+									},
+									"minimum_character_changes": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(4, 15),
+									},
+									"minimum_length": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(6, 20),
+									},
+									"minimum_lower_cases": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(1, 128),
+									},
+									"minimum_numerics": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(1, 128),
+									},
+									"minimum_punctuations": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(1, 128),
+									},
+									"minimum_reuse": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(1, 20),
+									},
+									"minimum_upper_cases": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(1, 128),
+									},
+								},
+							},
+						},
+						"retry_options": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"backoff_factor": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(5, 10),
+									},
+									"backoff_threshold": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(1, 3),
+									},
+									"lockout_period": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(1, 43200),
+									},
+									"maximum_time": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(20, 300),
+									},
+									"minimum_time": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(20, 60),
+									},
+									"tries_before_disconnect": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(2, 10),
+									},
+								},
+							},
 						},
 					},
 				},
@@ -567,6 +700,9 @@ func setSystem(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) e
 	if err := setSystemInternetOptions(d, m, jnprSess); err != nil {
 		return err
 	}
+	if err := setSystemLogin(d, m, jnprSess); err != nil {
+		return err
+	}
 	if d.Get("max_configuration_rollbacks").(int) != -1 {
 		configSet = append(configSet, setPrefix+
 			"max-configuration-rollbacks "+strconv.Itoa(d.Get("max_configuration_rollbacks").(int)))
@@ -855,6 +991,125 @@ func setSystemInternetOptions(d *schema.ResourceData, m interface{}, jnprSess *N
 	return nil
 }
 
+func setSystemLogin(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) error {
+	sess := m.(*Session)
+	setPrefix := "set system login "
+	configSet := make([]string, 0)
+	for _, v := range d.Get("login").([]interface{}) {
+		if v == nil {
+			return fmt.Errorf("login block is empty")
+		}
+		login := v.(map[string]interface{})
+		if login["announcement"].(string) != "" {
+			configSet = append(configSet, setPrefix+"announcement \""+login["announcement"].(string)+"\"")
+		}
+		for _, denySrcAddress := range login["deny_sources_address"].([]interface{}) {
+			configSet = append(configSet, setPrefix+"deny-sources address "+denySrcAddress.(string))
+		}
+		if login["idle_timeout"].(int) != 0 {
+			configSet = append(configSet, setPrefix+"idle-timeout "+strconv.Itoa(login["idle_timeout"].(int)))
+		}
+		if login["message"].(string) != "" {
+			configSet = append(configSet, setPrefix+"message \""+login["message"].(string)+"\"")
+		}
+		for _, v2 := range login["password"].([]interface{}) {
+			if v2 == nil {
+				return fmt.Errorf("login.0.password block is empty")
+			}
+			loginPassword := v2.(map[string]interface{})
+			if loginPassword["change_type"].(string) != "" {
+				configSet = append(configSet,
+					setPrefix+"password change-type "+loginPassword["change_type"].(string))
+			}
+			if loginPassword["format"].(string) != "" {
+				configSet = append(configSet,
+					setPrefix+"password format "+loginPassword["format"].(string))
+			}
+			if loginPassword["maximum_length"].(int) != 0 {
+				configSet = append(configSet,
+					setPrefix+"password maximum-length "+strconv.Itoa(loginPassword["maximum_length"].(int)))
+			}
+			if loginPassword["minimum_changes"].(int) != 0 {
+				configSet = append(configSet,
+					setPrefix+"password minimum-changes "+strconv.Itoa(loginPassword["minimum_changes"].(int)))
+			}
+			if loginPassword["minimum_character_changes"].(int) != 0 {
+				configSet = append(configSet, setPrefix+"password minimum-character-changes "+
+					strconv.Itoa(loginPassword["minimum_character_changes"].(int)))
+			}
+			if loginPassword["minimum_length"].(int) != 0 {
+				configSet = append(configSet, setPrefix+"password minimum-length "+
+					strconv.Itoa(loginPassword["minimum_length"].(int)))
+			}
+			if loginPassword["minimum_lower_cases"].(int) != 0 {
+				configSet = append(configSet, setPrefix+"password minimum-lower-cases "+
+					strconv.Itoa(loginPassword["minimum_lower_cases"].(int)))
+			}
+			if loginPassword["minimum_numerics"].(int) != 0 {
+				configSet = append(configSet, setPrefix+"password minimum-numerics "+
+					strconv.Itoa(loginPassword["minimum_numerics"].(int)))
+			}
+			if loginPassword["minimum_punctuations"].(int) != 0 {
+				configSet = append(configSet, setPrefix+"password minimum-punctuations "+
+					strconv.Itoa(loginPassword["minimum_punctuations"].(int)))
+			}
+			if loginPassword["minimum_reuse"].(int) != 0 {
+				configSet = append(configSet, setPrefix+"password minimum-reuse "+
+					strconv.Itoa(loginPassword["minimum_reuse"].(int)))
+			}
+			if loginPassword["minimum_upper_cases"].(int) != 0 {
+				configSet = append(configSet, setPrefix+"password minimum-upper-cases "+
+					strconv.Itoa(loginPassword["minimum_upper_cases"].(int)))
+			}
+		}
+		for _, v2 := range login["retry_options"].([]interface{}) {
+			if v2 == nil {
+				return fmt.Errorf("login.0.retry_options block is empty")
+			}
+			loginRetryOptions := v2.(map[string]interface{})
+			if loginRetryOptions["backoff_factor"].(int) != 0 {
+				configSet = append(configSet, setPrefix+"retry-options backoff-factor "+
+					strconv.Itoa(loginRetryOptions["backoff_factor"].(int)))
+			}
+			if loginRetryOptions["backoff_threshold"].(int) != 0 {
+				configSet = append(configSet, setPrefix+"retry-options backoff-threshold "+
+					strconv.Itoa(loginRetryOptions["backoff_threshold"].(int)))
+			}
+			if loginRetryOptions["lockout_period"].(int) != 0 {
+				configSet = append(configSet, setPrefix+"retry-options lockout-period "+
+					strconv.Itoa(loginRetryOptions["lockout_period"].(int)))
+			}
+			if loginRetryOptions["maximum_time"].(int) != 0 {
+				configSet = append(configSet, setPrefix+"retry-options maximum-time "+
+					strconv.Itoa(loginRetryOptions["maximum_time"].(int)))
+			}
+			if loginRetryOptions["minimum_time"].(int) != 0 {
+				configSet = append(configSet, setPrefix+"retry-options minimum-time "+
+					strconv.Itoa(loginRetryOptions["minimum_time"].(int)))
+			}
+			if loginRetryOptions["tries_before_disconnect"].(int) != 0 {
+				configSet = append(configSet, setPrefix+"retry-options tries-before-disconnect "+
+					strconv.Itoa(loginRetryOptions["tries_before_disconnect"].(int)))
+			}
+		}
+	}
+	if err := sess.configSet(configSet, jnprSess); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func listLinesLogin() []string {
+	return []string{
+		"login announcement",
+		"login deny-sources",
+		"login idle-timeout",
+		"login message",
+		"login password",
+		"login retry-options",
+	}
+}
 func listLinesServices() []string {
 	ls := make([]string, 0)
 	ls = append(ls, listLinesServicesSSH()...)
@@ -900,6 +1155,7 @@ func delSystem(m interface{}, jnprSess *NetconfObject) error {
 	listLinesToDelete = append(listLinesToDelete, "host-name")
 	listLinesToDelete = append(listLinesToDelete, "inet6-backup-router")
 	listLinesToDelete = append(listLinesToDelete, "internet-options")
+	listLinesToDelete = append(listLinesToDelete, listLinesLogin()...)
 	listLinesToDelete = append(listLinesToDelete, "max-configuration-rollbacks")
 	listLinesToDelete = append(listLinesToDelete, "max-configurations-on-flash")
 	listLinesToDelete = append(listLinesToDelete, "name-server")
@@ -975,6 +1231,10 @@ func readSystem(m interface{}, jnprSess *NetconfObject) (systemOptions, error) {
 				if err := readSystemInternetOptions(&confRead, itemTrim); err != nil {
 					return confRead, err
 				}
+			case checkStringHasPrefixInList(itemTrim, listLinesLogin()):
+				if err := readSystemLogin(&confRead, itemTrim); err != nil {
+					return confRead, err
+				}
 			case strings.HasPrefix(itemTrim, "max-configuration-rollbacks "):
 				var err error
 				confRead.maxConfigurationRollbacks, err = strconv.Atoi(strings.TrimPrefix(itemTrim, "max-configuration-rollbacks "))
@@ -1022,6 +1282,180 @@ func readSystem(m interface{}, jnprSess *NetconfObject) (systemOptions, error) {
 	}
 
 	return confRead, nil
+}
+
+func readSystemLogin(confRead *systemOptions, itemTrim string) error {
+	if len(confRead.login) == 0 {
+		confRead.login = append(confRead.login, map[string]interface{}{
+			"announcement":         "",
+			"deny_sources_address": make([]string, 0),
+			"idle_timeout":         0,
+			"message":              "",
+			"password":             make([]map[string]interface{}, 0),
+			"retry_options":        make([]map[string]interface{}, 0),
+		})
+	}
+	switch {
+	case strings.HasPrefix(itemTrim, "login announcement "):
+		confRead.login[0]["announcement"] = strings.Trim(strings.TrimPrefix(itemTrim, "login announcement "), "\"")
+	case strings.HasPrefix(itemTrim, "login deny-sources address "):
+		confRead.login[0]["deny_sources_address"] = append(confRead.login[0]["deny_sources_address"].([]string),
+			strings.TrimPrefix(itemTrim, "login deny-sources address "))
+	case strings.HasPrefix(itemTrim, "login idle-timeout "):
+		var err error
+		confRead.login[0]["idle_timeout"], err = strconv.Atoi(strings.TrimPrefix(itemTrim, "login idle-timeout "))
+		if err != nil {
+			return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+		}
+	case strings.HasPrefix(itemTrim, "login message "):
+		confRead.login[0]["message"] = strings.Trim(strings.TrimPrefix(itemTrim, "login message "), "\"")
+	case strings.HasPrefix(itemTrim, "login password "):
+		if len(confRead.login[0]["password"].([]map[string]interface{})) == 0 {
+			confRead.login[0]["password"] = append(confRead.login[0]["password"].([]map[string]interface{}),
+				map[string]interface{}{
+					"change_type":               "",
+					"format":                    "",
+					"maximum_length":            0,
+					"minimum_changes":           0,
+					"minimum_character_changes": 0,
+					"minimum_length":            0,
+					"minimum_lower_cases":       0,
+					"minimum_numerics":          0,
+					"minimum_punctuations":      0,
+					"minimum_reuse":             0,
+					"minimum_upper_cases":       0,
+				})
+		}
+		switch {
+		case strings.HasPrefix(itemTrim, "login password change-type "):
+			confRead.login[0]["password"].([]map[string]interface{})[0]["change_type"] =
+				strings.TrimPrefix(itemTrim, "login password change-type ")
+		case strings.HasPrefix(itemTrim, "login password format "):
+			confRead.login[0]["password"].([]map[string]interface{})[0]["format"] =
+				strings.TrimPrefix(itemTrim, "login password format ")
+		case strings.HasPrefix(itemTrim, "login password maximum-length "):
+			var err error
+			confRead.login[0]["password"].([]map[string]interface{})[0]["maximum_length"], err =
+				strconv.Atoi(strings.TrimPrefix(itemTrim, "login password maximum-length "))
+			if err != nil {
+				return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+			}
+		case strings.HasPrefix(itemTrim, "login password minimum-changes "):
+			var err error
+			confRead.login[0]["password"].([]map[string]interface{})[0]["minimum_changes"], err =
+				strconv.Atoi(strings.TrimPrefix(itemTrim, "login password minimum-changes "))
+			if err != nil {
+				return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+			}
+		case strings.HasPrefix(itemTrim, "login password minimum-character-changes "):
+			var err error
+			confRead.login[0]["password"].([]map[string]interface{})[0]["minimum_character_changes"], err =
+				strconv.Atoi(strings.TrimPrefix(itemTrim, "login password minimum-character-changes "))
+			if err != nil {
+				return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+			}
+		case strings.HasPrefix(itemTrim, "login password minimum-length "):
+			var err error
+			confRead.login[0]["password"].([]map[string]interface{})[0]["minimum_length"], err =
+				strconv.Atoi(strings.TrimPrefix(itemTrim, "login password minimum-length "))
+			if err != nil {
+				return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+			}
+		case strings.HasPrefix(itemTrim, "login password minimum-lower-cases "):
+			var err error
+			confRead.login[0]["password"].([]map[string]interface{})[0]["minimum_lower_cases"], err =
+				strconv.Atoi(strings.TrimPrefix(itemTrim, "login password minimum-lower-cases "))
+			if err != nil {
+				return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+			}
+		case strings.HasPrefix(itemTrim, "login password minimum-numerics "):
+			var err error
+			confRead.login[0]["password"].([]map[string]interface{})[0]["minimum_numerics"], err =
+				strconv.Atoi(strings.TrimPrefix(itemTrim, "login password minimum-numerics "))
+			if err != nil {
+				return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+			}
+		case strings.HasPrefix(itemTrim, "login password minimum-punctuations "):
+			var err error
+			confRead.login[0]["password"].([]map[string]interface{})[0]["minimum_punctuations"], err =
+				strconv.Atoi(strings.TrimPrefix(itemTrim, "login password minimum-punctuations "))
+			if err != nil {
+				return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+			}
+		case strings.HasPrefix(itemTrim, "login password minimum-reuse "):
+			var err error
+			confRead.login[0]["password"].([]map[string]interface{})[0]["minimum_reuse"], err =
+				strconv.Atoi(strings.TrimPrefix(itemTrim, "login password minimum-reuse "))
+			if err != nil {
+				return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+			}
+		case strings.HasPrefix(itemTrim, "login password minimum-upper-cases "):
+			var err error
+			confRead.login[0]["password"].([]map[string]interface{})[0]["minimum_upper_cases"], err =
+				strconv.Atoi(strings.TrimPrefix(itemTrim, "login password minimum-upper-cases "))
+			if err != nil {
+				return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+			}
+		}
+	case strings.HasPrefix(itemTrim, "login retry-options "):
+		if len(confRead.login[0]["retry_options"].([]map[string]interface{})) == 0 {
+			confRead.login[0]["retry_options"] = append(confRead.login[0]["retry_options"].([]map[string]interface{}),
+				map[string]interface{}{
+					"backoff_factor":          0,
+					"backoff_threshold":       0,
+					"lockout_period":          0,
+					"maximum_time":            0,
+					"minimum_time":            0,
+					"tries_before_disconnect": 0,
+				})
+		}
+		switch {
+		case strings.HasPrefix(itemTrim, "login retry-options backoff-factor "):
+			var err error
+			confRead.login[0]["retry_options"].([]map[string]interface{})[0]["backoff_factor"], err =
+				strconv.Atoi(strings.TrimPrefix(itemTrim, "login retry-options backoff-factor "))
+			if err != nil {
+				return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+			}
+		case strings.HasPrefix(itemTrim, "login retry-options backoff-threshold "):
+			var err error
+			confRead.login[0]["retry_options"].([]map[string]interface{})[0]["backoff_threshold"], err =
+				strconv.Atoi(strings.TrimPrefix(itemTrim, "login retry-options backoff-threshold "))
+			if err != nil {
+				return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+			}
+		case strings.HasPrefix(itemTrim, "login retry-options lockout-period "):
+			var err error
+			confRead.login[0]["retry_options"].([]map[string]interface{})[0]["lockout_period"], err =
+				strconv.Atoi(strings.TrimPrefix(itemTrim, "login retry-options lockout-period "))
+			if err != nil {
+				return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+			}
+		case strings.HasPrefix(itemTrim, "login retry-options maximum-time "):
+			var err error
+			confRead.login[0]["retry_options"].([]map[string]interface{})[0]["maximum_time"], err =
+				strconv.Atoi(strings.TrimPrefix(itemTrim, "login retry-options maximum-time "))
+			if err != nil {
+				return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+			}
+		case strings.HasPrefix(itemTrim, "login retry-options minimum-time "):
+			var err error
+			confRead.login[0]["retry_options"].([]map[string]interface{})[0]["minimum_time"], err =
+				strconv.Atoi(strings.TrimPrefix(itemTrim, "login retry-options minimum-time "))
+			if err != nil {
+				return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+			}
+		case strings.HasPrefix(itemTrim, "login retry-options tries-before-disconnect "):
+			var err error
+			confRead.login[0]["retry_options"].([]map[string]interface{})[0]["tries_before_disconnect"], err =
+				strconv.Atoi(strings.TrimPrefix(itemTrim, "login retry-options tries-before-disconnect "))
+			if err != nil {
+				return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+			}
+		}
+	}
+
+	return nil
 }
 
 func readSystemInternetOptions(confRead *systemOptions, itemTrim string) error {
@@ -1363,6 +1797,9 @@ func fillSystem(d *schema.ResourceData, systemOptions systemOptions) {
 		panic(tfErr)
 	}
 	if tfErr := d.Set("internet_options", systemOptions.internetOptions); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("login", systemOptions.login); tfErr != nil {
 		panic(tfErr)
 	}
 	if tfErr := d.Set("max_configuration_rollbacks", systemOptions.maxConfigurationRollbacks); tfErr != nil {

--- a/junos/resource_system_login_class.go
+++ b/junos/resource_system_login_class.go
@@ -1,0 +1,605 @@
+package junos
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+type systemLoginClassOptions struct {
+	allowHiddenCommands       bool
+	configurationBreadcrumbs  bool
+	loginAlarms               bool
+	loginTip                  bool
+	idleTimeout               int
+	name                      string
+	accessEnd                 string
+	accessStart               string
+	allowCommands             string
+	allowConfiguration        string
+	cliPrompt                 string
+	denyCommands              string
+	denyConfiguration         string
+	logicalSystem             string
+	loginScript               string
+	securityRole              string
+	tenant                    string
+	confirmCommands           []string
+	allowCommandsRegexps      []string
+	allowConfigurationRegexps []string
+	allowedDays               []string
+	denyCommandsRegexps       []string
+	denyConfigurationRegexps  []string
+	noHiddenCommandsExcept    []string
+	permissions               []string
+}
+
+func resourceSystemLoginClass() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSystemLoginClassCreate,
+		ReadContext:   resourceSystemLoginClassRead,
+		UpdateContext: resourceSystemLoginClassUpdate,
+		DeleteContext: resourceSystemLoginClassDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceSystemLoginClassImport,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:             schema.TypeString,
+				ForceNew:         true,
+				Required:         true,
+				ValidateDiagFunc: validateNameObjectJunos([]string{}),
+			},
+			"access_end": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				RequiredWith: []string{"access_end"},
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(
+					`^([0-1]\d|2[0-3]):([0-5]\d):([0-5]\d)$`), "must have HH:MM:SS format"),
+			},
+			"access_start": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				RequiredWith: []string{"access_end"},
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(
+					`^([0-1]\d|2[0-3]):([0-5]\d):([0-5]\d)$`), "must have HH:MM:SS format"),
+			},
+			"allow_commands": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"allow_commands_regexps"},
+			},
+			"allow_commands_regexps": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				ConflictsWith: []string{"allow_commands"},
+			},
+			"allow_configuration": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"allow_configuration_regexps"},
+			},
+			"allow_configuration_regexps": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				ConflictsWith: []string{"allow_configuration"},
+			},
+			"allow_hidden_commands": {
+				Type:          schema.TypeBool,
+				Optional:      true,
+				ConflictsWith: []string{"no_hidden_commands_except"},
+			},
+			"allowed_days": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"cli_prompt": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"configuration_breadcrumbs": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"confirm_commands": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"deny_commands": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"deny_commands_regexps"},
+			},
+			"deny_commands_regexps": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				ConflictsWith: []string{"deny_commands"},
+			},
+			"deny_configuration": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"deny_configuration_regexps"},
+			},
+			"deny_configuration_regexps": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				ConflictsWith: []string{"deny_configuration"},
+			},
+			"idle_timeout": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(1, 4294967295),
+			},
+			"logical_system": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"login_alarms": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"login_script": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"login_tip": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"no_hidden_commands_except": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				ConflictsWith: []string{"allow_hidden_commands"},
+			},
+			"permissions": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"security_role": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"audit-administrator", "crypto-administrator", "ids-administrator", "security-administrator"}, false),
+			},
+			"tenant": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceSystemLoginClassCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	sess.configLock(jnprSess)
+	systemLoginClassExists, err := checkSystemLoginClassExists(d.Get("name").(string), m, jnprSess)
+	if err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	if systemLoginClassExists {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(fmt.Errorf("system login class %v already exists", d.Get("name").(string)))
+	}
+
+	if err := setSystemLoginClass(d, m, jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	if err := sess.commitConf("create resource junos_system_login_class", jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	systemLoginClassExists, err = checkSystemLoginClassExists(d.Get("name").(string), m, jnprSess)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if systemLoginClassExists {
+		d.SetId(d.Get("name").(string))
+	} else {
+		return diag.FromErr(fmt.Errorf("system login class %v not exists after commit "+
+			"=> check your config", d.Get("name").(string)))
+	}
+
+	return resourceSystemLoginClassReadWJnprSess(d, m, jnprSess)
+}
+func resourceSystemLoginClassRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+
+	return resourceSystemLoginClassReadWJnprSess(d, m, jnprSess)
+}
+func resourceSystemLoginClassReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
+	systemLoginClassOptions, err := readSystemLoginClass(d.Get("name").(string), m, jnprSess)
+	mutex.Unlock()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if systemLoginClassOptions.name == "" {
+		d.SetId("")
+	} else {
+		fillSystemLoginClassData(d, systemLoginClassOptions)
+	}
+
+	return nil
+}
+func resourceSystemLoginClassUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	d.Partial(true)
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	sess.configLock(jnprSess)
+	if err := delSystemLoginClass(d.Get("name").(string), m, jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	if err := setSystemLoginClass(d, m, jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	if err := sess.commitConf("update resource junos_system_login_class", jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	d.Partial(false)
+
+	return resourceSystemLoginClassReadWJnprSess(d, m, jnprSess)
+}
+func resourceSystemLoginClassDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	sess.configLock(jnprSess)
+	if err := delSystemLoginClass(d.Get("name").(string), m, jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	if err := sess.commitConf("delete resource junos_system_login_class", jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+func resourceSystemLoginClassImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return nil, err
+	}
+	defer sess.closeSession(jnprSess)
+	result := make([]*schema.ResourceData, 1)
+
+	systemLoginClassExists, err := checkSystemLoginClassExists(d.Id(), m, jnprSess)
+	if err != nil {
+		return nil, err
+	}
+	if !systemLoginClassExists {
+		return nil, fmt.Errorf("don't find system login class with id '%v' (id must be <name>)", d.Id())
+	}
+	systemLoginClassOptions, err := readSystemLoginClass(d.Id(), m, jnprSess)
+	if err != nil {
+		return nil, err
+	}
+	fillSystemLoginClassData(d, systemLoginClassOptions)
+
+	result[0] = d
+
+	return result, nil
+}
+
+func checkSystemLoginClassExists(name string, m interface{}, jnprSess *NetconfObject) (bool, error) {
+	sess := m.(*Session)
+	systemLoginClassConfig, err := sess.command("show configuration system login class "+name+" | display set", jnprSess)
+	if err != nil {
+		return false, err
+	}
+	if systemLoginClassConfig == emptyWord {
+		return false, nil
+	}
+
+	return true, nil
+}
+func setSystemLoginClass(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) error {
+	sess := m.(*Session)
+	configSet := make([]string, 0)
+	setPrefix := "set system login class " + d.Get("name").(string) + " "
+
+	if d.Get("access_end").(string) != "" {
+		configSet = append(configSet, setPrefix+"access-end \""+d.Get("access_end").(string)+"\"")
+	}
+	if d.Get("access_start").(string) != "" {
+		configSet = append(configSet, setPrefix+"access-start \""+d.Get("access_start").(string)+"\"")
+	}
+	if d.Get("allow_commands").(string) != "" {
+		configSet = append(configSet, setPrefix+"allow-commands \""+d.Get("allow_commands").(string)+"\"")
+	}
+	for _, v := range d.Get("allow_commands_regexps").([]interface{}) {
+		configSet = append(configSet, setPrefix+"allow-commands-regexps \""+v.(string)+"\"")
+	}
+	if d.Get("allow_configuration").(string) != "" {
+		configSet = append(configSet, setPrefix+"allow-configuration \""+d.Get("allow_configuration").(string)+"\"")
+	}
+	for _, v := range d.Get("allow_configuration_regexps").([]interface{}) {
+		configSet = append(configSet, setPrefix+"allow-configuration-regexps \""+v.(string)+"\"")
+	}
+	if d.Get("allow_hidden_commands").(bool) {
+		configSet = append(configSet, setPrefix+"allow-hidden-commands")
+	}
+	for _, v := range d.Get("allowed_days").([]interface{}) {
+		configSet = append(configSet, setPrefix+"allowed-days "+v.(string))
+	}
+	if d.Get("configuration_breadcrumbs").(bool) {
+		configSet = append(configSet, setPrefix+"configuration-breadcrumbs")
+	}
+	if d.Get("cli_prompt").(string) != "" {
+		configSet = append(configSet, setPrefix+"cli prompt \""+d.Get("cli_prompt").(string)+"\"")
+	}
+	for _, v := range d.Get("confirm_commands").([]interface{}) {
+		configSet = append(configSet, setPrefix+"confirm-commands \""+v.(string)+"\"")
+	}
+	if d.Get("deny_commands").(string) != "" {
+		configSet = append(configSet, setPrefix+"deny-commands \""+d.Get("deny_commands").(string)+"\"")
+	}
+	for _, v := range d.Get("deny_commands_regexps").([]interface{}) {
+		configSet = append(configSet, setPrefix+"deny-commands-regexps \""+v.(string)+"\"")
+	}
+	if d.Get("deny_configuration").(string) != "" {
+		configSet = append(configSet, setPrefix+"deny-configuration \""+d.Get("deny_configuration").(string)+"\"")
+	}
+	for _, v := range d.Get("deny_configuration_regexps").([]interface{}) {
+		configSet = append(configSet, setPrefix+"deny-configuration-regexps \""+v.(string)+"\"")
+	}
+	if d.Get("idle_timeout").(int) != 0 {
+		configSet = append(configSet, setPrefix+"idle-timeout "+strconv.Itoa(d.Get("idle_timeout").(int)))
+	}
+	if d.Get("logical_system").(string) != "" {
+		configSet = append(configSet, setPrefix+"logical-system \""+d.Get("logical_system").(string)+"\"")
+	}
+	if d.Get("login_alarms").(bool) {
+		configSet = append(configSet, setPrefix+"login-alarms")
+	}
+	if d.Get("login_script").(string) != "" {
+		configSet = append(configSet, setPrefix+"login-script "+d.Get("login_script").(string))
+	}
+	if d.Get("login_tip").(bool) {
+		configSet = append(configSet, setPrefix+"login-tip")
+	}
+	for _, v := range d.Get("no_hidden_commands_except").([]interface{}) {
+		configSet = append(configSet, setPrefix+"no-hidden-commands except \""+v.(string)+"\"")
+	}
+	for _, v := range d.Get("permissions").(*schema.Set).List() {
+		configSet = append(configSet, setPrefix+"permissions "+v.(string))
+	}
+	if d.Get("security_role").(string) != "" {
+		configSet = append(configSet, setPrefix+"security-role "+d.Get("security_role").(string))
+	}
+	if d.Get("tenant").(string) != "" {
+		configSet = append(configSet, setPrefix+"tenant \""+d.Get("tenant").(string)+"\"")
+	}
+
+	if err := sess.configSet(configSet, jnprSess); err != nil {
+		return err
+	}
+
+	return nil
+}
+func readSystemLoginClass(class string, m interface{}, jnprSess *NetconfObject) (systemLoginClassOptions, error) {
+	sess := m.(*Session)
+	var confRead systemLoginClassOptions
+
+	systemLoginClassConfig, err := sess.command("show configuration system login class "+
+		class+" | display set relative", jnprSess)
+	if err != nil {
+		return confRead, err
+	}
+	if systemLoginClassConfig != emptyWord {
+		confRead.name = class
+		for _, item := range strings.Split(systemLoginClassConfig, "\n") {
+			if strings.Contains(item, "<configuration-output>") {
+				continue
+			}
+			if strings.Contains(item, "</configuration-output>") {
+				break
+			}
+			itemTrim := strings.TrimPrefix(item, setLineStart)
+			switch {
+			case strings.HasPrefix(itemTrim, "access-end "):
+				accessSplit := strings.Split(strings.Trim(strings.TrimPrefix(itemTrim, "access-end "), "\""), " ")
+				confRead.accessEnd = accessSplit[0]
+			case strings.HasPrefix(itemTrim, "access-start "):
+				accessSplit := strings.Split(strings.Trim(strings.TrimPrefix(itemTrim, "access-start "), "\""), " ")
+				confRead.accessStart = accessSplit[0]
+			case strings.HasPrefix(itemTrim, "allow-commands "):
+				confRead.allowCommands = strings.Trim(strings.TrimPrefix(itemTrim, "allow-commands "), "\"")
+			case strings.HasPrefix(itemTrim, "allow-commands-regexps "):
+				confRead.allowCommandsRegexps = append(confRead.allowCommandsRegexps,
+					strings.Trim(strings.TrimPrefix(itemTrim, "allow-commands-regexps "), "\""))
+			case strings.HasPrefix(itemTrim, "allow-configuration "):
+				confRead.allowConfiguration = strings.Trim(strings.TrimPrefix(itemTrim, "allow-configuration "), "\"")
+			case strings.HasPrefix(itemTrim, "allow-configuration-regexps "):
+				confRead.allowConfigurationRegexps = append(confRead.allowConfigurationRegexps,
+					strings.Trim(strings.TrimPrefix(itemTrim, "allow-configuration-regexps "), "\""))
+			case itemTrim == "allow-hidden-commands":
+				confRead.allowHiddenCommands = true
+			case strings.HasPrefix(itemTrim, "allowed-days "):
+				confRead.allowedDays = append(confRead.allowedDays, strings.TrimPrefix(itemTrim, "allowed-days "))
+			case itemTrim == "configuration-breadcrumbs":
+				confRead.configurationBreadcrumbs = true
+			case strings.HasPrefix(itemTrim, "cli prompt "):
+				confRead.cliPrompt = strings.Trim(strings.TrimPrefix(itemTrim, "cli prompt "), "\"")
+			case strings.HasPrefix(itemTrim, "confirm-commands "):
+				confRead.confirmCommands = append(confRead.confirmCommands,
+					strings.Trim(strings.TrimPrefix(itemTrim, "confirm-commands "), "\""))
+			case strings.HasPrefix(itemTrim, "deny-commands "):
+				confRead.denyCommands = strings.Trim(strings.TrimPrefix(itemTrim, "deny-commands "), "\"")
+			case strings.HasPrefix(itemTrim, "deny-commands-regexps "):
+				confRead.denyCommandsRegexps = append(confRead.denyCommandsRegexps,
+					strings.Trim(strings.TrimPrefix(itemTrim, "deny-commands-regexps "), "\""))
+			case strings.HasPrefix(itemTrim, "deny-configuration "):
+				confRead.denyConfiguration = strings.Trim(strings.TrimPrefix(itemTrim, "deny-configuration "), "\"")
+			case strings.HasPrefix(itemTrim, "deny-configuration-regexps "):
+				confRead.denyConfigurationRegexps = append(confRead.denyConfigurationRegexps,
+					strings.Trim(strings.TrimPrefix(itemTrim, "deny-configuration-regexps "), "\""))
+			case strings.HasPrefix(itemTrim, "idle-timeout "):
+				var err error
+				confRead.idleTimeout, err = strconv.Atoi(strings.TrimPrefix(itemTrim, "idle-timeout "))
+				if err != nil {
+					return confRead, fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+				}
+			case strings.HasPrefix(itemTrim, "logical-system "):
+				confRead.logicalSystem = strings.Trim(strings.TrimPrefix(itemTrim, "logical-system "), "\"")
+			case itemTrim == "login-alarms":
+				confRead.loginAlarms = true
+			case strings.HasPrefix(itemTrim, "login-script "):
+				confRead.loginScript = strings.TrimPrefix(itemTrim, "login-script ")
+			case itemTrim == "login-tip":
+				confRead.loginTip = true
+			case strings.HasPrefix(itemTrim, "no-hidden-commands except "):
+				confRead.noHiddenCommandsExcept = append(confRead.noHiddenCommandsExcept,
+					strings.Trim(strings.TrimPrefix(itemTrim, "no-hidden-commands except "), "\""))
+			case strings.HasPrefix(itemTrim, "permissions "):
+				confRead.permissions = append(confRead.permissions,
+					strings.TrimPrefix(itemTrim, "permissions "))
+			case strings.HasPrefix(itemTrim, "security-role "):
+				confRead.securityRole = strings.TrimPrefix(itemTrim, "security-role ")
+			case strings.HasPrefix(itemTrim, "tenant "):
+				confRead.tenant = strings.Trim(strings.TrimPrefix(itemTrim, "tenant "), "\"")
+			}
+		}
+	} else {
+		confRead.name = ""
+
+		return confRead, nil
+	}
+
+	return confRead, nil
+}
+
+func delSystemLoginClass(systemLoginClass string, m interface{}, jnprSess *NetconfObject) error {
+	sess := m.(*Session)
+	configSet := make([]string, 0, 1)
+	configSet = append(configSet, "delete system login class "+systemLoginClass)
+	if err := sess.configSet(configSet, jnprSess); err != nil {
+		return err
+	}
+
+	return nil
+}
+func fillSystemLoginClassData(d *schema.ResourceData, systemLoginClassOptions systemLoginClassOptions) {
+	if tfErr := d.Set("name", systemLoginClassOptions.name); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("access_end", systemLoginClassOptions.accessEnd); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("access_start", systemLoginClassOptions.accessStart); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("allow_commands", systemLoginClassOptions.allowCommands); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("allow_commands_regexps", systemLoginClassOptions.allowCommandsRegexps); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("allow_configuration", systemLoginClassOptions.allowConfiguration); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("allow_configuration_regexps", systemLoginClassOptions.allowConfigurationRegexps); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("allow_hidden_commands", systemLoginClassOptions.allowHiddenCommands); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("allowed_days", systemLoginClassOptions.allowedDays); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("cli_prompt", systemLoginClassOptions.cliPrompt); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("configuration_breadcrumbs", systemLoginClassOptions.configurationBreadcrumbs); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("confirm_commands", systemLoginClassOptions.confirmCommands); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("deny_commands", systemLoginClassOptions.denyCommands); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("deny_commands_regexps", systemLoginClassOptions.denyCommandsRegexps); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("deny_configuration", systemLoginClassOptions.denyConfiguration); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("deny_configuration_regexps", systemLoginClassOptions.denyConfigurationRegexps); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("idle_timeout", systemLoginClassOptions.idleTimeout); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("logical_system", systemLoginClassOptions.logicalSystem); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("login_alarms", systemLoginClassOptions.loginAlarms); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("login_script", systemLoginClassOptions.loginScript); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("login_tip", systemLoginClassOptions.loginTip); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("no_hidden_commands_except", systemLoginClassOptions.noHiddenCommandsExcept); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("permissions", systemLoginClassOptions.permissions); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("security_role", systemLoginClassOptions.securityRole); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("tenant", systemLoginClassOptions.tenant); tfErr != nil {
+		panic(tfErr)
+	}
+}

--- a/junos/resource_system_login_class_test.go
+++ b/junos/resource_system_login_class_test.go
@@ -1,0 +1,103 @@
+package junos_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccJunosSystemLoginClass_basic(t *testing.T) {
+	if os.Getenv("TESTACC_SWITCH") == "" {
+		resource.Test(t, resource.TestCase{
+			PreCheck:  func() { testAccPreCheck(t) },
+			Providers: testAccProviders,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccJunosSystemLoginClassConfigCreate(),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("junos_system_login_class.testacc",
+							"name", "testacc"),
+						resource.TestCheckResourceAttr("junos_system_login_class.testacc",
+							"allowed_days.#", "2"),
+						resource.TestCheckResourceAttr("junos_system_login_class.testacc",
+							"confirm_commands.#", "1"),
+						resource.TestCheckResourceAttr("junos_system_login_class.testacc",
+							"permissions.#", "2"),
+					),
+				},
+				{
+					Config: testAccJunosSystemLoginClassConfigUpdate(),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("junos_system_login_class.testacc",
+							"name", "testacc"),
+						resource.TestCheckResourceAttr("junos_system_login_class.testacc",
+							"allow_commands_regexps.#", "1"),
+						resource.TestCheckResourceAttr("junos_system_login_class.testacc",
+							"allow_configuration_regexps.#", "1"),
+						resource.TestCheckResourceAttr("junos_system_login_class.testacc",
+							"no_hidden_commands_except.#", "1"),
+						resource.TestCheckResourceAttr("junos_system_login_class.testacc",
+							"deny_commands_regexps.#", "1"),
+						resource.TestCheckResourceAttr("junos_system_login_class.testacc",
+							"deny_configuration_regexps.#", "1"),
+						resource.TestCheckResourceAttr("junos_system_login_class.testacc",
+							"allow_configuration_regexps.#", "1"),
+						resource.TestCheckResourceAttr("junos_system_login_class.testacc",
+							"allow_configuration_regexps.#", "1"),
+						resource.TestCheckResourceAttr("junos_system_login_class.testacc",
+							"permissions.#", "1"),
+					),
+				},
+				{
+					ResourceName:      "junos_system_login_class.testacc",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+			},
+		})
+	}
+}
+
+func testAccJunosSystemLoginClassConfigCreate() string {
+	return `
+resource "junos_system_login_class" "testacc" {
+  name                      = "testacc"
+  access_start              = "08:00:00"
+  access_end                = "18:00:00"
+  allow_commands            = ".*"
+  allow_configuration       = ".*"
+  allow_hidden_commands     = true
+  allowed_days              = ["sunday", "monday"]
+  cli_prompt                = "prompt cli"
+  configuration_breadcrumbs = true
+  confirm_commands          = ["confirm commands"]
+  deny_commands             = "request"
+  deny_configuration        = "system"
+  idle_timeout              = 120
+  login_alarms              = true
+  login_tip                 = true
+  permissions               = ["view", "floppy"]
+  security_role             = "security-administrator"
+}
+`
+}
+func testAccJunosSystemLoginClassConfigUpdate() string {
+	return `
+resource "junos_system_login_class" "testacc" {
+  name                        = "testacc"
+  access_start                = "08:00:00"
+  access_end                  = "18:00:00"
+  allow_commands_regexps      = [".*"]
+  allow_configuration_regexps = [".*"]
+  no_hidden_commands_except   = [".*"]
+  deny_commands_regexps       = ["request"]
+  deny_configuration_regexps  = ["system"]
+  idle_timeout                = 120
+  login_alarms                = true
+  login_tip                   = true
+  permissions                 = ["view"]
+  security_role               = "security-administrator"
+}
+`
+}

--- a/junos/resource_system_login_user.go
+++ b/junos/resource_system_login_user.go
@@ -1,0 +1,397 @@
+package junos
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"golang.org/x/crypto/ssh"
+)
+
+type systemLoginUserOptions struct {
+	uid            int
+	name           string
+	class          string
+	cliPrompt      string
+	fullName       string
+	authentication []map[string]interface{}
+}
+
+func resourceSystemLoginUser() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSystemLoginUserCreate,
+		ReadContext:   resourceSystemLoginUserRead,
+		UpdateContext: resourceSystemLoginUserUpdate,
+		DeleteContext: resourceSystemLoginUserDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceSystemLoginUserImport,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:             schema.TypeString,
+				ForceNew:         true,
+				Required:         true,
+				ValidateDiagFunc: validateNameObjectJunos([]string{}),
+			},
+			"class": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"cli_prompt": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"full_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"uid": {
+				Type:         schema.TypeInt,
+				ForceNew:     true,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IntBetween(100, 64000),
+			},
+			"authentication": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"encrypted_password": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"no_public_keys": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							ConflictsWith: []string{
+								"authentication.0.ssh_public_keys",
+							},
+						},
+						"ssh_public_keys": {
+							Type:          schema.TypeSet,
+							Optional:      true,
+							Elem:          &schema.Schema{Type: schema.TypeString},
+							ConflictsWith: []string{"authentication.0.no_public_keys"},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceSystemLoginUserCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	sess.configLock(jnprSess)
+	systemLoginUserExists, err := checkSystemLoginUserExists(d.Get("name").(string), m, jnprSess)
+	if err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	if systemLoginUserExists {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(fmt.Errorf("system login user %v already exists", d.Get("name").(string)))
+	}
+
+	if err := setSystemLoginUser(d, m, jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	if err := sess.commitConf("create resource junos_system_login_user", jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	systemLoginUserExists, err = checkSystemLoginUserExists(d.Get("name").(string), m, jnprSess)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if systemLoginUserExists {
+		d.SetId(d.Get("name").(string))
+	} else {
+		return diag.FromErr(fmt.Errorf("system login user %v not exists after commit "+
+			"=> check your config", d.Get("name").(string)))
+	}
+
+	return resourceSystemLoginUserReadWJnprSess(d, m, jnprSess)
+}
+func resourceSystemLoginUserRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+
+	return resourceSystemLoginUserReadWJnprSess(d, m, jnprSess)
+}
+func resourceSystemLoginUserReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
+	systemLoginUserOptions, err := readSystemLoginUser(d.Get("name").(string), m, jnprSess)
+	mutex.Unlock()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if systemLoginUserOptions.name == "" {
+		d.SetId("")
+	} else {
+		fillSystemLoginUserData(d, systemLoginUserOptions)
+	}
+
+	return nil
+}
+func resourceSystemLoginUserUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	d.Partial(true)
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	sess.configLock(jnprSess)
+	if err := delSystemLoginUser(d.Get("name").(string), m, jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	if err := setSystemLoginUser(d, m, jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	if err := sess.commitConf("update resource junos_system_login_user", jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	d.Partial(false)
+
+	return resourceSystemLoginUserReadWJnprSess(d, m, jnprSess)
+}
+func resourceSystemLoginUserDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	sess.configLock(jnprSess)
+	if err := delSystemLoginUser(d.Get("name").(string), m, jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	if err := sess.commitConf("delete resource junos_system_login_user", jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+func resourceSystemLoginUserImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return nil, err
+	}
+	defer sess.closeSession(jnprSess)
+	result := make([]*schema.ResourceData, 1)
+
+	systemLoginUserExists, err := checkSystemLoginUserExists(d.Id(), m, jnprSess)
+	if err != nil {
+		return nil, err
+	}
+	if !systemLoginUserExists {
+		return nil, fmt.Errorf("don't find system login user with id '%v' (id must be <name>)", d.Id())
+	}
+	systemLoginUserOptions, err := readSystemLoginUser(d.Id(), m, jnprSess)
+	if err != nil {
+		return nil, err
+	}
+	fillSystemLoginUserData(d, systemLoginUserOptions)
+
+	result[0] = d
+
+	return result, nil
+}
+
+func checkSystemLoginUserExists(name string, m interface{}, jnprSess *NetconfObject) (bool, error) {
+	sess := m.(*Session)
+	systemLoginUserConfig, err := sess.command("show configuration system login user "+name+" | display set", jnprSess)
+	if err != nil {
+		return false, err
+	}
+	if systemLoginUserConfig == emptyWord {
+		return false, nil
+	}
+
+	return true, nil
+}
+func setSystemLoginUser(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) error {
+	sess := m.(*Session)
+	configSet := make([]string, 0)
+	setPrefix := "set system login user " + d.Get("name").(string) + " "
+
+	configSet = append(configSet, setPrefix+"class "+d.Get("class").(string))
+
+	if d.Get("cli_prompt").(string) != "" {
+		configSet = append(configSet, setPrefix+"cli prompt \""+d.Get("cli_prompt").(string)+"\"")
+	}
+	if d.Get("full_name").(string) != "" {
+		configSet = append(configSet, setPrefix+"full-name \""+d.Get("full_name").(string)+"\"")
+	}
+	if d.Get("uid").(int) != 0 {
+		configSet = append(configSet, setPrefix+"uid "+strconv.Itoa(d.Get("uid").(int)))
+	}
+	for _, v := range d.Get("authentication").([]interface{}) {
+		if v == nil {
+			return fmt.Errorf("authentication block is empty")
+		}
+		authentication := v.(map[string]interface{})
+		if authentication["encrypted_password"].(string) != "" {
+			configSet = append(configSet, setPrefix+"authentication encrypted-password \""+
+				authentication["encrypted_password"].(string)+"\"")
+		}
+		if authentication["no_public_keys"].(bool) {
+			configSet = append(configSet, setPrefix+"authentication no-public-keys")
+		}
+		for _, v2 := range authentication["ssh_public_keys"].(*schema.Set).List() {
+			switch {
+			case strings.HasPrefix(v2.(string), ssh.KeyAlgoDSA):
+				configSet = append(configSet, setPrefix+"authentication ssh-dsa \""+v2.(string)+"\"")
+			case strings.HasPrefix(v2.(string), ssh.KeyAlgoRSA):
+				configSet = append(configSet, setPrefix+"authentication ssh-rsa \""+v2.(string)+"\"")
+			case strings.HasPrefix(v2.(string), ssh.KeyAlgoECDSA256),
+				strings.HasPrefix(v2.(string), ssh.KeyAlgoECDSA384),
+				strings.HasPrefix(v2.(string), ssh.KeyAlgoECDSA521):
+				configSet = append(configSet, setPrefix+"authentication ssh-ecdsa \""+v2.(string)+"\"")
+			case strings.HasPrefix(v2.(string), ssh.KeyAlgoED25519):
+				configSet = append(configSet, setPrefix+"authentication ssh-ed25519 \""+v2.(string)+"\"")
+			default:
+				return fmt.Errorf("format in public key '%v' not supported", v2.(string))
+			}
+		}
+	}
+
+	if err := sess.configSet(configSet, jnprSess); err != nil {
+		return err
+	}
+
+	return nil
+}
+func readSystemLoginUser(user string, m interface{}, jnprSess *NetconfObject) (systemLoginUserOptions, error) {
+	sess := m.(*Session)
+	var confRead systemLoginUserOptions
+
+	systemLoginUserConfig, err := sess.command("show configuration system login user "+
+		user+" | display set relative", jnprSess)
+	if err != nil {
+		return confRead, err
+	}
+	if systemLoginUserConfig != emptyWord {
+		confRead.name = user
+		for _, item := range strings.Split(systemLoginUserConfig, "\n") {
+			if strings.Contains(item, "<configuration-output>") {
+				continue
+			}
+			if strings.Contains(item, "</configuration-output>") {
+				break
+			}
+			itemTrim := strings.TrimPrefix(item, setLineStart)
+			switch {
+			case strings.HasPrefix(itemTrim, "class "):
+				confRead.class = strings.TrimPrefix(itemTrim, "class ")
+			case strings.HasPrefix(itemTrim, "cli prompt "):
+				confRead.cliPrompt = strings.Trim(strings.TrimPrefix(itemTrim, "cli prompt "), "\"")
+			case strings.HasPrefix(itemTrim, "full-name "):
+				confRead.fullName = strings.Trim(strings.TrimPrefix(itemTrim, "full-name "), "\"")
+			case strings.HasPrefix(itemTrim, "uid "):
+				var err error
+				confRead.uid, err = strconv.Atoi(strings.TrimPrefix(itemTrim, "uid "))
+				if err != nil {
+					return confRead, fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+				}
+			case strings.HasPrefix(itemTrim, "authentication "):
+				if len(confRead.authentication) == 0 {
+					confRead.authentication = append(confRead.authentication, map[string]interface{}{
+						"encrypted_password": "",
+						"no_public_keys":     false,
+						"ssh_public_keys":    make([]string, 0),
+					})
+				}
+				switch {
+				case strings.HasPrefix(itemTrim, "authentication encrypted-password "):
+					confRead.authentication[0]["encrypted_password"] = strings.Trim(strings.TrimPrefix(
+						itemTrim, "authentication encrypted-password "), "\"")
+				case itemTrim == "authentication no-public-keys":
+					confRead.authentication[0]["no_public_keys"] = true
+				case strings.HasPrefix(itemTrim, "authentication ssh-dsa "):
+					confRead.authentication[0]["ssh_public_keys"] = append(confRead.authentication[0]["ssh_public_keys"].([]string),
+						strings.Trim(strings.TrimPrefix(itemTrim, "authentication ssh-dsa "), "\""))
+				case strings.HasPrefix(itemTrim, "authentication ssh-ecdsa "):
+					confRead.authentication[0]["ssh_public_keys"] = append(confRead.authentication[0]["ssh_public_keys"].([]string),
+						strings.Trim(strings.TrimPrefix(itemTrim, "authentication ssh-ecdsa "), "\""))
+				case strings.HasPrefix(itemTrim, "authentication ssh-ed25519 "):
+					confRead.authentication[0]["ssh_public_keys"] = append(confRead.authentication[0]["ssh_public_keys"].([]string),
+						strings.Trim(strings.TrimPrefix(itemTrim, "authentication ssh-ed25519 "), "\""))
+				case strings.HasPrefix(itemTrim, "authentication ssh-rsa "):
+					confRead.authentication[0]["ssh_public_keys"] = append(confRead.authentication[0]["ssh_public_keys"].([]string),
+						strings.Trim(strings.TrimPrefix(itemTrim, "authentication ssh-rsa "), "\""))
+				}
+			}
+		}
+	} else {
+		confRead.name = ""
+
+		return confRead, nil
+	}
+
+	return confRead, nil
+}
+
+func delSystemLoginUser(systemLoginUser string, m interface{}, jnprSess *NetconfObject) error {
+	sess := m.(*Session)
+	configSet := make([]string, 0, 1)
+	configSet = append(configSet, "delete system login user "+systemLoginUser)
+	if err := sess.configSet(configSet, jnprSess); err != nil {
+		return err
+	}
+
+	return nil
+}
+func fillSystemLoginUserData(d *schema.ResourceData, systemLoginUserOptions systemLoginUserOptions) {
+	if tfErr := d.Set("name", systemLoginUserOptions.name); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("class", systemLoginUserOptions.class); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("cli_prompt", systemLoginUserOptions.cliPrompt); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("full_name", systemLoginUserOptions.fullName); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("uid", systemLoginUserOptions.uid); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("authentication", systemLoginUserOptions.authentication); tfErr != nil {
+		panic(tfErr)
+	}
+}

--- a/junos/resource_system_login_user_test.go
+++ b/junos/resource_system_login_user_test.go
@@ -1,0 +1,75 @@
+package junos_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccJunosSystemLoginUser_basic(t *testing.T) {
+	if os.Getenv("TESTACC_SWITCH") == "" {
+		resource.Test(t, resource.TestCase{
+			PreCheck:  func() { testAccPreCheck(t) },
+			Providers: testAccProviders,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccJunosSystemLoginUserConfigCreate(),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("junos_system_login_user.testacc",
+							"name", "testacc"),
+						resource.TestCheckResourceAttrSet("junos_system_login_user.testacc",
+							"uid"),
+						resource.TestCheckResourceAttr("junos_system_login_user.testacc",
+							"authentication.#", "1"),
+					),
+				},
+				{
+					Config: testAccJunosSystemLoginUserConfigUpdate(),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("junos_system_login_user.testacc",
+							"name", "testacc"),
+						resource.TestCheckResourceAttrSet("junos_system_login_user.testacc",
+							"uid"),
+						resource.TestCheckResourceAttr("junos_system_login_user.testacc",
+							"authentication.#", "1"),
+						resource.TestCheckResourceAttr("junos_system_login_user.testacc",
+							"authentication.0.ssh_public_keys.#", "1"),
+					),
+				},
+				{
+					ResourceName:      "junos_system_login_user.testacc",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+			},
+		})
+	}
+}
+
+func testAccJunosSystemLoginUserConfigCreate() string {
+	return `
+resource "junos_system_login_user" "testacc" {
+  name       = "testacc"
+  class      = "unauthorized"
+  cli_prompt = "test cli"
+  full_name  = "test name"
+  authentication {
+    encrypted_password = "test"
+    no_public_keys     = true
+  }
+}
+`
+}
+func testAccJunosSystemLoginUserConfigUpdate() string {
+	return `
+resource "junos_system_login_user" "testacc" {
+  name  = "testacc"
+  class = "unauthorized"
+  authentication {
+    encrypted_password = "test"
+    ssh_public_keys    = ["ssh-rsa testkey"]
+  }
+}
+`
+}

--- a/junos/resource_system_root_authentication.go
+++ b/junos/resource_system_root_authentication.go
@@ -1,0 +1,244 @@
+package junos
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"golang.org/x/crypto/ssh"
+)
+
+type systemRootAuthOptions struct {
+	noPublicKeys      bool
+	encryptedPassword string
+	sshPublicKeys     []string
+}
+
+func resourceSystemRootAuthentication() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSystemRootAuthenticationCreate,
+		ReadContext:   resourceSystemRootAuthenticationRead,
+		UpdateContext: resourceSystemRootAuthenticationUpdate,
+		DeleteContext: resourceSystemRootAuthenticationDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceSystemRootAuthenticationImport,
+		},
+		Schema: map[string]*schema.Schema{
+			"encrypted_password": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"no_public_keys": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ConflictsWith: []string{
+					"ssh_public_keys",
+				},
+			},
+			"ssh_public_keys": {
+				Type:          schema.TypeSet,
+				Optional:      true,
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				ConflictsWith: []string{"no_public_keys"},
+			},
+		},
+	}
+}
+
+func resourceSystemRootAuthenticationCreate(
+	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	sess.configLock(jnprSess)
+
+	if err := setSystemRootAuthentication(d, m, jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	if err := sess.commitConf("create resource junos_system_root_authentication", jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+
+	d.SetId("system_root_authentication")
+
+	return resourceSystemRootAuthenticationReadWJnprSess(d, m, jnprSess)
+}
+func resourceSystemRootAuthenticationRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+
+	return resourceSystemRootAuthenticationReadWJnprSess(d, m, jnprSess)
+}
+func resourceSystemRootAuthenticationReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
+	systemRootAuthOptions, err := readSystemRootAuthentication(m, jnprSess)
+	mutex.Unlock()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	fillSystemRootAuthenticationData(d, systemRootAuthOptions)
+
+	return nil
+}
+func resourceSystemRootAuthenticationUpdate(
+	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	d.Partial(true)
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	sess.configLock(jnprSess)
+	if err := delSystemRootAuthentication(m, jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	if err := setSystemRootAuthentication(d, m, jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	if err := sess.commitConf("update resource junos_system_root_authentication", jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	d.Partial(false)
+
+	return resourceSystemRootAuthenticationReadWJnprSess(d, m, jnprSess)
+}
+func resourceSystemRootAuthenticationDelete(
+	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	return nil
+}
+func resourceSystemRootAuthenticationImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return nil, err
+	}
+	defer sess.closeSession(jnprSess)
+	result := make([]*schema.ResourceData, 1)
+
+	systemRootAuthOptions, err := readSystemRootAuthentication(m, jnprSess)
+	if err != nil {
+		return nil, err
+	}
+	fillSystemRootAuthenticationData(d, systemRootAuthOptions)
+	d.SetId("system_root_authentication")
+	result[0] = d
+
+	return result, nil
+}
+
+func setSystemRootAuthentication(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) error {
+	sess := m.(*Session)
+	configSet := make([]string, 0)
+	setPrefix := "set system root-authentication "
+
+	configSet = append(configSet, setPrefix+"encrypted-password \""+d.Get("encrypted_password").(string)+"\"")
+	if d.Get("no_public_keys").(bool) {
+		configSet = append(configSet, setPrefix+"no-public-keys")
+	}
+	for _, v := range d.Get("ssh_public_keys").(*schema.Set).List() {
+		switch {
+		case strings.HasPrefix(v.(string), ssh.KeyAlgoDSA):
+			configSet = append(configSet, setPrefix+"ssh-dsa \""+v.(string)+"\"")
+		case strings.HasPrefix(v.(string), ssh.KeyAlgoRSA):
+			configSet = append(configSet, setPrefix+"ssh-rsa \""+v.(string)+"\"")
+		case strings.HasPrefix(v.(string), ssh.KeyAlgoECDSA256),
+			strings.HasPrefix(v.(string), ssh.KeyAlgoECDSA384),
+			strings.HasPrefix(v.(string), ssh.KeyAlgoECDSA521):
+			configSet = append(configSet, setPrefix+"ssh-ecdsa \""+v.(string)+"\"")
+		case strings.HasPrefix(v.(string), ssh.KeyAlgoED25519):
+			configSet = append(configSet, setPrefix+"ssh-ed25519 \""+v.(string)+"\"")
+		default:
+			return fmt.Errorf("format in public key '%v' not supported", v.(string))
+		}
+	}
+
+	if err := sess.configSet(configSet, jnprSess); err != nil {
+		return err
+	}
+
+	return nil
+}
+func readSystemRootAuthentication(m interface{}, jnprSess *NetconfObject) (systemRootAuthOptions, error) {
+	sess := m.(*Session)
+	var confRead systemRootAuthOptions
+
+	systemRootAuthConfig, err := sess.command("show configuration system root-authentication"+
+		" | display set relative", jnprSess)
+	if err != nil {
+		return confRead, err
+	}
+	if systemRootAuthConfig != emptyWord {
+		for _, item := range strings.Split(systemRootAuthConfig, "\n") {
+			if strings.Contains(item, "<configuration-output>") {
+				continue
+			}
+			if strings.Contains(item, "</configuration-output>") {
+				break
+			}
+			itemTrim := strings.TrimPrefix(item, setLineStart)
+			switch {
+			case strings.HasPrefix(itemTrim, "encrypted-password "):
+				confRead.encryptedPassword = strings.Trim(strings.TrimPrefix(itemTrim, "encrypted-password "), "\"")
+			case itemTrim == "no-public-keys":
+				confRead.noPublicKeys = true
+			case strings.HasPrefix(itemTrim, "ssh-dsa "):
+				confRead.sshPublicKeys = append(confRead.sshPublicKeys,
+					strings.Trim(strings.TrimPrefix(itemTrim, "ssh-dsa "), "\""))
+			case strings.HasPrefix(itemTrim, "ssh-ecdsa "):
+				confRead.sshPublicKeys = append(confRead.sshPublicKeys,
+					strings.Trim(strings.TrimPrefix(itemTrim, "ssh-ecdsa "), "\""))
+			case strings.HasPrefix(itemTrim, "ssh-ed25519 "):
+				confRead.sshPublicKeys = append(confRead.sshPublicKeys,
+					strings.Trim(strings.TrimPrefix(itemTrim, "ssh-ed25519 "), "\""))
+			case strings.HasPrefix(itemTrim, "ssh-rsa "):
+				confRead.sshPublicKeys = append(confRead.sshPublicKeys,
+					strings.Trim(strings.TrimPrefix(itemTrim, "ssh-rsa "), "\""))
+			}
+		}
+	}
+
+	return confRead, nil
+}
+
+func delSystemRootAuthentication(m interface{}, jnprSess *NetconfObject) error {
+	sess := m.(*Session)
+	configSet := make([]string, 0, 1)
+	configSet = append(configSet, "delete system root-authentication")
+	if err := sess.configSet(configSet, jnprSess); err != nil {
+		return err
+	}
+
+	return nil
+}
+func fillSystemRootAuthenticationData(d *schema.ResourceData, systemRootAuthOptions systemRootAuthOptions) {
+	if tfErr := d.Set("encrypted_password", systemRootAuthOptions.encryptedPassword); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("no_public_keys", systemRootAuthOptions.noPublicKeys); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("ssh_public_keys", systemRootAuthOptions.sshPublicKeys); tfErr != nil {
+		panic(tfErr)
+	}
+}

--- a/junos/resource_system_root_authentication_test.go
+++ b/junos/resource_system_root_authentication_test.go
@@ -1,0 +1,60 @@
+package junos_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccJunosSystemRootAuthentication_basic(t *testing.T) {
+	if os.Getenv("TESTACC_SWITCH") == "" {
+		resource.Test(t, resource.TestCase{
+			PreCheck:  func() { testAccPreCheck(t) },
+			Providers: testAccProviders,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccJunosSystemRootAuthenticationCreate(),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("junos_system_root_authentication.root_auth",
+							"encrypted_password", "$6$XXXX"),
+						resource.TestCheckResourceAttr("junos_system_root_authentication.root_auth",
+							"ssh_public_keys.#", "1"),
+					),
+				},
+				{
+					ResourceName:      "junos_system_root_authentication.root_auth",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+				{
+					Config: testAccJunosSystemRootAuthenticationUpdate(),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("junos_system_root_authentication.root_auth",
+							"ssh_public_keys.#", "0"),
+					),
+				},
+			},
+		})
+	}
+}
+
+func testAccJunosSystemRootAuthenticationCreate() string {
+	return `
+resource junos_system_root_authentication "root_auth" {
+  encrypted_password = "$6$XXXX"
+  ssh_public_keys = [
+    "ssh-rsa XXXX",
+  ]
+}
+`
+}
+
+func testAccJunosSystemRootAuthenticationUpdate() string {
+	return `
+resource junos_system_root_authentication "root_auth" {
+  encrypted_password = "$6$XXX"
+  no_public_keys     = true
+}
+`
+}

--- a/junos/resource_system_test.go
+++ b/junos/resource_system_test.go
@@ -69,6 +69,10 @@ func TestAccJunosSystem_basic(t *testing.T) {
 						resource.TestCheckResourceAttr("junos_system.testacc_system",
 							"internet_options.0.tcp_mss", "1400"),
 						resource.TestCheckResourceAttr("junos_system.testacc_system",
+							"login.#", "1"),
+						resource.TestCheckResourceAttr("junos_system.testacc_system",
+							"login.0.deny_sources_address.#", "1"),
+						resource.TestCheckResourceAttr("junos_system.testacc_system",
 							"max_configuration_rollbacks", "49"),
 						resource.TestCheckResourceAttr("junos_system.testacc_system",
 							"max_configurations_on_flash", "49"),
@@ -243,6 +247,33 @@ resource junos_system "testacc_system" {
     source_quench                           = true
     tcp_drop_synfin_set                     = true
     tcp_mss                                 = 1400
+  }
+  login {
+    announcement         = "test announce"
+    deny_sources_address = ["127.0.0.1"]
+    idle_timeout         = 60
+    message              = "test message"
+    password {
+      change_type               = "character-sets"
+      format                    = "sha512"
+      maximum_length            = 128
+      minimum_changes           = 1
+      minimum_character_changes = 4
+      minimum_length            = 6
+      minimum_lower_cases       = 1
+      minimum_numerics          = 1
+      minimum_punctuations      = 1
+      minimum_reuse             = 1
+      minimum_upper_cases       = 1
+    }
+    retry_options {
+      backoff_factor          = 5
+      backoff_threshold       = 1
+      lockout_period          = 1
+      maximum_time            = 300
+      minimum_time            = 20
+      tries_before_disconnect = 10
+    }
   }
   max_configuration_rollbacks = 49
   max_configurations_on_flash = 49

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -38,8 +38,6 @@ set system services netconf ssh
 and optionally a specific user for netconf:
 
 ```text
-set system login user netconf uid 200?
-
 set system login user netconf class xxxx
 ```
 with authentication method : ssh key or password

--- a/website/docs/r/routing_options.html.markdown
+++ b/website/docs/r/routing_options.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # junos_routing_options
 
--> **Note:** This resource should only create **once**. It's used to configure static (not object) options in `routing-options` block. Destroy this resource as no effect on Junos configuration.
+-> **Note:** This resource should only be created **once**. It's used to configure static (not object) options in `routing-options` block. Destroy this resource has no effect on the Junos configuration.
 
 Configure static configuration in `routing-options` block
 

--- a/website/docs/r/security.html.markdown
+++ b/website/docs/r/security.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # junos_security
 
--> **Note:** This resource should only create **once**. It's used to configure static (not object) options in `security` block. Destroy this resource as no effect on Junos configuration.
+-> **Note:** This resource should only be created **once**. It's used to configure static (not object) options in `security` block. Destroy this resource has no effect on the Junos configuration.
 
 Configure static configuration in `security` block
 

--- a/website/docs/r/system.html.markdown
+++ b/website/docs/r/system.html.markdown
@@ -41,10 +41,11 @@ The following arguments are supported:
 * `auto_snapshot` - (Optional)(`Bool`) Enable auto-snapshot when boots from alternate slice.
 * `domain_name` - (Optional)(`String`) Domain name.
 * `host_name` - (Optional)(`String`) Hostname.
-* `inet6_backup_router` (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once for declare 'inet6-backup-router' configuration.
+* `inet6_backup_router` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once for declare 'inet6-backup-router' configuration.
   * `address` - (Optional)(`String`) Address of router to use while booting.
   * `destination` - (Optional)(`ListOfString`) Destination networks reachable through the router.
-* `internet_options` (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once for declare 'internet-options configuration. See the [`internet_options` arguments] (#internet_options-arguments) block.
+* `internet_options` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once for declare 'internet-options' configuration. See the [`internet_options` arguments] (#internet_options-arguments) block.
+* `login` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once for declare 'login' configuration. See the [`login` arguments] (#login-arguments) block.
 * `max_configuration_rollbacks` - (Optional)(`Int`) Maximum rollback configuration (0..49).
 * `max_configurations_on_flash` - (Optional)(`Int`) Number of configuration files stored on flash (0..49).
 * `name_server` - (Optional)(`ListOfString`) DNS name servers.
@@ -89,6 +90,32 @@ The following arguments are supported:
 * `source_quench` - (Optional)(`Bool`) React to incoming ICMP Source Quench messages. Conflict with `no_source_quench`.
 * `tcp_drop_synfin_set` - (Optional)(`Bool`) Drop TCP packets that have both SYN and FIN flags.
 * `tcp_mss` - (Optional)(`Int`) Maximum value of TCP MSS for IPV4 traffic (64..65535 bytes).
+
+---
+#### login arguments
+* `announcement` - (Optional)(`String`) System announcement message (displayed after login).
+* `deny_sources_address` - (Optional)(`ListOfString`) Sources from which logins are denied.
+* `idle_timeout` - (Optional)(`Int`) Maximum idle time before logout (1..60 minutes).
+* `message` - (Optional)(`String`) System login message.
+* `password` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once for declare 'password' configuration.
+  * `change_type` - (Optional)(`String`) Password change type.
+  * `format` - (Optional)(`String`) Encryption method to use for password.
+  * `maximum_length` - (Optional)(`Int`) Maximum password length for all users (20..128).
+  * `minimum_changes` - (Optional)(`Int`) Minimum number of changes in password (1..128).
+  * `minimum_character_changes` - (Optional)(`Int`) Minimum number of character changes between old and new passwords (4..15).
+  * `minimum_length` - (Optional)(`Int`) Minimum password length for all users (6..20).
+  * `minimum_lower_cases` - (Optional)(`Int`) Minimum number of lower-case class characters in password (1..128)
+  * `minimum_numerics` - (Optional)(`Int`) Minimum number of numeric class characters in password (1..128).
+  * `minimum_punctuations` - (Optional)(`Int`) Minimum number of punctuation class characters in password (1..128).
+  * `minimum_reuse` - (Optional)(`Int`) Minimum number of old passwords which should not be same as the new password (1..20).
+  * `minimum_upper_cases` - (Optional)(`Int`) Minimum number of upper-case class characters in password (1..128).
+* `retry_options` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once for declare 'retry-options' configuration.
+  * `backoff_factor` - (Optional)(`Int`) Delay factor after 'backoff-threshold' password failures (5..10).
+  * `backoff_threshold` - (Optional)(`Int`) Number of password failures before delay is introduced (1..3).
+  * `lockout_period` - (Optional)(`Int`) Amount of time user account is locked after 'tries-before-disconnect' failures (1..43200 minutes).
+  * `maximum_time` - (Optional)(`Int`) Maximum time the connection will remain for user to enter username and password (20..300).
+  * `minimum_time` - (Optional)(`Int`) Minimum total connection time if all attempts fail (20..60).
+  * `tries_before_disconnect` - (Optional)(`Int`) Number of times user is allowed to try password (2..10).
 
 ---
 #### ssh arguments for services

--- a/website/docs/r/system.html.markdown
+++ b/website/docs/r/system.html.markdown
@@ -8,9 +8,10 @@ description: |-
 
 # junos_system
 
--> **Note:** This resource should only create **once**. It's used to configure static (not object) options in `system` block. Destroy this resource as no effect on Junos configuration.
+-> **Note:** This resource should only be created **once**. It's used to configure static (not object) options in `system` block. Destroy this resource has no effect on the Junos configuration.  
+There is an exception for `system root-authentication` static block. It's can be configured with the dedicated `junos_system_root_authentication` resource.
 
-Configure static configuration in `system` block
+Configure static configuration in `system` block (except `system root-authentication` block)
 
 ## Example Usage
 

--- a/website/docs/r/system_login_class.html.markdown
+++ b/website/docs/r/system_login_class.html.markdown
@@ -1,0 +1,61 @@
+---
+layout: "junos"
+page_title: "Junos: junos_system_login_class"
+sidebar_current: "docs-junos-resource-system-login-class"
+description: |-
+  Create a system login class
+---
+
+# junos_system_login_class
+
+Provides a system login class resource.
+
+## Example Usage
+
+```hcl
+# Add a system login class
+resource junos_system_login_class "engineering" {
+  name         = "engineering"
+  idle_timeout = 30
+  login_alarms = true
+  permissions  = ["all"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required, Forces new resource)(`String`) The name of system login class.
+* `access_end` - (Optional)(`String`) End time for remote access (HH:MM:SS).
+* `access_start` - (Optional)(`String`) Start time for remote access (HH:MM:SS).
+* `allow_commands` - (Optional)(`String`) Regular expression for commands to allow explicitly. Conflict with `allow_commands_regexps`.
+* `allow_commands_regexps` - (Optional)(`ListOfString`) Object path regular expressions to allow commands. Conflict with `allow_commands`.
+* `allow_configuration` - (Optional)(`String`) Regular expression for configure to allow explicitly. Conflict with `allow_configuration_regexps`.
+* `allow_configuration_regexps` - (Optional)(`ListOfString`) Object path regular expressions to allow. Conflict with `allow_configuration`.
+* `allow_hidden_commands` - (Optional)(`Bool`) Allow all hidden commands to be executed. Conflict with `no_hidden_commands_except`.
+* `allowed_days` - (Optional)(`ListOfString`) Day(s) of week when access is allowed.
+* `cli_prompt` - (Optional)(`String`) Cli prompt name for this class.
+* `configuration_breadcrumbs` - (Optional)(`Bool`) Enable breadcrumbs during display of configuration.
+* `confirm_commands` - (Optional)(`ListOfString`) List of commands to be confirmed explicitly.
+* `deny_commands` - (Optional)(`String`) Regular expression for commands to deny explicitly. Conflict with `deny_commands_regexps`.
+* `deny_commands_regexps` - (Optional)(`ListOfString`) Object path regular expressions to deny commands. Conflict with `deny_commands`.
+* `deny_configuration` - (Optional)(`String`) Regular expression for configure to deny explicitly. Conflict with `deny_configuration_regexps`.
+* `deny_configuration_regexps` - (Optional)(`ListOfString`) Object path regular expressions to deny. Conflict with `deny_configuration`.
+* `idle_timeout` - (Optional)(`Int`) Maximum idle time before logout (minutes).
+* `logical_system` - (Optional)(`String`) Logical system associated with login.
+* `login_alarms` - (Optional)(`Bool`) Display system alarms when logging in.
+* `login_script` - (Optional)(`String`) Execute this login-script when logging in.
+* `login_tip` - (Optional)(`Bool`) Display tip when logging in.
+* `no_hidden_commands_except` - (Optional)(`ListOfString`) Deny all hidden commands with exemptions.
+* `permissions` - (Optional)(`ListOfString`) Set of permitted operation categories.
+* `security_role` - (Optional)(`String`) Common Criteria security role.
+* `tenant` - (Optional)(`String`) Tenant associated with this login.
+
+## Import
+
+Junos system login class can be imported using an id made up of `<name>`, e.g.
+
+```
+$ terraform import junos_system_login_class.engineering engineering
+```

--- a/website/docs/r/system_login_user.html.markdown
+++ b/website/docs/r/system_login_user.html.markdown
@@ -1,0 +1,46 @@
+---
+layout: "junos"
+page_title: "Junos: junos_system_login_user"
+sidebar_current: "docs-junos-resource-system-login-user"
+description: |-
+  Create a system login user
+---
+
+# junos_system_login_user
+
+Provides a system login user resource.
+
+## Example Usage
+
+```hcl
+# Add a system login user
+resource junos_system_login_user "user1" {
+  name  = "user1"
+  class = "operator"
+  authentication {
+    ssh_public_keys = ["ssh-rsa XXXX user@host"]
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required, Forces new resource)(`String`) The name of system login user.
+* `class` - (Required)(`String`) Login class.
+* `cli_prompt` - (Optional)(`String`) Cli prompt name for this user.
+* `full_name` - (Optional)(`String`) Full name.
+* `uid` - (Optional,Computed, Forces new resource)(`Int`) User identifier (uid) (100..64000)
+* `authentication` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once for declare 'authentication' configuration.
+  * `encrypted_password` - (Optional)(`String`) Encrypted password string.
+  * `no_public_keys` - (Optional)(`Bool`) Disables ssh public key based authentication.
+  * `ssh_public_keys` - (Optional)(`ListOfString`) Secure shell (ssh) public key string.
+
+## Import
+
+Junos system login user can be imported using an id made up of `<name>`, e.g.
+
+```
+$ terraform import junos_system_login_user.user1 user1
+```

--- a/website/docs/r/system_root_authentication.html.markdown
+++ b/website/docs/r/system_root_authentication.html.markdown
@@ -1,0 +1,42 @@
+---
+layout: "junos"
+page_title: "Junos: junos_system_root_authentication"
+sidebar_current: "docs-junos-resource-system-root-authentication"
+description: |-
+  Configure static configuration in system root-authentication block
+---
+
+# junos_system_root_authentication
+
+-> **Note:** This resource should only be created **once**. It's used to configure static (not object) options in `system root-authentication` block. Destroy this resource has no effect on the Junos configuration.
+
+Configure `system root-authentication` block
+
+## Example Usage
+
+```hcl
+# Configure system root-authentication
+resource junos_system_root_authentication "root_auth" {
+  encrypted_password = "$6$XXX"
+  ssh_public_keys = [
+    "ssh-rsa XXXX",
+    "ecdsa-sha2-nistp256 XXXX",
+  ]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `encrypted_password` - (Required)(`String`) Encrypted password string.
+* `no_public_keys` - (Optional)(`Bool`) Disables ssh public key based authentication.
+* `ssh_public_keys` - (Optional)(`ListOfString`) Secure shell (ssh) public key string.
+
+## Import
+
+Junos system root-authentication can be imported using any id, e.g.
+
+```
+$ terraform import junos_system_root_authentication.root_auth random
+```

--- a/website/junos.erb
+++ b/website/junos.erb
@@ -171,6 +171,9 @@
           <li<%= sidebar_current("docs-junos-resource-system-login-class") %>>
             <a href="/docs/providers/junos/r/system_login_class.html">junos_system_login_class</a>
           </li>
+          <li<%= sidebar_current("docs-junos-resource-system-login-user") %>>
+            <a href="/docs/providers/junos/r/system_login_user.html">junos_system_login_user</a>
+          </li>
           <li<%= sidebar_current("docs-junos-resource-system-radius-server") %>>
             <a href="/docs/providers/junos/r/system_radius_server.html">junos_system_radius_server</a>
           </li>

--- a/website/junos.erb
+++ b/website/junos.erb
@@ -168,6 +168,9 @@
           <li<%= sidebar_current("docs-junos-resource-system-ntp-server") %>>
             <a href="/docs/providers/junos/r/system_ntp_server.html">junos_system_ntp_server</a>
           </li>
+          <li<%= sidebar_current("docs-junos-resource-system-login-class") %>>
+            <a href="/docs/providers/junos/r/system_login_class.html">junos_system_login_class</a>
+          </li>
           <li<%= sidebar_current("docs-junos-resource-system-radius-server") %>>
             <a href="/docs/providers/junos/r/system_radius_server.html">junos_system_radius_server</a>
           </li>

--- a/website/junos.erb
+++ b/website/junos.erb
@@ -177,6 +177,9 @@
           <li<%= sidebar_current("docs-junos-resource-system-radius-server") %>>
             <a href="/docs/providers/junos/r/system_radius_server.html">junos_system_radius_server</a>
           </li>
+          <li<%= sidebar_current("docs-junos-resource-system-root-authentication") %>>
+            <a href="/docs/providers/junos/r/system_root_authentication.html">junos_system_root_authentication</a>
+          </li>
           <li<%= sidebar_current("docs-junos-resource-system-syslog-file") %>>
             <a href="/docs/providers/junos/r/system_syslog_file.html">junos_system_syslog_file</a>
           </li>


### PR DESCRIPTION
ENHANCEMENTS:
* add `login` argument in `junos_system` resource (Fixes parts of [#88](https://github.com/jeremmfr/terraform-provider-junos/issues/88))
* add `junos_system_login_class` resource (Fixes parts of [#88](https://github.com/jeremmfr/terraform-provider-junos/issues/88))
* add `junos_system_login_user` resource (Fixes parts of [#88](https://github.com/jeremmfr/terraform-provider-junos/issues/88))
* add `junos_system_root_authentication` resource