### PR TITLE
Add option for  bgp group cluster id

### DIFF
--- a/junos/func_resource_bgp.go
+++ b/junos/func_resource_bgp.go
@@ -291,7 +291,7 @@ func readBgpOptsSimple(item string, confRead *bgpOptions) error {
 		confRead.authenticationKeyChain = strings.TrimPrefix(item, "authentication-key-chain ")
 	}
 	if strings.HasPrefix(item, "cluster ") {
-		confRead.localAddress = strings.TrimPrefix(item, "cluster ")
+		confRead.cluster = strings.TrimPrefix(item, "cluster ")
 	}
 	if item == "damping" {
 		confRead.damping = true

--- a/junos/func_resource_bgp.go
+++ b/junos/func_resource_bgp.go
@@ -42,6 +42,7 @@ type bgpOptions struct {
 	authenticationKey            string
 	authenticationKeyChain       string
 	bgpType                      string // group only
+	cluster                      string
 	localAddress                 string
 	localAs                      string
 	localInterface               string
@@ -90,6 +91,7 @@ func delBgpOpts(d *schema.ResourceData, typebgp string, m interface{}, jnprSess 
 		delPrefix+"authentication-key",
 		delPrefix+"authentication-key-chain",
 		delPrefix+"bfd-liveness-detection",
+		delPrefix+"cluster",
 		delPrefix+"damping",
 		delPrefix+"export",
 		delPrefix+"family inet",
@@ -149,6 +151,9 @@ func setBgpOptsSimple(setPrefix string, d *schema.ResourceData, m interface{}, j
 	}
 	if d.Get("authentication_key_chain").(string) != "" {
 		configSet = append(configSet, setPrefix+"authentication-key-chain "+d.Get("authentication_key_chain").(string))
+	}
+	if d.Get("cluster").(string) != "" {
+		configSet = append(configSet, setPrefix+"cluster "+d.Get("cluster").(string))
 	}
 	if d.Get("damping").(bool) {
 		configSet = append(configSet, setPrefix+"damping")
@@ -284,6 +289,9 @@ func readBgpOptsSimple(item string, confRead *bgpOptions) error {
 	}
 	if strings.HasPrefix(item, "authentication-key-chain ") {
 		confRead.authenticationKeyChain = strings.TrimPrefix(item, "authentication-key-chain ")
+	}
+	if strings.HasPrefix(item, "cluster ") {
+		confRead.localAddress = strings.TrimPrefix(item, "cluster ")
 	}
 	if item == "damping" {
 		confRead.damping = true

--- a/junos/resource_bgp_group.go
+++ b/junos/resource_bgp_group.go
@@ -153,6 +153,11 @@ func resourceBgpGroup() *schema.Resource {
 					},
 				},
 			},
+			"cluster": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.IsIPAddress,
+			},
 			"damping": {
 				Type:     schema.TypeBool,
 				Optional: true,


### PR DESCRIPTION
This adds the option for cluster id in BGP group.

Usage:

```
resource "junos_bgp_group" "main" {
  name = "resource_name"
  cluster = "1.1.1.1"
}
```