### PR TITLE
Multipath multiple as

### DIFF
--- a/junos/func_resource_bgp.go
+++ b/junos/func_resource_bgp.go
@@ -26,6 +26,7 @@ type bgpOptions struct {
 	metricOutMinimumIgp          bool
 	mtuDiscovery                 bool
 	multihop                     bool
+	multipath                    bool
 	noAdvertisePeerAs            bool
 	removePrivate                bool
 	passive                      bool
@@ -54,7 +55,7 @@ type bgpOptions struct {
 	familyInet                   []map[string]interface{}
 	familyInet6                  []map[string]interface{}
 	gracefulRestart              []map[string]interface{}
-	multipath                    []map[string]interface{}
+	multipath_options            []map[string]interface{}
 }
 
 func delBgpOpts(d *schema.ResourceData, typebgp string, m interface{}, jnprSess *NetconfObject) error {
@@ -225,6 +226,9 @@ func setBgpOptsSimple(setPrefix string, d *schema.ResourceData, m interface{}, j
 	}
 	if d.Get("multihop").(bool) {
 		configSet = append(configSet, setPrefix+"multihop")
+	}
+	if d.Get("multipath").(bool) {
+		configSet = append(configSet, setPrefix+"multipath")
 	}
 	if d.Get("no_advertise_peer_as").(bool) {
 		configSet = append(configSet, setPrefix+"no-advertise-peer-as")
@@ -782,9 +786,6 @@ func setBgpOptsMultipath(setPrefix string, multipaths []interface{},
 	for _, v := range multipaths {
 		if v != nil {
 			m := v.(map[string]interface{})
-			if m["enable"].(bool) {
-				configSet = append(configSet, setPrefix+"multipath")
-			}
 			if m["disable"].(bool) {
 				configSet = append(configSet, setPrefix+"multipath disable")
 			}
@@ -808,7 +809,6 @@ func setBgpOptsMultipath(setPrefix string, multipaths []interface{},
 func readBgpOptsMultipath(item string, grOpts []map[string]interface{}) ([]map[string]interface{}, error) {
 	itemTrim := strings.TrimPrefix(item, "multipath ")
 	grRead := map[string]interface{}{
-		"enable":           false,
 		"disable":          false,
 		"allow_protection": false,
 		"multiple_as":      false,
@@ -817,9 +817,6 @@ func readBgpOptsMultipath(item string, grOpts []map[string]interface{}) ([]map[s
 		for k, v := range grOpts[0] {
 			grRead[k] = v
 		}
-	}
-	if itemTrim == "multipath" {
-		grRead["enable"] = true
 	}
 	if itemTrim == disableW {
 		grRead["disable"] = true

--- a/junos/func_resource_bgp.go
+++ b/junos/func_resource_bgp.go
@@ -782,6 +782,9 @@ func setBgpOptsMultipath(setPrefix string, multipaths []interface{},
 	for _, v := range multipaths {
 		if v != nil {
 			m := v.(map[string]interface{})
+			if m["enable"].(bool) {
+				configSet = append(configSet, setPrefix+"multipath")
+			}
 			if m["disable"].(bool) {
 				configSet = append(configSet, setPrefix+"multipath disable")
 			}
@@ -805,14 +808,18 @@ func setBgpOptsMultipath(setPrefix string, multipaths []interface{},
 func readBgpOptsMultipath(item string, grOpts []map[string]interface{}) ([]map[string]interface{}, error) {
 	itemTrim := strings.TrimPrefix(item, "multipath ")
 	grRead := map[string]interface{}{
+		"enable":           false,
 		"disable":          false,
 		"allow_protection": false,
-		"multiple-as":      false,
+		"multiple_as":      false,
 	}
 	if len(grOpts) > 0 {
 		for k, v := range grOpts[0] {
 			grRead[k] = v
 		}
+	}
+	if itemTrim == "multipath" {
+		grRead["enable"] = true
 	}
 	if itemTrim == disableW {
 		grRead["disable"] = true

--- a/junos/func_resource_bgp.go
+++ b/junos/func_resource_bgp.go
@@ -367,6 +367,9 @@ func readBgpOptsSimple(item string, confRead *bgpOptions) error {
 	if item == "multihop" {
 		confRead.multihop = true
 	}
+	if item == "multipath" {
+		confRead.multipath = true
+	}
 	if item == "no-advertise-peer-as" {
 		confRead.noAdvertisePeerAs = true
 	}

--- a/junos/resource_bgp_group.go
+++ b/junos/resource_bgp_group.go
@@ -454,10 +454,6 @@ func resourceBgpGroup() *schema.Resource {
 				ConflictsWith: []string{"multipath"},
                                 Elem: &schema.Resource{
                                         Schema: map[string]*schema.Schema{
-                                                "enable": {
-                                                        Type:     schema.TypeBool,
-                                                        Optional: true,
-                                                },
                                                 "disable": {
                                                         Type:     schema.TypeBool,
                                                         Optional: true,

--- a/junos/resource_bgp_group.go
+++ b/junos/resource_bgp_group.go
@@ -445,9 +445,12 @@ func resourceBgpGroup() *schema.Resource {
 			"multipath": {
                                 Type:     schema.TypeList,
                                 Optional: true,
-                                MaxItems: 1,
                                 Elem: &schema.Resource{
                                         Schema: map[string]*schema.Schema{
+						"enable" : {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
                                                 "disable": {
                                                         Type:     schema.TypeBool,
                                                         Optional: true,
@@ -718,6 +721,9 @@ func setBgpGroup(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject)
 	if err := setBgpOptsGrafefulRestart(setPrefix, d.Get("graceful_restart").([]interface{}), m, jnprSess); err != nil {
 		return err
 	}
+	if err := setBgpOptsMultipath(setPrefix, d.Get("multipath").([]interface{}), m, jnprSess); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -774,6 +780,11 @@ func readBgpGroup(bgpGroup, instance string, m interface{}, jnprSess *NetconfObj
 				}
 			case strings.HasPrefix(itemTrim, "graceful-restart "):
 				confRead.gracefulRestart, err = readBgpOptsGracefulRestart(itemTrim, confRead.gracefulRestart)
+				if err != nil {
+					return confRead, err
+				}
+			case strings.HasPrefix(itemTrim, "multipath"):
+				confRead.multipath, err = readBgpOptsMultipath(itemTrim, confRead.multipath)
 				if err != nil {
 					return confRead, err
 				}

--- a/junos/resource_bgp_group.go
+++ b/junos/resource_bgp_group.go
@@ -445,13 +445,19 @@ func resourceBgpGroup() *schema.Resource {
 			"multipath": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				ConflictsWith: []string{"multipath_options"},
 			},
 			"multipath_options": {
                                 Type:     schema.TypeList,
                                 Optional: true,
 				MaxItems: 1,
+				ConflictsWith: []string{"multipath"},
                                 Elem: &schema.Resource{
                                         Schema: map[string]*schema.Schema{
+                                                "enable": {
+                                                        Type:     schema.TypeBool,
+                                                        Optional: true,
+                                                },
                                                 "disable": {
                                                         Type:     schema.TypeBool,
                                                         Optional: true,
@@ -786,7 +792,6 @@ func readBgpGroup(bgpGroup, instance string, m interface{}, jnprSess *NetconfObj
 				}
 			case strings.HasPrefix(itemTrim, "multipath "):
 				confRead.multipath_options, err = readBgpOptsMultipath(itemTrim, confRead.multipath_options)
-				confRead.multipath = true
 				if err != nil {
 					return confRead, err
 				}

--- a/junos/resource_bgp_group.go
+++ b/junos/resource_bgp_group.go
@@ -443,6 +443,10 @@ func resourceBgpGroup() *schema.Resource {
 				Optional: true,
 			},
 			"multipath": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"multipath_options": {
                                 Type:     schema.TypeList,
                                 Optional: true,
                                 Elem: &schema.Resource{
@@ -721,7 +725,7 @@ func setBgpGroup(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject)
 	if err := setBgpOptsGrafefulRestart(setPrefix, d.Get("graceful_restart").([]interface{}), m, jnprSess); err != nil {
 		return err
 	}
-	if err := setBgpOptsMultipath(setPrefix, d.Get("multipath").([]interface{}), m, jnprSess); err != nil {
+	if err := setBgpOptsMultipath(setPrefix, d.Get("multipath_options").([]interface{}), m, jnprSess); err != nil {
 		return err
 	}
 
@@ -783,8 +787,8 @@ func readBgpGroup(bgpGroup, instance string, m interface{}, jnprSess *NetconfObj
 				if err != nil {
 					return confRead, err
 				}
-			case strings.HasPrefix(itemTrim, "multipath"):
-				confRead.multipath, err = readBgpOptsMultipath(itemTrim, confRead.multipath)
+			case strings.HasPrefix(itemTrim, "multipath "):
+				confRead.multipath_options, err = readBgpOptsMultipath(itemTrim, confRead.multipath_options)
 				if err != nil {
 					return confRead, err
 				}
@@ -925,6 +929,9 @@ func fillBgpGroupData(d *schema.ResourceData, bgpGroupOptions bgpOptions) {
 		panic(tfErr)
 	}
 	if tfErr := d.Set("multipath", bgpGroupOptions.multipath); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("multipath_options", bgpGroupOptions.multipath_options); tfErr != nil {
 		panic(tfErr)
 	}
 	if tfErr := d.Set("no_advertise_peer_as", bgpGroupOptions.noAdvertisePeerAs); tfErr != nil {

--- a/junos/resource_bgp_group.go
+++ b/junos/resource_bgp_group.go
@@ -443,8 +443,26 @@ func resourceBgpGroup() *schema.Resource {
 				Optional: true,
 			},
 			"multipath": {
-				Type:     schema.TypeBool,
-				Optional: true,
+                                Type:     schema.TypeList,
+                                Optional: true,
+                                MaxItems: 1,
+                                Elem: &schema.Resource{
+                                        Schema: map[string]*schema.Schema{
+                                                "disable": {
+                                                        Type:     schema.TypeBool,
+                                                        Optional: true,
+                                                },
+                                                "allow_protection": {
+                                                        Type:          schema.TypeBool,
+                                                        Optional:      true,
+                                                },
+                                                "multiple_as": {
+                                                        Type:          schema.TypeBool,
+                                                        Optional:      true,
+                                                },
+                                        },
+                                },
+
 			},
 			"out_delay": {
 				Type:         schema.TypeInt,

--- a/junos/resource_bgp_group.go
+++ b/junos/resource_bgp_group.go
@@ -449,12 +449,9 @@ func resourceBgpGroup() *schema.Resource {
 			"multipath_options": {
                                 Type:     schema.TypeList,
                                 Optional: true,
+				MaxItems: 1,
                                 Elem: &schema.Resource{
                                         Schema: map[string]*schema.Schema{
-						"enable" : {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
                                                 "disable": {
                                                         Type:     schema.TypeBool,
                                                         Optional: true,
@@ -789,6 +786,7 @@ func readBgpGroup(bgpGroup, instance string, m interface{}, jnprSess *NetconfObj
 				}
 			case strings.HasPrefix(itemTrim, "multipath "):
 				confRead.multipath_options, err = readBgpOptsMultipath(itemTrim, confRead.multipath_options)
+				confRead.multipath = true
 				if err != nil {
 					return confRead, err
 				}

--- a/junos/resource_bgp_neighbor.go
+++ b/junos/resource_bgp_neighbor.go
@@ -436,10 +436,32 @@ func resourceBgpNeighbor() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
-			"multipath": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
+                        "multipath": {
+                                Type:     schema.TypeList,
+                                Optional: true,
+                                Elem: &schema.Resource{
+                                        Schema: map[string]*schema.Schema{
+                                                "enable" : {
+                                                        Type:     schema.TypeBool,
+                                                        Optional: true,
+                                                },
+                                                "disable": {
+                                                        Type:     schema.TypeBool,
+                                                        Optional: true,
+                                                },
+                                                "allow_protection": {
+                                                        Type:          schema.TypeBool,
+                                                        Optional:      true,
+                                                },
+                                                "multiple_as": {
+                                                        Type:          schema.TypeBool,
+                                                        Optional:      true,
+                                                },
+                                        },
+                                },
+
+                        },
+
 			"out_delay": {
 				Type:         schema.TypeInt,
 				Optional:     true,

--- a/junos/resource_bgp_neighbor.go
+++ b/junos/resource_bgp_neighbor.go
@@ -436,15 +436,16 @@ func resourceBgpNeighbor() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
-                        "multipath": {
+			"multipath": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+                        "multipath_options": {
                                 Type:     schema.TypeList,
                                 Optional: true,
+				MaxItems: 1,
                                 Elem: &schema.Resource{
                                         Schema: map[string]*schema.Schema{
-                                                "enable" : {
-                                                        Type:     schema.TypeBool,
-                                                        Optional: true,
-                                                },
                                                 "disable": {
                                                         Type:     schema.TypeBool,
                                                         Optional: true,
@@ -786,6 +787,13 @@ func readBgpNeighbor(ip, instance, group string, m interface{}, jnprSess *Netcon
 				if err != nil {
 					return confRead, err
 				}
+                        case strings.HasPrefix(itemTrim, "multipath "):
+                                confRead.multipath_options, err = readBgpOptsMultipath(itemTrim, confRead.multipath_options)
+                                confRead.multipath = true
+                                if err != nil {
+                                        return confRead, err
+                                }
+
 			default:
 				err = readBgpOptsSimple(itemTrim, &confRead)
 				if err != nil {
@@ -930,6 +938,9 @@ func fillBgpNeighborData(d *schema.ResourceData, bgpNeighborOptions bgpOptions) 
 		panic(tfErr)
 	}
 	if tfErr := d.Set("multipath", bgpNeighborOptions.multipath); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("multipath_options", bgpNeighborOptions.multipath_options); tfErr != nil {
 		panic(tfErr)
 	}
 	if tfErr := d.Set("no_advertise_peer_as", bgpNeighborOptions.noAdvertisePeerAs); tfErr != nil {

--- a/junos/resource_bgp_neighbor.go
+++ b/junos/resource_bgp_neighbor.go
@@ -448,10 +448,6 @@ func resourceBgpNeighbor() *schema.Resource {
 				ConflictsWith: []string{"multipath"},
                                 Elem: &schema.Resource{
                                         Schema: map[string]*schema.Schema{
-                                                "enable": {
-                                                        Type:     schema.TypeBool,
-                                                        Optional: true,
-                                                },
                                                 "disable": {
                                                         Type:     schema.TypeBool,
                                                         Optional: true,

--- a/junos/resource_bgp_neighbor.go
+++ b/junos/resource_bgp_neighbor.go
@@ -439,13 +439,19 @@ func resourceBgpNeighbor() *schema.Resource {
 			"multipath": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				ConflictsWith: []string{"multipath_options"},
 			},
                         "multipath_options": {
                                 Type:     schema.TypeList,
                                 Optional: true,
 				MaxItems: 1,
+				ConflictsWith: []string{"multipath"},
                                 Elem: &schema.Resource{
                                         Schema: map[string]*schema.Schema{
+                                                "enable": {
+                                                        Type:     schema.TypeBool,
+                                                        Optional: true,
+                                                },
                                                 "disable": {
                                                         Type:     schema.TypeBool,
                                                         Optional: true,
@@ -789,7 +795,6 @@ func readBgpNeighbor(ip, instance, group string, m interface{}, jnprSess *Netcon
 				}
                         case strings.HasPrefix(itemTrim, "multipath "):
                                 confRead.multipath_options, err = readBgpOptsMultipath(itemTrim, confRead.multipath_options)
-                                confRead.multipath = true
                                 if err != nil {
                                         return confRead, err
                                 }


### PR DESCRIPTION
Provide ability to set options on bgp-group multipath setting with new attribute 'multipath_options'. Conflicts with multipath.

Usage:
```
resource "junos_bgp_group" "main" {
  name = "group_name"
  multipath_options = {
    disable = [bool]
    multiple_as = [bool]
    allow_protection = [bool]    
  }
}
```