### PR TITLE
Add multipath arguments

### DIFF
--- a/junos/func_resource_bgp.go
+++ b/junos/func_resource_bgp.go
@@ -782,6 +782,9 @@ func setBgpOptsMultipath(setPrefix string, multipaths []interface{},
 	for _, v := range multipaths {
 		if v != nil {
 			m := v.(map[string]interface{})
+			if m["enable"].(bool) {
+				configSet = append(configSet, setPrefix+"multipath")
+			}
 			if m["disable"].(bool) {
 				configSet = append(configSet, setPrefix+"multipath disable")
 			}
@@ -805,14 +808,18 @@ func setBgpOptsMultipath(setPrefix string, multipaths []interface{},
 func readBgpOptsMultipath(item string, grOpts []map[string]interface{}) ([]map[string]interface{}, error) {
 	itemTrim := strings.TrimPrefix(item, "multipath ")
 	grRead := map[string]interface{}{
+		"enable":           false,
 		"disable":          false,
 		"allow_protection": false,
-		"multiple-as":      false,
+		"multiple_as":      false,
 	}
 	if len(grOpts) > 0 {
 		for k, v := range grOpts[0] {
 			grRead[k] = v
 		}
+	}
+	if itemTrim == "multipath" {
+		grRead["enable"] = true
 	}
 	if itemTrim == disableW {
 		grRead["disable"] = true

--- a/junos/resource_bgp_group.go
+++ b/junos/resource_bgp_group.go
@@ -445,9 +445,12 @@ func resourceBgpGroup() *schema.Resource {
 			"multipath": {
                                 Type:     schema.TypeList,
                                 Optional: true,
-                                MaxItems: 1,
                                 Elem: &schema.Resource{
                                         Schema: map[string]*schema.Schema{
+						"enable" : {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
                                                 "disable": {
                                                         Type:     schema.TypeBool,
                                                         Optional: true,
@@ -718,6 +721,9 @@ func setBgpGroup(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject)
 	if err := setBgpOptsGrafefulRestart(setPrefix, d.Get("graceful_restart").([]interface{}), m, jnprSess); err != nil {
 		return err
 	}
+	if err := setBgpOptsMultipath(setPrefix, d.Get("multipath").([]interface{}), m, jnprSess); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -774,6 +780,11 @@ func readBgpGroup(bgpGroup, instance string, m interface{}, jnprSess *NetconfObj
 				}
 			case strings.HasPrefix(itemTrim, "graceful-restart "):
 				confRead.gracefulRestart, err = readBgpOptsGracefulRestart(itemTrim, confRead.gracefulRestart)
+				if err != nil {
+					return confRead, err
+				}
+			case strings.HasPrefix(itemTrim, "multipath"):
+				confRead.multipath, err = readBgpOptsMultipath(itemTrim, confRead.multipath)
 				if err != nil {
 					return confRead, err
 				}

--- a/junos/resource_bgp_group.go
+++ b/junos/resource_bgp_group.go
@@ -443,8 +443,26 @@ func resourceBgpGroup() *schema.Resource {
 				Optional: true,
 			},
 			"multipath": {
-				Type:     schema.TypeBool,
-				Optional: true,
+                                Type:     schema.TypeList,
+                                Optional: true,
+                                MaxItems: 1,
+                                Elem: &schema.Resource{
+                                        Schema: map[string]*schema.Schema{
+                                                "disable": {
+                                                        Type:     schema.TypeBool,
+                                                        Optional: true,
+                                                },
+                                                "allow_protection": {
+                                                        Type:          schema.TypeBool,
+                                                        Optional:      true,
+                                                },
+                                                "multiple_as": {
+                                                        Type:          schema.TypeBool,
+                                                        Optional:      true,
+                                                },
+                                        },
+                                },
+
 			},
 			"out_delay": {
 				Type:         schema.TypeInt,

--- a/junos/resource_bgp_neighbor.go
+++ b/junos/resource_bgp_neighbor.go
@@ -436,10 +436,32 @@ func resourceBgpNeighbor() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
-			"multipath": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
+                        "multipath": {
+                                Type:     schema.TypeList,
+                                Optional: true,
+                                Elem: &schema.Resource{
+                                        Schema: map[string]*schema.Schema{
+                                                "enable" : {
+                                                        Type:     schema.TypeBool,
+                                                        Optional: true,
+                                                },
+                                                "disable": {
+                                                        Type:     schema.TypeBool,
+                                                        Optional: true,
+                                                },
+                                                "allow_protection": {
+                                                        Type:          schema.TypeBool,
+                                                        Optional:      true,
+                                                },
+                                                "multiple_as": {
+                                                        Type:          schema.TypeBool,
+                                                        Optional:      true,
+                                                },
+                                        },
+                                },
+
+                        },
+
 			"out_delay": {
 				Type:         schema.TypeInt,
 				Optional:     true,


### PR DESCRIPTION
This is a breaking change, as it changes the terraform.state object from bool to list. This change provides ability to add BGP multipath arguments beyond true:false.

Usage:
```
resource "junos_bgp_group" "main" {
   name = resource_name
   multipath {
     enable = true. #optional
     disable = true #optional
     multiple_as = true #optional
     allow_protection = true #optional
   }
}
```