### PR TITLE
Add support for additional security algs

### DIFF
--- a/junos/resource_security.go
+++ b/junos/resource_security.go
@@ -139,6 +139,26 @@ func resourceSecurity() *schema.Resource {
 							Type:     schema.TypeBool,
 							Optional: true,
 						},
+						"h323_disable": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"mgcp_disable": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"rtsp_disable": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"sccp_disable": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"sip_disable": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
 					},
 				},
 			},
@@ -801,6 +821,21 @@ func setSecurityAlg(alg interface{}) ([]string, error) {
 		if algM["tftp_disable"].(bool) {
 			configSet = append(configSet, setPrefix+"tftp disable")
 		}
+		if algM["h323_disable"].(bool) {
+			configSet = append(configSet, setPrefix+"h323 disable")
+		}
+		if algM["mgcp_disable"].(bool) {
+			configSet = append(configSet, setPrefix+"mgcp disable")
+		}
+		if algM["rtsp_disable"].(bool) {
+			configSet = append(configSet, setPrefix+"rtsp disable")
+		}
+		if algM["sccp_disable"].(bool) {
+			configSet = append(configSet, setPrefix+"sccp disable")
+		}
+		if algM["sip_disable"].(bool) {
+			configSet = append(configSet, setPrefix+"sip disable")
+		}
 	} else {
 		return configSet, fmt.Errorf("alg block is empty")
 	}
@@ -1126,6 +1161,11 @@ func listLinesSecurityAlg() []string {
 		"alg sunrpc disable",
 		"alg talk disable",
 		"alg tftp disable",
+		"alg h323 disable",
+		"alg mgcp disable",
+		"alg rtsp disable",
+		"alg sccp disable",
+		"alg sip disable",
 	}
 }
 
@@ -1329,6 +1369,11 @@ func readSecurityAlg(confRead *securityOptions, itemTrimAlg string) {
 			"sunrpc_disable": false,
 			"talk_disable":   false,
 			"tftp_disable":   false,
+			"h323_disable":   false,
+			"mgcp_disable":   false,
+			"rtsp_disable":   false,
+			"sccp_disable":   false,
+			"sip_disable":    false,
 		})
 	}
 	if itemTrim == "dns disable" {
@@ -1351,6 +1396,21 @@ func readSecurityAlg(confRead *securityOptions, itemTrimAlg string) {
 	}
 	if itemTrim == "tftp disable" {
 		confRead.alg[0]["tftp_disable"] = true
+	}
+	if itemTrim == "h323 disable" {
+		confRead.alg[0]["h323_disable"] = true
+	}
+	if itemTrim == "mgcp disable" {
+		confRead.alg[0]["mgcp_disable"] = true
+	}
+	if itemTrim == "rtsp disable" {
+		confRead.alg[0]["rtsp_disable"] = true
+	}
+	if itemTrim == "sccp disable" {
+		confRead.alg[0]["sccp_disable"] = true
+	}
+	if itemTrim == "sip disable" {
+		confRead.alg[0]["sip_disable"] = true
 	}
 }
 

--- a/junos/resource_security_test.go
+++ b/junos/resource_security_test.go
@@ -295,7 +295,12 @@ resource junos_security "testacc_security" {
     pptp_disable   = true
     sunrpc_disable = true
     talk_disable   = true
-    tftp_disable   = true
+	tftp_disable   = true
+	h323_disable   = true
+    mgcp_disable   = true
+    rtsp_disable   = true
+	sccp_disable   = true
+	sip_disable    = true
   }
   flow {
     advanced_options {

--- a/junos/resource_security_test.go
+++ b/junos/resource_security_test.go
@@ -295,12 +295,12 @@ resource junos_security "testacc_security" {
     pptp_disable   = true
     sunrpc_disable = true
     talk_disable   = true
-	tftp_disable   = true
-	h323_disable   = true
+    tftp_disable   = true
+    h323_disable   = true
     mgcp_disable   = true
     rtsp_disable   = true
-	sccp_disable   = true
-	sip_disable    = true
+    sccp_disable   = true
+    sip_disable    = true
   }
   flow {
     advanced_options {

--- a/website/docs/r/security.html.markdown
+++ b/website/docs/r/security.html.markdown
@@ -59,6 +59,11 @@ The following arguments are supported:
 * `sunrpc_disable` - (Optional)(`Bool`) Disable sunrpc alg.
 * `talk_disable` - (Optional)(`Bool`) Disable talk alg.
 * `tftp_disable` - (Optional)(`Bool`) Disable tftp alg.
+* `h323_disable` - (Optional)(`Bool`) Disable h323 alg.
+* `mgcp_disable` - (Optional)(`Bool`) Disable mgcp alg.
+* `rtsp_disable` - (Optional)(`Bool`) Disable rtsp alg.
+* `sccp_disable` - (Optional)(`Bool`) Disable sccp alg.
+* `sip_disable` - (Optional)(`Bool`) Disable sip alg.
 
 ---
 #### flow arguments


### PR DESCRIPTION
Adds support to disable the below security algs that are enabled by default

H323, MGCP, RTSP, SCCP, SIP