### PR TITLE
Fixes #117: filter_output not set with good argument for family inet6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ BUG FIXES:
 * fix IP/Mask validation for point to point IPs
 * fix possibility to create `junos_interface_physical` and `junos_interface_logical` resource on a non-existent interface (Fixes #111). Read configuration before read interface status for validate resource existence.
 * fix integer compute for `chassis aggregated-devices ethernet device-count` when create/update/delete `junos_interface_physical` resource. Now this uses current configuration instead of the status of 'ae' interfaces and also takes into account resource with prefix name 'ae' in addition to `ether802_3ad` argument.
+* fix `filter_output` not set with good argument for `family inet6` in `junos_interface_logical` resource  (Fixes [#117](https://github.com/jeremmfr/terraform-provider-junos/issues/117))
 
 ## 1.12.3 (February 5, 2021)
 BUG FIXES:

--- a/junos/resource_interface_logical.go
+++ b/junos/resource_interface_logical.go
@@ -778,7 +778,7 @@ func setInterfaceLogical(d *schema.ResourceData, m interface{}, jnprSess *Netcon
 			}
 			if familyInet6["filter_output"].(string) != "" {
 				configSet = append(configSet, setPrefix+"family inet6 filter output "+
-					familyInet6["filter_input"].(string))
+					familyInet6["filter_output"].(string))
 			}
 			if familyInet6["mtu"].(int) > 0 {
 				configSet = append(configSet, setPrefix+"family inet6 mtu "+


### PR DESCRIPTION
BUG FIXES:
* fix `filter_output` not set with good argument for `family inet6` in `junos_interface_logical` resource  (Fixes [#117](https://github.com/jeremmfr/terraform-provider-junos/issues/117))