### PR TITLE
Fixes #92: Add support for Juniper Screen & more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ENHANCEMENTS:
 * add `h323_disable`, `mgcp_disable`, `rtsp_disable`, `sccp_disable` and `sip_disable` arguments in `junos_security` resource (Fixes #95) Thanks [@a-d-v](https://github.com/a-d-v)
 * add `default_address_selection` and `no_multicast_echo` arguments in `junos_system` resource (Fixes #97) Thanks [@a-d-v](https://github.com/a-d-v)
+* add `junos_security_screen` resource (Fixes parts of [#92](https://github.com/jeremmfr/terraform-provider-junos/issues/92))
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ ENHANCEMENTS:
 * add `h323_disable`, `mgcp_disable`, `rtsp_disable`, `sccp_disable` and `sip_disable` arguments in `junos_security` resource (Fixes #95) Thanks [@a-d-v](https://github.com/a-d-v)
 * add `default_address_selection` and `no_multicast_echo` arguments in `junos_system` resource (Fixes #97) Thanks [@a-d-v](https://github.com/a-d-v)
 * add `junos_security_screen` resource (Fixes parts of [#92](https://github.com/jeremmfr/terraform-provider-junos/issues/92))
+* add `junos_security_screen_whitelist` resource
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ ENHANCEMENTS:
 * add `default_address_selection` and `no_multicast_echo` arguments in `junos_system` resource (Fixes #97) Thanks [@a-d-v](https://github.com/a-d-v)
 * add `junos_security_screen` resource (Fixes parts of [#92](https://github.com/jeremmfr/terraform-provider-junos/issues/92))
 * add `junos_security_screen_whitelist` resource
+* add `advance_policy_based_routing_profile`, `application_tracking`, `description`, `reverse_reroute`, `screen`, `source_identity_log` and `tcp_rst` arguments in `junos_security_zone` resource (Fixes parts of [#92](https://github.com/jeremmfr/terraform-provider-junos/issues/92))
 
 BUG FIXES:
 

--- a/junos/provider.go
+++ b/junos/provider.go
@@ -144,6 +144,7 @@ func Provider() *schema.Provider {
 			"junos_security_policy_tunnel_pair_policy":                   resourceSecurityPolicyTunnelPairPolicy(),
 			"junos_security_policy":                                      resourceSecurityPolicy(),
 			"junos_security_screen":                                      resourceSecurityScreen(),
+			"junos_security_screen_whitelist":                            resourceSecurityScreenWhiteList(),
 			"junos_security_utm_policy":                                  resourceSecurityUtmPolicy(),
 			"junos_security_utm_custom_url_pattern":                      resourceSecurityUtmCustomURLPattern(),
 			"junos_security_utm_profile_web_filtering_juniper_enhanced":  resourceSecurityUtmProfileWebFilteringEnhanced(),

--- a/junos/provider.go
+++ b/junos/provider.go
@@ -143,6 +143,7 @@ func Provider() *schema.Provider {
 			"junos_security_nat_static":                                  resourceSecurityNatStatic(),
 			"junos_security_policy_tunnel_pair_policy":                   resourceSecurityPolicyTunnelPairPolicy(),
 			"junos_security_policy":                                      resourceSecurityPolicy(),
+			"junos_security_screen":                                      resourceSecurityScreen(),
 			"junos_security_utm_policy":                                  resourceSecurityUtmPolicy(),
 			"junos_security_utm_custom_url_pattern":                      resourceSecurityUtmCustomURLPattern(),
 			"junos_security_utm_profile_web_filtering_juniper_enhanced":  resourceSecurityUtmProfileWebFilteringEnhanced(),

--- a/junos/resource_security_policy.go
+++ b/junos/resource_security_policy.go
@@ -323,12 +323,12 @@ func resourceSecurityPolicyImport(d *schema.ResourceData, m interface{}) ([]*sch
 
 func checkSecurityPolicyExists(fromZone, toZone string, m interface{}, jnprSess *NetconfObject) (bool, error) {
 	sess := m.(*Session)
-	zoneConfig, err := sess.command("show configuration"+
+	policyConfig, err := sess.command("show configuration"+
 		" security policies from-zone "+fromZone+" to-zone "+toZone+" | display set", jnprSess)
 	if err != nil {
 		return false, err
 	}
-	if zoneConfig == emptyWord {
+	if policyConfig == emptyWord {
 		return false, nil
 	}
 

--- a/junos/resource_security_screen.go
+++ b/junos/resource_security_screen.go
@@ -1,0 +1,1830 @@
+package junos
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+const (
+	userDefinedOptionTypeRegex = `^([1-9]|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])( to ([1-9]|[1-9]\d|1\d\d|2[0-4]\d|25[0-5]))?$`
+	userDefinedHeaderTypeRegex = `^(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])( to ([1-9]|[1-9]\d|1\d\d|2[0-4]\d|25[0-5]))?$`
+)
+
+type screenOptions struct {
+	alarmWithoutDrop bool
+	name             string
+	description      string
+	icmp             []map[string]interface{}
+	ip               []map[string]interface{}
+	limitSession     []map[string]interface{}
+	tcp              []map[string]interface{}
+	udp              []map[string]interface{}
+}
+
+func resourceSecurityScreen() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSecurityScreenCreate,
+		ReadContext:   resourceSecurityScreenRead,
+		UpdateContext: resourceSecurityScreenUpdate,
+		DeleteContext: resourceSecurityScreenDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceSecurityScreenImport,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			"alarm_without_drop": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"icmp": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"flood": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"threshold": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(1, 1000000),
+									},
+								},
+							},
+						},
+						"fragment": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"icmpv6_malformed": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"large": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"ping_death": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"sweep": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"threshold": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(1000, 1000000),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"ip": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"bad_option": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"block_frag": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"ipv6_extension_header": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"ah_header": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"esp_header": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"hip_header": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"destination_header": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"ilnp_nonce_option": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"home_address_option": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"line_identification_option": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"tunnel_encapsulation_limit_option": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"user_defined_option_type": {
+													Type:     schema.TypeList,
+													Optional: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+											},
+										},
+									},
+									"fragment_header": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"hop_by_hop_header": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"calipso_option": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"rpl_option": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"smf_dpd_option": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"jumbo_payload_option": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"quick_start_option": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"router_alert_option": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"user_defined_option_type": {
+													Type:     schema.TypeList,
+													Optional: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+											},
+										},
+									},
+									"mobility_header": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"no_next_header": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"routing_header": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"shim6_header": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"user_defined_header_type": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+						"ipv6_extension_header_limit": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      -1,
+							ValidateFunc: validation.IntBetween(0, 32),
+						},
+						"ipv6_malformed_header": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"loose_source_route_option": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"record_route_option": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"security_option": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"source_route_option": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"spoofing": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"stream_option": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"strict_source_route_option": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"tear_drop": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"timestamp_option": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"tunnel": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"bad_inner_header": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"gre": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"gre_4in4": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"gre_4in6": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"gre_6in4": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"gre_6in6": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+											},
+										},
+									},
+									"ip_in_udp_teredo": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"ipip": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"ipip_4in4": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"ipip_4in6": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"ipip_6in4": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"ipip_6in6": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"ipip_6over4": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"ipip_6to4relay": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"dslite": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+												"isatap": {
+													Type:     schema.TypeBool,
+													Optional: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"unknown_protocol": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"limit_session": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"destination_ip_based": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(1, 2000000),
+						},
+						"source_ip_based": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(1, 2000000),
+						},
+					},
+				},
+			},
+			"tcp": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"fin_no_ack": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"land": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"no_flag": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"port_scan": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"threshold": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(1000, 1000000),
+									},
+								},
+							},
+						},
+						"syn_ack_ack_proxy": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"threshold": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(1, 250000),
+									},
+								},
+							},
+						},
+						"syn_fin": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"syn_flood": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"alarm_threshold": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(1, 500000),
+									},
+									"attack_threshold": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(1, 500000),
+									},
+									"destination_threshold": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(4, 500000),
+									},
+									"source_threshold": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(4, 500000),
+									},
+									"timeout": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(1, 50),
+									},
+									"whitelist": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"name": {
+													Type:             schema.TypeString,
+													Required:         true,
+													ValidateDiagFunc: validateNameObjectJunos([]string{}),
+												},
+												"destination_address": {
+													Type:     schema.TypeList,
+													Optional: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+												"source_address": {
+													Type:     schema.TypeList,
+													Optional: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"syn_frag": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"sweep": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"threshold": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(1000, 1000000),
+									},
+								},
+							},
+						},
+						"winnuke": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"udp": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"flood": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"threshold": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(1, 1000000),
+									},
+									"whitelist": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+						"port_scan": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"threshold": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(1000, 1000000),
+									},
+								},
+							},
+						},
+						"sweep": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"threshold": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(1000, 1000000),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceSecurityScreenCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	if !checkCompatibilitySecurity(jnprSess) {
+		return diag.FromErr(fmt.Errorf("security screen not compatible with Junos device %s",
+			jnprSess.SystemInformation.HardwareModel))
+	}
+	sess.configLock(jnprSess)
+	securityScreenExists, err := checkSecurityScreenExists(d.Get("name").(string), m, jnprSess)
+	if err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	if securityScreenExists {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(fmt.Errorf("security screen %v already exists", d.Get("name").(string)))
+	}
+
+	if err := setSecurityScreen(d, m, jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	if err := sess.commitConf("create resource junos_security_screen", jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	securityScreenExists, err = checkSecurityScreenExists(d.Get("name").(string), m, jnprSess)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if securityScreenExists {
+		d.SetId(d.Get("name").(string))
+	} else {
+		return diag.FromErr(fmt.Errorf("security screen %v not exists after commit "+
+			"=> check your config", d.Get("name").(string)))
+	}
+
+	return resourceSecurityScreenReadWJnprSess(d, m, jnprSess)
+}
+func resourceSecurityScreenRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+
+	return resourceSecurityScreenReadWJnprSess(d, m, jnprSess)
+}
+func resourceSecurityScreenReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
+	screenOptions, err := readSecurityScreen(d.Get("name").(string), m, jnprSess)
+	mutex.Unlock()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if screenOptions.name == "" {
+		d.SetId("")
+	} else {
+		fillSecurityScreenData(d, screenOptions)
+	}
+
+	return nil
+}
+func resourceSecurityScreenUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	d.Partial(true)
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	sess.configLock(jnprSess)
+
+	if err := delSecurityScreen(d.Get("name").(string), m, jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+
+	if err := setSecurityScreen(d, m, jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	if err := sess.commitConf("update resource junos_security_screen", jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	d.Partial(false)
+
+	return resourceSecurityScreenReadWJnprSess(d, m, jnprSess)
+}
+func resourceSecurityScreenDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	sess.configLock(jnprSess)
+	if err := delSecurityScreen(d.Get("name").(string), m, jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	if err := sess.commitConf("delete resource junos_security_screen", jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+func resourceSecurityScreenImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return nil, err
+	}
+	defer sess.closeSession(jnprSess)
+	result := make([]*schema.ResourceData, 1)
+	securityScreenExists, err := checkSecurityScreenExists(d.Id(), m, jnprSess)
+	if err != nil {
+		return nil, err
+	}
+	if !securityScreenExists {
+		return nil, fmt.Errorf("don't find screen with id '%v' (id must be <name>)", d.Id())
+	}
+	screenOptions, err := readSecurityScreen(d.Id(), m, jnprSess)
+	if err != nil {
+		return nil, err
+	}
+	fillSecurityScreenData(d, screenOptions)
+
+	result[0] = d
+
+	return result, nil
+}
+
+func checkSecurityScreenExists(name string, m interface{}, jnprSess *NetconfObject) (bool, error) {
+	sess := m.(*Session)
+	screenConfig, err := sess.command("show configuration"+
+		" security screen ids-option \""+name+"\" | display set", jnprSess)
+	if err != nil {
+		return false, err
+	}
+	if screenConfig == emptyWord {
+		return false, nil
+	}
+
+	return true, nil
+}
+func setSecurityScreen(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) error {
+	sess := m.(*Session)
+	configSet := make([]string, 0)
+
+	setPrefix := "set security screen ids-option \"" + d.Get("name").(string) + "\" "
+
+	if d.Get("alarm_without_drop").(bool) {
+		configSet = append(configSet, setPrefix+"alarm-without-drop")
+	}
+	if d.Get("description").(string) != "" {
+		configSet = append(configSet, setPrefix+"description \""+d.Get("description").(string)+"\"")
+	}
+	for _, v := range d.Get("icmp").([]interface{}) {
+		if v == nil {
+			return fmt.Errorf("icmp block is empty")
+		}
+		icmp := v.(map[string]interface{})
+		configSet = append(configSet, setSecurityScreenIcmp(icmp, setPrefix)...)
+	}
+	for _, v := range d.Get("ip").([]interface{}) {
+		if v == nil {
+			return fmt.Errorf("ip block is empty")
+		}
+		ip := v.(map[string]interface{})
+		if err := checkSetSecurityScreenIP(ip); err != nil {
+			return err
+		}
+		ipSet, err := setSecurityScreenIP(ip, setPrefix)
+		if err != nil {
+			return err
+		}
+		configSet = append(configSet, ipSet...)
+	}
+	for _, v := range d.Get("limit_session").([]interface{}) {
+		if v == nil {
+			return fmt.Errorf("limit_session block is empty")
+		}
+		limitSession := v.(map[string]interface{})
+		if limitSession["destination_ip_based"].(int) != 0 {
+			configSet = append(configSet, setPrefix+"limit-session destination-ip-based "+
+				strconv.Itoa(limitSession["destination_ip_based"].(int)))
+		}
+		if limitSession["source_ip_based"].(int) != 0 {
+			configSet = append(configSet, setPrefix+"limit-session source-ip-based "+
+				strconv.Itoa(limitSession["source_ip_based"].(int)))
+		}
+	}
+	for _, v := range d.Get("tcp").([]interface{}) {
+		if v == nil {
+			return fmt.Errorf("tcp block is empty")
+		}
+		tcp := v.(map[string]interface{})
+		configSetTCP, err := setSecurityScreenTCP(tcp, setPrefix)
+		if err != nil {
+			return err
+		}
+		configSet = append(configSet, configSetTCP...)
+	}
+	for _, v := range d.Get("udp").([]interface{}) {
+		if v == nil {
+			return fmt.Errorf("udp block is empty")
+		}
+		udp := v.(map[string]interface{})
+		configSet = append(configSet, setSecurityScreenUDP(udp, setPrefix)...)
+	}
+
+	if err := sess.configSet(configSet, jnprSess); err != nil {
+		return err
+	}
+
+	return nil
+}
+func setSecurityScreenIcmp(icmp map[string]interface{}, setPrefix string) []string {
+	configSet := make([]string, 0)
+	setPrefix += "icmp "
+	for _, v := range icmp["flood"].([]interface{}) {
+		configSet = append(configSet, setPrefix+"flood")
+		if v != nil {
+			icmpFlood := v.(map[string]interface{})
+			if icmpFlood["threshold"].(int) != 0 {
+				configSet = append(configSet, setPrefix+"flood threshold "+
+					strconv.Itoa(icmpFlood["threshold"].(int)))
+			}
+		}
+	}
+	if icmp["fragment"].(bool) {
+		configSet = append(configSet, setPrefix+"fragment")
+	}
+	if icmp["icmpv6_malformed"].(bool) {
+		configSet = append(configSet, setPrefix+"icmpv6-malformed")
+	}
+	if icmp["large"].(bool) {
+		configSet = append(configSet, setPrefix+"large")
+	}
+	if icmp["ping_death"].(bool) {
+		configSet = append(configSet, setPrefix+"ping-death")
+	}
+	for _, v2 := range icmp["sweep"].([]interface{}) {
+		configSet = append(configSet, setPrefix+"ip-sweep")
+		if v2 != nil {
+			icmpSweep := v2.(map[string]interface{})
+			if icmpSweep["threshold"].(int) != 0 {
+				configSet = append(configSet, setPrefix+"ip-sweep threshold "+
+					strconv.Itoa(icmpSweep["threshold"].(int)))
+			}
+		}
+	}
+
+	return configSet
+}
+func checkSetSecurityScreenIP(ip map[string]interface{}) error {
+	if !ip["bad_option"].(bool) &&
+		!ip["block_frag"].(bool) &&
+		len(ip["ipv6_extension_header"].([]interface{})) == 0 &&
+		ip["ipv6_extension_header_limit"].(int) == -1 &&
+		!ip["ipv6_malformed_header"].(bool) &&
+		!ip["loose_source_route_option"].(bool) &&
+		!ip["record_route_option"].(bool) &&
+		!ip["security_option"].(bool) &&
+		!ip["source_route_option"].(bool) &&
+		!ip["spoofing"].(bool) &&
+		!ip["stream_option"].(bool) &&
+		!ip["strict_source_route_option"].(bool) &&
+		!ip["tear_drop"].(bool) &&
+		!ip["timestamp_option"].(bool) &&
+		len(ip["tunnel"].([]interface{})) == 0 &&
+		!ip["unknown_protocol"].(bool) {
+		return fmt.Errorf("ip block is empty")
+	}
+
+	return nil
+}
+func setSecurityScreenIP(ip map[string]interface{}, setPrefix string) ([]string, error) {
+	configSet := make([]string, 0)
+	setPrefix += "ip "
+	if ip["bad_option"].(bool) {
+		configSet = append(configSet, setPrefix+"bad-option")
+	}
+	if ip["block_frag"].(bool) {
+		configSet = append(configSet, setPrefix+"block-frag")
+	}
+	for _, v := range ip["ipv6_extension_header"].([]interface{}) {
+		if v == nil {
+			return configSet, fmt.Errorf("ip.0.ipv6_extension_header block is empty")
+		}
+		ipIPv6ExtHeader := v.(map[string]interface{})
+		if ipIPv6ExtHeader["ah_header"].(bool) {
+			configSet = append(configSet, setPrefix+"ipv6-extension-header AH-header")
+		}
+		if ipIPv6ExtHeader["esp_header"].(bool) {
+			configSet = append(configSet, setPrefix+"ipv6-extension-header ESP-header")
+		}
+		if ipIPv6ExtHeader["hip_header"].(bool) {
+			configSet = append(configSet, setPrefix+"ipv6-extension-header HIP-header")
+		}
+		for _, v2 := range ipIPv6ExtHeader["destination_header"].([]interface{}) {
+			configSet = append(configSet, setPrefix+"ipv6-extension-header destination-header")
+			if v2 != nil {
+				ipIPv6ExtHeaderDestHeader := v2.(map[string]interface{})
+				if ipIPv6ExtHeaderDestHeader["ilnp_nonce_option"].(bool) {
+					configSet = append(configSet, setPrefix+"ipv6-extension-header destination-header ILNP-nonce-option")
+				}
+				if ipIPv6ExtHeaderDestHeader["home_address_option"].(bool) {
+					configSet = append(configSet, setPrefix+"ipv6-extension-header destination-header home-address-option")
+				}
+				if ipIPv6ExtHeaderDestHeader["line_identification_option"].(bool) {
+					configSet = append(configSet, setPrefix+"ipv6-extension-header destination-header line-identification-option")
+				}
+				if ipIPv6ExtHeaderDestHeader["tunnel_encapsulation_limit_option"].(bool) {
+					configSet = append(configSet, setPrefix+"ipv6-extension-header destination-header "+
+						"tunnel-encapsulation-limit-option")
+				}
+				for _, v3 := range ipIPv6ExtHeaderDestHeader["user_defined_option_type"].([]interface{}) {
+					if r := regexp.MustCompile(userDefinedOptionTypeRegex); !r.Match([]byte(v3.(string))) {
+						return configSet, fmt.Errorf(
+							"user_defined_option_type %v doesn't match '(1..255)' or '(1..255) to (1..255)'", v3.(string))
+					}
+					configSet = append(configSet,
+						setPrefix+"ipv6-extension-header destination-header user-defined-option-type "+v3.(string))
+				}
+			}
+		}
+		if ipIPv6ExtHeader["fragment_header"].(bool) {
+			configSet = append(configSet, setPrefix+"ipv6-extension-header fragment-header")
+		}
+		for _, v2 := range ipIPv6ExtHeader["hop_by_hop_header"].([]interface{}) {
+			configSet = append(configSet, setPrefix+"ipv6-extension-header hop-by-hop-header")
+			if v2 != nil {
+				ipIPv6ExtHeaderHopByHopHeader := v2.(map[string]interface{})
+				if ipIPv6ExtHeaderHopByHopHeader["calipso_option"].(bool) {
+					configSet = append(configSet, setPrefix+"ipv6-extension-header hop-by-hop-header CALIPSO-option")
+				}
+				if ipIPv6ExtHeaderHopByHopHeader["rpl_option"].(bool) {
+					configSet = append(configSet, setPrefix+"ipv6-extension-header hop-by-hop-header RPL-option")
+				}
+				if ipIPv6ExtHeaderHopByHopHeader["smf_dpd_option"].(bool) {
+					configSet = append(configSet, setPrefix+"ipv6-extension-header hop-by-hop-header SMF-DPD-option")
+				}
+				if ipIPv6ExtHeaderHopByHopHeader["jumbo_payload_option"].(bool) {
+					configSet = append(configSet, setPrefix+"ipv6-extension-header hop-by-hop-header jumbo-payload-option")
+				}
+				if ipIPv6ExtHeaderHopByHopHeader["quick_start_option"].(bool) {
+					configSet = append(configSet, setPrefix+"ipv6-extension-header hop-by-hop-header quick-start-option")
+				}
+				if ipIPv6ExtHeaderHopByHopHeader["router_alert_option"].(bool) {
+					configSet = append(configSet, setPrefix+"ipv6-extension-header hop-by-hop-header router-alert-option")
+				}
+				for _, v3 := range ipIPv6ExtHeaderHopByHopHeader["user_defined_option_type"].([]interface{}) {
+					if r := regexp.MustCompile(userDefinedOptionTypeRegex); !r.Match([]byte(v3.(string))) {
+						return configSet, fmt.Errorf(
+							"user_defined_option_type %v doesn't match '(1..255)' or '(1..255) to (1..255)'", v3.(string))
+					}
+					configSet = append(configSet,
+						setPrefix+"ipv6-extension-header hop-by-hop-header user-defined-option-type "+v3.(string))
+				}
+			}
+		}
+		if ipIPv6ExtHeader["mobility_header"].(bool) {
+			configSet = append(configSet, setPrefix+"ipv6-extension-header mobility-header")
+		}
+		if ipIPv6ExtHeader["no_next_header"].(bool) {
+			configSet = append(configSet, setPrefix+"ipv6-extension-header no-next-header")
+		}
+		if ipIPv6ExtHeader["routing_header"].(bool) {
+			configSet = append(configSet, setPrefix+"ipv6-extension-header routing-header")
+		}
+		if ipIPv6ExtHeader["shim6_header"].(bool) {
+			configSet = append(configSet, setPrefix+"ipv6-extension-header shim6-header")
+		}
+		for _, v2 := range ipIPv6ExtHeader["user_defined_header_type"].([]interface{}) {
+			if r := regexp.MustCompile(userDefinedHeaderTypeRegex); !r.Match([]byte(v2.(string))) {
+				return configSet, fmt.Errorf(
+					"user_defined_header_type %v doesn't match '(0..255)' or '(0..255) to (0..255)'", v2.(string))
+			}
+			configSet = append(configSet, setPrefix+"ipv6-extension-header user-defined-header-type "+v2.(string))
+		}
+	}
+	if ip["ipv6_extension_header_limit"].(int) != -1 {
+		configSet = append(configSet, setPrefix+"ipv6-extension-header-limit "+
+			strconv.Itoa(ip["ipv6_extension_header_limit"].(int)))
+	}
+	if ip["ipv6_malformed_header"].(bool) {
+		configSet = append(configSet, setPrefix+"ipv6-malformed-header")
+	}
+	if ip["loose_source_route_option"].(bool) {
+		configSet = append(configSet, setPrefix+"loose-source-route-option")
+	}
+	if ip["record_route_option"].(bool) {
+		configSet = append(configSet, setPrefix+"record-route-option")
+	}
+	if ip["security_option"].(bool) {
+		configSet = append(configSet, setPrefix+"security-option")
+	}
+	if ip["source_route_option"].(bool) {
+		configSet = append(configSet, setPrefix+"source-route-option")
+	}
+	if ip["spoofing"].(bool) {
+		configSet = append(configSet, setPrefix+"spoofing")
+	}
+	if ip["stream_option"].(bool) {
+		configSet = append(configSet, setPrefix+"stream-option")
+	}
+	if ip["strict_source_route_option"].(bool) {
+		configSet = append(configSet, setPrefix+"strict-source-route-option")
+	}
+	if ip["tear_drop"].(bool) {
+		configSet = append(configSet, setPrefix+"tear-drop")
+	}
+	if ip["timestamp_option"].(bool) {
+		configSet = append(configSet, setPrefix+"timestamp-option")
+	}
+	for _, v := range ip["tunnel"].([]interface{}) {
+		if v == nil {
+			return configSet, fmt.Errorf("ip.0.tunnel block is empty")
+		}
+		ipTunnel := v.(map[string]interface{})
+		if ipTunnel["bad_inner_header"].(bool) {
+			configSet = append(configSet, setPrefix+"tunnel bad-inner-header")
+		}
+		for _, v2 := range ipTunnel["gre"].([]interface{}) {
+			if v2 == nil {
+				return configSet, fmt.Errorf("ip.0.tunnel.0.gre block is empty")
+			}
+			ipTunnelGre := v2.(map[string]interface{})
+			if ipTunnelGre["gre_4in4"].(bool) {
+				configSet = append(configSet, setPrefix+"tunnel gre gre-4in4")
+			}
+			if ipTunnelGre["gre_4in6"].(bool) {
+				configSet = append(configSet, setPrefix+"tunnel gre gre-4in6")
+			}
+			if ipTunnelGre["gre_6in4"].(bool) {
+				configSet = append(configSet, setPrefix+"tunnel gre gre-6in4")
+			}
+			if ipTunnelGre["gre_6in6"].(bool) {
+				configSet = append(configSet, setPrefix+"tunnel gre gre-6in6")
+			}
+		}
+		if ipTunnel["ip_in_udp_teredo"].(bool) {
+			configSet = append(configSet, setPrefix+"tunnel ip-in-udp teredo")
+		}
+		for _, v2 := range ipTunnel["ipip"].([]interface{}) {
+			if v2 == nil {
+				return configSet, fmt.Errorf("ip.0.tunnel.0.ipip block is empty")
+			}
+			ipTunnelIPIP := v2.(map[string]interface{})
+			if ipTunnelIPIP["ipip_4in4"].(bool) {
+				configSet = append(configSet, setPrefix+"tunnel ipip ipip-4in4")
+			}
+			if ipTunnelIPIP["ipip_4in6"].(bool) {
+				configSet = append(configSet, setPrefix+"tunnel ipip ipip-4in6")
+			}
+			if ipTunnelIPIP["ipip_6in4"].(bool) {
+				configSet = append(configSet, setPrefix+"tunnel ipip ipip-6in4")
+			}
+			if ipTunnelIPIP["ipip_6in6"].(bool) {
+				configSet = append(configSet, setPrefix+"tunnel ipip ipip-6in6")
+			}
+			if ipTunnelIPIP["ipip_6over4"].(bool) {
+				configSet = append(configSet, setPrefix+"tunnel ipip ipip-6over4")
+			}
+			if ipTunnelIPIP["ipip_6to4relay"].(bool) {
+				configSet = append(configSet, setPrefix+"tunnel ipip ipip-6to4relay")
+			}
+			if ipTunnelIPIP["dslite"].(bool) {
+				configSet = append(configSet, setPrefix+"tunnel ipip dslite")
+			}
+			if ipTunnelIPIP["isatap"].(bool) {
+				configSet = append(configSet, setPrefix+"tunnel ipip isatap")
+			}
+		}
+	}
+	if ip["unknown_protocol"].(bool) {
+		configSet = append(configSet, setPrefix+"unknown-protocol")
+	}
+
+	return configSet, nil
+}
+func setSecurityScreenTCP(tcp map[string]interface{}, setPrefix string) ([]string, error) {
+	configSet := make([]string, 0)
+	setPrefix += "tcp "
+	if tcp["fin_no_ack"].(bool) {
+		configSet = append(configSet, setPrefix+"fin-no-ack")
+	}
+	if tcp["land"].(bool) {
+		configSet = append(configSet, setPrefix+"land")
+	}
+	if tcp["no_flag"].(bool) {
+		configSet = append(configSet, setPrefix+"tcp-no-flag")
+	}
+	for _, v := range tcp["port_scan"].([]interface{}) {
+		configSet = append(configSet, setPrefix+"port-scan")
+		if v != nil {
+			tcpPortScan := v.(map[string]interface{})
+			if tcpPortScan["threshold"].(int) != 0 {
+				configSet = append(configSet, setPrefix+"port-scan threshold "+
+					strconv.Itoa(tcpPortScan["threshold"].(int)))
+			}
+		}
+	}
+	for _, v := range tcp["sweep"].([]interface{}) {
+		configSet = append(configSet, setPrefix+"tcp-sweep")
+		if v != nil {
+			tcpSweep := v.(map[string]interface{})
+			if tcpSweep["threshold"].(int) != 0 {
+				configSet = append(configSet, setPrefix+"tcp-sweep threshold "+
+					strconv.Itoa(tcpSweep["threshold"].(int)))
+			}
+		}
+	}
+	for _, v := range tcp["syn_ack_ack_proxy"].([]interface{}) {
+		configSet = append(configSet, setPrefix+"syn-ack-ack-proxy")
+		if v != nil {
+			tcpSAAP := v.(map[string]interface{})
+			if tcpSAAP["threshold"].(int) != 0 {
+				configSet = append(configSet, setPrefix+"syn-ack-ack-proxy threshold "+
+					strconv.Itoa(tcpSAAP["threshold"].(int)))
+			}
+		}
+	}
+	if tcp["syn_fin"].(bool) {
+		configSet = append(configSet, setPrefix+"syn-fin")
+	}
+	for _, v := range tcp["syn_flood"].([]interface{}) {
+		configSet = append(configSet, setPrefix+"syn-flood")
+		if v != nil {
+			tcpSynFlood := v.(map[string]interface{})
+			if tcpSynFlood["alarm_threshold"].(int) != 0 {
+				configSet = append(configSet, setPrefix+"syn-flood alarm-threshold "+
+					strconv.Itoa(tcpSynFlood["alarm_threshold"].(int)))
+			}
+			if tcpSynFlood["attack_threshold"].(int) != 0 {
+				configSet = append(configSet, setPrefix+"syn-flood attack-threshold "+
+					strconv.Itoa(tcpSynFlood["attack_threshold"].(int)))
+			}
+			if tcpSynFlood["destination_threshold"].(int) != 0 {
+				configSet = append(configSet, setPrefix+"syn-flood destination-threshold "+
+					strconv.Itoa(tcpSynFlood["destination_threshold"].(int)))
+			}
+			if tcpSynFlood["source_threshold"].(int) != 0 {
+				configSet = append(configSet, setPrefix+"syn-flood source-threshold "+
+					strconv.Itoa(tcpSynFlood["source_threshold"].(int)))
+			}
+			if tcpSynFlood["timeout"].(int) != 0 {
+				configSet = append(configSet, setPrefix+"syn-flood timeout "+
+					strconv.Itoa(tcpSynFlood["timeout"].(int)))
+			}
+			for _, v2 := range tcpSynFlood["whitelist"].(*schema.Set).List() {
+				whitelist := v2.(map[string]interface{})
+				if len(whitelist["source_address"].([]interface{})) == 0 &&
+					len(whitelist["destination_address"].([]interface{})) == 0 {
+					return configSet, fmt.Errorf("white-list %s need to have a source or destination address set",
+						whitelist["name"].(string))
+				}
+				for _, destination := range whitelist["destination_address"].([]interface{}) {
+					if err := validateCIDRNetwork(destination.(string)); err != nil {
+						return configSet, err
+					}
+					configSet = append(configSet, setPrefix+"syn-flood white-list "+whitelist["name"].(string)+
+						" destination-address "+destination.(string))
+				}
+				for _, source := range whitelist["source_address"].([]interface{}) {
+					if err := validateCIDRNetwork(source.(string)); err != nil {
+						return configSet, err
+					}
+					configSet = append(configSet, setPrefix+"syn-flood white-list "+whitelist["name"].(string)+
+						" source-address "+source.(string))
+				}
+			}
+		}
+	}
+	if tcp["syn_frag"].(bool) {
+		configSet = append(configSet, setPrefix+"syn-frag")
+	}
+	if tcp["winnuke"].(bool) {
+		configSet = append(configSet, setPrefix+"winnuke")
+	}
+
+	return configSet, nil
+}
+func setSecurityScreenUDP(udp map[string]interface{}, setPrefix string) []string {
+	configSet := make([]string, 0)
+	setPrefix += "udp "
+	for _, v := range udp["flood"].([]interface{}) {
+		configSet = append(configSet, setPrefix+"flood")
+		if v != nil {
+			udpFlood := v.(map[string]interface{})
+			if udpFlood["threshold"].(int) != 0 {
+				configSet = append(configSet, setPrefix+"flood threshold "+
+					strconv.Itoa(udpFlood["threshold"].(int)))
+			}
+			for _, whitelist := range udpFlood["whitelist"].([]interface{}) {
+				configSet = append(configSet, setPrefix+"flood white-list "+whitelist.(string))
+			}
+		}
+	}
+	for _, v := range udp["port_scan"].([]interface{}) {
+		configSet = append(configSet, setPrefix+"port-scan")
+		if v != nil {
+			udpPortScan := v.(map[string]interface{})
+			if udpPortScan["threshold"].(int) != 0 {
+				configSet = append(configSet, setPrefix+"port-scan threshold "+
+					strconv.Itoa(udpPortScan["threshold"].(int)))
+			}
+		}
+	}
+	for _, v := range udp["sweep"].([]interface{}) {
+		configSet = append(configSet, setPrefix+"udp-sweep")
+		if v != nil {
+			udpSweep := v.(map[string]interface{})
+			if udpSweep["threshold"].(int) != 0 {
+				configSet = append(configSet, setPrefix+"udp-sweep threshold "+
+					strconv.Itoa(udpSweep["threshold"].(int)))
+			}
+		}
+	}
+
+	return configSet
+}
+func readSecurityScreen(name string, m interface{}, jnprSess *NetconfObject) (screenOptions, error) {
+	sess := m.(*Session)
+	var confRead screenOptions
+
+	screenConfig, err := sess.command("show configuration security screen ids-option "+
+		"\""+name+"\" | display set relative ", jnprSess)
+	if err != nil {
+		return confRead, err
+	}
+	if screenConfig != emptyWord {
+		confRead.name = name
+		for _, item := range strings.Split(screenConfig, "\n") {
+			if strings.Contains(item, "<configuration-output>") {
+				continue
+			}
+			if strings.Contains(item, "</configuration-output>") {
+				break
+			}
+			itemTrim := strings.TrimPrefix(item, setLineStart)
+			switch {
+			case itemTrim == "alarm-without-drop":
+				confRead.alarmWithoutDrop = true
+			case strings.HasPrefix(itemTrim, "description "):
+				confRead.description = strings.Trim(strings.TrimPrefix(itemTrim, "description "), "\"")
+			case strings.HasPrefix(itemTrim, "icmp "):
+				if err := readSecurityScreenIcmp(&confRead, itemTrim); err != nil {
+					return confRead, err
+				}
+			case strings.HasPrefix(itemTrim, "ip"):
+				if err := readSecurityScreenIP(&confRead, itemTrim); err != nil {
+					return confRead, err
+				}
+			case strings.HasPrefix(itemTrim, "limit-session "):
+				if len(confRead.limitSession) == 0 {
+					confRead.limitSession = append(confRead.limitSession, map[string]interface{}{
+						"destination_ip_based": 0,
+						"source_ip_based":      0,
+					})
+				}
+				switch {
+				case strings.HasPrefix(itemTrim, "limit-session destination-ip-based "):
+					var err error
+					confRead.limitSession[0]["destination_ip_based"], err = strconv.Atoi(
+						strings.TrimPrefix(itemTrim, "limit-session destination-ip-based "))
+					if err != nil {
+						return confRead, fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+					}
+				case strings.HasPrefix(itemTrim, "limit-session source-ip-based "):
+					var err error
+					confRead.limitSession[0]["source_ip_based"], err = strconv.Atoi(
+						strings.TrimPrefix(itemTrim, "limit-session source-ip-based "))
+					if err != nil {
+						return confRead, fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+					}
+				}
+			case strings.HasPrefix(itemTrim, "tcp"):
+				if err := readSecurityScreenTCP(&confRead, itemTrim); err != nil {
+					return confRead, err
+				}
+			case strings.HasPrefix(itemTrim, "udp"):
+				if err := readSecurityScreenUDP(&confRead, itemTrim); err != nil {
+					return confRead, err
+				}
+			}
+		}
+	}
+
+	return confRead, nil
+}
+func readSecurityScreenIcmp(confRead *screenOptions, itemTrim string) error {
+	if len(confRead.icmp) == 0 {
+		confRead.icmp = append(confRead.icmp, map[string]interface{}{
+			"flood":            make([]map[string]interface{}, 0),
+			"fragment":         false,
+			"icmpv6_malformed": false,
+			"sweep":            make([]map[string]interface{}, 0),
+			"large":            false,
+			"ping_death":       false,
+		})
+	}
+	switch {
+	case strings.HasPrefix(itemTrim, "icmp flood"):
+		if len(confRead.icmp[0]["flood"].([]map[string]interface{})) == 0 {
+			confRead.icmp[0]["flood"] = append(confRead.icmp[0]["flood"].([]map[string]interface{}), map[string]interface{}{
+				"threshold": 0,
+			})
+		}
+		if strings.HasPrefix(itemTrim, "icmp flood threshold ") {
+			var err error
+			confRead.icmp[0]["flood"].([]map[string]interface{})[0]["threshold"], err = strconv.Atoi(
+				strings.TrimPrefix(itemTrim, "icmp flood threshold "))
+			if err != nil {
+				return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+			}
+		}
+	case itemTrim == "icmp fragment":
+		confRead.icmp[0]["fragment"] = true
+	case itemTrim == "icmp icmpv6-malformed":
+		confRead.icmp[0]["icmpv6_malformed"] = true
+	case itemTrim == "icmp large":
+		confRead.icmp[0]["large"] = true
+	case itemTrim == "icmp ping-death":
+		confRead.icmp[0]["ping_death"] = true
+	case strings.HasPrefix(itemTrim, "icmp ip-sweep"):
+		if len(confRead.icmp[0]["sweep"].([]map[string]interface{})) == 0 {
+			confRead.icmp[0]["sweep"] = append(confRead.icmp[0]["sweep"].([]map[string]interface{}), map[string]interface{}{
+				"threshold": 0,
+			})
+		}
+		if strings.HasPrefix(itemTrim, "icmp ip-sweep threshold ") {
+			var err error
+			confRead.icmp[0]["sweep"].([]map[string]interface{})[0]["threshold"], err = strconv.Atoi(
+				strings.TrimPrefix(itemTrim, "icmp ip-sweep threshold "))
+			if err != nil {
+				return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+			}
+		}
+	}
+
+	return nil
+}
+func readSecurityScreenIP(confRead *screenOptions, itemTrim string) error {
+	if len(confRead.ip) == 0 {
+		confRead.ip = append(confRead.ip, map[string]interface{}{
+			"bad_option":                  false,
+			"block_frag":                  false,
+			"ipv6_extension_header":       make([]map[string]interface{}, 0),
+			"ipv6_extension_header_limit": -1,
+			"ipv6_malformed_header":       false,
+			"loose_source_route_option":   false,
+			"record_route_option":         false,
+			"security_option":             false,
+			"source_route_option":         false,
+			"spoofing":                    false,
+			"stream_option":               false,
+			"strict_source_route_option":  false,
+			"tear_drop":                   false,
+			"timestamp_option":            false,
+			"tunnel":                      make([]map[string]interface{}, 0),
+			"unknown_protocol":            false,
+		})
+	}
+	switch {
+	case itemTrim == "ip bad-option":
+		confRead.ip[0]["bad_option"] = true
+	case itemTrim == "ip block-frag":
+		confRead.ip[0]["block_frag"] = true
+	case strings.HasPrefix(itemTrim, "ip ipv6-extension-header "):
+		if len(confRead.ip[0]["ipv6_extension_header"].([]map[string]interface{})) == 0 {
+			confRead.ip[0]["ipv6_extension_header"] = append(
+				confRead.ip[0]["ipv6_extension_header"].([]map[string]interface{}), map[string]interface{}{
+					"ah_header":                false,
+					"esp_header":               false,
+					"hip_header":               false,
+					"destination_header":       make([]map[string]interface{}, 0),
+					"fragment_header":          false,
+					"hop_by_hop_header":        make([]map[string]interface{}, 0),
+					"mobility_header":          false,
+					"no_next_header":           false,
+					"routing_header":           false,
+					"shim6_header":             false,
+					"user_defined_header_type": make([]string, 0),
+				})
+		}
+		switch {
+		case strings.HasPrefix(itemTrim, "ip ipv6-extension-header AH-header"):
+			confRead.ip[0]["ipv6_extension_header"].([]map[string]interface{})[0]["ah_header"] = true
+		case strings.HasPrefix(itemTrim, "ip ipv6-extension-header ESP-header"):
+			confRead.ip[0]["ipv6_extension_header"].([]map[string]interface{})[0]["esp_header"] = true
+		case strings.HasPrefix(itemTrim, "ip ipv6-extension-header HIP-header"):
+			confRead.ip[0]["ipv6_extension_header"].([]map[string]interface{})[0]["hip_header"] = true
+		case strings.HasPrefix(itemTrim, "ip ipv6-extension-header destination-header"):
+			if len(confRead.ip[0]["ipv6_extension_header"].([]map[string]interface{})[0]["destination_header"].([]map[string]interface{})) == 0 { // nolint: lll
+				confRead.ip[0]["ipv6_extension_header"].([]map[string]interface{})[0]["destination_header"] = append(
+					confRead.ip[0]["ipv6_extension_header"].([]map[string]interface{})[0]["destination_header"].([]map[string]interface{}), // nolint: lll
+					map[string]interface{}{
+						"ilnp_nonce_option":                 false,
+						"home_address_option":               false,
+						"line_identification_option":        false,
+						"tunnel_encapsulation_limit_option": false,
+						"user_defined_option_type":          make([]string, 0),
+					})
+			}
+			switch {
+			case itemTrim == "ip ipv6-extension-header destination-header ILNP-nonce-option":
+				confRead.ip[0]["ipv6_extension_header"].([]map[string]interface{})[0]["destination_header"].([]map[string]interface{})[0]["ilnp_nonce_option"] = // nolint: lll
+					true
+			case itemTrim == "ip ipv6-extension-header destination-header home-address-option":
+				confRead.ip[0]["ipv6_extension_header"].([]map[string]interface{})[0]["destination_header"].([]map[string]interface{})[0]["home_address_option"] = // nolint: lll
+					true
+			case itemTrim == "ip ipv6-extension-header destination-header line-identification-option":
+				confRead.ip[0]["ipv6_extension_header"].([]map[string]interface{})[0]["destination_header"].([]map[string]interface{})[0]["line_identification_option"] = // nolint: lll
+					true
+			case itemTrim == "ip ipv6-extension-header destination-header tunnel-encapsulation-limit-option":
+				confRead.ip[0]["ipv6_extension_header"].([]map[string]interface{})[0]["destination_header"].([]map[string]interface{})[0]["tunnel_encapsulation_limit_option"] = // nolint: lll
+					true
+			case strings.HasPrefix(itemTrim, "ip ipv6-extension-header destination-header user-defined-option-type "):
+				confRead.ip[0]["ipv6_extension_header"].([]map[string]interface{})[0]["destination_header"].([]map[string]interface{})[0]["user_defined_option_type"] = // nolint: lll
+					append(
+						confRead.ip[0]["ipv6_extension_header"].([]map[string]interface{})[0]["destination_header"].([]map[string]interface{})[0]["user_defined_option_type"].([]string), // nolint: lll
+						strings.TrimPrefix(itemTrim, "ip ipv6-extension-header destination-header user-defined-option-type "))
+			}
+		case strings.HasPrefix(itemTrim, "ip ipv6-extension-header fragment-header"):
+			confRead.ip[0]["ipv6_extension_header"].([]map[string]interface{})[0]["fragment_header"] = true
+		case strings.HasPrefix(itemTrim, "ip ipv6-extension-header hop-by-hop-header"):
+			if len(confRead.ip[0]["ipv6_extension_header"].([]map[string]interface{})[0]["hop_by_hop_header"].([]map[string]interface{})) == 0 { // nolint: lll
+				confRead.ip[0]["ipv6_extension_header"].([]map[string]interface{})[0]["hop_by_hop_header"] = append(
+					confRead.ip[0]["ipv6_extension_header"].([]map[string]interface{})[0]["hop_by_hop_header"].([]map[string]interface{}), // nolint: lll
+					map[string]interface{}{
+						"calipso_option":           false,
+						"rpl_option":               false,
+						"smf_dpd_option":           false,
+						"jumbo_payload_option":     false,
+						"quick_start_option":       false,
+						"router_alert_option":      false,
+						"user_defined_option_type": make([]string, 0),
+					})
+			}
+			switch {
+			case itemTrim == "ip ipv6-extension-header hop-by-hop-header CALIPSO-option":
+				confRead.ip[0]["ipv6_extension_header"].([]map[string]interface{})[0]["hop_by_hop_header"].([]map[string]interface{})[0]["calipso_option"] = // nolint: lll
+					true
+			case itemTrim == "ip ipv6-extension-header hop-by-hop-header RPL-option":
+				confRead.ip[0]["ipv6_extension_header"].([]map[string]interface{})[0]["hop_by_hop_header"].([]map[string]interface{})[0]["rpl_option"] = // nolint: lll
+					true
+			case itemTrim == "ip ipv6-extension-header hop-by-hop-header SMF-DPD-option":
+				confRead.ip[0]["ipv6_extension_header"].([]map[string]interface{})[0]["hop_by_hop_header"].([]map[string]interface{})[0]["smf_dpd_option"] = // nolint: lll
+					true
+			case itemTrim == "ip ipv6-extension-header hop-by-hop-header jumbo-payload-option":
+				confRead.ip[0]["ipv6_extension_header"].([]map[string]interface{})[0]["hop_by_hop_header"].([]map[string]interface{})[0]["jumbo_payload_option"] = // nolint: lll
+					true
+			case itemTrim == "ip ipv6-extension-header hop-by-hop-header quick-start-option":
+				confRead.ip[0]["ipv6_extension_header"].([]map[string]interface{})[0]["hop_by_hop_header"].([]map[string]interface{})[0]["quick_start_option"] = // nolint: lll
+					true
+			case itemTrim == "ip ipv6-extension-header hop-by-hop-header router-alert-option":
+				confRead.ip[0]["ipv6_extension_header"].([]map[string]interface{})[0]["hop_by_hop_header"].([]map[string]interface{})[0]["router_alert_option"] = // nolint: lll
+					true
+			case strings.HasPrefix(itemTrim, "ip ipv6-extension-header hop-by-hop-header user-defined-option-type "):
+				confRead.ip[0]["ipv6_extension_header"].([]map[string]interface{})[0]["hop_by_hop_header"].([]map[string]interface{})[0]["user_defined_option_type"] = // nolint: lll
+					append(
+						confRead.ip[0]["ipv6_extension_header"].([]map[string]interface{})[0]["hop_by_hop_header"].([]map[string]interface{})[0]["user_defined_option_type"].([]string), // nolint: lll
+						strings.TrimPrefix(itemTrim, "ip ipv6-extension-header hop-by-hop-header user-defined-option-type "))
+			}
+		case itemTrim == "ip ipv6-extension-header mobility-header":
+			confRead.ip[0]["ipv6_extension_header"].([]map[string]interface{})[0]["mobility_header"] = true
+		case itemTrim == "ip ipv6-extension-header no-next-header":
+			confRead.ip[0]["ipv6_extension_header"].([]map[string]interface{})[0]["no_next_header"] = true
+		case itemTrim == "ip ipv6-extension-header routing-header":
+			confRead.ip[0]["ipv6_extension_header"].([]map[string]interface{})[0]["routing_header"] = true
+		case itemTrim == "ip ipv6-extension-header shim6-header":
+			confRead.ip[0]["ipv6_extension_header"].([]map[string]interface{})[0]["shim6_header"] = true
+		case strings.HasPrefix(itemTrim, "ip ipv6-extension-header user-defined-header-type "):
+			confRead.ip[0]["ipv6_extension_header"].([]map[string]interface{})[0]["user_defined_header_type"] = append(
+				confRead.ip[0]["ipv6_extension_header"].([]map[string]interface{})[0]["user_defined_header_type"].([]string),
+				strings.TrimPrefix(itemTrim, "ip ipv6-extension-header user-defined-header-type "))
+		}
+	case strings.HasPrefix(itemTrim, "ip ipv6-extension-header-limit "):
+		var err error
+		confRead.ip[0]["ipv6_extension_header_limit"], err = strconv.Atoi(strings.TrimPrefix(itemTrim,
+			"ip ipv6-extension-header-limit "))
+		if err != nil {
+			return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+		}
+	case itemTrim == "ip ipv6-malformed-header":
+		confRead.ip[0]["ipv6_malformed_header"] = true
+	case itemTrim == "ip loose-source-route-option":
+		confRead.ip[0]["loose_source_route_option"] = true
+	case itemTrim == "ip record-route-option":
+		confRead.ip[0]["record_route_option"] = true
+	case itemTrim == "ip security-option":
+		confRead.ip[0]["security_option"] = true
+	case itemTrim == "ip source-route-option":
+		confRead.ip[0]["source_route_option"] = true
+	case itemTrim == "ip spoofing":
+		confRead.ip[0]["spoofing"] = true
+	case itemTrim == "ip stream-option":
+		confRead.ip[0]["stream_option"] = true
+	case itemTrim == "ip strict-source-route-option":
+		confRead.ip[0]["strict_source_route_option"] = true
+	case itemTrim == "ip tear-drop":
+		confRead.ip[0]["tear_drop"] = true
+	case itemTrim == "ip timestamp-option":
+		confRead.ip[0]["timestamp_option"] = true
+	case strings.HasPrefix(itemTrim, "ip tunnel "):
+		if len(confRead.ip[0]["tunnel"].([]map[string]interface{})) == 0 {
+			confRead.ip[0]["tunnel"] = append(
+				confRead.ip[0]["tunnel"].([]map[string]interface{}), map[string]interface{}{
+					"bad_inner_header": false,
+					"gre":              make([]map[string]interface{}, 0),
+					"ip_in_udp_teredo": false,
+					"ipip":             make([]map[string]interface{}, 0),
+				})
+		}
+		switch {
+		case itemTrim == "ip tunnel bad-inner-header":
+			confRead.ip[0]["tunnel"].([]map[string]interface{})[0]["bad_inner_header"] = true
+		case strings.HasPrefix(itemTrim, "ip tunnel gre "):
+			if len(confRead.ip[0]["tunnel"].([]map[string]interface{})[0]["gre"].([]map[string]interface{})) == 0 {
+				confRead.ip[0]["tunnel"].([]map[string]interface{})[0]["gre"] = append(
+					confRead.ip[0]["tunnel"].([]map[string]interface{})[0]["gre"].([]map[string]interface{}),
+					map[string]interface{}{
+						"gre_4in4": false,
+						"gre_4in6": false,
+						"gre_6in4": false,
+						"gre_6in6": false,
+					})
+			}
+			switch {
+			case itemTrim == "ip tunnel gre gre-4in4":
+				confRead.ip[0]["tunnel"].([]map[string]interface{})[0]["gre"].([]map[string]interface{})[0]["gre_4in4"] = true
+			case itemTrim == "ip tunnel gre gre-4in6":
+				confRead.ip[0]["tunnel"].([]map[string]interface{})[0]["gre"].([]map[string]interface{})[0]["gre_4in6"] = true
+			case itemTrim == "ip tunnel gre gre-6in4":
+				confRead.ip[0]["tunnel"].([]map[string]interface{})[0]["gre"].([]map[string]interface{})[0]["gre_6in4"] = true
+			case itemTrim == "ip tunnel gre gre-6in6":
+				confRead.ip[0]["tunnel"].([]map[string]interface{})[0]["gre"].([]map[string]interface{})[0]["gre_6in6"] = true
+			}
+		case itemTrim == "ip tunnel ip-in-udp teredo":
+			confRead.ip[0]["tunnel"].([]map[string]interface{})[0]["ip_in_udp_teredo"] = true
+		case strings.HasPrefix(itemTrim, "ip tunnel ipip "):
+			if len(confRead.ip[0]["tunnel"].([]map[string]interface{})[0]["ipip"].([]map[string]interface{})) == 0 {
+				confRead.ip[0]["tunnel"].([]map[string]interface{})[0]["ipip"] = append(
+					confRead.ip[0]["tunnel"].([]map[string]interface{})[0]["ipip"].([]map[string]interface{}),
+					map[string]interface{}{
+						"ipip_4in4":      false,
+						"ipip_4in6":      false,
+						"ipip_6in4":      false,
+						"ipip_6in6":      false,
+						"ipip_6over4":    false,
+						"ipip_6to4relay": false,
+						"dslite":         false,
+						"isatap":         false,
+					})
+			}
+			switch {
+			case itemTrim == "ip tunnel ipip ipip-4in4":
+				confRead.ip[0]["tunnel"].([]map[string]interface{})[0]["ipip"].([]map[string]interface{})[0]["ipip_4in4"] = true
+			case itemTrim == "ip tunnel ipip ipip-4in6":
+				confRead.ip[0]["tunnel"].([]map[string]interface{})[0]["ipip"].([]map[string]interface{})[0]["ipip_4in6"] = true
+			case itemTrim == "ip tunnel ipip ipip-6in4":
+				confRead.ip[0]["tunnel"].([]map[string]interface{})[0]["ipip"].([]map[string]interface{})[0]["ipip_6in4"] = true
+			case itemTrim == "ip tunnel ipip ipip-6in6":
+				confRead.ip[0]["tunnel"].([]map[string]interface{})[0]["ipip"].([]map[string]interface{})[0]["ipip_6in6"] = true
+			case itemTrim == "ip tunnel ipip ipip-6over4":
+				confRead.ip[0]["tunnel"].([]map[string]interface{})[0]["ipip"].([]map[string]interface{})[0]["ipip_6over4"] = true
+			case itemTrim == "ip tunnel ipip ipip-6to4relay":
+				confRead.ip[0]["tunnel"].([]map[string]interface{})[0]["ipip"].([]map[string]interface{})[0]["ipip_6to4relay"] =
+					true
+			case itemTrim == "ip tunnel ipip dslite":
+				confRead.ip[0]["tunnel"].([]map[string]interface{})[0]["ipip"].([]map[string]interface{})[0]["dslite"] = true
+			case itemTrim == "ip tunnel ipip isatap":
+				confRead.ip[0]["tunnel"].([]map[string]interface{})[0]["ipip"].([]map[string]interface{})[0]["isatap"] = true
+			}
+		}
+	case itemTrim == "ip unknown-protocol":
+		confRead.ip[0]["unknown_protocol"] = true
+	}
+
+	return nil
+}
+func readSecurityScreenTCP(confRead *screenOptions, itemTrim string) error {
+	if len(confRead.tcp) == 0 {
+		confRead.tcp = append(confRead.tcp, map[string]interface{}{
+			"fin_no_ack":        false,
+			"land":              false,
+			"no_flag":           false,
+			"port_scan":         make([]map[string]interface{}, 0),
+			"syn_ack_ack_proxy": make([]map[string]interface{}, 0),
+			"syn_fin":           false,
+			"syn_flood":         make([]map[string]interface{}, 0),
+			"syn_frag":          false,
+			"sweep":             make([]map[string]interface{}, 0),
+			"winnuke":           false,
+		})
+	}
+	switch {
+	case itemTrim == "tcp fin-no-ack":
+		confRead.tcp[0]["fin_no_ack"] = true
+	case itemTrim == "tcp land":
+		confRead.tcp[0]["land"] = true
+	case itemTrim == "tcp tcp-no-flag":
+		confRead.tcp[0]["no_flag"] = true
+	case strings.HasPrefix(itemTrim, "tcp port-scan"):
+		if len(confRead.tcp[0]["port_scan"].([]map[string]interface{})) == 0 {
+			confRead.tcp[0]["port_scan"] = append(confRead.tcp[0]["port_scan"].([]map[string]interface{}),
+				map[string]interface{}{
+					"threshold": 0,
+				})
+		}
+		if strings.HasPrefix(itemTrim, "tcp port-scan threshold ") {
+			var err error
+			confRead.tcp[0]["port_scan"].([]map[string]interface{})[0]["threshold"], err =
+				strconv.Atoi(strings.TrimPrefix(itemTrim, "tcp port-scan threshold "))
+			if err != nil {
+				return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+			}
+		}
+	case strings.HasPrefix(itemTrim, "tcp tcp-sweep"):
+		if len(confRead.tcp[0]["sweep"].([]map[string]interface{})) == 0 {
+			confRead.tcp[0]["sweep"] = append(confRead.tcp[0]["sweep"].([]map[string]interface{}),
+				map[string]interface{}{
+					"threshold": 0,
+				})
+		}
+		if strings.HasPrefix(itemTrim, "tcp tcp-sweep threshold ") {
+			var err error
+			confRead.tcp[0]["sweep"].([]map[string]interface{})[0]["threshold"], err =
+				strconv.Atoi(strings.TrimPrefix(itemTrim, "tcp tcp-sweep threshold "))
+			if err != nil {
+				return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+			}
+		}
+	case strings.HasPrefix(itemTrim, "tcp syn-ack-ack-proxy"):
+		if len(confRead.tcp[0]["syn_ack_ack_proxy"].([]map[string]interface{})) == 0 {
+			confRead.tcp[0]["syn_ack_ack_proxy"] = append(confRead.tcp[0]["syn_ack_ack_proxy"].([]map[string]interface{}),
+				map[string]interface{}{
+					"threshold": 0,
+				})
+		}
+		if strings.HasPrefix(itemTrim, "tcp syn-ack-ack-proxy threshold ") {
+			var err error
+			confRead.tcp[0]["syn_ack_ack_proxy"].([]map[string]interface{})[0]["threshold"], err =
+				strconv.Atoi(strings.TrimPrefix(itemTrim, "tcp syn-ack-ack-proxy threshold "))
+			if err != nil {
+				return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+			}
+		}
+	case itemTrim == "tcp syn-fin":
+		confRead.tcp[0]["syn_fin"] = true
+	case strings.HasPrefix(itemTrim, "tcp syn-flood"):
+		if len(confRead.tcp[0]["syn_flood"].([]map[string]interface{})) == 0 {
+			confRead.tcp[0]["syn_flood"] = append(
+				confRead.tcp[0]["syn_flood"].([]map[string]interface{}), map[string]interface{}{
+					"alarm_threshold":       0,
+					"attack_threshold":      0,
+					"destination_threshold": 0,
+					"source_threshold":      0,
+					"timeout":               0,
+					"whitelist":             make([]map[string]interface{}, 0),
+				})
+		}
+		switch {
+		case strings.HasPrefix(itemTrim, "tcp syn-flood alarm-threshold "):
+			var err error
+			confRead.tcp[0]["syn_flood"].([]map[string]interface{})[0]["alarm_threshold"], err =
+				strconv.Atoi(strings.TrimPrefix(itemTrim, "tcp syn-flood alarm-threshold "))
+			if err != nil {
+				return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+			}
+		case strings.HasPrefix(itemTrim, "tcp syn-flood attack-threshold "):
+			var err error
+			confRead.tcp[0]["syn_flood"].([]map[string]interface{})[0]["attack_threshold"], err =
+				strconv.Atoi(strings.TrimPrefix(itemTrim, "tcp syn-flood attack-threshold "))
+			if err != nil {
+				return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+			}
+		case strings.HasPrefix(itemTrim, "tcp syn-flood destination-threshold "):
+			var err error
+			confRead.tcp[0]["syn_flood"].([]map[string]interface{})[0]["destination_threshold"], err =
+				strconv.Atoi(strings.TrimPrefix(itemTrim, "tcp syn-flood destination-threshold "))
+			if err != nil {
+				return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+			}
+		case strings.HasPrefix(itemTrim, "tcp syn-flood source-threshold "):
+			var err error
+			confRead.tcp[0]["syn_flood"].([]map[string]interface{})[0]["source_threshold"], err =
+				strconv.Atoi(strings.TrimPrefix(itemTrim, "tcp syn-flood source-threshold "))
+			if err != nil {
+				return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+			}
+		case strings.HasPrefix(itemTrim, "tcp syn-flood timeout "):
+			var err error
+			confRead.tcp[0]["syn_flood"].([]map[string]interface{})[0]["timeout"], err =
+				strconv.Atoi(strings.TrimPrefix(itemTrim, "tcp syn-flood timeout "))
+			if err != nil {
+				return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+			}
+		case strings.HasPrefix(itemTrim, "tcp syn-flood white-list "):
+			whiteListLineCut := strings.Split(strings.TrimPrefix(itemTrim, "tcp syn-flood white-list "), " ")
+			m := map[string]interface{}{
+				"name":                whiteListLineCut[0],
+				"destination_address": make([]string, 0),
+				"source_address":      make([]string, 0),
+			}
+			m, confRead.tcp[0]["syn_flood"].([]map[string]interface{})[0]["whitelist"] = copyAndRemoveItemMapList(
+				"name", false, m,
+				confRead.tcp[0]["syn_flood"].([]map[string]interface{})[0]["whitelist"].([]map[string]interface{}))
+			itemTrimWhiteList := strings.TrimPrefix(itemTrim, "tcp syn-flood white-list "+whiteListLineCut[0]+" ")
+			switch {
+			case strings.HasPrefix(itemTrimWhiteList, "destination-address "):
+				m["destination_address"] = append(m["destination_address"].([]string),
+					strings.TrimPrefix(itemTrimWhiteList, "destination-address "))
+			case strings.HasPrefix(itemTrimWhiteList, "source-address "):
+				m["source_address"] = append(m["source_address"].([]string),
+					strings.TrimPrefix(itemTrimWhiteList, "source-address "))
+			}
+			confRead.tcp[0]["syn_flood"].([]map[string]interface{})[0]["whitelist"] = append(
+				confRead.tcp[0]["syn_flood"].([]map[string]interface{})[0]["whitelist"].([]map[string]interface{}), m)
+		}
+	case itemTrim == "tcp syn-frag":
+		confRead.tcp[0]["syn_frag"] = true
+	case itemTrim == "tcp winnuke":
+		confRead.tcp[0]["winnuke"] = true
+	}
+
+	return nil
+}
+func readSecurityScreenUDP(confRead *screenOptions, itemTrim string) error {
+	if len(confRead.udp) == 0 {
+		confRead.udp = append(confRead.udp, map[string]interface{}{
+			"flood":     make([]map[string]interface{}, 0),
+			"port_scan": make([]map[string]interface{}, 0),
+			"sweep":     make([]map[string]interface{}, 0),
+		})
+	}
+	switch {
+	case strings.HasPrefix(itemTrim, "udp flood"):
+		if len(confRead.udp[0]["flood"].([]map[string]interface{})) == 0 {
+			confRead.udp[0]["flood"] = append(confRead.udp[0]["flood"].([]map[string]interface{}), map[string]interface{}{
+				"threshold": 0,
+				"whitelist": make([]string, 0),
+			})
+		}
+		switch {
+		case strings.HasPrefix(itemTrim, "udp flood threshold "):
+			var err error
+			confRead.udp[0]["flood"].([]map[string]interface{})[0]["threshold"], err =
+				strconv.Atoi(strings.TrimPrefix(itemTrim, "udp flood threshold "))
+			if err != nil {
+				return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+			}
+		case strings.HasPrefix(itemTrim, "udp flood white-list "):
+			confRead.udp[0]["flood"].([]map[string]interface{})[0]["whitelist"] = append(
+				confRead.udp[0]["flood"].([]map[string]interface{})[0]["whitelist"].([]string),
+				strings.TrimPrefix(itemTrim, "udp flood white-list "))
+		}
+	case strings.HasPrefix(itemTrim, "udp port-scan"):
+		if len(confRead.udp[0]["port_scan"].([]map[string]interface{})) == 0 {
+			confRead.udp[0]["port_scan"] = append(
+				confRead.udp[0]["port_scan"].([]map[string]interface{}), map[string]interface{}{
+					"threshold": 0,
+				})
+		}
+		if strings.HasPrefix(itemTrim, "udp port-scan threshold ") {
+			var err error
+			confRead.udp[0]["port_scan"].([]map[string]interface{})[0]["threshold"], err =
+				strconv.Atoi(strings.TrimPrefix(itemTrim, "udp port-scan threshold "))
+			if err != nil {
+				return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+			}
+		}
+	case strings.HasPrefix(itemTrim, "udp udp-sweep"):
+		if len(confRead.udp[0]["sweep"].([]map[string]interface{})) == 0 {
+			confRead.udp[0]["sweep"] = append(
+				confRead.udp[0]["sweep"].([]map[string]interface{}), map[string]interface{}{
+					"threshold": 0,
+				})
+		}
+		if strings.HasPrefix(itemTrim, "udp udp-sweep threshold ") {
+			var err error
+			confRead.udp[0]["sweep"].([]map[string]interface{})[0]["threshold"], err =
+				strconv.Atoi(strings.TrimPrefix(itemTrim, "udp udp-sweep threshold "))
+			if err != nil {
+				return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func delSecurityScreen(name string, m interface{}, jnprSess *NetconfObject) error {
+	sess := m.(*Session)
+	configSet := make([]string, 0, 1)
+	configSet = append(configSet, "delete security screen ids-option \""+name+"\"")
+	if err := sess.configSet(configSet, jnprSess); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func fillSecurityScreenData(d *schema.ResourceData, screenOptions screenOptions) {
+	if tfErr := d.Set("name", screenOptions.name); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("alarm_without_drop", screenOptions.alarmWithoutDrop); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("description", screenOptions.description); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("icmp", screenOptions.icmp); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("ip", screenOptions.ip); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("limit_session", screenOptions.limitSession); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("tcp", screenOptions.tcp); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("udp", screenOptions.udp); tfErr != nil {
+		panic(tfErr)
+	}
+}

--- a/junos/resource_security_screen.go
+++ b/junos/resource_security_screen.go
@@ -476,7 +476,7 @@ func resourceSecurityScreen() *schema.Resource {
 												"name": {
 													Type:             schema.TypeString,
 													Required:         true,
-													ValidateDiagFunc: validateNameObjectJunos([]string{}),
+													ValidateDiagFunc: validateNameObjectJunos([]string{}, 32),
 												},
 												"destination_address": {
 													Type:     schema.TypeList,

--- a/junos/resource_security_screen_test.go
+++ b/junos/resource_security_screen_test.go
@@ -1,0 +1,325 @@
+package junos_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccJunosSecurityScreen_basic(t *testing.T) {
+	if os.Getenv("TESTACC_SWITCH") == "" {
+		resource.Test(t, resource.TestCase{
+			PreCheck:  func() { testAccPreCheck(t) },
+			Providers: testAccProviders,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccJunosSecurityScreenConfigCreate(),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("junos_security_screen.testacc_securityScreen",
+							"icmp.#", "1"),
+						resource.TestCheckResourceAttr("junos_security_screen.testacc_securityScreen",
+							"ip.#", "1"),
+						resource.TestCheckResourceAttr("junos_security_screen.testacc_securityScreen",
+							"limit_session.#", "1"),
+						resource.TestCheckResourceAttr("junos_security_screen.testacc_securityScreen",
+							"tcp.#", "1"),
+						resource.TestCheckResourceAttr("junos_security_screen.testacc_securityScreen",
+							"udp.#", "1"),
+						resource.TestCheckResourceAttr("junos_security_screen_whitelist.testacc1",
+							"address.#", "2"),
+					),
+				},
+				{
+					Config: testAccJunosSecurityScreenConfigUpdate(),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("junos_security_screen_whitelist.testacc2",
+							"address.#", "1"),
+					),
+				},
+				{
+					ResourceName:      "junos_security_screen.testacc_securityScreen",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+				{
+					ResourceName:      "junos_security_screen_whitelist.testacc1",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+			},
+		})
+	}
+}
+
+func testAccJunosSecurityScreenConfigCreate() string {
+	return `
+resource junos_security_screen testacc_securityScreen {
+  name               = "testacc 1"
+  alarm_without_drop = true
+  description        = "desc testacc 1"
+  icmp {
+    flood {}
+    fragment         = true
+    icmpv6_malformed = true
+    large            = true
+    ping_death       = true
+    sweep {}
+  }
+  ip {
+    bad_option = true
+    block_frag = true
+    ipv6_extension_header {
+      ah_header  = true
+      esp_header = true
+      hip_header = true
+      destination_header {}
+      fragment_header = true
+      hop_by_hop_header {}
+      mobility_header = true
+      no_next_header  = true
+      routing_header  = true
+      shim6_header    = true
+      user_defined_header_type = [
+        "10 to 20",
+        "2 to 5",
+        "1",
+      ]
+    }
+    ipv6_extension_header_limit = 32
+    ipv6_malformed_header       = true
+    loose_source_route_option   = true
+    record_route_option         = true
+    security_option             = true
+    source_route_option         = true
+    spoofing                    = true
+    stream_option               = true
+    strict_source_route_option  = true
+    tear_drop                   = true
+    timestamp_option            = true
+    tunnel {
+      bad_inner_header = true
+      gre {
+        gre_4in4 = true
+        gre_4in6 = true
+        gre_6in4 = true
+        gre_6in6 = true
+      }
+      ip_in_udp_teredo = true
+      ipip {
+        ipip_4in4      = true
+        ipip_4in6      = true
+        ipip_6in4      = true
+        ipip_6in6      = true
+        ipip_6over4    = true
+        ipip_6to4relay = true
+        dslite         = true
+        isatap         = true
+      }
+    }
+    unknown_protocol = true
+  }
+  limit_session {
+    destination_ip_based = 2000
+    source_ip_based      = 3000
+  }
+  tcp {
+    fin_no_ack = true
+    land       = true
+    no_flag    = true
+    port_scan {}
+    syn_ack_ack_proxy {}
+    syn_fin = true
+    syn_flood {
+      alarm_threshold       = 10011
+      attack_threshold      = 10012
+      destination_threshold = 10013
+      source_threshold      = 10014
+      timeout               = 10
+      whitelist {
+        name                = "test3"
+        source_address      = ["192.0.2.0/26"]
+        destination_address = ["192.0.2.64/26"]
+      }
+    }
+    syn_frag = true
+    sweep {}
+    winnuke = true
+  }
+  udp {
+    flood {}
+    port_scan {}
+    sweep {}
+  }
+}
+resource "junos_security_screen_whitelist" "testacc1" {
+  name = "testacc1"
+  address = [
+    "192.0.2.128/26",
+    "192.0.2.64/26",
+  ]
+}
+`
+}
+func testAccJunosSecurityScreenConfigUpdate() string {
+	return `
+resource junos_security_screen testacc_securityScreen {
+  name               = "testacc 1"
+  alarm_without_drop = true
+  description        = "desc testacc 1"
+  icmp {
+    flood {
+      threshold = 10000
+    }
+    fragment         = true
+    icmpv6_malformed = true
+    large            = true
+    ping_death       = true
+    sweep {
+      threshold = 10000
+    }
+  }
+  ip {
+    bad_option = true
+    block_frag = true
+    ipv6_extension_header {
+      ah_header  = true
+      esp_header = true
+      hip_header = true
+      destination_header {
+        ilnp_nonce_option                 = true
+        home_address_option               = true
+        line_identification_option        = true
+        tunnel_encapsulation_limit_option = true
+        user_defined_option_type = [
+          "10 to 20",
+          "2 to 5",
+          "1",
+        ]
+      }
+      fragment_header = true
+      hop_by_hop_header {
+        calipso_option       = true
+        rpl_option           = true
+        smf_dpd_option       = true
+        jumbo_payload_option = true
+        quick_start_option   = true
+        router_alert_option  = true
+        user_defined_option_type = [
+          "10 to 20",
+          "2 to 5",
+          "1",
+        ]
+      }
+      mobility_header = true
+      no_next_header  = true
+      routing_header  = true
+      shim6_header    = true
+      user_defined_header_type = [
+        "10 to 20",
+        "2 to 5",
+        "1",
+      ]
+    }
+    ipv6_extension_header_limit = 32
+    ipv6_malformed_header       = true
+    loose_source_route_option   = true
+    record_route_option         = true
+    security_option             = true
+    source_route_option         = true
+    spoofing                    = true
+    stream_option               = true
+    strict_source_route_option  = true
+    tear_drop                   = true
+    timestamp_option            = true
+    tunnel {
+      bad_inner_header = true
+      gre {
+        gre_4in4 = true
+        gre_4in6 = true
+        gre_6in4 = true
+        gre_6in6 = true
+      }
+      ip_in_udp_teredo = true
+      ipip {
+        ipip_4in4      = true
+        ipip_4in6      = true
+        ipip_6in4      = true
+        ipip_6in6      = true
+        ipip_6over4    = true
+        ipip_6to4relay = true
+        dslite         = true
+        isatap         = true
+      }
+    }
+    unknown_protocol = true
+  }
+  limit_session {
+    destination_ip_based = 2000
+    source_ip_based      = 3000
+  }
+  tcp {
+    fin_no_ack = true
+    land       = true
+    no_flag    = true
+    port_scan {
+      threshold = 10000
+    }
+    syn_ack_ack_proxy {
+      threshold = 10001
+    }
+    syn_fin = true
+    syn_flood {
+      alarm_threshold       = 10011
+      attack_threshold      = 10012
+      destination_threshold = 10013
+      source_threshold      = 10014
+      timeout               = 10
+      whitelist {
+        name                = "test3"
+        source_address      = ["192.0.2.0/26"]
+        destination_address = ["192.0.2.64/26"]
+      }
+      whitelist {
+        name                = "test2"
+        source_address      = ["192.0.2.128/26"]
+        destination_address = ["192.0.2.192/26"]
+      }
+    }
+    syn_frag = true
+    sweep {
+      threshold = 10002
+    }
+    winnuke = true
+  }
+  udp {
+    flood {
+      threshold = 1000
+      whitelist = [
+        junos_security_screen_whitelist.testacc2.name,
+        junos_security_screen_whitelist.testacc1.name,
+      ]
+    }
+    port_scan {
+      threshold = 1000
+    }
+    sweep {
+      threshold = 1000
+    }
+  }
+}
+resource "junos_security_screen_whitelist" "testacc1" {
+  name = "testacc1"
+  address = [
+    "192.0.2.128/26",
+    "192.0.2.64/26",
+  ]
+}
+resource "junos_security_screen_whitelist" "testacc2" {
+  name = "testacc2"
+  address = [
+    "192.0.2.0/26",
+  ]
+}
+`
+}

--- a/junos/resource_security_screen_whitelist.go
+++ b/junos/resource_security_screen_whitelist.go
@@ -28,7 +28,7 @@ func resourceSecurityScreenWhiteList() *schema.Resource {
 				Type:             schema.TypeString,
 				ForceNew:         true,
 				Required:         true,
-				ValidateDiagFunc: validateNameObjectJunos([]string{}),
+				ValidateDiagFunc: validateNameObjectJunos([]string{}, 32),
 			},
 			"address": {
 				Type:     schema.TypeList,

--- a/junos/resource_security_screen_whitelist.go
+++ b/junos/resource_security_screen_whitelist.go
@@ -1,0 +1,275 @@
+package junos
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type screenWhiteListOptions struct {
+	name    string
+	address []string
+}
+
+func resourceSecurityScreenWhiteList() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSecurityScreenWhiteListCreate,
+		ReadContext:   resourceSecurityScreenWhiteListRead,
+		UpdateContext: resourceSecurityScreenWhiteListUpdate,
+		DeleteContext: resourceSecurityScreenWhiteListDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceSecurityScreenWhiteListImport,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:             schema.TypeString,
+				ForceNew:         true,
+				Required:         true,
+				ValidateDiagFunc: validateNameObjectJunos([]string{}),
+			},
+			"address": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func resourceSecurityScreenWhiteListCreate(
+	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	if !checkCompatibilitySecurity(jnprSess) {
+		return diag.FromErr(fmt.Errorf("security screen white-list not compatible with Junos device %s",
+			jnprSess.SystemInformation.HardwareModel))
+	}
+	sess.configLock(jnprSess)
+	securityScreenWhiteListExists, err := checkSecurityScreenWhiteListExists(d.Get("name").(string), m, jnprSess)
+	if err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	if securityScreenWhiteListExists {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(fmt.Errorf("security screen white-list %v already exists", d.Get("name").(string)))
+	}
+
+	if err := setSecurityScreenWhiteList(d, m, jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	if err := sess.commitConf("create resource junos_security_screen_whitelist", jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	securityScreenWhiteListExists, err = checkSecurityScreenWhiteListExists(d.Get("name").(string), m, jnprSess)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if securityScreenWhiteListExists {
+		d.SetId(d.Get("name").(string))
+	} else {
+		return diag.FromErr(fmt.Errorf("security screen white-list %v not exists after commit "+
+			"=> check your config", d.Get("name").(string)))
+	}
+
+	return resourceSecurityScreenWhiteListReadWJnprSess(d, m, jnprSess)
+}
+func resourceSecurityScreenWhiteListRead(
+	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+
+	return resourceSecurityScreenWhiteListReadWJnprSess(d, m, jnprSess)
+}
+func resourceSecurityScreenWhiteListReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
+	whiteListOptions, err := readSecurityScreenWhiteList(d.Get("name").(string), m, jnprSess)
+	mutex.Unlock()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if whiteListOptions.name == "" {
+		d.SetId("")
+	} else {
+		fillSecurityScreenWhiteListData(d, whiteListOptions)
+	}
+
+	return nil
+}
+func resourceSecurityScreenWhiteListUpdate(
+	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	d.Partial(true)
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	sess.configLock(jnprSess)
+
+	if err := delSecurityScreenWhiteList(d.Get("name").(string), m, jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+
+	if err := setSecurityScreenWhiteList(d, m, jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	if err := sess.commitConf("update resource junos_security_screen_whitelist", jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	d.Partial(false)
+
+	return resourceSecurityScreenWhiteListReadWJnprSess(d, m, jnprSess)
+}
+func resourceSecurityScreenWhiteListDelete(
+	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	sess.configLock(jnprSess)
+	if err := delSecurityScreenWhiteList(d.Get("name").(string), m, jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+	if err := sess.commitConf("delete resource junos_security_screen_whitelist", jnprSess); err != nil {
+		sess.configClear(jnprSess)
+
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+func resourceSecurityScreenWhiteListImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return nil, err
+	}
+	defer sess.closeSession(jnprSess)
+	result := make([]*schema.ResourceData, 1)
+	securityScreenWhiteListExists, err := checkSecurityScreenWhiteListExists(d.Id(), m, jnprSess)
+	if err != nil {
+		return nil, err
+	}
+	if !securityScreenWhiteListExists {
+		return nil, fmt.Errorf("don't find screen white-list with id '%v' (id must be <name>)", d.Id())
+	}
+	whiteListOptions, err := readSecurityScreenWhiteList(d.Id(), m, jnprSess)
+	if err != nil {
+		return nil, err
+	}
+	fillSecurityScreenWhiteListData(d, whiteListOptions)
+
+	result[0] = d
+
+	return result, nil
+}
+
+func checkSecurityScreenWhiteListExists(name string, m interface{}, jnprSess *NetconfObject) (bool, error) {
+	sess := m.(*Session)
+	whiteListConfig, err := sess.command("show configuration"+
+		" security screen white-list "+name+" | display set", jnprSess)
+	if err != nil {
+		return false, err
+	}
+	if whiteListConfig == emptyWord {
+		return false, nil
+	}
+
+	return true, nil
+}
+func setSecurityScreenWhiteList(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) error {
+	sess := m.(*Session)
+	configSet := make([]string, 0)
+
+	setPrefix := "set security screen white-list " + d.Get("name").(string) + " "
+
+	for _, v := range d.Get("address").([]interface{}) {
+		if err := validateCIDRNetwork(v.(string)); err != nil {
+			return err
+		}
+		configSet = append(configSet, setPrefix+"address "+v.(string))
+	}
+
+	if err := sess.configSet(configSet, jnprSess); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func readSecurityScreenWhiteList(name string, m interface{}, jnprSess *NetconfObject) (screenWhiteListOptions, error) {
+	sess := m.(*Session)
+	var confRead screenWhiteListOptions
+
+	whiteListConfig, err := sess.command("show configuration security screen white-list "+
+		name+" | display set relative ", jnprSess)
+	if err != nil {
+		return confRead, err
+	}
+	if whiteListConfig != emptyWord {
+		confRead.name = name
+		for _, item := range strings.Split(whiteListConfig, "\n") {
+			if strings.Contains(item, "<configuration-output>") {
+				continue
+			}
+			if strings.Contains(item, "</configuration-output>") {
+				break
+			}
+			itemTrim := strings.TrimPrefix(item, setLineStart)
+			if strings.HasPrefix(itemTrim, "address ") {
+				confRead.address = append(confRead.address, strings.TrimPrefix(itemTrim, "address "))
+			}
+		}
+	}
+
+	return confRead, nil
+}
+
+func delSecurityScreenWhiteList(name string, m interface{}, jnprSess *NetconfObject) error {
+	sess := m.(*Session)
+	configSet := make([]string, 0, 1)
+	configSet = append(configSet, "delete security screen white-list "+name)
+	if err := sess.configSet(configSet, jnprSess); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func fillSecurityScreenWhiteListData(d *schema.ResourceData, whiteListOptions screenWhiteListOptions) {
+	if tfErr := d.Set("name", whiteListOptions.name); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("address", whiteListOptions.address); tfErr != nil {
+		panic(tfErr)
+	}
+}

--- a/junos/resource_security_zone.go
+++ b/junos/resource_security_zone.go
@@ -304,10 +304,6 @@ func readSecurityZone(zone string, m interface{}, jnprSess *NetconfObject) (zone
 	if err != nil {
 		return confRead, err
 	}
-	inboundServices := make([]string, 0)
-	inboundProtocols := make([]string, 0)
-	addressBook := make([]map[string]interface{}, 0)
-	addressBookSet := make([]map[string]interface{}, 0)
 	if zoneConfig != emptyWord {
 		confRead.name = zone
 		for _, item := range strings.Split(zoneConfig, "\n") {
@@ -324,10 +320,10 @@ func readSecurityZone(zone string, m interface{}, jnprSess *NetconfObject) (zone
 				addressWords := strings.Split(address, " ")
 				// addressWords[0] = name of address
 				// addressWords[1] = network
-				m := make(map[string]interface{})
-				m["name"] = addressWords[0]
-				m["network"] = addressWords[1]
-				addressBook = append(addressBook, m)
+				confRead.addressBook = append(confRead.addressBook, map[string]interface{}{
+					"name":    addressWords[0],
+					"network": addressWords[1],
+				})
 			case strings.HasPrefix(itemTrim, "address-book address-set "):
 				address := strings.TrimPrefix(itemTrim, "address-book address-set ")
 				addressWords := strings.Split(address, " ")
@@ -339,10 +335,10 @@ func readSecurityZone(zone string, m interface{}, jnprSess *NetconfObject) (zone
 					"address": make([]string, 0),
 				}
 				// search if name of address-set already create
-				m, addressBookSet = copyAndRemoveItemMapList("name", false, m, addressBookSet)
+				m, confRead.addressBookSet = copyAndRemoveItemMapList("name", false, m, confRead.addressBookSet)
 				// append new address find
 				m["address"] = append(m["address"].([]string), addressWords[2])
-				addressBookSet = append(addressBookSet, m)
+				confRead.addressBookSet = append(confRead.addressBookSet, m)
 			case strings.HasPrefix(itemTrim, "host-inbound-traffic protocols "):
 				confRead.inboundProtocols = append(confRead.inboundProtocols, strings.TrimPrefix(itemTrim,
 					"host-inbound-traffic protocols "))
@@ -351,15 +347,7 @@ func readSecurityZone(zone string, m interface{}, jnprSess *NetconfObject) (zone
 					"host-inbound-traffic system-services "))
 			}
 		}
-	} else {
-		confRead.name = ""
-
-		return confRead, nil
 	}
-	confRead.inboundServices = inboundServices
-	confRead.inboundProtocols = inboundProtocols
-	confRead.addressBook = addressBook
-	confRead.addressBookSet = addressBookSet
 
 	return confRead, nil
 }

--- a/junos/resource_security_zone_test.go
+++ b/junos/resource_security_zone_test.go
@@ -17,10 +17,6 @@ func TestAccJunosSecurityZone_basic(t *testing.T) {
 					Config: testAccJunosSecurityZoneConfigCreate(),
 					Check: resource.ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr("junos_security_zone.testacc_securityZone",
-							"inbound_protocols.#", "1"),
-						resource.TestCheckResourceAttr("junos_security_zone.testacc_securityZone",
-							"inbound_protocols.0", "bgp"),
-						resource.TestCheckResourceAttr("junos_security_zone.testacc_securityZone",
 							"address_book.#", "1"),
 						resource.TestCheckResourceAttr("junos_security_zone.testacc_securityZone",
 							"address_book.0.name", "testacc_address1"),
@@ -32,15 +28,15 @@ func TestAccJunosSecurityZone_basic(t *testing.T) {
 							"address_book_set.0.address.#", "1"),
 						resource.TestCheckResourceAttr("junos_security_zone.testacc_securityZone",
 							"address_book_set.0.address.0", "testacc_address1"),
+						resource.TestCheckResourceAttr("junos_security_zone.testacc_securityZone",
+							"inbound_protocols.0", "bgp"),
+						resource.TestCheckResourceAttr("junos_security_zone.testacc_securityZone",
+							"inbound_protocols.#", "1"),
 					),
 				},
 				{
 					Config: testAccJunosSecurityZoneConfigUpdate(),
 					Check: resource.ComposeTestCheckFunc(
-						resource.TestCheckResourceAttr("junos_security_zone.testacc_securityZone",
-							"inbound_services.#", "1"),
-						resource.TestCheckResourceAttr("junos_security_zone.testacc_securityZone",
-							"inbound_services.0", "ssh"),
 						resource.TestCheckResourceAttr("junos_security_zone.testacc_securityZone",
 							"address_book.#", "2"),
 						resource.TestCheckResourceAttr("junos_security_zone.testacc_securityZone",
@@ -49,6 +45,10 @@ func TestAccJunosSecurityZone_basic(t *testing.T) {
 							"address_book_set.0.address.#", "2"),
 						resource.TestCheckResourceAttr("junos_security_zone.testacc_securityZone",
 							"address_book_set.0.address.1", "testacc_address2"),
+						resource.TestCheckResourceAttr("junos_security_zone.testacc_securityZone",
+							"inbound_services.#", "1"),
+						resource.TestCheckResourceAttr("junos_security_zone.testacc_securityZone",
+							"inbound_services.0", "ssh"),
 					),
 				},
 				{
@@ -64,8 +64,7 @@ func TestAccJunosSecurityZone_basic(t *testing.T) {
 func testAccJunosSecurityZoneConfigCreate() string {
 	return `
 resource junos_security_zone "testacc_securityZone" {
-  name              = "testacc_securityZone"
-  inbound_protocols = ["bgp"]
+  name = "testacc_securityZone"
   address_book {
     name    = "testacc_address1"
     network = "192.0.2.0/25"
@@ -74,15 +73,14 @@ resource junos_security_zone "testacc_securityZone" {
     name    = "testacc_addressSet"
     address = ["testacc_address1"]
   }
+  inbound_protocols = ["bgp"]
 }
 `
 }
 func testAccJunosSecurityZoneConfigUpdate() string {
 	return `
 resource junos_security_zone "testacc_securityZone" {
-  name              = "testacc_securityZone"
-  inbound_protocols = ["bgp"]
-  inbound_services  = ["ssh"]
+  name = "testacc_securityZone"
   address_book {
     name    = "testacc_address1"
     network = "192.0.2.0/25"
@@ -95,6 +93,8 @@ resource junos_security_zone "testacc_securityZone" {
     name    = "testacc_addressSet"
     address = ["testacc_address1", "testacc_address2"]
   }
+  inbound_protocols = ["bgp"]
+  inbound_services  = ["ssh"]
 }
 `
 }

--- a/website/docs/r/security_screen.html.markdown
+++ b/website/docs/r/security_screen.html.markdown
@@ -1,0 +1,175 @@
+---
+layout: "junos"
+page_title: "Junos: junos_security_screen"
+sidebar_current: "docs-junos-resource-security-screen"
+description: |-
+  Create a security screen (when Junos device supports it)
+---
+
+# junos_security_screen
+
+Provides a security screen resource.
+
+## Example Usage
+
+```hcl
+# Add a security screen
+resource junos_security_screen "demo_screen" {
+  name               = "demo_screen"
+  alarm_without_drop = true
+  description        = "desc screen"
+  icmp {
+    flood {}
+    ping_death = true
+  }
+  ip {
+    spoofing = true
+  }
+  limit_session {
+    destination_ip_based = 2000
+    source_ip_based      = 3000
+  }
+  tcp {
+    syn_flood {}
+  }
+  udp {
+    flood {}
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required, Forces new resource)(`String`) The name of screen.
+* `alarm_without_drop` - (Optional)(`Bool`) Do not drop packet, only generate alarm.
+* `description` - (Optional)(`String`) Text description of screen.
+* `icmp` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once for declare 'icmp' configuration. See the [`icmp` arguments] (#icmp-arguments) block.
+* `ip` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once for declare 'ip' configuration. See the [`ip` arguments] (#ip-arguments) block.
+* `limit_session` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once for declare 'limit-session' configuration.
+  * `destination_ip_based` - (Optional)(`ListOfString`) Limit sessions to the same destination IP (1..2000000).
+  * `source_ip_based` - (Optional)(`ListOfString`) Limit sessions from the same source IP (1..2000000).
+* `tcp` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once for declare 'tcp' configuration. See the [`tcp` arguments] (#tcp-arguments) block.
+* `udp` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once for declare 'udp' configuration. See the [`udp` arguments] (#udp-arguments) block.
+
+---
+#### icmp arguments
+* `flood` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to enable icmp flood ids option.
+  * `threshold` - (Optional)(`Int`) Threshold (1..1000000 ICMP packets per second).
+* `fragment` - (Optional)(`Bool`) Enable ICMP fragment ids option.
+* `icmpv6_malformed` - (Optional)(`Bool`) Enable icmpv6 malformed ids option
+* `large` - (Optional)(`Bool`) Enable large ICMP packet (size > 1024) ids option
+* `ping_death` - (Optional)(`Bool`) Enable ping of death ids option
+* `sweep` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to enable ip sweep ids option.
+  * `threshold` - (Optional)(`Int`) Threshold (1000..1000000 microseconds in which 10 ICMP packets are detected).
+
+---
+#### ip arguments
+* `bad_option` - (Optional)(`Bool`) Enable ip with bad option ids option.
+* `block_frag` - (Optional)(`Bool`) Enable ip fragment blocking ids option.
+* `ipv6_extension_header` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once for declare 'ip ipv6-extension-header' configuration. See the [`ipv6_extension_header` arguments for ip] (#ipv6_extension_header-arguments-for-ip) block.
+* `ipv6_extension_header_limit` - (Optional)(`Int`) Enable ipv6 extension header limit ids option (0..32).
+* `ipv6_malformed_header` - (Optional)(`Bool`) Enable ipv6 malformed header ids option.
+* `loose_source_route_option` - (Optional)(`Bool`) Enable ip with loose source route ids option.
+* `record_route_option` - (Optional)(`Bool`) Enable ip with record route option ids option.
+* `security_option` - (Optional)(`Bool`) Enable ip with security option ids option.
+* `source_route_option` - (Optional)(`Bool`) Enable ip source route ids option.
+* `spoofing` - (Optional)(`Bool`) Enable ip address spoofing ids option.
+* `stream_option` - (Optional)(`Bool`) Enable ip with stream option ids option.
+* `strict_source_route_option` - (Optional)(`Bool`) Enable ip with strict source route ids option.
+* `tear_drop` - (Optional)(`Bool`) Enable tear drop ids option.
+* `timestamp_option` - (Optional)(`Bool`) Enable ip with timestamp option ids option.
+* `tunnel` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once for declare 'ip tunnel' configuration. See the [`tunnel` arguments for ip] (#tunnel-arguments-for-ip) block.
+* `unknown_protocol` - (Optional)(`Bool`) Enable ip unknown protocol ids option.
+
+---
+#### tcp arguments
+* `fin_no_ack` - (Optional)(`Bool`) Enable Fin bit with no ACK bit ids option.
+* `land` - (Optional)(`Bool`) Enable land attack ids option.
+* `no_flag` - (Optional)(`Bool`) Enable TCP packet without flag ids option.
+* `port_scan` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to enable TCP port scan ids option.
+  * `threshold` - (Optional)(`Int`) Threshold (1000..1000000 microseconds in which 10 attack packets are detected).
+* `syn_ack_ack_proxy` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to enable syn-ack-ack proxy ids option.
+  * `threshold` - (Optional)(`Int`) Threshold (1..250000 un-authenticated connections).
+* `syn_fin` - (Optional)(`Bool`) Enable SYN and FIN bits set attack ids option.
+* `syn_flood` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to enable SYN flood ids option. See the optional [`syn_flood` arguments for ip] (#syn_flood-arguments-for-tcp) block.
+* `syn_frag` - (Optional)(`Bool`) Enable SYN fragment ids option.
+* `sweep` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to enable TCP sweep ids option.
+  * `threshold` - (Optional)(`Int`) Threshold (1000..1000000 microseconds in which 10 TCP packets are detected).
+* `winnuke` - (Optional)(`Bool`) Enable winnuke attack ids option.
+
+---
+#### udp arguments
+* `flood` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to UDP flood ids option.
+  * `threshold` - (Optional)(`Int`) Threshold (1..1000000 UDP packets per second).
+  * `whitelist` - (Optional)(`ListOfString`) List of UDP flood white list group name.
+* `port_scan` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to UDP port scan ids option.
+  * `threshold` - (Optional)(`Int`) Threshold (1000..1000000 microseconds in which 10 attack packets are detected).
+* `sweep` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to UDP sweep ids option.
+  * `threshold` - (Optional)(`Int`) Threshold (1000..1000000 microseconds in which 10 UDP packets are detected).
+
+---
+#### ipv6_extension_header arguments for ip
+* `ah_header` - (Optional)(`Bool`) Enable ipv6 Authentication Header ids option.
+* `esp_header` - (Optional)(`Bool`) Enable ipv6 Encapsulating Security Payload header ids option.
+* `hip_header` - (Optional)(`Bool`) Enable ipv6 Host Identify Protocol header ids option.
+* `destination_header` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to enable ipv6 destination option header ids option.
+  * `ilnp_nonce_option` - (Optional)(`Bool`) Enable Identifier-Locator Network Protocol Nonce option ids option.
+  * `home_address_option` - (Optional)(`Bool`) Enable home address option ids option.
+  * `line_identification_option` - (Optional)(`Bool`) Enable line identification option ids option.
+  * `tunnel_encapsulation_limit_option` - (Optional)(`Bool`) Enable tunnel encapsulation limit option ids option.
+  * `user_defined_option_type` - (Optional)(`ListOfString`) User-defined option type range. Need to be '(1..255)' or '(1..255) to (1..255)'. 
+* `fragment_header` - (Optional)(`Bool`) Enable ipv6 fragment header ids option.
+* `hop_by_hop_header` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to enable ipv6 hop by hop option header ids option.
+  * `calipso_option` - (Optional)(`Bool`) Enable Common Architecture Label ipv6 Security Option ids option.
+  * `rpl_option` - (Optional)(`Bool`) Enable Routing Protocol for Low-power and Lossy networks option ids option.
+  * `smf_dpd_option` - (Optional)(`Bool`) Enable Simplified Multicast Forwarding ipv6 Duplicate Packet Detection option ids option.
+  * `jumbo_payload_option` - (Optional)(`Bool`) Enable jumbo payload option ids option.
+  * `quick_start_option` - (Optional)(`Bool`) Enable quick start option ids option.
+  * `router_alert_option` - (Optional)(`Bool`) Enable router alert option ids option.
+  * `user_defined_option_type` - (Optional)(`ListOfString`) User-defined option type range. Need to be '(1..255)' or '(1..255) to (1..255)'. 
+* `mobility_header` - (Optional)(`Bool`) Enable ipv6 mobility header ids option.
+* `no_next_header` - (Optional)(`Bool`) Enable ipv6 no next header ids option.
+* `routing_header` - (Optional)(`Bool`) Enable ipv6 routing header ids option.
+* `shim6_header` - (Optional)(`Bool`) Enable ipv6 shim header ids option.
+* `user_defined_header_type` - (Optional)(`ListOfString`)  User-defined header type range. Need to be '(0..255)' or '(0..255) to (0..255)'.
+
+---
+#### tunnel arguments for ip
+* `bad_inner_header` - (Optional)(`Bool`) Enable IP tunnel bad inner header ids option.
+* `gre` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once for declare 'ip tunnel gre' configuration.
+  * `gre_4in4` - (Optional)(`Bool`) Enable IP tunnel GRE 4in4 ids option.
+  * `gre_4in6` - (Optional)(`Bool`) Enable IP tunnel GRE 4in6 ids option.
+  * `gre_6in4` - (Optional)(`Bool`) Enable IP tunnel GRE 6in4 ids option.
+  * `gre_6in6` - (Optional)(`Bool`) Enable IP tunnel GRE 6in6 ids option.
+* `ip_in_udp_teredo` - (Optional)(`Bool`) Enable IP tunnel IPinUDP Teredo ids option.
+* `ipip` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once for declare 'ip tunnel ipip' configuration.
+  * `ipip_4in4` - (Optional)(`Bool`) Enable IP tunnel IPIP 4in4 ids option.
+  * `ipip_4in6` - (Optional)(`Bool`) Enable IP tunnel IPIP 4in6 ids option.
+  * `ipip_6in4` - (Optional)(`Bool`) Enable IP tunnel IPIP 6in4 ids option.
+  * `ipip_6in6` - (Optional)(`Bool`) Enable IP tunnel IPIP 6in6 ids option.
+  * `ipip_6over4` - (Optional)(`Bool`) Enable IP tunnel IPIP 6over4 ids option.
+  * `ipip_6to4relay` - (Optional)(`Bool`) Enable IP tunnel IPIP 6to4 Relay ids option.
+  * `dslite` - (Optional)(`Bool`) Enable IP tunnel IPIP DS-Lite ids option.
+  * `isatap` - (Optional)(`Bool`) Enable IP tunnel IPIP ISATAP ids option.
+
+---
+#### syn_flood arguments for tcp
+* `alarm_threshold` - (Optional)(`Int`) Alarm threshold (1..500000 requests per second).
+* `attack_threshold` - (Optional)(`Int`) Attack threshold (1..500000 proxied requests per second).
+* `destination_threshold` - (Optional)(`Int`) Destination threshold (4..500000 SYN pps).
+* `source_threshold` - (Optional)(`Int`) Source threshold (4..500000 SYN pps).
+* `timeout` - (Optional)(`Int`) SYN flood ager timeout (1..50 seconds).
+* `whitelist` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified multiple times for each white-list to declare.
+  * `name` - (Required)(`String`) White-list name.
+  * `destination_address` - (Optional)(`ListOfString`) Destination address. Need to be a valid CIDR network.
+  * `source_address` - (Optional)(`ListOfString`) Source address. Need to be a valid CIDR network.
+
+## Import
+
+Junos security screen can be imported using an id made up of `<name>`, e.g.
+
+```
+$ terraform import junos_security_screen.demo_screen demo_screen
+```

--- a/website/docs/r/security_screen_whitelist.html.markdown
+++ b/website/docs/r/security_screen_whitelist.html.markdown
@@ -1,0 +1,39 @@
+---
+layout: "junos"
+page_title: "Junos: junos_security_screen_whitelist"
+sidebar_current: "docs-junos-resource-security-screen-whitelist"
+description: |-
+  Create a security screen white-list (when Junos device supports it)
+---
+
+# junos_security_screen_whitelist
+
+Provides a security screen white-list resource.
+
+## Example Usage
+
+```hcl
+# Add a security screen white-list
+resource junos_security_screen_whitelist "demo_screen_whitelist" {
+  name = "demo_screen_whitelist"
+  address = [
+    "192.0.2.128/26",
+    "192.0.2.64/26",
+  ]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required, Forces new resource)(`String`) The name of screen.
+* `address` - (Required)(`ListOfString`) List of address. Need to be a valid CIDR network.
+
+## Import
+
+Junos security screen white-list can be imported using an id made up of `<name>`, e.g.
+
+```
+$ terraform import junos_security_screen_whitelist.demo_screen_whitelist demo_screen_whitelist
+```

--- a/website/docs/r/security_zone.html.markdown
+++ b/website/docs/r/security_zone.html.markdown
@@ -29,14 +29,14 @@ resource junos_security_zone "demo_zone" {
 The following arguments are supported:
 
 * `name` - (Required, Forces new resource)(`String`) The name of security zone.
-* `inbound_services` - (Optional)(`ListOfString`) The inbound services allowed. Must be a list of Junos services
-* `inbound_protocols` - (Optional)(`ListOfString`) The inbound protocols allowed. Must be a list of Junos protocols
 * `address_book` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified multiple times for each address to declare.
   * `name` - (Required)(`String`) Name of address
   * `network` - (Required)(`String`) CIDR of address
 * `address_book_set` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified multiple times for each address-set to declare.
   * `name` - (Required)(`String`) Name of address-set
   * `address` - (Required)(`ListOfString`) List of address names
+* `inbound_protocols` - (Optional)(`ListOfString`) The inbound protocols allowed. Must be a list of Junos protocols
+* `inbound_services` - (Optional)(`ListOfString`) The inbound services allowed. Must be a list of Junos services
 
 ## Import
 

--- a/website/docs/r/security_zone.html.markdown
+++ b/website/docs/r/security_zone.html.markdown
@@ -30,13 +30,20 @@ The following arguments are supported:
 
 * `name` - (Required, Forces new resource)(`String`) The name of security zone.
 * `address_book` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified multiple times for each address to declare.
-  * `name` - (Required)(`String`) Name of address
-  * `network` - (Required)(`String`) CIDR of address
+  * `name` - (Required)(`String`) Name of address.
+  * `network` - (Required)(`String`) CIDR of address.
 * `address_book_set` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified multiple times for each address-set to declare.
-  * `name` - (Required)(`String`) Name of address-set
-  * `address` - (Required)(`ListOfString`) List of address names
-* `inbound_protocols` - (Optional)(`ListOfString`) The inbound protocols allowed. Must be a list of Junos protocols
-* `inbound_services` - (Optional)(`ListOfString`) The inbound services allowed. Must be a list of Junos services
+  * `name` - (Required)(`String`) Name of address-set.
+  * `address` - (Required)(`ListOfString`) List of address names.
+* `advance_policy_based_routing_profile` - (Optional)(`String`) Enable Advance Policy Based Routing on this zone with a profile.
+* `application_tracking` - (Optional)(`Bool`) Enable Application tracking support for this zone.
+* `description` - (Optional)(`String`) Text description of zone.
+* `inbound_protocols` - (Optional)(`ListOfString`) The inbound protocols allowed. Must be a list of Junos protocols.
+* `inbound_services` - (Optional)(`ListOfString`) The inbound services allowed. Must be a list of Junos services.
+* `reverse_reroute` - (Optional)(`Bool`) Enable Reverse route lookup when there is change in ingress interface.
+* `screen` - (Optional)(`String`) Name of ids option object (screen) applied to the zone.
+* `source_identity_log` - (Optional)(`Bool`) Show user and group info in session log for this zone.
+* `tcp_rst` - (Optional)(`Bool`) Send RST for NON-SYN packet not matching TCP session.
 
 ## Import
 


### PR DESCRIPTION
ENHANCEMENTS:
* add `junos_security_screen` resource (Fixes parts of [#92](https://github.com/jeremmfr/terraform-provider-junos/issues/92))
* add `junos_security_screen_whitelist` resource
* add `advance_policy_based_routing_profile`, `application_tracking`, `description`, `reverse_reroute`, `screen`, `source_identity_log` and `tcp_rst` arguments in `junos_security_zone` resource (Fixes parts of [#92](https://github.com/jeremmfr/terraform-provider-junos/issues/92))