### PR TITLE
Several arguments to bgp resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## upcoming release
 ENHANCEMENTS:
-* add `cluster` argument in `junos_bgp_group` and `junos_bgp_neighbor` resource.
+* add `cluster`, `family_evpn` arguments in `junos_bgp_group` and `junos_bgp_neighbor` resource.
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## upcoming release
 ENHANCEMENTS:
+* add `cluster` argument in `junos_bgp_group` and `junos_bgp_neighbor` resource.
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## upcoming release
 ENHANCEMENTS:
 * add `cluster`, `family_evpn` arguments in `junos_bgp_group` and `junos_bgp_neighbor` resource.
+* add new `bgp_multipath` block argument to replace `multipath` bool argument in `junos_bgp_group` and `junos_bgp_neighbor` resource.
+`bgp_multipath` let add optional arguments. `multipath` is now **deprecated**.
 
 BUG FIXES:
 

--- a/junos/func_resource_bgp.go
+++ b/junos/func_resource_bgp.go
@@ -53,6 +53,7 @@ type bgpOptions struct {
 	exportPolicy                 []string
 	importPolicy                 []string
 	bfdLivenessDetection         []map[string]interface{}
+	familyEvpn                   []map[string]interface{}
 	familyInet                   []map[string]interface{}
 	familyInet6                  []map[string]interface{}
 	gracefulRestart              []map[string]interface{}
@@ -94,6 +95,7 @@ func delBgpOpts(d *schema.ResourceData, typebgp string, m interface{}, jnprSess 
 		delPrefix+"cluster",
 		delPrefix+"damping",
 		delPrefix+"export",
+		delPrefix+"family evpn",
 		delPrefix+"family inet",
 		delPrefix+"family inet6",
 		delPrefix+"graceful-restart",
@@ -569,9 +571,12 @@ func setBgpOptsFamily(setPrefix, familyType string, familyOptsList []interface{}
 	sess := m.(*Session)
 	configSet := make([]string, 0)
 	setPrefixFamily := setPrefix + "family "
-	if familyType == inetWord {
+	switch familyType {
+	case "evpn":
+		setPrefixFamily += "evpn "
+	case inetWord:
 		setPrefixFamily += "inet "
-	} else if familyType == inet6Word {
+	case inet6Word:
 		setPrefixFamily += "inet6 "
 	}
 	for _, familyOpts := range familyOptsList {
@@ -633,10 +638,12 @@ func readBgpOptsFamily(item, familyType string, opts []map[string]interface{}) (
 		"prefix_limit":          make([]map[string]interface{}, 0, 1),
 	}
 	setPrefix := "family "
-	if familyType == inetWord {
+	switch familyType {
+	case "evpn":
+		setPrefix += "evpn "
+	case inetWord:
 		setPrefix += "inet "
-	}
-	if familyType == inet6Word {
+	case inet6Word:
 		setPrefix += "inet6 "
 	}
 	trimSplit := strings.Split(strings.TrimPrefix(item, setPrefix), " ")

--- a/junos/func_resource_bgp.go
+++ b/junos/func_resource_bgp.go
@@ -42,6 +42,7 @@ type bgpOptions struct {
 	authenticationKey            string
 	authenticationKeyChain       string
 	bgpType                      string // group only
+	cluster                      string
 	localAddress                 string
 	localAs                      string
 	localInterface               string
@@ -90,6 +91,7 @@ func delBgpOpts(d *schema.ResourceData, typebgp string, m interface{}, jnprSess 
 		delPrefix+"authentication-key",
 		delPrefix+"authentication-key-chain",
 		delPrefix+"bfd-liveness-detection",
+		delPrefix+"cluster",
 		delPrefix+"damping",
 		delPrefix+"export",
 		delPrefix+"family inet",
@@ -149,6 +151,9 @@ func setBgpOptsSimple(setPrefix string, d *schema.ResourceData, m interface{}, j
 	}
 	if d.Get("authentication_key_chain").(string) != "" {
 		configSet = append(configSet, setPrefix+"authentication-key-chain "+d.Get("authentication_key_chain").(string))
+	}
+	if v := d.Get("cluster").(string); v != "" {
+		configSet = append(configSet, setPrefix+"cluster "+v)
 	}
 	if d.Get("damping").(bool) {
 		configSet = append(configSet, setPrefix+"damping")
@@ -284,6 +289,9 @@ func readBgpOptsSimple(item string, confRead *bgpOptions) error {
 	}
 	if strings.HasPrefix(item, "authentication-key-chain ") {
 		confRead.authenticationKeyChain = strings.TrimPrefix(item, "authentication-key-chain ")
+	}
+	if strings.HasPrefix(item, "cluster ") {
+		confRead.cluster = strings.TrimPrefix(item, "cluster ")
 	}
 	if item == "damping" {
 		confRead.damping = true

--- a/junos/resource_bgp_group.go
+++ b/junos/resource_bgp_group.go
@@ -153,6 +153,28 @@ func resourceBgpGroup() *schema.Resource {
 					},
 				},
 			},
+			"bgp_multipath": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				MaxItems:      1,
+				ConflictsWith: []string{"multipath"},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"allow_protection": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"disable": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"multiple_as": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+					},
+				},
+			},
 			"cluster": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -518,8 +540,10 @@ func resourceBgpGroup() *schema.Resource {
 				Optional: true,
 			},
 			"multipath": {
-				Type:     schema.TypeBool,
-				Optional: true,
+				Type:          schema.TypeBool,
+				Optional:      true,
+				ConflictsWith: []string{"bgp_multipath"},
+				Deprecated:    "use bgp_multipath instead",
 			},
 			"out_delay": {
 				Type:         schema.TypeInt,
@@ -983,8 +1007,14 @@ func fillBgpGroupData(d *schema.ResourceData, bgpGroupOptions bgpOptions) {
 	if tfErr := d.Set("multihop", bgpGroupOptions.multihop); tfErr != nil {
 		panic(tfErr)
 	}
-	if tfErr := d.Set("multipath", bgpGroupOptions.multipath); tfErr != nil {
-		panic(tfErr)
+	if _, ok := d.GetOk("multipath"); ok {
+		if tfErr := d.Set("multipath", bgpGroupOptions.multipath); tfErr != nil {
+			panic(tfErr)
+		}
+	} else {
+		if tfErr := d.Set("bgp_multipath", bgpGroupOptions.bgpMultipath); tfErr != nil {
+			panic(tfErr)
+		}
 	}
 	if tfErr := d.Set("no_advertise_peer_as", bgpGroupOptions.noAdvertisePeerAs); tfErr != nil {
 		panic(tfErr)

--- a/junos/resource_bgp_group.go
+++ b/junos/resource_bgp_group.go
@@ -167,6 +167,76 @@ func resourceBgpGroup() *schema.Resource {
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"family_evpn": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"nlri_type": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      "signaling",
+							ValidateFunc: validation.StringInSlice([]string{"signaling"}, false),
+						},
+						"accepted_prefix_limit": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"maximum": {
+										Type:         schema.TypeInt,
+										Required:     true,
+										ValidateFunc: validation.IntBetween(1, 4294967295),
+									},
+									"teardown": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(1, 100),
+									},
+									"teardown_idle_timeout": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(1, 2400),
+									},
+									"teardown_idle_timeout_forever": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+								},
+							},
+						},
+						"prefix_limit": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"maximum": {
+										Type:         schema.TypeInt,
+										Required:     true,
+										ValidateFunc: validation.IntBetween(1, 4294967295),
+									},
+									"teardown": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(1, 100),
+									},
+									"teardown_idle_timeout": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(1, 2400),
+									},
+									"teardown_idle_timeout_forever": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 			"family_inet": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -696,6 +766,9 @@ func setBgpGroup(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject)
 	if err := setBgpOptsBfd(setPrefix, d.Get("bfd_liveness_detection").([]interface{}), m, jnprSess); err != nil {
 		return err
 	}
+	if err := setBgpOptsFamily(setPrefix, "evpn", d.Get("family_evpn").([]interface{}), m, jnprSess); err != nil {
+		return err
+	}
 	if err := setBgpOptsFamily(setPrefix, inetWord, d.Get("family_inet").([]interface{}), m, jnprSess); err != nil {
 		return err
 	}
@@ -748,12 +821,16 @@ func readBgpGroup(bgpGroup, instance string, m interface{}, jnprSess *NetconfObj
 				if err != nil {
 					return confRead, err
 				}
+			case strings.HasPrefix(itemTrim, "family evpn "):
+				confRead.familyEvpn, err = readBgpOptsFamily(itemTrim, "evpn", confRead.familyEvpn)
+				if err != nil {
+					return confRead, err
+				}
 			case strings.HasPrefix(itemTrim, "family inet "):
 				confRead.familyInet, err = readBgpOptsFamily(itemTrim, inetWord, confRead.familyInet)
 				if err != nil {
 					return confRead, err
 				}
-
 			case strings.HasPrefix(itemTrim, "family inet6 "):
 				confRead.familyInet6, err = readBgpOptsFamily(itemTrim, inet6Word, confRead.familyInet6)
 				if err != nil {
@@ -835,6 +912,9 @@ func fillBgpGroupData(d *schema.ResourceData, bgpGroupOptions bgpOptions) {
 		panic(tfErr)
 	}
 	if tfErr := d.Set("export", bgpGroupOptions.exportPolicy); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("family_evpn", bgpGroupOptions.familyEvpn); tfErr != nil {
 		panic(tfErr)
 	}
 	if tfErr := d.Set("family_inet", bgpGroupOptions.familyInet); tfErr != nil {

--- a/junos/resource_bgp_group.go
+++ b/junos/resource_bgp_group.go
@@ -153,6 +153,11 @@ func resourceBgpGroup() *schema.Resource {
 					},
 				},
 			},
+			"cluster": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.IsIPAddress,
+			},
 			"damping": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -821,6 +826,9 @@ func fillBgpGroupData(d *schema.ResourceData, bgpGroupOptions bgpOptions) {
 		panic(tfErr)
 	}
 	if tfErr := d.Set("bfd_liveness_detection", bgpGroupOptions.bfdLivenessDetection); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("cluster", bgpGroupOptions.cluster); tfErr != nil {
 		panic(tfErr)
 	}
 	if tfErr := d.Set("damping", bgpGroupOptions.damping); tfErr != nil {

--- a/junos/resource_bgp_group_test.go
+++ b/junos/resource_bgp_group_test.go
@@ -30,6 +30,8 @@ func TestAccJunosBgpGroup_basic(t *testing.T) {
 						resource.TestCheckResourceAttr("junos_bgp_group.testacc_bgpgroup",
 							"as_override", "true"),
 						resource.TestCheckResourceAttr("junos_bgp_group.testacc_bgpgroup",
+							"cluster", "192.0.2.3"),
+						resource.TestCheckResourceAttr("junos_bgp_group.testacc_bgpgroup",
 							"damping", "true"),
 						resource.TestCheckResourceAttr("junos_bgp_group.testacc_bgpgroup",
 							"log_updown", "true"),
@@ -214,6 +216,7 @@ resource junos_bgp_group "testacc_bgpgroup" {
   advertise_inactive       = true
   advertise_peer_as        = true
   as_override              = true
+  cluster                  = "192.0.2.3"
   damping                  = true
   log_updown               = true
   mtu_discovery            = true

--- a/junos/resource_bgp_group_test.go
+++ b/junos/resource_bgp_group_test.go
@@ -332,6 +332,18 @@ resource junos_bgp_group "testacc_bgpgroup" {
   local_as_no_prepend_global_as = true
   metric_out_minimum_igp_offset = -10
   type                          = "internal"
+  family_evpn {
+    accepted_prefix_limit {
+      maximum               = 2
+      teardown              = 50
+      teardown_idle_timeout = 30
+    }
+    prefix_limit {
+      maximum               = 2
+      teardown              = 50
+      teardown_idle_timeout = 30
+    }
+  }
 }
 `
 }
@@ -342,6 +354,7 @@ resource junos_bgp_group "testacc_bgpgroup" {
   local_as               = "65000"
   local_as_alias         = true
   metric_out_minimum_igp = true
+  family_evpn {}
 }
 `
 }

--- a/junos/resource_bgp_group_test.go
+++ b/junos/resource_bgp_group_test.go
@@ -38,7 +38,7 @@ func TestAccJunosBgpGroup_basic(t *testing.T) {
 						resource.TestCheckResourceAttr("junos_bgp_group.testacc_bgpgroup",
 							"mtu_discovery", "true"),
 						resource.TestCheckResourceAttr("junos_bgp_group.testacc_bgpgroup",
-							"multipath", "true"),
+							"bgp_multipath.#", "1"),
 						resource.TestCheckResourceAttr("junos_bgp_group.testacc_bgpgroup",
 							"remove_private", "true"),
 						resource.TestCheckResourceAttr("junos_bgp_group.testacc_bgpgroup",
@@ -143,6 +143,10 @@ func TestAccJunosBgpGroup_basic(t *testing.T) {
 						resource.TestCheckResourceAttr("junos_bgp_group.testacc_bgpgroup",
 							"advertise_external_conditional", "true"),
 						resource.TestCheckResourceAttr("junos_bgp_group.testacc_bgpgroup",
+							"bgp_multipath.#", "1"),
+						resource.TestCheckResourceAttr("junos_bgp_group.testacc_bgpgroup",
+							"bgp_multipath.0.multiple_as", "true"),
+						resource.TestCheckResourceAttr("junos_bgp_group.testacc_bgpgroup",
 							"no_advertise_peer_as", "true"),
 						resource.TestCheckResourceAttr("junos_bgp_group.testacc_bgpgroup",
 							"metric_out_igp_offset", "-10"),
@@ -211,16 +215,16 @@ resource junos_policyoptions_policy_statement "testacc_bgpgroup" {
   }
 }
 resource junos_bgp_group "testacc_bgpgroup" {
-  name                     = "testacc_bgpgroup"
-  routing_instance         = junos_routing_instance.testacc_bgpgroup.name
-  advertise_inactive       = true
-  advertise_peer_as        = true
-  as_override              = true
+  name               = "testacc_bgpgroup"
+  routing_instance   = junos_routing_instance.testacc_bgpgroup.name
+  advertise_inactive = true
+  advertise_peer_as  = true
+  as_override        = true
+  bgp_multipath {}
   cluster                  = "192.0.2.3"
   damping                  = true
   log_updown               = true
   mtu_discovery            = true
-  multipath                = true
   remove_private           = true
   passive                  = true
   hold_time                = 30
@@ -313,12 +317,14 @@ resource junos_bgp_group "testacc_bgpgroup" {
   metric_out_igp_delay_med_update = true
   authentication_key              = "password"
   type                            = "internal"
+  bgp_multipath {
+    multiple_as = true
+  }
   graceful_restart {
     restart_time     = 10
     stale_route_time = 10
   }
 }
-
 `
 }
 func testAccJunosBgpGroupConfigUpdate2() string {

--- a/junos/resource_bgp_neighbor.go
+++ b/junos/resource_bgp_neighbor.go
@@ -151,6 +151,11 @@ func resourceBgpNeighbor() *schema.Resource {
 					},
 				},
 			},
+			"cluster": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.IsIPAddress,
+			},
 			"damping": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -833,6 +838,9 @@ func fillBgpNeighborData(d *schema.ResourceData, bgpNeighborOptions bgpOptions) 
 		panic(tfErr)
 	}
 	if tfErr := d.Set("bfd_liveness_detection", bgpNeighborOptions.bfdLivenessDetection); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("cluster", bgpNeighborOptions.cluster); tfErr != nil {
 		panic(tfErr)
 	}
 	if tfErr := d.Set("damping", bgpNeighborOptions.damping); tfErr != nil {

--- a/junos/resource_bgp_neighbor.go
+++ b/junos/resource_bgp_neighbor.go
@@ -151,6 +151,28 @@ func resourceBgpNeighbor() *schema.Resource {
 					},
 				},
 			},
+			"bgp_multipath": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				MaxItems:      1,
+				ConflictsWith: []string{"multipath"},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"allow_protection": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"disable": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"multiple_as": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+					},
+				},
+			},
 			"cluster": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -512,8 +534,10 @@ func resourceBgpNeighbor() *schema.Resource {
 				Optional: true,
 			},
 			"multipath": {
-				Type:     schema.TypeBool,
-				Optional: true,
+				Type:          schema.TypeBool,
+				Optional:      true,
+				ConflictsWith: []string{"bgp_multipath"},
+				Deprecated:    "use bgp_multipath instead",
 			},
 			"out_delay": {
 				Type:         schema.TypeInt,
@@ -995,8 +1019,14 @@ func fillBgpNeighborData(d *schema.ResourceData, bgpNeighborOptions bgpOptions) 
 	if tfErr := d.Set("multihop", bgpNeighborOptions.multihop); tfErr != nil {
 		panic(tfErr)
 	}
-	if tfErr := d.Set("multipath", bgpNeighborOptions.multipath); tfErr != nil {
-		panic(tfErr)
+	if _, ok := d.GetOk("multipath"); ok {
+		if tfErr := d.Set("multipath", bgpNeighborOptions.multipath); tfErr != nil {
+			panic(tfErr)
+		}
+	} else {
+		if tfErr := d.Set("bgp_multipath", bgpNeighborOptions.bgpMultipath); tfErr != nil {
+			panic(tfErr)
+		}
 	}
 	if tfErr := d.Set("no_advertise_peer_as", bgpNeighborOptions.noAdvertisePeerAs); tfErr != nil {
 		panic(tfErr)

--- a/junos/resource_bgp_neighbor_test.go
+++ b/junos/resource_bgp_neighbor_test.go
@@ -38,7 +38,7 @@ func TestAccJunosBgpNeighbor_basic(t *testing.T) {
 						resource.TestCheckResourceAttr("junos_bgp_neighbor.testacc_bgpneighbor",
 							"mtu_discovery", "true"),
 						resource.TestCheckResourceAttr("junos_bgp_neighbor.testacc_bgpneighbor",
-							"multipath", "true"),
+							"bgp_multipath.#", "1"),
 						resource.TestCheckResourceAttr("junos_bgp_neighbor.testacc_bgpneighbor",
 							"remove_private", "true"),
 						resource.TestCheckResourceAttr("junos_bgp_neighbor.testacc_bgpneighbor",
@@ -148,6 +148,10 @@ func TestAccJunosBgpNeighbor_basic(t *testing.T) {
 						resource.TestCheckResourceAttr("junos_bgp_neighbor.testacc_bgpneighbor",
 							"advertise_external_conditional", "true"),
 						resource.TestCheckResourceAttr("junos_bgp_neighbor.testacc_bgpneighbor",
+							"bgp_multipath.#", "1"),
+						resource.TestCheckResourceAttr("junos_bgp_neighbor.testacc_bgpneighbor",
+							"bgp_multipath.0.multiple_as", "true"),
+						resource.TestCheckResourceAttr("junos_bgp_neighbor.testacc_bgpneighbor",
 							"no_advertise_peer_as", "true"),
 						resource.TestCheckResourceAttr("junos_bgp_neighbor.testacc_bgpneighbor",
 							"metric_out_igp_offset", "-10"),
@@ -220,17 +224,17 @@ resource junos_bgp_group "testacc_bgpneighbor" {
   routing_instance = junos_routing_instance.testacc_bgpneighbor.name
 }
 resource junos_bgp_neighbor "testacc_bgpneighbor" {
-  ip                       = "192.0.2.4"
-  routing_instance         = junos_routing_instance.testacc_bgpneighbor.name
-  group                    = junos_bgp_group.testacc_bgpneighbor.name
-  advertise_inactive       = true
-  advertise_peer_as        = true
-  as_override              = true
+  ip                 = "192.0.2.4"
+  routing_instance   = junos_routing_instance.testacc_bgpneighbor.name
+  group              = junos_bgp_group.testacc_bgpneighbor.name
+  advertise_inactive = true
+  advertise_peer_as  = true
+  as_override        = true
+  bgp_multipath {}
   cluster                  = "192.0.2.3"
   damping                  = true
   log_updown               = true
   mtu_discovery            = true
-  multipath                = true
   remove_private           = true
   passive                  = true
   hold_time                = 30
@@ -328,6 +332,9 @@ resource junos_bgp_neighbor "testacc_bgpneighbor" {
   metric_out_igp_offset           = -10
   metric_out_igp_delay_med_update = true
   authentication_key              = "password"
+  bgp_multipath {
+    multiple_as = true
+  }
   graceful_restart {
     restart_time     = 10
     stale_route_time = 10

--- a/junos/resource_bgp_neighbor_test.go
+++ b/junos/resource_bgp_neighbor_test.go
@@ -30,6 +30,8 @@ func TestAccJunosBgpNeighbor_basic(t *testing.T) {
 						resource.TestCheckResourceAttr("junos_bgp_neighbor.testacc_bgpneighbor",
 							"as_override", "true"),
 						resource.TestCheckResourceAttr("junos_bgp_neighbor.testacc_bgpneighbor",
+							"cluster", "192.0.2.3"),
+						resource.TestCheckResourceAttr("junos_bgp_neighbor.testacc_bgpneighbor",
 							"damping", "true"),
 						resource.TestCheckResourceAttr("junos_bgp_neighbor.testacc_bgpneighbor",
 							"log_updown", "true"),
@@ -221,6 +223,7 @@ resource junos_bgp_neighbor "testacc_bgpneighbor" {
   advertise_inactive       = true
   advertise_peer_as        = true
   as_override              = true
+  cluster                  = "192.0.2.3"
   damping                  = true
   log_updown               = true
   mtu_discovery            = true

--- a/junos/resource_bgp_neighbor_test.go
+++ b/junos/resource_bgp_neighbor_test.go
@@ -181,9 +181,9 @@ func TestAccJunosBgpNeighbor_basic(t *testing.T) {
 				{
 					Config: testAccJunosBgpNeighborConfigUpdate3(),
 					Check: resource.ComposeTestCheckFunc(
-						resource.TestCheckResourceAttr("junos_bgp_neighbor.testacc_bgpneighbor3",
+						resource.TestCheckResourceAttr("junos_bgp_neighbor.testacc_bgpneighbor2",
 							"local_as_alias", "true"),
-						resource.TestCheckResourceAttr("junos_bgp_neighbor.testacc_bgpneighbor3",
+						resource.TestCheckResourceAttr("junos_bgp_neighbor.testacc_bgpneighbor2",
 							"metric_out_minimum_igp", "true"),
 					),
 				},
@@ -195,6 +195,9 @@ func TestAccJunosBgpNeighbor_basic(t *testing.T) {
 func testAccJunosBgpConfigPreCreate() string {
 	return `
 resource junos_routing_options "testacc_routing_options" {
+  autonomous_system {
+    number = "65001"
+  }
   graceful_restart {}
 }
 `
@@ -355,26 +358,55 @@ resource junos_bgp_neighbor "testacc_bgpneighbor2" {
   local_as_no_prepend_global_as = true
   metric_out_minimum_igp_offset = -10
 }
+resource junos_bgp_group "testacc_bgpneighbor2b" {
+  name = "testacc_bgpneighbor2b"
+  type = "internal"
+}
+resource junos_bgp_neighbor "testacc_bgpneighbor2b" {
+  ip    = "192.0.2.5"
+  group = junos_bgp_group.testacc_bgpneighbor2b.name
+  family_evpn {
+    accepted_prefix_limit {
+      maximum               = 2
+      teardown              = 50
+      teardown_idle_timeout = 30
+    }
+    prefix_limit {
+      maximum               = 2
+      teardown              = 50
+      teardown_idle_timeout = 30
+    }
+  }
+}
 `
 }
 func testAccJunosBgpNeighborConfigUpdate3() string {
 	return `
-resource junos_routing_instance "testacc_bgpneighbor3" {
-  name = "testacc_bgpneighbor3"
+resource junos_routing_instance "testacc_bgpneighbor2" {
+  name = "testacc_bgpneighbor2"
   as   = "65000"
 }
-resource junos_bgp_group "testacc_bgpneighbor3" {
-  name             = "testacc_bgpneighbor3"
-  routing_instance = junos_routing_instance.testacc_bgpneighbor3.name
+resource junos_bgp_group "testacc_bgpneighbor2" {
+  name             = "testacc_bgpneighbor2"
+  routing_instance = junos_routing_instance.testacc_bgpneighbor2.name
   type             = "internal"
 }
-resource junos_bgp_neighbor "testacc_bgpneighbor3" {
+resource junos_bgp_neighbor "testacc_bgpneighbor2" {
   ip                     = "192.0.2.4"
-  routing_instance       = junos_routing_instance.testacc_bgpneighbor3.name
-  group                  = junos_bgp_group.testacc_bgpneighbor3.name
+  routing_instance       = junos_routing_instance.testacc_bgpneighbor2.name
+  group                  = junos_bgp_group.testacc_bgpneighbor2.name
   local_as               = "65000"
   local_as_alias         = true
   metric_out_minimum_igp = true
+}
+resource junos_bgp_group "testacc_bgpneighbor2b" {
+  name = "testacc_bgpneighbor2b"
+  type = "internal"
+}
+resource junos_bgp_neighbor "testacc_bgpneighbor2b" {
+  ip    = "192.0.2.5"
+  group = junos_bgp_group.testacc_bgpneighbor2b.name
+  family_evpn {}
 }
 `
 }

--- a/website/docs/r/bgp_group.html.markdown
+++ b/website/docs/r/bgp_group.html.markdown
@@ -41,6 +41,10 @@ The following arguments are supported:
 **WARNING** Clear in tfstate.
 * `authentication_key_chain` - (Optional)(`String`) Key chain name. Conflict with `authentication_key`.
 * `bfd_liveness_detection` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Define Bidirectional Forwarding Detection (BFD) options. See the [`bfd_liveness_detection` arguments](#bfd_liveness_detection-arguments) block. Max of 1.
+* `bgp_multipath` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to allow load sharing among multiple BGP paths.
+  * `allow_protection` - (Optional)(`Bool`) Allows the BGP multipath and protection to co-exist.
+  * `disable` - (Optional)(`Bool`) Disable Multipath.
+  * `multiple_as` - (Optional)(`Bool`) Use paths received from different ASs.
 * `cluster` - (Optional)(`String`) Cluster identifier. Must be a valid IP address.
 * `damping` - (Optional)(`Bool`) Enable route flap damping.
 * `export` - (Optional)(`ListOfString`) Export policy list.
@@ -70,7 +74,8 @@ See the [`family_inet` arguments](#family_inet-arguments) block.
 * `metric_out_minimum_igp_offset` - (Optional)(`Bool`) Metric offset for MED. Conflict with `metric_out` and `metric_out_(?!minimum)_*`.
 * `mtu_discovery` - (Optional)(`Bool`) Enable TCP path MTU discovery.
 * `multihop` - (Optional)(`Bool`) Configure an EBGP multihop session.
-* `multipath` - (Optional)(`Bool`) Allow load sharing among multiple BGP paths.
+* `multipath` - (Optional,**DEPRECATED**)(`Bool`) Allow load sharing among multiple BGP paths.  
+Deprecated argument, use the `bgp_multipath` argument instead.
 * `out_delay` - (Optional)(`Int`) How long before exporting routes from routing table.
 * `passive` - (Optional)(`Bool`) Do not send open messages to a peer.
 * `peer_as` - (Optional)(`String`) Autonomous system number.

--- a/website/docs/r/bgp_group.html.markdown
+++ b/website/docs/r/bgp_group.html.markdown
@@ -41,6 +41,7 @@ The following arguments are supported:
 **WARNING** Clear in tfstate.
 * `authentication_key_chain` - (Optional)(`String`) Key chain name. Conflict with `authentication_key`.
 * `bfd_liveness_detection` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Define Bidirectional Forwarding Detection (BFD) options. See the [`bfd_liveness_detection` arguments](#bfd_liveness_detection-arguments) block. Max of 1.
+* `cluster` - (Optional)(`String`) Cluster identifier. Must be a valid IP address.
 * `damping` - (Optional)(`Bool`) Enable route flap damping.
 * `export` - (Optional)(`ListOfString`) Export policy list.
 * `family_inet` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified multiple times for each nlri_type.

--- a/website/docs/r/bgp_group.html.markdown
+++ b/website/docs/r/bgp_group.html.markdown
@@ -44,6 +44,9 @@ The following arguments are supported:
 * `cluster` - (Optional)(`String`) Cluster identifier. Must be a valid IP address.
 * `damping` - (Optional)(`Bool`) Enable route flap damping.
 * `export` - (Optional)(`ListOfString`) Export policy list.
+* `family_evpn` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once for the `signaling` nlri_type.
+  * `nlri_type` - (Optional)(`String`) NLRI type. Need to be `signaling`. Default to `signaling`.
+  * other options same as [`family_inet` arguments](#family_inet-arguments).
 * `family_inet` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified multiple times for each nlri_type.
 See the [`family_inet` arguments](#family_inet-arguments) block.
 * `family_inet6` Same options as [`family_inet` arguments](#family_inet-arguments) but for inet6 family.
@@ -91,7 +94,7 @@ See the [`family_inet` arguments](#family_inet-arguments) block.
 
 ---
 #### family_inet arguments
-Also for `family_inet6`
+Also for `family_inet6` and `family_evpn` (except `nlri_type`)
 
 * `nlri_type` - (Required)(`String`) NLRI type. Need to be 'any', 'flow', 'labeled-unicast', 'unicast' or 'multicast'.
 * `accepted_prefix_limit` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once for define maximum number of prefixes accepted from a peer and options.

--- a/website/docs/r/bgp_neighbor.html.markdown
+++ b/website/docs/r/bgp_neighbor.html.markdown
@@ -42,6 +42,10 @@ The following arguments are supported:
 **WARNING** Clear in tfstate.
 * `authentication_key_chain` - (Optional)(`String`) Key chain name. Conflict with `authentication_key`.
 * `bfd_liveness_detection` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Define Bidirectional Forwarding Detection (BFD) options. See the [`bfd_liveness_detection` arguments](#bfd_liveness_detection-arguments) block. Max of 1.
+* `bgp_multipath` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to allow load sharing among multiple BGP paths.
+  * `allow_protection` - (Optional)(`Bool`) Allows the BGP multipath and protection to co-exist.
+  * `disable` - (Optional)(`Bool`) Disable Multipath.
+  * `multiple_as` - (Optional)(`Bool`) Use paths received from different ASs.
 * `cluster` - (Optional)(`String`) Cluster identifier. Must be a valid IP address.
 * `damping` - (Optional)(`Bool`) Enable route flap damping.
 * `export` - (Optional)(`ListOfString`) Export policy list.
@@ -71,7 +75,8 @@ See the [`family_inet` arguments](#family_inet-arguments) block.
 * `metric_out_minimum_igp_offset` - (Optional)(`Bool`) Metric offset for MED. Conflict with `metric_out` and `metric_out_(?!minimum)_*`.
 * `mtu_discovery` - (Optional)(`Bool`) Enable TCP path MTU discovery.
 * `multihop` - (Optional)(`Bool`) Configure an EBGP multihop session.
-* `multipath` - (Optional)(`Bool`) Allow load sharing among multiple BGP paths.
+* `multipath` - (Optional,**DEPRECATED**)(`Bool`) Allow load sharing among multiple BGP paths.  
+Deprecated argument, use the `bgp_multipath` argument instead.
 * `out_delay` - (Optional)(`Int`) How long before exporting routes from routing table.
 * `passive` - (Optional)(`Bool`) Do not send open messages to a peer.
 * `peer_as` - (Optional)(`String`) Autonomous system number.

--- a/website/docs/r/bgp_neighbor.html.markdown
+++ b/website/docs/r/bgp_neighbor.html.markdown
@@ -45,6 +45,9 @@ The following arguments are supported:
 * `cluster` - (Optional)(`String`) Cluster identifier. Must be a valid IP address.
 * `damping` - (Optional)(`Bool`) Enable route flap damping.
 * `export` - (Optional)(`ListOfString`) Export policy list.
+* `family_evpn` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once for the `signaling` nlri_type.
+  * `nlri_type` - (Optional)(`String`) NLRI type. Need to be `signaling`. Default to `signaling`.
+  * other options same as [`family_inet` arguments](#family_inet-arguments).
 * `family_inet` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified multiple times for each nlri_type.
 See the [`family_inet` arguments](#family_inet-arguments) block.
 * `family_inet6` Same options as [`family_inet` arguments](#family_inet-arguments)  but for inet6 family.
@@ -92,7 +95,7 @@ See the [`family_inet` arguments](#family_inet-arguments) block.
 
 ---
 #### family_inet arguments
-Also for `family_inet6`
+Also for `family_inet6` and `family_evpn` (except `nlri_type`)
 
 * `nlri_type` - (Required)(`String`) NLRI type. Need to be 'any', 'flow', 'labeled-unicast', 'unicast' or 'multicast'.
 * `accepted_prefix_limit` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once for define maximum number of prefixes accepted from a peer and options.

--- a/website/docs/r/bgp_neighbor.html.markdown
+++ b/website/docs/r/bgp_neighbor.html.markdown
@@ -42,6 +42,7 @@ The following arguments are supported:
 **WARNING** Clear in tfstate.
 * `authentication_key_chain` - (Optional)(`String`) Key chain name. Conflict with `authentication_key`.
 * `bfd_liveness_detection` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Define Bidirectional Forwarding Detection (BFD) options. See the [`bfd_liveness_detection` arguments](#bfd_liveness_detection-arguments) block. Max of 1.
+* `cluster` - (Optional)(`String`) Cluster identifier. Must be a valid IP address.
 * `damping` - (Optional)(`Bool`) Enable route flap damping.
 * `export` - (Optional)(`ListOfString`) Export policy list.
 * `family_inet` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified multiple times for each nlri_type.


### PR DESCRIPTION
ENHANCEMENTS:
* add `cluster`, `family_evpn` arguments in `junos_bgp_group` and `junos_bgp_neighbor` resource.
* add new `bgp_multipath` block argument to replace `multipath` bool argument in `junos_bgp_group` and `junos_bgp_neighbor` resource.
`bgp_multipath` let add optional arguments. `multipath` is now **deprecated**.