### PR TITLE
Fixes #158: add Application Identification support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ ENHANCEMENTS:
 * add `junos_services` resource (Fixes parts of #145)
 * add `match_destination_address_excluded` and `match_source_address_excluded` arguments in `junos_security_global_policy` and `junos_security_policy` resources (Fixes #159)
 * add `match_dynamic_application` argument in `junos_security_global_policy` and `junos_security_policy` resources (Fixes parts of #158)
+* add `forwarding_process` argument in `junos_security` resource (Fixes parts of #158)
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ ENHANCEMENTS:
 * add `match_destination_address_excluded` and `match_source_address_excluded` arguments in `junos_security_global_policy` and `junos_security_policy` resources (Fixes #159)
 * add `match_dynamic_application` argument in `junos_security_global_policy` and `junos_security_policy` resources (Fixes parts of #158)
 * add `forwarding_process` argument in `junos_security` resource (Fixes parts of #158)
+* add `application_identification` argument in `junos_services` resource (Fixes parts of #158)
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ ENHANCEMENTS:
 * add `junos_services_proxy_profile` resource
 * add `junos_services` resource (Fixes parts of #145)
 * add `match_destination_address_excluded` and `match_source_address_excluded` arguments in `junos_security_global_policy` and `junos_security_policy` resources (Fixes #159)
+* add `match_dynamic_application` argument in `junos_security_global_policy` and `junos_security_policy` resources (Fixes parts of #158)
 
 BUG FIXES:
 

--- a/junos/resource_security_global_policy.go
+++ b/junos/resource_security_global_policy.go
@@ -81,6 +81,11 @@ func resourceSecurityGlobalPolicy() *schema.Resource {
 							Type:     schema.TypeBool,
 							Optional: true,
 						},
+						"match_dynamic_application": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
 						"match_source_address_excluded": {
 							Type:     schema.TypeBool,
 							Optional: true,
@@ -357,6 +362,9 @@ func setSecurityGlobalPolicy(d *schema.ResourceData, m interface{}, jnprSess *Ne
 		if policy["match_destination_address_excluded"].(bool) {
 			configSet = append(configSet, setPrefixPolicy+" match destination-address-excluded")
 		}
+		for _, v := range policy["match_dynamic_application"].([]interface{}) {
+			configSet = append(configSet, setPrefixPolicy+" match dynamic-application "+v.(string))
+		}
 		if policy["match_source_address_excluded"].(bool) {
 			configSet = append(configSet, setPrefixPolicy+" match source-address-excluded")
 		}
@@ -420,6 +428,9 @@ func readSecurityGlobalPolicy(m interface{}, jnprSess *NetconfObject) (globalPol
 						strings.TrimPrefix(itemTrimPolicy, "match to-zone "))
 				case strings.HasPrefix(itemTrimPolicy, "match destination-address-excluded"):
 					m["match_destination_address_excluded"] = true
+				case strings.HasPrefix(itemTrimPolicy, "match dynamic-application "):
+					m["match_dynamic_application"] = append(m["match_dynamic_application"].([]string),
+						strings.TrimPrefix(itemTrimPolicy, "match dynamic-application "))
 				case strings.HasPrefix(itemTrimPolicy, "match source-address-excluded"):
 					m["match_source_address_excluded"] = true
 				case strings.HasPrefix(itemTrimPolicy, "then "):
@@ -475,6 +486,7 @@ func genMapGlobalPolicyWithName(name string) map[string]interface{} {
 		"log_init":                           false,
 		"log_close":                          false,
 		"match_destination_address_excluded": false,
+		"match_dynamic_application":          make([]string, 0),
 		"match_source_address_excluded":      false,
 		"permit_application_services":        make([]map[string]interface{}, 0),
 	}

--- a/junos/resource_security_global_policy_test.go
+++ b/junos/resource_security_global_policy_test.go
@@ -73,6 +73,7 @@ resource junos_security_global_policy "testacc_secglobpolicy" {
     match_destination_address          = ["green"]
     match_destination_address_excluded = true
     match_application                  = ["any"]
+    match_dynamic_application          = ["junos:web:wiki", "junos:web:infrastructure"]
     match_from_zone                    = [junos_security_zone.testacc_secglobpolicy1.name]
     match_to_zone                      = [junos_security_zone.testacc_secglobpolicy2.name]
   }
@@ -123,6 +124,7 @@ resource junos_security_global_policy "testacc_secglobpolicy" {
     match_source_address          = ["blue"]
     match_destination_address     = ["any"]
     match_application             = ["any"]
+    match_dynamic_application     = ["junos:web:wiki", "junos:web:search", "junos:web:infrastructure"]
     match_from_zone               = ["any"]
     match_to_zone                 = ["any"]
     match_source_address_excluded = true

--- a/junos/resource_security_policy.go
+++ b/junos/resource_security_policy.go
@@ -85,6 +85,11 @@ func resourceSecurityPolicy() *schema.Resource {
 							Type:     schema.TypeBool,
 							Optional: true,
 						},
+						"match_dynamic_application": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
 						"match_source_address_excluded": {
 							Type:     schema.TypeBool,
 							Optional: true,
@@ -404,6 +409,9 @@ func setSecurityPolicy(d *schema.ResourceData, m interface{}, jnprSess *NetconfO
 		if policy["match_destination_address_excluded"].(bool) {
 			configSet = append(configSet, setPrefixPolicy+" match destination-address-excluded")
 		}
+		for _, v := range policy["match_dynamic_application"].([]interface{}) {
+			configSet = append(configSet, setPrefixPolicy+" match dynamic-application "+v.(string))
+		}
 		if policy["match_source_address_excluded"].(bool) {
 			configSet = append(configSet, setPrefixPolicy+" match source-address-excluded")
 		}
@@ -476,6 +484,9 @@ func readSecurityPolicy(idPolicy string, m interface{}, jnprSess *NetconfObject)
 						strings.TrimPrefix(itemTrimPolicy, "match application "))
 				case strings.HasPrefix(itemTrimPolicy, "match destination-address-excluded"):
 					m["match_destination_address_excluded"] = true
+				case strings.HasPrefix(itemTrimPolicy, "match dynamic-application "):
+					m["match_dynamic_application"] = append(m["match_dynamic_application"].([]string),
+						strings.TrimPrefix(itemTrimPolicy, "match dynamic-application "))
 				case strings.HasPrefix(itemTrimPolicy, "match source-address-excluded"):
 					m["match_source_address_excluded"] = true
 				case strings.HasPrefix(itemTrimPolicy, "then "):
@@ -539,6 +550,7 @@ func genMapPolicyWithName(name string) map[string]interface{} {
 		"log_init":                           false,
 		"log_close":                          false,
 		"match_destination_address_excluded": false,
+		"match_dynamic_application":          make([]string, 0),
 		"match_source_address_excluded":      false,
 		"permit_application_services":        make([]map[string]interface{}, 0),
 		"permit_tunnel_ipsec_vpn":            "",

--- a/junos/resource_security_policy_test.go
+++ b/junos/resource_security_policy_test.go
@@ -69,6 +69,7 @@ resource junos_security_policy testacc_securityPolicy {
     match_source_address      = ["testacc_address1"]
     match_destination_address = ["any"]
     match_application         = ["junos-ssh"]
+    match_dynamic_application = ["junos:web:wiki", "junos:web:infrastructure"]
     log_init                  = true
     log_close                 = true
     count                     = true
@@ -105,6 +106,7 @@ resource junos_security_policy testacc_securityPolicy {
     match_destination_address          = ["testacc_address1"]
     match_destination_address_excluded = true
     match_application                  = ["any"]
+    match_dynamic_application          = ["junos:web:wiki", "junos:web:search", "junos:web:infrastructure"]
     then                               = "reject"
   }
 }

--- a/junos/resource_security_test.go
+++ b/junos/resource_security_test.go
@@ -340,6 +340,9 @@ resource junos_security "testacc_security" {
     mpls_mode             = "flow-based"
     iso_mode_packet_based = "true"
   }
+  forwarding_process {
+    enhanced_services_mode = true
+  }
   ike_traceoptions {
     file {
       name           = "ike.log"

--- a/junos/resource_services.go
+++ b/junos/resource_services.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -13,6 +14,7 @@ import (
 )
 
 type servicesOptions struct {
+	appIdent             []map[string]interface{}
 	securityIntelligence []map[string]interface{}
 }
 
@@ -26,6 +28,170 @@ func resourceServices() *schema.Resource {
 			State: resourceServicesImport,
 		},
 		Schema: map[string]*schema.Schema{
+			"application_identification": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"application_system_cache": {
+							Type:          schema.TypeList,
+							Optional:      true,
+							MaxItems:      1,
+							ConflictsWith: []string{"application_identification.0.no_application_system_cache"},
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"no_miscellaneous_services": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"security_services": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+								},
+							},
+						},
+						"no_application_system_cache": {
+							Type:          schema.TypeBool,
+							Optional:      true,
+							ConflictsWith: []string{"application_identification.0.application_system_cache"},
+						},
+
+						"application_system_cache_timeout": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      -1,
+							ValidateFunc: validation.IntBetween(0, 1000000),
+						},
+						"download": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"automatic_interval": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(6, 720),
+									},
+									"automatic_start_time": {
+										Type:     schema.TypeString,
+										Optional: true,
+										ValidateFunc: validation.StringMatch(regexp.MustCompile(
+											`^([0-9]{4}-)?(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1]).(2[0-3]|[01][0-9]):[0-5][0-9](:[0-5][0-9])?$`),
+											"Invalid date; format is MM-DD.hh:mm / YYYY-MM-DD.hh:mm:ss"),
+									},
+									"ignore_server_validation": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"proxy_profile": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"url": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+						"enable_performance_mode": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"max_packet_threshold": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(1, 100),
+									},
+								},
+							},
+						},
+						"global_offload_byte_limit": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      -1,
+							ValidateFunc: validation.IntBetween(0, 4294967295),
+						},
+						"imap_cache_size": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(60, 512000),
+						},
+						"imap_cache_timeout": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(1, 86400),
+						},
+						"inspection_limit_tcp": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"byte_limit": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Default:      -1,
+										ValidateFunc: validation.IntBetween(0, 4294967295),
+									},
+									"packet_limit": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Default:      -1,
+										ValidateFunc: validation.IntBetween(0, 4294967295),
+									},
+								},
+							},
+						},
+						"inspection_limit_udp": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"byte_limit": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Default:      -1,
+										ValidateFunc: validation.IntBetween(0, 4294967295),
+									},
+									"packet_limit": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Default:      -1,
+										ValidateFunc: validation.IntBetween(0, 4294967295),
+									},
+								},
+							},
+						},
+						"max_memory": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(1, 200000),
+						},
+						"max_transactions": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      -1,
+							ValidateFunc: validation.IntBetween(0, 25),
+						},
+						"micro_apps": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"statistics_interval": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(1, 1440),
+						},
+					},
+				},
+			},
 			"security_intelligence": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -199,6 +365,13 @@ func setServices(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject)
 	// setPrefix := "set services "
 	configSet := make([]string, 0)
 
