### PR TITLE
security inbound-traffic on logical interface & fix description null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ ENHANCEMENTS:
 * add `junos_group_dual_system` resource (Fixes #120)
 * add `junos_chassis_cluster` resource (Fixes parts of #106)
 * add `ether_opts`, `gigether_opts` and `parent_ether_opts` arguments in `junos_interface_physical` resource to add more options and replace `ae_lacp`, `ae_link_speed`, `ae_minimum_links`, `ether802_3ad` arguments which are now deprecated (Fixes #133, #127, parts of #106)
-* add `security_inbound_protocols` and `security_inbound_services` arguments in `junos_interface_logical` resource (Fixes #141)
+* add `security_inbound_protocols` and `security_inbound_services` arguments in `junos_interface_logical` resource and data source (Fixes #141)
 
 BUG FIXES:
 * fix change `description` to null in `junos_interface_logical` and `junos_interface_physical` resource

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ ENHANCEMENTS:
 * add `security_inbound_protocols` and `security_inbound_services` arguments in `junos_interface_logical` resource (Fixes #141)
 
 BUG FIXES:
+* fix change `description` to null in `junos_interface_logical` and `junos_interface_physical` resource
 
 ## 1.13.1 (February 18, 2021)
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ ENHANCEMENTS:
 * add `junos_group_dual_system` resource (Fixes #120)
 * add `junos_chassis_cluster` resource (Fixes parts of #106)
 * add `ether_opts`, `gigether_opts` and `parent_ether_opts` arguments in `junos_interface_physical` resource to add more options and replace `ae_lacp`, `ae_link_speed`, `ae_minimum_links`, `ether802_3ad` arguments which are now deprecated (Fixes #133, #127, parts of #106)
+* add `security_inbound_protocols` and `security_inbound_services` arguments in `junos_interface_logical` resource (Fixes #141)
 
 BUG FIXES:
 

--- a/junos/data_source_interface_logical.go
+++ b/junos/data_source_interface_logical.go
@@ -309,6 +309,17 @@ func dataSourceInterfaceLogical() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"security_inbound_protocols": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"security_inbound_services": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
 			"security_zone": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/junos/resource_interface_logical.go
+++ b/junos/resource_interface_logical.go
@@ -1071,6 +1071,7 @@ func delInterfaceLogicalOpts(d *schema.ResourceData, m interface{}, jnprSess *Ne
 	configSet := make([]string, 0, 1)
 	delPrefix := "delete interfaces " + d.Get("name").(string) + " "
 	configSet = append(configSet,
+		delPrefix+"description",
 		delPrefix+"family inet",
 		delPrefix+"family inet6")
 

--- a/junos/resource_interface_logical.go
+++ b/junos/resource_interface_logical.go
@@ -14,12 +14,14 @@ import (
 )
 
 type interfaceLogicalOptions struct {
-	vlanID          int
-	description     string
-	routingInstance string
-	securityZone    string
-	familyInet      []map[string]interface{}
-	familyInet6     []map[string]interface{}
+	vlanID                   int
+	description              string
+	routingInstance          string
+	securityZone             string
+	securityInboundProtocols []string
+	securityInboundServices  []string
+	familyInet               []map[string]interface{}
+	familyInet6              []map[string]interface{}
 }
 
 func resourceInterfaceLogical() *schema.Resource {
@@ -357,6 +359,18 @@ func resourceInterfaceLogical() *schema.Resource {
 				Optional:         true,
 				ValidateDiagFunc: validateNameObjectJunos([]string{}, 64),
 			},
+			"security_inbound_protocols": {
+				Type:         schema.TypeList,
+				Optional:     true,
+				RequiredWith: []string{"security_zone"},
+				Elem:         &schema.Schema{Type: schema.TypeString},
+			},
+			"security_inbound_services": {
+				Type:         schema.TypeList,
+				Optional:     true,
+				RequiredWith: []string{"security_zone"},
+				Elem:         &schema.Schema{Type: schema.TypeString},
+			},
 			"security_zone": {
 				Type:             schema.TypeString,
 				Optional:         true,
@@ -555,6 +569,12 @@ func resourceInterfaceLogicalUpdate(ctx context.Context, d *schema.ResourceData,
 
 				return diag.FromErr(err)
 			}
+		}
+	} else if v := d.Get("security_zone").(string); v != "" {
+		if err := delZoneInterfaceLogical(v, d, m, jnprSess); err != nil {
+			sess.configClear(jnprSess)
+
+			return diag.FromErr(err)
 		}
 	}
 	if d.HasChange("routing_instance") {
@@ -806,6 +826,16 @@ func setInterfaceLogical(d *schema.ResourceData, m interface{}, jnprSess *Netcon
 	if checkCompatibilitySecurity(jnprSess) && d.Get("security_zone").(string) != "" {
 		configSet = append(configSet, "set security zones security-zone "+
 			d.Get("security_zone").(string)+" interfaces "+d.Get("name").(string))
+		for _, v := range d.Get("security_inbound_protocols").([]interface{}) {
+			configSet = append(configSet, "set security zones security-zone "+
+				d.Get("security_zone").(string)+" interfaces "+d.Get("name").(string)+
+				" host-inbound-traffic protocols "+v.(string))
+		}
+		for _, v := range d.Get("security_inbound_services").([]interface{}) {
+			configSet = append(configSet, "set security zones security-zone "+
+				d.Get("security_zone").(string)+" interfaces "+d.Get("name").(string)+
+				" host-inbound-traffic system-services "+v.(string))
+		}
 	}
 	if d.Get("vlan_id").(int) != 0 {
 		configSet = append(configSet, setPrefix+"vlan-id "+strconv.Itoa(d.Get("vlan_id").(int)))
@@ -958,12 +988,15 @@ func readInterfaceLogical(interFace string, m interface{}, jnprSess *NetconfObje
 		if err != nil {
 			return confRead, err
 		}
-		regexpInts := regexp.MustCompile(`set security-zone \S+ interfaces ` + interFace + `$`)
+		regexpInts := regexp.MustCompile(`set security-zone \S+ interfaces ` + interFace + `( host-inbound-traffic .*)?$`)
 		for _, item := range strings.Split(zonesConfig, "\n") {
 			intMatch := regexpInts.MatchString(item)
 			if intMatch {
-				confRead.securityZone = strings.TrimPrefix(strings.TrimSuffix(item, " interfaces "+interFace),
-					"set security-zone ")
+				itemTrimSplit := strings.Split(strings.TrimPrefix(item, "set security-zone "), " ")
+				confRead.securityZone = itemTrimSplit[0]
+				if err := readInterfaceLogicalSecurityInboundTraffic(interFace, &confRead, m, jnprSess); err != nil {
+					return confRead, err
+				}
 
 				break
 			}
@@ -972,6 +1005,39 @@ func readInterfaceLogical(interFace string, m interface{}, jnprSess *NetconfObje
 
 	return confRead, nil
 }
+func readInterfaceLogicalSecurityInboundTraffic(interFace string, confRead *interfaceLogicalOptions,
+	m interface{}, jnprSess *NetconfObject) error {
+	sess := m.(*Session)
+
+	intConfig, err := sess.command("show configuration security zones security-zone "+confRead.securityZone+
+		" interfaces "+interFace+" | display set relative", jnprSess)
+	if err != nil {
+		return err
+	}
+
+	if intConfig != emptyWord {
+		for _, item := range strings.Split(intConfig, "\n") {
+			if strings.Contains(item, "<configuration-output>") {
+				continue
+			}
+			if strings.Contains(item, "</configuration-output>") {
+				break
+			}
+			itemTrim := strings.TrimPrefix(item, setLineStart)
+			switch {
+			case strings.HasPrefix(itemTrim, "host-inbound-traffic protocols "):
+				confRead.securityInboundProtocols = append(confRead.securityInboundProtocols,
+					strings.TrimPrefix(itemTrim, "host-inbound-traffic protocols "))
+			case strings.HasPrefix(itemTrim, "host-inbound-traffic system-services "):
+				confRead.securityInboundServices = append(confRead.securityInboundServices,
+					strings.TrimPrefix(itemTrim, "host-inbound-traffic system-services "))
+			}
+		}
+	}
+
+	return nil
+}
+
 func delInterfaceLogical(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) error {
 	sess := m.(*Session)
 	if err := sess.configSet([]string{"delete interfaces " + d.Get("name").(string)}, jnprSess); err != nil {
@@ -1037,6 +1103,12 @@ func fillInterfaceLogicalData(d *schema.ResourceData, interfaceLogicalOpt interf
 		panic(tfErr)
 	}
 	if tfErr := d.Set("routing_instance", interfaceLogicalOpt.routingInstance); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("security_inbound_protocols", interfaceLogicalOpt.securityInboundProtocols); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("security_inbound_services", interfaceLogicalOpt.securityInboundServices); tfErr != nil {
 		panic(tfErr)
 	}
 	if tfErr := d.Set("security_zone", interfaceLogicalOpt.securityZone); tfErr != nil {

--- a/junos/resource_interface_logical_test.go
+++ b/junos/resource_interface_logical_test.go
@@ -219,10 +219,12 @@ resource junos_interface_physical testacc_interface_logical_phy {
   vlan_tagging = true
 }
 resource junos_interface_logical testacc_interface_logical {
-  name             = "${junos_interface_physical.testacc_interface_logical_phy.name}.100"
-  description      = "testacc_interface_${junos_interface_physical.testacc_interface_logical_phy.name}.100"
-  security_zone    = junos_security_zone.testacc_interface_logical.name
-  routing_instance = junos_routing_instance.testacc_interface_logical.name
+  name                       = "${junos_interface_physical.testacc_interface_logical_phy.name}.100"
+  description                = "testacc_interface_${junos_interface_physical.testacc_interface_logical_phy.name}.100"
+  security_zone              = junos_security_zone.testacc_interface_logical.name
+  security_inbound_protocols = ["bgp"]
+  security_inbound_services  = ["ssh"]
+  routing_instance           = junos_routing_instance.testacc_interface_logical.name
   family_inet {
     mtu           = 1400
     filter_input  = junos_firewall_filter.testacc_intlogicalInet.name
@@ -318,11 +320,13 @@ resource junos_interface_physical testacc_interface_logical_phy {
   vlan_tagging = true
 }
 resource junos_interface_logical testacc_interface_logical {
-  name             = "${junos_interface_physical.testacc_interface_logical_phy.name}.100"
-  vlan_id          = 101
-  description      = "testacc_interface_${junos_interface_physical.testacc_interface_logical_phy.name}.100"
-  security_zone    = junos_security_zone.testacc_interface_logical.name
-  routing_instance = junos_routing_instance.testacc_interface_logical.name
+  name                       = "${junos_interface_physical.testacc_interface_logical_phy.name}.100"
+  vlan_id                    = 101
+  description                = "testacc_interface_${junos_interface_physical.testacc_interface_logical_phy.name}.100"
+  security_zone              = junos_security_zone.testacc_interface_logical.name
+  security_inbound_protocols = ["ospf"]
+  security_inbound_services  = ["telnet"]
+  routing_instance           = junos_routing_instance.testacc_interface_logical.name
   family_inet {
     mtu           = 1500
     filter_input  = junos_firewall_filter.testacc_intlogicalInet.name

--- a/junos/resource_interface_physical.go
+++ b/junos/resource_interface_physical.go
@@ -1636,6 +1636,7 @@ func delInterfacePhysicalOpts(d *schema.ResourceData, m interface{}, jnprSess *N
 	delPrefix := "delete interfaces " + d.Get("name").(string) + " "
 	configSet = append(configSet,
 		delPrefix+"aggregated-ether-options",
+		delPrefix+"description",
 		delPrefix+"esi",
 		delPrefix+"ether-options",
 		delPrefix+"gigether-options",

--- a/website/docs/d/interface_logical.html.markdown
+++ b/website/docs/d/interface_logical.html.markdown
@@ -50,6 +50,8 @@ The following arguments are supported:
   * `mtu` - Maximum transmission unit.
   * `rpf_check` - Reverse-path-forwarding checks enabled and possible configuration. See the [`rpf_check` attributes](#rpf_check-attributes) block for attributes.
 * `routing_instance` - Routing_instance where the interface is (if not default instance).
+* `security_inbound_protocols` - The inbound protocols allowed.
+* `security_inbound_services` - The inbound services allowed.
 * `security_zone` - Security zone where the interface is.
 * `vlan_id` - 802.1q VLAN ID for unit interface.
 

--- a/website/docs/r/interface_logical.html.markdown
+++ b/website/docs/r/interface_logical.html.markdown
@@ -45,6 +45,8 @@ The following arguments are supported:
   * `mtu` - (Optional)(`Int`) Maximum transmission unit.
   * `rpf_check` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once for enable reverse-path-forwarding checks on this interface. See the [`rpf_check` arguments](#rpf_check-arguments) block for optional arguments. 
 * `routing_instance` - (Optional)(`String`) Add this interface in routing_instance. Need to be created before.
+* `security_inbound_protocols` - (Optional)(`ListOfString`) The inbound protocols allowed. Must be a list of Junos protocols. `security_zone` need to be set.
+* `security_inbound_services` - (Optional)(`ListOfString`) The inbound services allowed. Must be a list of Junos services. `security_zone` need to be set.
 * `security_zone` - (Optional)(`String`) Add this interface in security_zone. Need to be created before.
 * `vlan_id` - (Optional,Computed)(`Int`) 802.1q VLAN ID for unit interface. If not set, computed with `name` of interface (ge-0/0/0.100 = 100) except if name has '.0' suffix or 'st0.' prefix.
 


### PR DESCRIPTION
ENHANCEMENTS:
* add `security_inbound_protocols` and `security_inbound_services` arguments in `junos_interface_logical` resource and data source (Fixes #141)

BUG FIXES:
* fix change `description` to null in `junos_interface_logical` and `junos_interface_physical` resource