### PR TITLE
Fixes #111 : non-existent interface and compute ae maximum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ BUG FIXES:
 * clean code: remove useless else when read a empty config
 * fix typo in name of `accounting_timeout` argument in `junos_system_radius_server` resource. **Update your config for new version of this argument**
 * fix warnings received from the device generate failures on resource actions. Now, received warnings are send to terraform under warnings format (Fixes #105)
+* fix integer compute for `chassis aggregated-devices ethernet device-count` when create/update/delete `junos_interface_physical` resource. Now this uses current configuration instead of the status of 'ae' interfaces and also takes into account resource with prefix name 'ae' in addition to `ether802_3ad` argument.
 
 ## 1.12.3 (February 5, 2021)
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ BUG FIXES:
 * clean code: remove useless else when read a empty config
 * fix typo in name of `accounting_timeout` argument in `junos_system_radius_server` resource. **Update your config for new version of this argument**
 * fix warnings received from the device generate failures on resource actions. Now, received warnings are send to terraform under warnings format (Fixes #105)
+* fix possibility to create `junos_interface_physical` and `junos_interface_logical` resource on a non-existent interface (Fixes #111). Read configuration before read interface status for validate resource existence.
 * fix integer compute for `chassis aggregated-devices ethernet device-count` when create/update/delete `junos_interface_physical` resource. Now this uses current configuration instead of the status of 'ae' interfaces and also takes into account resource with prefix name 'ae' in addition to `ether802_3ad` argument.
 
 ## 1.12.3 (February 5, 2021)

--- a/junos/func_common.go
+++ b/junos/func_common.go
@@ -218,6 +218,25 @@ func uniqueListString(s []string) []string {
 	return r
 }
 
+type sortStringsLength []string
+
+func (s sortStringsLength) Len() int {
+	return len(s)
+}
+func (s sortStringsLength) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+func (s sortStringsLength) Less(i, j int) bool {
+	if len(s[i]) < len(s[j]) {
+		return true
+	}
+	if len(s[j]) < len(s[i]) {
+		return false
+	}
+
+	return s[i] < s[j]
+}
+
 func checkStringHasPrefixInList(s string, list []string) bool {
 	for _, item := range list {
 		if strings.HasPrefix(s, item) {

--- a/junos/resource_security_ipsec_vpn.go
+++ b/junos/resource_security_ipsec_vpn.go
@@ -267,7 +267,7 @@ func resourceIpsecVpnUpdate(ctx context.Context, d *schema.ResourceData, m inter
 	}
 	if d.HasChanges("bind_interface") && d.Get("bind_interface_auto").(bool) {
 		oldInt, _ := d.GetChange("bind_interface")
-		st0NC, st0Emtpy, err := checkInterfaceLogicalNC(oldInt.(string), m, jnprSess)
+		st0NC, st0Emtpy, _, err := checkInterfaceLogicalNCEmpty(oldInt.(string), m, jnprSess)
 		if err != nil {
 			sess.configClear(jnprSess)
 
@@ -535,7 +535,7 @@ func delIpsecVpn(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject)
 	configSet := make([]string, 0, 1)
 	configSet = append(configSet, "delete security ipsec vpn "+d.Get("name").(string))
 	if d.Get("bind_interface_auto").(bool) {
-		st0NC, st0Emtpy, err := checkInterfaceLogicalNC(d.Get("bind_interface").(string), m, jnprSess)
+		st0NC, st0Emtpy, _, err := checkInterfaceLogicalNCEmpty(d.Get("bind_interface").(string), m, jnprSess)
 		if err != nil {
 			return err
 		}

--- a/website/docs/r/interface_physical.html.markdown
+++ b/website/docs/r/interface_physical.html.markdown
@@ -44,6 +44,8 @@ The following arguments are supported:
 * `vlan_native` - (Optional)(`Int`) Vlan for untagged frames.
 * `vlan_tagging` - (Optional)(`Bool`) Add 802.1q VLAN tagging support.
 
+~> **NOTE:** This resource computes the maximum number of aggregate interfaces required with the current configuration (searches lines `ether-options 802.3ad` and `ae` interfaces set) then add/remove `chassis aggregated-devices ethernet device-count` line with this maximum.
+
 ## Import
 
 Junos interface can be imported using an id made up of `<name>`, e.g.


### PR DESCRIPTION
BUG FIXES:
* fix possibility to create `junos_interface_physical` and `junos_interface_logical` resource on a non-existent interface (Fixes #111). Read configuration before read interface status for validate resource existence.
* fix integer compute for `chassis aggregated-devices ethernet device-count` when create/update/delete `junos_interface_physical` resource. Now this uses current configuration instead of the status of 'ae' interfaces and also takes into account resource with prefix name 'ae' in addition to `ether802_3ad` argument.