+	for _, v := range d.Get("application_identification").([]interface{}) {
+		configSetApplicationIdentification, err := setServicesApplicationIdentification(v)
+		if err != nil {
+			return err
+		}
+		configSet = append(configSet, configSetApplicationIdentification...)
+	}
 	for _, v := range d.Get("security_intelligence").([]interface{}) {
 		configSetSecurityIntel, err := setServicesSecurityIntell(v)
 		if err != nil {
@@ -208,6 +381,112 @@ func setServices(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject)
 	}
 
 	return sess.configSet(configSet, jnprSess)
+}
+
+func setServicesApplicationIdentification(appID interface{}) ([]string, error) {
+	setPrefix := "set services application-identification "
+	configSet := make([]string, 0)
+	if appID != nil {
+		appIDM := appID.(map[string]interface{})
+		for _, v := range appIDM["application_system_cache"].([]interface{}) {
+			configSet = append(configSet, setPrefix+"application-system-cache")
+			if v != nil {
+				appSysCache := v.(map[string]interface{})
+				if appSysCache["no_miscellaneous_services"].(bool) {
+					configSet = append(configSet, setPrefix+"application-system-cache no-miscellaneous-services")
+				}
+				if appSysCache["security_services"].(bool) {
+					configSet = append(configSet, setPrefix+"application-system-cache security-services")
+				}
+			}
+		}
+		if appIDM["no_application_system_cache"].(bool) {
+			configSet = append(configSet, setPrefix+"no-application-system-cache")
+		}
+		if v := appIDM["application_system_cache_timeout"].(int); v != -1 {
+			configSet = append(configSet, setPrefix+"application-system-cache-timeout "+strconv.Itoa(v))
+		}
+		for _, v := range appIDM["download"].([]interface{}) {
+			if v != nil {
+				download := v.(map[string]interface{})
+				if v2 := download["automatic_interval"].(int); v2 != 0 {
+					configSet = append(configSet, setPrefix+"download automatic interval "+strconv.Itoa(v2))
+				}
+				if v2 := download["automatic_start_time"].(string); v2 != "" {
+					configSet = append(configSet, setPrefix+"download automatic start-time "+v2)
+				}
+				if download["ignore_server_validation"].(bool) {
+					configSet = append(configSet, setPrefix+"download ignore-server-validation")
+				}
+				if v2 := download["proxy_profile"].(string); v2 != "" {
+					configSet = append(configSet, setPrefix+"download proxy-profile \""+v2+"\"")
+				}
+				if v2 := download["url"].(string); v2 != "" {
+					configSet = append(configSet, setPrefix+"download url \""+v2+"\"")
+				}
+			} else {
+				return configSet, fmt.Errorf("application_identification.0.download block is empty")
+			}
+		}
+		for _, v := range appIDM["enable_performance_mode"].([]interface{}) {
+			configSet = append(configSet, setPrefix+"enable-performance-mode")
+			if v != nil {
+				enPerfMode := v.(map[string]interface{})
+				if v := enPerfMode["max_packet_threshold"].(int); v != 0 {
+					configSet = append(configSet, setPrefix+"enable-performance-mode max-packet-threshold "+strconv.Itoa(v))
+				}
+			}
+		}
+		if v := appIDM["global_offload_byte_limit"].(int); v != -1 {
+			configSet = append(configSet, setPrefix+"global-offload-byte-limit "+strconv.Itoa(v))
+		}
+		if v := appIDM["imap_cache_size"].(int); v != 0 {
+			configSet = append(configSet, setPrefix+"imap-cache-size "+strconv.Itoa(v))
+		}
+		if v := appIDM["imap_cache_timeout"].(int); v != 0 {
+			configSet = append(configSet, setPrefix+"imap-cache-timeout "+strconv.Itoa(v))
+		}
+		for _, v := range appIDM["inspection_limit_tcp"].([]interface{}) {
+			configSet = append(configSet, setPrefix+"inspection-limit tcp")
+			if v != nil {
+				inspLimitTCP := v.(map[string]interface{})
+				if v := inspLimitTCP["byte_limit"].(int); v != -1 {
+					configSet = append(configSet, setPrefix+"inspection-limit tcp byte-limit "+strconv.Itoa(v))
+				}
+				if v := inspLimitTCP["packet_limit"].(int); v != -1 {
+					configSet = append(configSet, setPrefix+"inspection-limit tcp packet-limit "+strconv.Itoa(v))
+				}
+			}
+		}
+		for _, v := range appIDM["inspection_limit_udp"].([]interface{}) {
+			configSet = append(configSet, setPrefix+"inspection-limit udp")
+			if v != nil {
+				inspLimitUDP := v.(map[string]interface{})
+				if v := inspLimitUDP["byte_limit"].(int); v != -1 {
+					configSet = append(configSet, setPrefix+"inspection-limit udp byte-limit "+strconv.Itoa(v))
+				}
+				if v := inspLimitUDP["packet_limit"].(int); v != -1 {
+					configSet = append(configSet, setPrefix+"inspection-limit udp packet-limit "+strconv.Itoa(v))
+				}
+			}
+		}
+		if v := appIDM["max_memory"].(int); v != 0 {
+			configSet = append(configSet, setPrefix+"max-memory "+strconv.Itoa(v))
+		}
+		if v := appIDM["max_transactions"].(int); v != -1 {
+			configSet = append(configSet, setPrefix+"max-transactions "+strconv.Itoa(v))
+		}
+		if appIDM["micro_apps"].(bool) {
+			configSet = append(configSet, setPrefix+"micro-apps")
+		}
+		if v := appIDM["statistics_interval"].(int); v != 0 {
+			configSet = append(configSet, setPrefix+"statistics interval "+strconv.Itoa(v))
+		}
+	} else {
+		return configSet, fmt.Errorf("application_identification block is empty")
+	}
+
+	return configSet, nil
 }
 
 func setServicesSecurityIntell(secuIntel interface{}) ([]string, error) {
@@ -249,6 +528,24 @@ func setServicesSecurityIntell(secuIntel interface{}) ([]string, error) {
 	return configSet, nil
 }
 
+func listLinesServicesApplicationIdentification() []string {
+	return []string{
+		"application-identification application-system-cache",
+		"application-identification no-application-system-cache",
+		"application-identification application-system-cache-timeout",
+		"application-identification download",
+		"application-identification global-offload-byte-limit",
+		"application-identification enable-performance-mode",
+		"application-identification imap-cache-size",
+		"application-identification imap-cache-timeout",
+		"application-identification inspection-limit tcp",
+		"application-identification inspection-limit udp",
+		"application-identification max-memory",
+		"application-identification max-transactions",
+		"application-identification micro-apps",
+		"application-identification statistics interval",
+	}
+}
 func listLinesServicesSecurityIntel() []string {
 	return []string{
 		"security-intelligence authentication",
@@ -262,6 +559,7 @@ func listLinesServicesSecurityIntel() []string {
 
 func delServices(m interface{}, jnprSess *NetconfObject) error {
 	listLinesToDelete := make([]string, 0)
+	listLinesToDelete = append(listLinesToDelete, listLinesServicesApplicationIdentification()...)
 	listLinesToDelete = append(listLinesToDelete, listLinesServicesSecurityIntel()...)
 	sess := m.(*Session)
 	configSet := make([]string, 0)
@@ -291,7 +589,12 @@ func readServices(m interface{}, jnprSess *NetconfObject) (servicesOptions, erro
 				break
 			}
 			itemTrim := strings.TrimPrefix(item, setLineStart)
-			if checkStringHasPrefixInList(itemTrim, listLinesServicesSecurityIntel()) {
+			switch {
+			case checkStringHasPrefixInList(itemTrim, listLinesServicesApplicationIdentification()):
+				if err := readServicesApplicationIdentification(&confRead, itemTrim); err != nil {
+					return confRead, err
+				}
+			case checkStringHasPrefixInList(itemTrim, listLinesServicesSecurityIntel()):
 				if err := readServicesSecurityIntel(&confRead, itemTrim); err != nil {
 					return confRead, err
 				}
@@ -356,7 +659,201 @@ func readServicesSecurityIntel(confRead *servicesOptions, itemTrimSecurityIntel 
 	return nil
 }
 
+func readServicesApplicationIdentification(confRead *servicesOptions, itemTrimAppID string) error {
+	itemTrim := strings.TrimPrefix(itemTrimAppID, "application-identification ")
+	if len(confRead.appIdent) == 0 {
+		confRead.appIdent = append(confRead.appIdent, map[string]interface{}{
+			"application_system_cache":         make([]map[string]interface{}, 0),
+			"no_application_system_cache":      false,
+			"application_system_cache_timeout": -1,
+			"download":                         make([]map[string]interface{}, 0),
+			"enable_performance_mode":          make([]map[string]interface{}, 0),
+			"global_offload_byte_limit":        -1,
+			"imap_cache_size":                  0,
+			"imap_cache_timeout":               0,
+			"inspection_limit_tcp":             make([]map[string]interface{}, 0),
+			"inspection_limit_udp":             make([]map[string]interface{}, 0),
+			"max_memory":                       0,
+			"max_transactions":                 -1,
+			"micro_apps":                       false,
+			"statistics_interval":              0,
+		})
+	}
+	switch {
+	case strings.HasPrefix(itemTrim, "application-system-cache-timeout "):
+		var err error
+		confRead.appIdent[0]["application_system_cache_timeout"], err =
+			strconv.Atoi(strings.TrimPrefix(itemTrim, "application-system-cache-timeout "))
+		if err != nil {
+			return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+		}
+	case strings.HasPrefix(itemTrim, "application-system-cache"):
+		if len(confRead.appIdent[0]["application_system_cache"].([]map[string]interface{})) == 0 {
+			confRead.appIdent[0]["application_system_cache"] = append(
+				confRead.appIdent[0]["application_system_cache"].([]map[string]interface{}),
+				map[string]interface{}{
+					"no_miscellaneous_services": false,
+					"security_services":         false,
+				})
+		}
+		switch {
+		case itemTrim == "application-system-cache no-miscellaneous-services":
+			confRead.appIdent[0]["application_system_cache"].([]map[string]interface{})[0]["no_miscellaneous_services"] = // nolint: lll
+				true
+		case itemTrim == "application-system-cache security-services":
+			confRead.appIdent[0]["application_system_cache"].([]map[string]interface{})[0]["security_services"] =
+				true
+		}
+	case itemTrim == "no-application-system-cache":
+		confRead.appIdent[0]["no_application_system_cache"] = true
+	case strings.HasPrefix(itemTrim, "download "):
+		if len(confRead.appIdent[0]["download"].([]map[string]interface{})) == 0 {
+			confRead.appIdent[0]["download"] = append(
+				confRead.appIdent[0]["download"].([]map[string]interface{}), map[string]interface{}{
+					"automatic_interval":       0,
+					"automatic_start_time":     "",
+					"ignore_server_validation": false,
+					"proxy_profile":            "",
+					"url":                      "",
+				})
+		}
+		switch {
+		case strings.HasPrefix(itemTrim, "download automatic interval "):
+			var err error
+			confRead.appIdent[0]["download"].([]map[string]interface{})[0]["automatic_interval"], err =
+				strconv.Atoi(strings.TrimPrefix(itemTrim, "download automatic interval "))
+			if err != nil {
+				return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+			}
+		case strings.HasPrefix(itemTrim, "download automatic start-time "):
+			confRead.appIdent[0]["download"].([]map[string]interface{})[0]["automatic_start_time"] =
+				strings.TrimPrefix(itemTrim, "download automatic start-time ")
+		case itemTrim == "download ignore-server-validation":
+			confRead.appIdent[0]["download"].([]map[string]interface{})[0]["ignore_server_validation"] =
+				true
+		case strings.HasPrefix(itemTrim, "download proxy-profile "):
+			confRead.appIdent[0]["download"].([]map[string]interface{})[0]["proxy_profile"] =
+				strings.Trim(strings.TrimPrefix(itemTrim, "download proxy-profile "), "\"")
+		case strings.HasPrefix(itemTrim, "download url "):
+			confRead.appIdent[0]["download"].([]map[string]interface{})[0]["url"] =
+				strings.Trim(strings.TrimPrefix(itemTrim, "download url "), "\"")
+		}
+	case strings.HasPrefix(itemTrim, "enable-performance-mode"):
+		if len(confRead.appIdent[0]["enable_performance_mode"].([]map[string]interface{})) == 0 {
+			confRead.appIdent[0]["enable_performance_mode"] = append(
+				confRead.appIdent[0]["enable_performance_mode"].([]map[string]interface{}), map[string]interface{}{
+					"max_packet_threshold": 0,
+				})
+		}
+		if strings.HasPrefix(itemTrim, "enable-performance-mode max-packet-threshold ") {
+			var err error
+			confRead.appIdent[0]["enable_performance_mode"].([]map[string]interface{})[0]["max_packet_threshold"], err =
+				strconv.Atoi(strings.TrimPrefix(itemTrim, "enable-performance-mode max-packet-threshold "))
+			if err != nil {
+				return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+			}
+		}
+	case strings.HasPrefix(itemTrim, "global-offload-byte-limit "):
+		var err error
+		confRead.appIdent[0]["global_offload_byte_limit"], err =
+			strconv.Atoi(strings.TrimPrefix(itemTrim, "global-offload-byte-limit "))
+		if err != nil {
+			return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+		}
+	case strings.HasPrefix(itemTrim, "imap-cache-size "):
+		var err error
+		confRead.appIdent[0]["imap_cache_size"], err =
+			strconv.Atoi(strings.TrimPrefix(itemTrim, "imap-cache-size "))
+		if err != nil {
+			return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+		}
+	case strings.HasPrefix(itemTrim, "imap-cache-timeout "):
+		var err error
+		confRead.appIdent[0]["imap_cache_timeout"], err =
+			strconv.Atoi(strings.TrimPrefix(itemTrim, "imap-cache-timeout "))
+		if err != nil {
+			return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+		}
+	case strings.HasPrefix(itemTrim, "inspection-limit tcp"):
+		if len(confRead.appIdent[0]["inspection_limit_tcp"].([]map[string]interface{})) == 0 {
+			confRead.appIdent[0]["inspection_limit_tcp"] = append(
+				confRead.appIdent[0]["inspection_limit_tcp"].([]map[string]interface{}), map[string]interface{}{
+					"byte_limit":   -1,
+					"packet_limit": -1,
+				})
+		}
+		switch {
+		case strings.HasPrefix(itemTrim, "inspection-limit tcp byte-limit "):
+			var err error
+			confRead.appIdent[0]["inspection_limit_tcp"].([]map[string]interface{})[0]["byte_limit"], err =
+				strconv.Atoi(strings.TrimPrefix(itemTrim, "inspection-limit tcp byte-limit "))
+			if err != nil {
+				return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+			}
+		case strings.HasPrefix(itemTrim, "inspection-limit tcp packet-limit "):
+			var err error
+			confRead.appIdent[0]["inspection_limit_tcp"].([]map[string]interface{})[0]["packet_limit"], err =
+				strconv.Atoi(strings.TrimPrefix(itemTrim, "inspection-limit tcp packet-limit "))
+			if err != nil {
+				return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+			}
+		}
+	case strings.HasPrefix(itemTrim, "inspection-limit udp"):
+		if len(confRead.appIdent[0]["inspection_limit_udp"].([]map[string]interface{})) == 0 {
+			confRead.appIdent[0]["inspection_limit_udp"] = append(
+				confRead.appIdent[0]["inspection_limit_udp"].([]map[string]interface{}), map[string]interface{}{
+					"byte_limit":   -1,
+					"packet_limit": -1,
+				})
+		}
+		switch {
+		case strings.HasPrefix(itemTrim, "inspection-limit udp byte-limit "):
+			var err error
+			confRead.appIdent[0]["inspection_limit_udp"].([]map[string]interface{})[0]["byte_limit"], err =
+				strconv.Atoi(strings.TrimPrefix(itemTrim, "inspection-limit udp byte-limit "))
+			if err != nil {
+				return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+			}
+		case strings.HasPrefix(itemTrim, "inspection-limit udp packet-limit "):
+			var err error
+			confRead.appIdent[0]["inspection_limit_udp"].([]map[string]interface{})[0]["packet_limit"], err =
+				strconv.Atoi(strings.TrimPrefix(itemTrim, "inspection-limit udp packet-limit "))
+			if err != nil {
+				return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+			}
+		}
+	case strings.HasPrefix(itemTrim, "max-memory "):
+		var err error
+		confRead.appIdent[0]["max_memory"], err =
+			strconv.Atoi(strings.TrimPrefix(itemTrim, "max-memory "))
+		if err != nil {
+			return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+		}
+	case strings.HasPrefix(itemTrim, "max-transactions "):
+		var err error
+		confRead.appIdent[0]["max_transactions"], err =
+			strconv.Atoi(strings.TrimPrefix(itemTrim, "max-transactions "))
+		if err != nil {
+			return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+		}
+	case itemTrim == "micro-apps":
+		confRead.appIdent[0]["micro_apps"] = true
+	case strings.HasPrefix(itemTrim, "statistics interval "):
+		var err error
+		confRead.appIdent[0]["statistics_interval"], err =
+			strconv.Atoi(strings.TrimPrefix(itemTrim, "statistics interval "))
+		if err != nil {
+			return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+		}
+	}
+
+	return nil
+}
+
 func fillServices(d *schema.ResourceData, servicesOptions servicesOptions) {
+	if tfErr := d.Set("application_identification", servicesOptions.appIdent); tfErr != nil {
+		panic(tfErr)
+	}
 	if tfErr := d.Set("security_intelligence", servicesOptions.securityIntelligence); tfErr != nil {
 		panic(tfErr)
 	}

--- a/junos/resource_services_test.go
+++ b/junos/resource_services_test.go
@@ -30,6 +30,9 @@ func TestAccJunosServices_basic(t *testing.T) {
 					),
 				},
 				{
+					Config: testAccJunosServicesConfigUpdate2(),
+				},
+				{
 					ResourceName:      "junos_services_proxy_profile.testacc_services",
 					ImportState:       true,
 					ImportStateVerify: true,
@@ -55,6 +58,14 @@ resource "junos_services_proxy_profile" "testacc_services" {
   protocol_http_port = 3128
 }
 resource "junos_services" "testacc" {
+  application_identification {
+    application_system_cache {}
+    download {
+      automatic_start_time = "12-24.22:00"
+    }
+    enable_performance_mode {}
+    max_transactions = 10
+  }
   security_intelligence {
     authentication_token = "abcdefghijklmnopqrstuvwxyz123456"
     category_disable     = ["all"]
@@ -84,6 +95,26 @@ resource "junos_services_security_intelligence_profile" "testacc_services" {
   }
 }
 resource "junos_services" "testacc" {
+  application_identification {
+    application_system_cache {
+      security_services = true
+    }
+    application_system_cache_timeout = 120
+    download {
+      automatic_interval       = 120
+      automatic_start_time     = "12-24.22:00"
+      ignore_server_validation = true
+      proxy_profile            = junos_services_proxy_profile.testacc_services.name
+      url                      = "https://example.com/"
+    }
+    enable_performance_mode {
+      max_packet_threshold = 50
+    }
+    imap_cache_size     = 120
+    imap_cache_timeout  = 120
+    max_transactions    = 10
+    statistics_interval = 120
+  }
   security_intelligence {
     authentication_token = "abcdefghijklmnopqrstuvwxyz123400"
     category_disable     = ["CC"]
@@ -98,7 +129,8 @@ resource "junos_services" "testacc" {
 }
 `
 }
-func testAccJunosServicesConfigPostCheck() string {
+
+func testAccJunosServicesConfigUpdate2() string {
 	return `
 resource "junos_services_proxy_profile" "testacc_services" {
   name               = "testacc_services"
@@ -115,6 +147,20 @@ resource "junos_services_security_intelligence_profile" "testacc_services" {
     }
     then_action = "permit"
   }
+}
+resource "junos_services" "testacc" {
+  application_identification {
+    no_application_system_cache = true
+  }
+}
+  `
+}
+func testAccJunosServicesConfigPostCheck() string {
+	return `
+resource "junos_services_proxy_profile" "testacc_services" {
+  name               = "testacc_services"
+  protocol_http_host = "192.0.2.2"
+  protocol_http_port = 3129
 }
 resource "junos_services" "testacc" {
 }

--- a/website/docs/r/security.html.markdown
+++ b/website/docs/r/security.html.markdown
@@ -33,6 +33,8 @@ The following arguments are supported:
 * `alg` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare 'alg' configuration. See the [`alg` arguments] (#alg-arguments) block.
 * `flow` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare 'flow' configuration. See the [`flow` arguments] (#flow-arguments) block.
 * `forwarding_options` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare 'forwarding-options' configuration. See the [`forwarding_options` arguments] (#forwarding_options-arguments) block.
+* `forwarding_process` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare 'forwarding-process' configuration.
+  * `enhanced_services_mode` - (Optional)(`Bool`) Enable enhanced application services mode.
 * `ike_traceoptions` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare 'ike traceoptions' configuration.
   * `file` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare 'file' configuration. See the [`file` arguments for ike_traceoptions] (#file-arguments-for-ike_traceoptions) block.
   * `flag` - (Optional)(`ListOfString`) Tracing parameters for IKE.

--- a/website/docs/r/security_global_policy.html.markdown
+++ b/website/docs/r/security_global_policy.html.markdown
@@ -53,6 +53,7 @@ The following arguments are supported:
   * `log_init` - (Optional)(`Bool`) Log at session init time.
   * `log_close` - (Optional)(`Bool`) Log at session close time.
   * `match_destination_address_excluded` - (Optional)(`Bool`) Exclude destination addresses.
+  * `match_dynamic_application` - (Optional)(`ListOfString`) List of dynamic application or group match.
   * `match_source_address_excluded` - (Optional)(`Bool`) Exclude source addresses.
   * `permit_application_services` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare 'permit application-services' configuration. See the [`permit_application_services` arguments] (#permit_application_services-arguments) block.
 

--- a/website/docs/r/security_policy.html.markdown
+++ b/website/docs/r/security_policy.html.markdown
@@ -42,6 +42,7 @@ The following arguments are supported:
   * `log_init` - (Optional)(`Bool`) Log at session init time.
   * `log_close` - (Optional)(`Bool`) Log at session close time.
   * `match_destination_address_excluded` - (Optional)(`Bool`) Exclude destination addresses.
+  * `match_dynamic_application` - (Optional)(`ListOfString`) List of dynamic application or group match.
   * `match_source_address_excluded` - (Optional)(`Bool`) Exclude source addresses.
   * `permit_tunnel_ipsec_vpn` - (Optional)(`String`) Name of vpn to permit with a tunnel ipsec.
   * `permit_application_services` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html) Define application services for permit. See the [`permit_application_services` arguments for policy](#permit_application_services-arguments-for-policy) block. Max of 1.

--- a/website/docs/r/services.html.markdown
+++ b/website/docs/r/services.html.markdown
@@ -28,7 +28,37 @@ resource junos_services "services" {
 
 The following arguments are supported:
 
+* `application_identification` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare 'application-identification' configuration. See the [`application_identification` arguments] (#application_identification-arguments) block.
 * `security_intelligence` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare 'security-intelligence' configuration. See the [`security_intelligence` arguments] (#security_intelligence-arguments) block.
+
+---
+#### application_identification arguments
+* `application_system_cache` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to enable application system cache. Conflict with `no_application_system_cache`.
+  * `no_miscellaneous_services` - (Optional)(`Bool`) Disable ASC for miscellaneous services APBR,...
+  * `security-services` - (Optional)(`Bool`) Enable ASC for security services (appfw, appqos, idp, skyatp..).
+* `no_application_system_cache` - (Optional)(`Bool`) Disable storing AI result in application system cache. Conflict with `application_system_cache`.
+* `application_system_cache_timeout` - (Optional)(`Int`) Application system cache entry lifetime (0..1000000).
+* `download` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare 'download' configuration.
+  * `automatic_interval` - (Optional)(`Int`) Attempt to download new application package (6..720 hours).
+  * `automatic_start_time` - (Optional)(`String`) Start time to scheduled download and update (MM-DD.hh:mm / YYYY-MM-DD.hh:mm:ss).
+  * `ignore_server_validation` - (Optional)(`Bool`) Disable server authentication for Applicaton Signature download.
+  * `proxy_profile` - (Optional)(`String`) Configure web proxy for Application signature download
+  * `url` - (Optional)(`String`) URL for application package download.
+* `enable_performance_mode` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to enable performance mode knobs for best DPI performance.
+  * `max_packet_threshold` - (Optional)(`Int`) Set the maximum packet threshold for DPI performance mode (1..100).
+* `global_offload_byte_limit` - (Optional)(`Int`) Global byte limit to offload AppID inspection (0..4294967295).
+* `imap_cache_size` - (Optional)(`Int`) IMAP cache size, it will be effective only after next appid sigpack install (60..512000).
+* `imap_cache_timeout` - (Optional)(`Int`) IMAP cache entry timeout in seconds (1..86400).
+* `inspection_limit_tcp` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to enable TCP byte/packet inspection limit.
+  * `byte_limit` - (Optional)(`Int`) TCP byte inspection limit (0..4294967295).
+  * `packet_limit` - (Optional)(`Int`) TCP packet inspection limit (0..4294967295).
+* `inspection_limit_udp` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to enable UDP byte/packet inspection limit.
+  * `byte_limit` - (Optional)(`Int`) UDP byte inspection limit (0..4294967295).
+  * `packet_limit` - (Optional)(`Int`) UDP packet inspection limit (0..4294967295).
+* `max_memory` - (Optional)(`Int`) Maximum amount of object cache memory JDPI can use (in MB) (1..200000).
+* `max_transactions` - (Optional)(`Int`) Number of transaction finals to terminate application classification (0..25)
+* `micro_apps` - (Optional)(`Bool`) Enable Micro Apps identifcation.
+* `statistics_interval` - (Optional)(`Int`) Configure application statistics information with collection interval (1..1440 minutes).
 
 ---
 #### security_intelligence arguments


### PR DESCRIPTION
ENHANCEMENTS:
* add `match_dynamic_application` argument in `junos_security_global_policy` and `junos_security_policy` resources (Fixes parts of #158)
* add `forwarding_process` argument in `junos_security` resource (Fixes parts of #158)
* add `application_identification` argument in `junos_services` resource (Fixes parts of #158)