### PR TITLE
Fixes #159: add match_(destination|source)_address_excluded arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## upcoming release
 ENHANCEMENTS:
+* add `match_destination_address_excluded` and `match_source_address_excluded` arguments in `junos_security_global_policy` and `junos_security_policy` resources (Fixes #159)
 
 BUG FIXES:
 

--- a/junos/resource_security_global_policy.go
+++ b/junos/resource_security_global_policy.go
@@ -77,6 +77,14 @@ func resourceSecurityGlobalPolicy() *schema.Resource {
 							Type:     schema.TypeBool,
 							Optional: true,
 						},
+						"match_destination_address_excluded": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"match_source_address_excluded": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
 						"permit_application_services": {
 							Type:     schema.TypeList,
 							Optional: true,
@@ -346,6 +354,12 @@ func setSecurityGlobalPolicy(d *schema.ResourceData, m interface{}, jnprSess *Ne
 		if policy["log_close"].(bool) {
 			configSet = append(configSet, setPrefixPolicy+" then log session-close")
 		}
+		if policy["match_destination_address_excluded"].(bool) {
+			configSet = append(configSet, setPrefixPolicy+" match destination-address-excluded")
+		}
+		if policy["match_source_address_excluded"].(bool) {
+			configSet = append(configSet, setPrefixPolicy+" match source-address-excluded")
+		}
 		if len(policy["permit_application_services"].([]interface{})) > 0 {
 			if policy["permit_application_services"].([]interface{})[0] == nil {
 				return fmt.Errorf("permit_application_services block is empty")
@@ -404,6 +418,10 @@ func readSecurityGlobalPolicy(m interface{}, jnprSess *NetconfObject) (globalPol
 				case strings.HasPrefix(itemTrimPolicy, "match to-zone "):
 					m["match_to_zone"] = append(m["match_to_zone"].([]string),
 						strings.TrimPrefix(itemTrimPolicy, "match to-zone "))
+				case strings.HasPrefix(itemTrimPolicy, "match destination-address-excluded"):
+					m["match_destination_address_excluded"] = true
+				case strings.HasPrefix(itemTrimPolicy, "match source-address-excluded"):
+					m["match_source_address_excluded"] = true
 				case strings.HasPrefix(itemTrimPolicy, "then "):
 					switch {
 					case strings.HasSuffix(itemTrimPolicy, permitWord),
@@ -446,17 +464,19 @@ func fillSecurityGlobalPolicyData(d *schema.ResourceData, globalPolicyOptions gl
 
 func genMapGlobalPolicyWithName(name string) map[string]interface{} {
 	return map[string]interface{}{
-		"name":                        name,
-		"match_source_address":        make([]string, 0),
-		"match_destination_address":   make([]string, 0),
-		"match_application":           make([]string, 0),
-		"match_from_zone":             make([]string, 0),
-		"match_to_zone":               make([]string, 0),
-		"then":                        "",
-		"count":                       false,
-		"log_init":                    false,
-		"log_close":                   false,
-		"permit_application_services": make([]map[string]interface{}, 0),
+		"name":                               name,
+		"match_source_address":               make([]string, 0),
+		"match_destination_address":          make([]string, 0),
+		"match_application":                  make([]string, 0),
+		"match_from_zone":                    make([]string, 0),
+		"match_to_zone":                      make([]string, 0),
+		"then":                               "",
+		"count":                              false,
+		"log_init":                           false,
+		"log_close":                          false,
+		"match_destination_address_excluded": false,
+		"match_source_address_excluded":      false,
+		"permit_application_services":        make([]map[string]interface{}, 0),
 	}
 }
 

--- a/junos/resource_security_global_policy_test.go
+++ b/junos/resource_security_global_policy_test.go
@@ -68,12 +68,13 @@ resource junos_security_global_policy "testacc_secglobpolicy" {
     junos_security_address_book.testacc_secglobpolicy
   ]
   policy {
-    name                      = "test"
-    match_source_address      = ["blue"]
-    match_destination_address = ["green"]
-    match_application         = ["any"]
-    match_from_zone           = [junos_security_zone.testacc_secglobpolicy1.name]
-    match_to_zone             = [junos_security_zone.testacc_secglobpolicy2.name]
+    name                               = "test"
+    match_source_address               = ["blue"]
+    match_destination_address          = ["green"]
+    match_destination_address_excluded = true
+    match_application                  = ["any"]
+    match_from_zone                    = [junos_security_zone.testacc_secglobpolicy1.name]
+    match_to_zone                      = [junos_security_zone.testacc_secglobpolicy2.name]
   }
 }
 `
@@ -118,13 +119,14 @@ resource junos_security_global_policy "testacc_secglobpolicy" {
     }
   }
   policy {
-    name                      = "drop"
-    match_source_address      = ["blue"]
-    match_destination_address = ["any"]
-    match_application         = ["any"]
-    match_from_zone           = ["any"]
-    match_to_zone             = ["any"]
-    then                      = "deny"
+    name                          = "drop"
+    match_source_address          = ["blue"]
+    match_destination_address     = ["any"]
+    match_application             = ["any"]
+    match_from_zone               = ["any"]
+    match_to_zone                 = ["any"]
+    match_source_address_excluded = true
+    then                          = "deny"
   }
 }
 `

--- a/junos/resource_security_policy.go
+++ b/junos/resource_security_policy.go
@@ -81,6 +81,14 @@ func resourceSecurityPolicy() *schema.Resource {
 							Type:     schema.TypeBool,
 							Optional: true,
 						},
+						"match_destination_address_excluded": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"match_source_address_excluded": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
 						"permit_application_services": {
 							Type:     schema.TypeList,
 							Optional: true,
@@ -393,6 +401,12 @@ func setSecurityPolicy(d *schema.ResourceData, m interface{}, jnprSess *NetconfO
 		if policy["log_close"].(bool) {
 			configSet = append(configSet, setPrefixPolicy+" then log session-close")
 		}
+		if policy["match_destination_address_excluded"].(bool) {
+			configSet = append(configSet, setPrefixPolicy+" match destination-address-excluded")
+		}
+		if policy["match_source_address_excluded"].(bool) {
+			configSet = append(configSet, setPrefixPolicy+" match source-address-excluded")
+		}
 		if policy["permit_tunnel_ipsec_vpn"].(string) != "" {
 			if policy["then"].(string) != permitWord {
 				return fmt.Errorf("conflict policy then %v and policy permit_tunnel_ipsec_vpn",
@@ -460,6 +474,10 @@ func readSecurityPolicy(idPolicy string, m interface{}, jnprSess *NetconfObject)
 				case strings.HasPrefix(itemTrimPolicy, "match application "):
 					m["match_application"] = append(m["match_application"].([]string),
 						strings.TrimPrefix(itemTrimPolicy, "match application "))
+				case strings.HasPrefix(itemTrimPolicy, "match destination-address-excluded"):
+					m["match_destination_address_excluded"] = true
+				case strings.HasPrefix(itemTrimPolicy, "match source-address-excluded"):
+					m["match_source_address_excluded"] = true
 				case strings.HasPrefix(itemTrimPolicy, "then "):
 					switch {
 					case strings.HasSuffix(itemTrimPolicy, permitWord),
@@ -512,16 +530,18 @@ func fillSecurityPolicyData(d *schema.ResourceData, policyOptions policyOptions)
 
 func genMapPolicyWithName(name string) map[string]interface{} {
 	return map[string]interface{}{
-		"name":                        name,
-		"match_source_address":        make([]string, 0),
-		"match_destination_address":   make([]string, 0),
-		"match_application":           make([]string, 0),
-		"then":                        "",
-		"count":                       false,
-		"log_init":                    false,
-		"log_close":                   false,
-		"permit_application_services": make([]map[string]interface{}, 0),
-		"permit_tunnel_ipsec_vpn":     "",
+		"name":                               name,
+		"match_source_address":               make([]string, 0),
+		"match_destination_address":          make([]string, 0),
+		"match_application":                  make([]string, 0),
+		"then":                               "",
+		"count":                              false,
+		"log_init":                           false,
+		"log_close":                          false,
+		"match_destination_address_excluded": false,
+		"match_source_address_excluded":      false,
+		"permit_application_services":        make([]map[string]interface{}, 0),
+		"permit_tunnel_ipsec_vpn":            "",
 	}
 }
 

--- a/junos/resource_security_policy_test.go
+++ b/junos/resource_security_policy_test.go
@@ -90,20 +90,22 @@ resource junos_security_policy testacc_securityPolicy {
   from_zone = junos_security_zone.testacc_seczonePolicy1.name
   to_zone   = junos_security_zone.testacc_seczonePolicy1.name
   policy {
-    name                      = "testacc_Policy_1"
-    match_source_address      = ["testacc_address1"]
-    match_destination_address = ["any"]
-    match_application         = ["junos-ssh"]
-    log_init                  = true
-    log_close                 = true
-    count                     = true
+    name                          = "testacc_Policy_1"
+    match_source_address          = ["testacc_address1"]
+    match_destination_address     = ["any"]
+    match_application             = ["junos-ssh"]
+    match_source_address_excluded = true
+    log_init                      = true
+    log_close                     = true
+    count                         = true
   }
   policy {
-    name                      = "testacc_Policy_2"
-    match_source_address      = ["testacc_address1"]
-    match_destination_address = ["any"]
-    match_application         = ["any"]
-    then                      = "reject"
+    name                               = "testacc_Policy_2"
+    match_source_address               = ["testacc_address1"]
+    match_destination_address          = ["testacc_address1"]
+    match_destination_address_excluded = true
+    match_application                  = ["any"]
+    then                               = "reject"
   }
 }
 

--- a/website/docs/r/security_global_policy.html.markdown
+++ b/website/docs/r/security_global_policy.html.markdown
@@ -52,6 +52,8 @@ The following arguments are supported:
   * `count` - (Optional)(`Bool`) Enable count.
   * `log_init` - (Optional)(`Bool`) Log at session init time.
   * `log_close` - (Optional)(`Bool`) Log at session close time.
+  * `match_destination_address_excluded` - (Optional)(`Bool`) Exclude destination addresses.
+  * `match_source_address_excluded` - (Optional)(`Bool`) Exclude source addresses.
   * `permit_application_services` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare 'permit application-services' configuration. See the [`permit_application_services` arguments] (#permit_application_services-arguments) block.
 
 ---

--- a/website/docs/r/security_policy.html.markdown
+++ b/website/docs/r/security_policy.html.markdown
@@ -41,6 +41,8 @@ The following arguments are supported:
   * `count` - (Optional)(`Bool`) Enable count.
   * `log_init` - (Optional)(`Bool`) Log at session init time.
   * `log_close` - (Optional)(`Bool`) Log at session close time.
+  * `match_destination_address_excluded` - (Optional)(`Bool`) Exclude destination addresses.
+  * `match_source_address_excluded` - (Optional)(`Bool`) Exclude source addresses.
   * `permit_tunnel_ipsec_vpn` - (Optional)(`String`) Name of vpn to permit with a tunnel ipsec.
   * `permit_application_services` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html) Define application services for permit. See the [`permit_application_services` arguments for policy](#permit_application_services-arguments-for-policy) block. Max of 1.
 


### PR DESCRIPTION
ENHANCEMENTS:
* add `match_destination_address_excluded` and `match_source_address_excluded` arguments in `junos_security_global_policy` and `junos_security_policy` resources (Fixes #159)