### PR TITLE
Fixes #165: add parts of supporting sampling config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ ENHANCEMENTS:
 * clean code: remove useless type/func exporting, and fixes formating golang code
 * add `junos_services_flowmonitoring_vipfix_template` resource (Fixes parts of #165)
 * add `junos_forwardingoptions_sampling_instance` resource (Fixes parts of #165)
+* add `sampling_input` and `sampling_output` arguments in `family_inet` and `family_inet6` arguments of `junos_interface_logical` resource (Fixes parts of #165)
 
 BUG FIXES:
 * fix panic when candidate config clear or unlock generate Junos error(s)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ ENHANCEMENTS:
 * add `forwarding_process` argument in `junos_security` resource (Fixes parts of #158)
 * clean code: remove useless type/func exporting, and fixes formating golang code
 * add `junos_services_flowmonitoring_vipfix_template` resource (Fixes parts of #165)
+* add `junos_forwardingoptions_sampling_instance` resource (Fixes parts of #165)
 
 BUG FIXES:
 * fix panic when candidate config clear or unlock generate Junos error(s)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ ENHANCEMENTS:
 * add `vni_extend_evpn` argument on `vxlan` argument in `junos_vlan` resource (Fixes parts of #132) Thanks @dejongm
 * add `forwarding_process` argument in `junos_security` resource (Fixes parts of #158)
 * clean code: remove useless type/func exporting, and fixes formating golang code
+* add `junos_services_flowmonitoring_vipfix_template` resource (Fixes parts of #165)
 
 BUG FIXES:
 * fix panic when candidate config clear or unlock generate Junos error(s)

--- a/junos/provider.go
+++ b/junos/provider.go
@@ -167,6 +167,7 @@ func Provider() *schema.Provider {
 			"junos_security_utm_profile_web_filtering_websense_redirect": resourceSecurityUtmProfileWebFilteringWebsense(),
 			"junos_security_zone":                                        resourceSecurityZone(),
 			"junos_services":                                             resourceServices(),
+			"junos_services_flowmonitoring_vipfix_template":              resourceServicesFlowMonitoringVIPFixTemplate(),
 			"junos_services_proxy_profile":                               resourceServicesProxyProfile(),
 			"junos_services_security_intelligence_policy":                resourceServicesSecurityIntellPolicy(),
 			"junos_services_security_intelligence_profile":               resourceServicesSecurityIntellProfile(),

--- a/junos/provider.go
+++ b/junos/provider.go
@@ -125,6 +125,7 @@ func Provider() *schema.Provider {
 			"junos_chassis_cluster":                                      resourceChassisCluster(),
 			"junos_firewall_filter":                                      resourceFirewallFilter(),
 			"junos_firewall_policer":                                     resourceFirewallPolicer(),
+			"junos_forwardingoptions_sampling_instance":                  resourceForwardingoptionsSamplingInstance(),
 			"junos_group_dual_system":                                    resourceGroupDualSystem(),
 			"junos_interface":                                            resourceInterface(),
 			"junos_interface_logical":                                    resourceInterfaceLogical(),

--- a/junos/resource_forwardingoptions_sampling_instance.go
+++ b/junos/resource_forwardingoptions_sampling_instance.go
@@ -1,0 +1,1376 @@
+package junos
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+type samplingInstanceOptions struct {
+	disable           bool
+	name              string
+	familyInetInput   []map[string]interface{}
+	familyInetOutput  []map[string]interface{}
+	familyInet6Input  []map[string]interface{}
+	familyInet6Output []map[string]interface{}
+	familyMplsInput   []map[string]interface{}
+	familyMplsOutput  []map[string]interface{}
+	input             []map[string]interface{}
+}
+
+func resourceForwardingoptionsSamplingInstance() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceForwardingoptionsSamplingInstanceCreate,
+		ReadContext:   resourceForwardingoptionsSamplingInstanceRead,
+		UpdateContext: resourceForwardingoptionsSamplingInstanceUpdate,
+		DeleteContext: resourceForwardingoptionsSamplingInstanceDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceForwardingoptionsSamplingInstanceImport,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			"disable": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"family_inet_input": {
+				Type:         schema.TypeList,
+				Optional:     true,
+				AtLeastOneOf: []string{"family_inet_input", "family_inet6_input", "family_mpls_input", "input"},
+				MaxItems:     1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"max_packets_per_second": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      -1,
+							ValidateFunc: validation.IntBetween(0, 65535),
+						},
+						"maximum_packet_length": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      -1,
+							ValidateFunc: validation.IntBetween(0, 9192),
+						},
+						"rate": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(1, 16000000),
+						},
+						"run_length": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      -1,
+							ValidateFunc: validation.IntBetween(0, 20),
+						},
+					},
+				},
+			},
+			"family_inet_output": {
+				Type:         schema.TypeList,
+				Optional:     true,
+				AtLeastOneOf: []string{"family_inet_output", "family_inet6_output", "family_mpls_output"},
+				MaxItems:     1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"aggregate_export_interval": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(90, 1800),
+						},
+						"extension_service": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"flow_active_timeout": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(60, 1800),
+						},
+						"flow_inactive_timeout": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(15, 1800),
+						},
+						"flow_server": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"hostname": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"port": {
+										Type:         schema.TypeInt,
+										Required:     true,
+										ValidateFunc: validation.IntBetween(1, 65535),
+									},
+									"aggregation_autonomous_system": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"aggregation_destination_prefix": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"aggregation_protocol_port": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"aggregation_source_destination_prefix": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"aggregation_source_destination_prefix_caida_compliant": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"aggregation_source_prefix": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"autonomous_system_type": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringInSlice([]string{"origin", "peer"}, false),
+									},
+									"dscp": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Default:      -1,
+										ValidateFunc: validation.IntBetween(0, 63),
+									},
+									"forwarding_class": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"local_dump": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"no_local_dump": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"routing_instance": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"source_address": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"version": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntInSlice([]int{5, 8}),
+									},
+									"version_ipfix_template": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"version9_template": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+						"inline_jflow_export_rate": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(1, 3200),
+							RequiredWith: []string{"family_inet_output.0.inline_jflow_source_address"},
+						},
+						"inline_jflow_source_address": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							RequiredWith: []string{"family_inet_output.0.flow_server"},
+						},
+						"interface": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"engine_id": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Default:      -1,
+										ValidateFunc: validation.IntBetween(0, 255),
+									},
+									"engine_type": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Default:      -1,
+										ValidateFunc: validation.IntBetween(0, 255),
+									},
+									"source_address": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"family_inet6_input": {
+				Type:         schema.TypeList,
+				Optional:     true,
+				AtLeastOneOf: []string{"family_inet_input", "family_inet6_input", "family_mpls_input", "input"},
+				MaxItems:     1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"max_packets_per_second": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      -1,
+							ValidateFunc: validation.IntBetween(0, 65535),
+						},
+						"maximum_packet_length": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      -1,
+							ValidateFunc: validation.IntBetween(0, 9192),
+						},
+						"rate": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(1, 16000000),
+						},
+						"run_length": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      -1,
+							ValidateFunc: validation.IntBetween(0, 20),
+						},
+					},
+				},
+			},
+			"family_inet6_output": {
+				Type:         schema.TypeList,
+				Optional:     true,
+				AtLeastOneOf: []string{"family_inet_output", "family_inet6_output", "family_mpls_output"},
+				MaxItems:     1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"aggregate_export_interval": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(90, 1800),
+						},
+						"extension_service": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"flow_active_timeout": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(60, 1800),
+						},
+						"flow_inactive_timeout": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(15, 1800),
+						},
+						"flow_server": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"hostname": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"port": {
+										Type:         schema.TypeInt,
+										Required:     true,
+										ValidateFunc: validation.IntBetween(1, 65535),
+									},
+									"aggregation_autonomous_system": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"aggregation_destination_prefix": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"aggregation_protocol_port": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"aggregation_source_destination_prefix": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"aggregation_source_destination_prefix_caida_compliant": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"aggregation_source_prefix": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"autonomous_system_type": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringInSlice([]string{"origin", "peer"}, false),
+									},
+									"dscp": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Default:      -1,
+										ValidateFunc: validation.IntBetween(0, 63),
+									},
+									"forwarding_class": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"local_dump": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"no_local_dump": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"routing_instance": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"source_address": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"version_ipfix_template": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"version9_template": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+						"inline_jflow_export_rate": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(1, 3200),
+							RequiredWith: []string{"family_inet6_output.0.inline_jflow_source_address"},
+						},
+						"inline_jflow_source_address": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							RequiredWith: []string{"family_inet6_output.0.flow_server"},
+						},
+						"interface": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"engine_id": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Default:      -1,
+										ValidateFunc: validation.IntBetween(0, 255),
+									},
+									"engine_type": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Default:      -1,
+										ValidateFunc: validation.IntBetween(0, 255),
+									},
+									"source_address": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"family_mpls_input": {
+				Type:         schema.TypeList,
+				Optional:     true,
+				AtLeastOneOf: []string{"family_inet_input", "family_inet6_input", "family_mpls_input", "input"},
+				MaxItems:     1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"max_packets_per_second": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      -1,
+							ValidateFunc: validation.IntBetween(0, 65535),
+						},
+						"maximum_packet_length": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      -1,
+							ValidateFunc: validation.IntBetween(0, 9192),
+						},
+						"rate": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(1, 16000000),
+						},
+						"run_length": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      -1,
+							ValidateFunc: validation.IntBetween(0, 20),
+						},
+					},
+				},
+			},
+			"family_mpls_output": {
+				Type:         schema.TypeList,
+				Optional:     true,
+				AtLeastOneOf: []string{"family_inet_output", "family_inet6_output", "family_mpls_output"},
+				MaxItems:     1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"aggregate_export_interval": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(90, 1800),
+						},
+						"flow_active_timeout": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(60, 1800),
+						},
+						"flow_inactive_timeout": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(15, 1800),
+						},
+						"flow_server": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"hostname": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"port": {
+										Type:         schema.TypeInt,
+										Required:     true,
+										ValidateFunc: validation.IntBetween(1, 65535),
+									},
+									"aggregation_autonomous_system": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"aggregation_destination_prefix": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"aggregation_protocol_port": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"aggregation_source_destination_prefix": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"aggregation_source_destination_prefix_caida_compliant": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"aggregation_source_prefix": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"autonomous_system_type": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringInSlice([]string{"origin", "peer"}, false),
+									},
+									"dscp": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Default:      -1,
+										ValidateFunc: validation.IntBetween(0, 63),
+									},
+									"forwarding_class": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"local_dump": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"no_local_dump": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"routing_instance": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"source_address": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"version_ipfix_template": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"version9_template": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+						"inline_jflow_export_rate": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(1, 3200),
+							RequiredWith: []string{"family_mpls_output.0.inline_jflow_source_address"},
+						},
+						"inline_jflow_source_address": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							RequiredWith: []string{"family_mpls_output.0.flow_server"},
+						},
+						"interface": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"engine_id": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Default:      -1,
+										ValidateFunc: validation.IntBetween(0, 255),
+									},
+									"engine_type": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Default:      -1,
+										ValidateFunc: validation.IntBetween(0, 255),
+									},
+									"source_address": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"input": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				AtLeastOneOf:  []string{"family_inet_input", "family_inet6_input", "family_mpls_input", "input"},
+				ConflictsWith: []string{"family_inet_input", "family_inet6_input", "family_mpls_input"},
+				MaxItems:      1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"max_packets_per_second": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      -1,
+							ValidateFunc: validation.IntBetween(0, 65535),
+						},
+						"maximum_packet_length": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      -1,
+							ValidateFunc: validation.IntBetween(0, 9192),
+						},
+						"rate": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(1, 16000000),
+						},
+						"run_length": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      -1,
+							ValidateFunc: validation.IntBetween(0, 20),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceForwardingoptionsSamplingInstanceCreate(
+	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	if sess.junosFakeCreateSetFile != "" {
+		if err := setForwardingoptionsSamplingInstance(d, m, nil); err != nil {
+			return diag.FromErr(err)
+		}
+		d.SetId(d.Get("name").(string))
+
+		return nil
+	}
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	sess.configLock(jnprSess)
+	var diagWarns diag.Diagnostics
+	fwdoptsSamplingInstanceExists, err := checkForwardingoptionsSamplingInstanceExists(d.Get("name").(string), m, jnprSess)
+	if err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	if fwdoptsSamplingInstanceExists {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns,
+			diag.FromErr(fmt.Errorf("forwarding-options sampling instance %v already exists", d.Get("name").(string)))...)
+	}
+
+	if err := setForwardingoptionsSamplingInstance(d, m, jnprSess); err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+
+	warns, err := sess.commitConf("create resource junos_forwardingoptions_sampling_instance", jnprSess)
+	appendDiagWarns(&diagWarns, warns)
+	if err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	fwdoptsSamplingInstanceExists, err = checkForwardingoptionsSamplingInstanceExists(d.Get("name").(string), m, jnprSess)
+	if err != nil {
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	if fwdoptsSamplingInstanceExists {
+		d.SetId(d.Get("name").(string))
+	} else {
+		return append(diagWarns, diag.FromErr(fmt.Errorf("forwarding-options sampling instance %v not exists after commit "+
+			"=> check your config", d.Get("name").(string)))...)
+	}
+
+	return append(diagWarns, resourceForwardingoptionsSamplingInstanceReadWJnprSess(d, m, jnprSess)...)
+}
+
+func resourceForwardingoptionsSamplingInstanceRead(ctx context.Context,
+	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+
+	return resourceForwardingoptionsSamplingInstanceReadWJnprSess(d, m, jnprSess)
+}
+
+func resourceForwardingoptionsSamplingInstanceReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
+	samplingInstanceOptions, err := readForwardingoptionsSamplingInstance(d.Get("name").(string), m, jnprSess)
+	mutex.Unlock()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if samplingInstanceOptions.name == "" {
+		d.SetId("")
+	} else {
+		fillForwardingoptionsSamplingInstanceData(d, samplingInstanceOptions)
+	}
+
+	return nil
+}
+
+func resourceForwardingoptionsSamplingInstanceUpdate(
+	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	d.Partial(true)
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	sess.configLock(jnprSess)
+	var diagWarns diag.Diagnostics
+	if err := delForwardingoptionsSamplingInstance(d.Get("name").(string), m, jnprSess); err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	if err := setForwardingoptionsSamplingInstance(d, m, jnprSess); err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+
+	warns, err := sess.commitConf("update resource junos_forwardingoptions_sampling_instance", jnprSess)
+	appendDiagWarns(&diagWarns, warns)
+	if err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	d.Partial(false)
+
+	return append(diagWarns, resourceForwardingoptionsSamplingInstanceReadWJnprSess(d, m, jnprSess)...)
+}
+
+func resourceForwardingoptionsSamplingInstanceDelete(
+	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	sess.configLock(jnprSess)
+	var diagWarns diag.Diagnostics
+	if err := delForwardingoptionsSamplingInstance(d.Get("name").(string), m, jnprSess); err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	warns, err := sess.commitConf("delete resource junos_forwardingoptions_sampling_instance", jnprSess)
+	appendDiagWarns(&diagWarns, warns)
+	if err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+
+	return diagWarns
+}
+
+func resourceForwardingoptionsSamplingInstanceImport(d *schema.ResourceData,
+	m interface{}) ([]*schema.ResourceData, error) {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return nil, err
+	}
+	defer sess.closeSession(jnprSess)
+	result := make([]*schema.ResourceData, 1)
+
+	fwdoptsSamplingInstanceExists, err := checkForwardingoptionsSamplingInstanceExists(d.Id(), m, jnprSess)
+	if err != nil {
+		return nil, err
+	}
+	if !fwdoptsSamplingInstanceExists {
+		return nil, fmt.Errorf("don't find forwarding-options sampling instance with id '%v' (id must be <name>)", d.Id())
+	}
+	samplingInstanceOptions, err := readForwardingoptionsSamplingInstance(d.Id(), m, jnprSess)
+	if err != nil {
+		return nil, err
+	}
+	fillForwardingoptionsSamplingInstanceData(d, samplingInstanceOptions)
+
+	result[0] = d
+
+	return result, nil
+}
+
+func checkForwardingoptionsSamplingInstanceExists(
+	name string, m interface{}, jnprSess *NetconfObject) (bool, error) {
+	sess := m.(*Session)
+	samplingInstanceConfig, err := sess.command(
+		"show configuration forwarding-options sampling instance \""+name+"\" | display set", jnprSess)
+	if err != nil {
+		return false, err
+	}
+	if samplingInstanceConfig == emptyWord {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func setForwardingoptionsSamplingInstance(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) error {
+	sess := m.(*Session)
+	configSet := make([]string, 0)
+
+	setPrefix := "set forwarding-options sampling instance \"" + d.Get("name").(string) + "\" "
+	if d.Get("disable").(bool) {
+		configSet = append(configSet, setPrefix+"disable")
+	}
+	for _, v := range d.Get("family_inet_input").([]interface{}) {
+		if v == nil {
+			return fmt.Errorf("family_inet_input block is empty")
+		}
+		if err := setForwardingoptionsSamplingInstanceInput(setPrefix,
+			v.(map[string]interface{}), inetWord, sess, jnprSess); err != nil {
+			return err
+		}
+	}
+	for _, v := range d.Get("family_inet_output").([]interface{}) {
+		if v == nil {
+			return fmt.Errorf("family_inet_output block is empty")
+		}
+		if err := setForwardingoptionsSamplingInstanceOutput(setPrefix,
+			v.(map[string]interface{}), inetWord, sess, jnprSess); err != nil {
+			return err
+		}
+	}
+	for _, v := range d.Get("family_inet6_input").([]interface{}) {
+		if v == nil {
+			return fmt.Errorf("family_inet6_input block is empty")
+		}
+		if err := setForwardingoptionsSamplingInstanceInput(setPrefix,
+			v.(map[string]interface{}), inet6Word, sess, jnprSess); err != nil {
+			return err
+		}
+	}
+	for _, v := range d.Get("family_inet6_output").([]interface{}) {
+		if v == nil {
+			return fmt.Errorf("family_inet6_output block is empty")
+		}
+		if err := setForwardingoptionsSamplingInstanceOutput(setPrefix,
+			v.(map[string]interface{}), inet6Word, sess, jnprSess); err != nil {
+			return err
+		}
+	}
+	for _, v := range d.Get("family_mpls_input").([]interface{}) {
+		if v == nil {
+			return fmt.Errorf("family_mpls_input block is empty")
+		}
+		if err := setForwardingoptionsSamplingInstanceInput(setPrefix,
+			v.(map[string]interface{}), "mpls", sess, jnprSess); err != nil {
+			return err
+		}
+	}
+	for _, v := range d.Get("family_mpls_output").([]interface{}) {
+		if v == nil {
+			return fmt.Errorf("family_mpls_output block is empty")
+		}
+		if err := setForwardingoptionsSamplingInstanceOutput(setPrefix,
+			v.(map[string]interface{}), "mpls", sess, jnprSess); err != nil {
+			return err
+		}
+	}
+	for _, v := range d.Get("input").([]interface{}) {
+		if v == nil {
+			return fmt.Errorf("input block is empty")
+		}
+		if err := setForwardingoptionsSamplingInstanceInput(setPrefix,
+			v.(map[string]interface{}), "", sess, jnprSess); err != nil {
+			return err
+		}
+	}
+
+	return sess.configSet(configSet, jnprSess)
+}
+
+func setForwardingoptionsSamplingInstanceInput(
+	setPrefix string, input map[string]interface{}, family string, sess *Session, jnprSess *NetconfObject) error {
+	configSet := make([]string, 0)
+	switch family {
+	case inetWord:
+		setPrefix += "family inet input "
+	case inet6Word:
+		setPrefix += "family inet6 input "
+	case "mpls":
+		setPrefix += "family mpls input "
+	default:
+		setPrefix += "input "
+	}
+	if v := input["max_packets_per_second"].(int); v != -1 {
+		configSet = append(configSet, setPrefix+"max-packets-per-second "+strconv.Itoa(v))
+	}
+	if v := input["maximum_packet_length"].(int); v != -1 {
+		configSet = append(configSet, setPrefix+"maximum-packet-length "+strconv.Itoa(v))
+	}
+	if v := input["rate"].(int); v != 0 {
+		configSet = append(configSet, setPrefix+"rate "+strconv.Itoa(v))
+	}
+	if v := input["run_length"].(int); v != -1 {
+		configSet = append(configSet, setPrefix+"run-length "+strconv.Itoa(v))
+	}
+
+	return sess.configSet(configSet, jnprSess)
+}
+
+func setForwardingoptionsSamplingInstanceOutput(
+	setPrefix string, output map[string]interface{}, family string, sess *Session, jnprSess *NetconfObject) error {
+	configSet := make([]string, 0)
+	switch family {
+	case inetWord:
+		setPrefix += "family inet output "
+	case inet6Word:
+		setPrefix += "family inet6 output "
+	case "mpls":
+		setPrefix += "family mpls output "
+	default:
+		return fmt.Errorf("internal error: setForwardingoptionsSamplingInstanceOutput call with bad family")
+	}
+	if v := output["aggregate_export_interval"].(int); v != 0 {
+		configSet = append(configSet, setPrefix+"aggregate-export-interval "+strconv.Itoa(v))
+	}
+	if family == inetWord || family == inet6Word {
+		for _, v := range output["extension_service"].([]interface{}) {
+			configSet = append(configSet, setPrefix+"extension-service \""+v.(string)+"\"")
+		}
+	}
+	if v := output["flow_active_timeout"].(int); v != 0 {
+		configSet = append(configSet, setPrefix+"flow-active-timeout "+strconv.Itoa(v))
+	}
+	if v := output["flow_inactive_timeout"].(int); v != 0 {
+		configSet = append(configSet, setPrefix+"flow-inactive-timeout "+strconv.Itoa(v))
+	}
+	for _, vFS := range output["flow_server"].([]interface{}) {
+		flowServer := vFS.(map[string]interface{})
+		setPrefixFlowServer := setPrefix + "flow-server " + flowServer["hostname"].(string) + " "
+		configSet = append(configSet, setPrefixFlowServer+"port "+strconv.Itoa(flowServer["port"].(int)))
+		if flowServer["aggregation_autonomous_system"].(bool) {
+			configSet = append(configSet, setPrefixFlowServer+"aggregation autonomous-system")
+		}
+		if flowServer["aggregation_destination_prefix"].(bool) {
+			configSet = append(configSet, setPrefixFlowServer+"aggregation destination-prefix")
+		}
+		if flowServer["aggregation_protocol_port"].(bool) {
+			configSet = append(configSet, setPrefixFlowServer+"aggregation protocol-port")
+		}
+		if flowServer["aggregation_source_destination_prefix"].(bool) {
+			configSet = append(configSet, setPrefixFlowServer+"aggregation source-destination-prefix")
+			if flowServer["aggregation_source_destination_prefix_caida_compliant"].(bool) {
+				configSet = append(configSet, setPrefixFlowServer+"aggregation source-destination-prefix caida-compliant")
+			}
+		} else if flowServer["aggregation_source_destination_prefix_caida_compliant"].(bool) {
+			return fmt.Errorf("aggregation_source_destination_prefix_caida_compliant = true " +
+				"without aggregation_source_destination_prefix on flow-server " + flowServer["hostname"].(string))
+		}
+		if flowServer["aggregation_source_prefix"].(bool) {
+			configSet = append(configSet, setPrefixFlowServer+"aggregation source-prefix")
+		}
+		if v := flowServer["autonomous_system_type"].(string); v != "" {
+			configSet = append(configSet, setPrefixFlowServer+"autonomous-system-type "+v)
+		}
+		if v := flowServer["dscp"].(int); v != -1 {
+			configSet = append(configSet, setPrefixFlowServer+"dscp "+strconv.Itoa(v))
+		}
+		if v := flowServer["forwarding_class"].(string); v != "" {
+			configSet = append(configSet, setPrefixFlowServer+"forwarding-class "+v)
+		}
+		if flowServer["local_dump"].(bool) {
+			configSet = append(configSet, setPrefixFlowServer+"local-dump")
+		}
+		if flowServer["no_local_dump"].(bool) {
+			configSet = append(configSet, setPrefixFlowServer+"no-local-dump")
+		}
+		if v := flowServer["routing_instance"].(string); v != "" {
+			configSet = append(configSet, setPrefixFlowServer+"routing-instance "+v)
+		}
+		if v := flowServer["source_address"].(string); v != "" {
+			configSet = append(configSet, setPrefixFlowServer+"source-address "+v)
+		}
+		if family == inetWord {
+			if v := flowServer["version"].(int); v != 0 {
+				configSet = append(configSet, setPrefixFlowServer+"version "+strconv.Itoa(v))
+			}
+		}
+		if v := flowServer["version_ipfix_template"].(string); v != "" {
+			configSet = append(configSet, setPrefixFlowServer+"version-ipfix template \""+v+"\"")
+		}
+		if v := flowServer["version9_template"].(string); v != "" {
+			configSet = append(configSet, setPrefixFlowServer+"version9 template \""+v+"\"")
+		}
+	}
+	if v := output["inline_jflow_export_rate"].(int); v != 0 {
+		configSet = append(configSet, setPrefix+"inline-jflow flow-export-rate "+strconv.Itoa(v))
+	}
+	if v := output["inline_jflow_source_address"].(string); v != "" {
+		configSet = append(configSet, setPrefix+"inline-jflow source-address "+v)
+	}
+	for _, vIF := range output["interface"].([]interface{}) {
+		interFace := vIF.(map[string]interface{})
+		setPrefixInterface := setPrefix + "interface " + interFace["name"].(string) + " "
+		configSet = append(configSet, setPrefixInterface)
+		if v := interFace["engine_id"].(int); v != -1 {
+			configSet = append(configSet, setPrefixInterface+"engine-id "+strconv.Itoa(v))
+		}
+		if v := interFace["engine_type"].(int); v != -1 {
+			configSet = append(configSet, setPrefixInterface+"engine-type "+strconv.Itoa(v))
+		}
+		if v := interFace["source_address"].(string); v != "" {
+			configSet = append(configSet, setPrefixInterface+"source-address "+v)
+		}
+	}
+
+	return sess.configSet(configSet, jnprSess)
+}
+
+func readForwardingoptionsSamplingInstance(
+	samplingInstance string, m interface{}, jnprSess *NetconfObject) (samplingInstanceOptions, error) {
+	sess := m.(*Session)
+	var confRead samplingInstanceOptions
+
+	samplingInstanceConfig, err := sess.command("show configuration forwarding-options sampling instance \""+
+		samplingInstance+"\" | display set relative", jnprSess)
+	if err != nil {
+		return confRead, err
+	}
+	if samplingInstanceConfig != emptyWord {
+		confRead.name = samplingInstance
+		for _, item := range strings.Split(samplingInstanceConfig, "\n") {
+			itemTrim := strings.TrimPrefix(item, setLineStart)
+			if strings.Contains(item, "<configuration-output>") {
+				continue
+			}
+			if strings.Contains(item, "</configuration-output>") {
+				break
+			}
+			switch {
+			case itemTrim == "disable":
+				confRead.disable = true
+			case strings.HasPrefix(itemTrim, "family inet input "):
+				if len(confRead.familyInetInput) == 0 {
+					confRead.familyInetInput = append(confRead.familyInetInput, map[string]interface{}{
+						"max_packets_per_second": -1,
+						"maximum_packet_length":  -1,
+						"rate":                   0,
+						"run_length":             -1,
+					})
+				}
+				if err := readForwardingoptionsSamplingInstanceInput(confRead.familyInetInput[0],
+					strings.TrimPrefix(itemTrim, "family inet input ")); err != nil {
+					return confRead, err
+				}
+			case strings.HasPrefix(itemTrim, "family inet6 input "):
+				if len(confRead.familyInet6Input) == 0 {
+					confRead.familyInet6Input = append(confRead.familyInet6Input, map[string]interface{}{
+						"max_packets_per_second": -1,
+						"maximum_packet_length":  -1,
+						"rate":                   0,
+						"run_length":             -1,
+					})
+				}
+				if err := readForwardingoptionsSamplingInstanceInput(confRead.familyInet6Input[0],
+					strings.TrimPrefix(itemTrim, "family inet6 input ")); err != nil {
+					return confRead, err
+				}
+			case strings.HasPrefix(itemTrim, "family mpls input "):
+				if len(confRead.familyMplsInput) == 0 {
+					confRead.familyMplsInput = append(confRead.familyMplsInput, map[string]interface{}{
+						"max_packets_per_second": -1,
+						"maximum_packet_length":  -1,
+						"rate":                   0,
+						"run_length":             -1,
+					})
+				}
+				if err := readForwardingoptionsSamplingInstanceInput(confRead.familyMplsInput[0],
+					strings.TrimPrefix(itemTrim, "family mpls input ")); err != nil {
+					return confRead, err
+				}
+			case strings.HasPrefix(itemTrim, "input "):
+				if len(confRead.input) == 0 {
+					confRead.input = append(confRead.input, map[string]interface{}{
+						"max_packets_per_second": -1,
+						"maximum_packet_length":  -1,
+						"rate":                   0,
+						"run_length":             -1,
+					})
+				}
+				if err := readForwardingoptionsSamplingInstanceInput(confRead.input[0],
+					strings.TrimPrefix(itemTrim, "input ")); err != nil {
+					return confRead, err
+				}
+			case strings.HasPrefix(itemTrim, "family inet output "):
+				if len(confRead.familyInetOutput) == 0 {
+					confRead.familyInetOutput = append(confRead.familyInetOutput, map[string]interface{}{
+						"aggregate_export_interval":   0,
+						"extension_service":           make([]string, 0),
+						"flow_active_timeout":         0,
+						"flow_inactive_timeout":       0,
+						"flow_server":                 make([]map[string]interface{}, 0),
+						"inline_jflow_export_rate":    0,
+						"inline_jflow_source_address": "",
+						"interface":                   make([]map[string]interface{}, 0),
+					})
+				}
+				if err := readForwardingoptionsSamplingInstanceOutput(confRead.familyInetOutput[0],
+					strings.TrimPrefix(itemTrim, "family inet output "), inetWord); err != nil {
+					return confRead, err
+				}
+			case strings.HasPrefix(itemTrim, "family inet6 output "):
+				if len(confRead.familyInet6Output) == 0 {
+					confRead.familyInet6Output = append(confRead.familyInet6Output, map[string]interface{}{
+						"aggregate_export_interval":   0,
+						"extension_service":           make([]string, 0),
+						"flow_active_timeout":         0,
+						"flow_inactive_timeout":       0,
+						"flow_server":                 make([]map[string]interface{}, 0),
+						"inline_jflow_export_rate":    0,
+						"inline_jflow_source_address": "",
+						"interface":                   make([]map[string]interface{}, 0),
+					})
+				}
+				if err := readForwardingoptionsSamplingInstanceOutput(confRead.familyInet6Output[0],
+					strings.TrimPrefix(itemTrim, "family inet6 output "), inet6Word); err != nil {
+					return confRead, err
+				}
+			case strings.HasPrefix(itemTrim, "family mpls output "):
+				if len(confRead.familyMplsOutput) == 0 {
+					confRead.familyMplsOutput = append(confRead.familyMplsOutput, map[string]interface{}{
+						"aggregate_export_interval":   0,
+						"flow_active_timeout":         0,
+						"flow_inactive_timeout":       0,
+						"flow_server":                 make([]map[string]interface{}, 0),
+						"inline_jflow_export_rate":    0,
+						"inline_jflow_source_address": "",
+						"interface":                   make([]map[string]interface{}, 0),
+					})
+				}
+				if err := readForwardingoptionsSamplingInstanceOutput(confRead.familyMplsOutput[0],
+					strings.TrimPrefix(itemTrim, "family mpls output "), "mpls"); err != nil {
+					return confRead, err
+				}
+			}
+		}
+	}
+
+	return confRead, nil
+}
+
+func readForwardingoptionsSamplingInstanceInput(inputRead map[string]interface{}, itemTrim string) error {
+	switch {
+	case strings.HasPrefix(itemTrim, "max-packets-per-second "):
+		var err error
+		inputRead["max_packets_per_second"], err = strconv.Atoi(strings.TrimPrefix(itemTrim, "max-packets-per-second "))
+		if err != nil {
+			return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+		}
+	case strings.HasPrefix(itemTrim, "maximum-packet-length "):
+		var err error
+		inputRead["maximum_packet_length"], err = strconv.Atoi(strings.TrimPrefix(itemTrim, "maximum-packet-length "))
+		if err != nil {
+			return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+		}
+	case strings.HasPrefix(itemTrim, "rate "):
+		var err error
+		inputRead["rate"], err = strconv.Atoi(strings.TrimPrefix(itemTrim, "rate "))
+		if err != nil {
+			return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+		}
+	case strings.HasPrefix(itemTrim, "run-length "):
+		var err error
+		inputRead["run_length"], err = strconv.Atoi(strings.TrimPrefix(itemTrim, "run-length "))
+		if err != nil {
+			return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+		}
+	}
+
+	return nil
+}
+
+func readForwardingoptionsSamplingInstanceOutput(
+	outputRead map[string]interface{}, itemTrim string, family string) error {
+	switch {
+	case strings.HasPrefix(itemTrim, "aggregate-export-interval "):
+		var err error
+		outputRead["aggregate_export_interval"], err =
+			strconv.Atoi(strings.TrimPrefix(itemTrim, "aggregate-export-interval "))
+		if err != nil {
+			return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+		}
+	case strings.HasPrefix(itemTrim, "extension-service "):
+		outputRead["extension_service"] = append(outputRead["extension_service"].([]string),
+			strings.Trim(strings.TrimPrefix(itemTrim, "extension-service "), "\""))
+	case strings.HasPrefix(itemTrim, "flow-active-timeout "):
+		var err error
+		outputRead["flow_active_timeout"], err = strconv.Atoi(strings.TrimPrefix(itemTrim, "flow-active-timeout "))
+		if err != nil {
+			return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+		}
+	case strings.HasPrefix(itemTrim, "flow-inactive-timeout "):
+		var err error
+		outputRead["flow_inactive_timeout"], err = strconv.Atoi(strings.TrimPrefix(itemTrim, "flow-inactive-timeout "))
+		if err != nil {
+			return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+		}
+	case strings.HasPrefix(itemTrim, "flow-server "):
+		flowServerLineCut := strings.Split(itemTrim, " ")
+		flowServer := map[string]interface{}{
+			"hostname":                              flowServerLineCut[1],
+			"port":                                  0,
+			"aggregation_autonomous_system":         false,
+			"aggregation_destination_prefix":        false,
+			"aggregation_protocol_port":             false,
+			"aggregation_source_destination_prefix": false,
+			"aggregation_source_destination_prefix_caida_compliant": false,
+			"aggregation_source_prefix":                             false,
+			"autonomous_system_type":                                "",
+			"dscp":                                                  -1,
+			"forwarding_class":                                      "",
+			"local_dump":                                            false,
+			"no_local_dump":                                         false,
+			"routing_instance":                                      "",
+			"source_address":                                        "",
+			"version_ipfix_template":                                "",
+			"version9_template":                                     "",
+		}
+		if family == inetWord {
+			flowServer["version"] = 0
+		}
+		flowServer, outputRead["flow_server"] = copyAndRemoveItemMapList(
+			"hostname", false, flowServer, outputRead["flow_server"].([]map[string]interface{}))
+		itemTrimFlowServer := strings.TrimPrefix(itemTrim, "flow-server "+flowServerLineCut[1]+" ")
+		switch {
+		case strings.HasPrefix(itemTrimFlowServer, "port "):
+			var err error
+			flowServer["port"], err = strconv.Atoi(strings.TrimPrefix(itemTrimFlowServer, "port "))
+			if err != nil {
+				return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrimFlowServer, err)
+			}
+		case itemTrimFlowServer == "aggregation autonomous-system":
+			flowServer["aggregation_autonomous_system"] = true
+		case itemTrimFlowServer == "aggregation destination-prefix":
+			flowServer["aggregation_destination_prefix"] = true
+		case itemTrimFlowServer == "aggregation protocol-port":
+			flowServer["aggregation_protocol_port"] = true
+		case strings.HasPrefix(itemTrimFlowServer, "aggregation source-destination-prefix"):
+			flowServer["aggregation_source_destination_prefix"] = true
+			if itemTrimFlowServer == "aggregation source-destination-prefix caida-compliant" {
+				flowServer["aggregation_source_destination_prefix_caida_compliant"] = true
+			}
+		case itemTrimFlowServer == "aggregation source-prefix":
+			flowServer["aggregation_source_prefix"] = true
+		case strings.HasPrefix(itemTrimFlowServer, "autonomous-system-type "):
+			flowServer["autonomous_system_type"] = strings.TrimPrefix(itemTrimFlowServer, "autonomous-system-type ")
+		case strings.HasPrefix(itemTrimFlowServer, "dscp "):
+			var err error
+			flowServer["dscp"], err = strconv.Atoi(strings.TrimPrefix(itemTrimFlowServer, "dscp "))
+			if err != nil {
+				return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrimFlowServer, err)
+			}
+		case strings.HasPrefix(itemTrimFlowServer, "forwarding-class "):
+			flowServer["forwarding_class"] = strings.TrimPrefix(itemTrimFlowServer, "forwarding-class ")
+		case itemTrimFlowServer == "local-dump":
+			flowServer["local_dump"] = true
+		case itemTrimFlowServer == "no-local-dump":
+			flowServer["no_local_dump"] = true
+		case strings.HasPrefix(itemTrimFlowServer, "routing-instance "):
+			flowServer["routing_instance"] = strings.TrimPrefix(itemTrimFlowServer, "routing-instance ")
+		case strings.HasPrefix(itemTrimFlowServer, "source-address "):
+			flowServer["source_address"] = strings.TrimPrefix(itemTrimFlowServer, "source-address ")
+		case strings.HasPrefix(itemTrimFlowServer, "version "):
+			var err error
+			flowServer["version"], err = strconv.Atoi(strings.TrimPrefix(itemTrimFlowServer, "version "))
+			if err != nil {
+				return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrimFlowServer, err)
+			}
+		case strings.HasPrefix(itemTrimFlowServer, "version-ipfix template "):
+			flowServer["version_ipfix_template"] =
+				strings.Trim(strings.TrimPrefix(itemTrimFlowServer, "version-ipfix template "), "\"")
+		case strings.HasPrefix(itemTrimFlowServer, "version9 template "):
+			flowServer["version9_template"] = strings.Trim(strings.TrimPrefix(itemTrimFlowServer, "version9 template "), "\"")
+		}
+		outputRead["flow_server"] = append(outputRead["flow_server"].([]map[string]interface{}), flowServer)
+	case strings.HasPrefix(itemTrim, "inline-jflow flow-export-rate "):
+		var err error
+		outputRead["inline_jflow_export_rate"], err =
+			strconv.Atoi(strings.TrimPrefix(itemTrim, "inline-jflow flow-export-rate "))
+		if err != nil {
+			return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+		}
+	case strings.HasPrefix(itemTrim, "inline-jflow source-address "):
+		outputRead["inline_jflow_source_address"] = strings.TrimPrefix(itemTrim, "inline-jflow source-address ")
+	case strings.HasPrefix(itemTrim, "interface "):
+		interfaceLineCut := strings.Split(itemTrim, " ")
+		iFace := map[string]interface{}{
+			"name":           interfaceLineCut[1],
+			"engine_id":      -1,
+			"engine_type":    -1,
+			"source_address": "",
+		}
+		iFace, outputRead["interface"] = copyAndRemoveItemMapList(
+			"name", false, iFace, outputRead["interface"].([]map[string]interface{}))
+		itemTrimInterface := strings.TrimPrefix(itemTrim, "interface "+interfaceLineCut[1]+" ")
+		switch {
+		case strings.HasPrefix(itemTrimInterface, "engine-id "):
+			var err error
+			iFace["engine_id"], err = strconv.Atoi(strings.TrimPrefix(itemTrimInterface, "engine-id "))
+			if err != nil {
+				return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrimInterface, err)
+			}
+		case strings.HasPrefix(itemTrimInterface, "engine-type "):
+			var err error
+			iFace["engine_type"], err = strconv.Atoi(strings.TrimPrefix(itemTrimInterface, "engine-type "))
+			if err != nil {
+				return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrimInterface, err)
+			}
+		case strings.HasPrefix(itemTrimInterface, "source-address "):
+			iFace["source_address"] = strings.TrimPrefix(itemTrimInterface, "source-address ")
+		}
+		outputRead["interface"] = append(outputRead["interface"].([]map[string]interface{}), iFace)
+	}
+
+	return nil
+}
+
+func delForwardingoptionsSamplingInstance(samplingInstance string, m interface{}, jnprSess *NetconfObject) error {
+	sess := m.(*Session)
+	configSet := []string{"delete forwarding-options sampling instance \"" + samplingInstance + "\""}
+
+	return sess.configSet(configSet, jnprSess)
+}
+
+func fillForwardingoptionsSamplingInstanceData(
+	d *schema.ResourceData, samplingInstanceOptions samplingInstanceOptions) {
+	if tfErr := d.Set("name", samplingInstanceOptions.name); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("disable", samplingInstanceOptions.disable); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("family_inet_input", samplingInstanceOptions.familyInetInput); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("family_inet_output", samplingInstanceOptions.familyInetOutput); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("family_inet6_input", samplingInstanceOptions.familyInet6Input); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("family_inet6_output", samplingInstanceOptions.familyInet6Output); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("family_mpls_input", samplingInstanceOptions.familyMplsInput); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("family_mpls_output", samplingInstanceOptions.familyMplsOutput); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("input", samplingInstanceOptions.input); tfErr != nil {
+		panic(tfErr)
+	}
+}

--- a/junos/resource_forwardingoptions_sampling_instance_test.go
+++ b/junos/resource_forwardingoptions_sampling_instance_test.go
@@ -1,0 +1,234 @@
+package junos_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccJunosForwardingOptionsSamplingInstance_basic(t *testing.T) {
+	if os.Getenv("TESTACC_ROUTER") != "" {
+		resource.Test(t, resource.TestCase{
+			PreCheck:  func() { testAccPreCheck(t) },
+			Providers: testAccProviders,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccJunosForwardingOptionsSamplingInstanceConfigCreate(),
+				},
+				{
+					Config: testAccJunosForwardingOptionsSamplingInstanceConfigUpdate(),
+				},
+				{
+					ResourceName:      "junos_forwardingoptions_sampling_instance.testacc_sampInstance",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+				{
+					ResourceName:      "junos_forwardingoptions_sampling_instance.testacc_sampInstance2",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+				{
+					ResourceName:      "junos_forwardingoptions_sampling_instance.testacc_sampInstance3",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+			},
+		})
+	}
+}
+
+func testAccJunosForwardingOptionsSamplingInstanceConfigCreate() string {
+	return `
+resource "junos_forwardingoptions_sampling_instance" "testacc_sampInstance" {
+  depends_on = [
+    junos_interface_logical.testacc_sampInstance,
+    junos_system_ntp_server.testacc_sampInstance,
+  ]
+
+  name = "testacc_instance@1"
+  input {
+    rate = 1
+  }
+  family_inet_output {
+    flow_server {
+      hostname = "192.0.2.1"
+      port     = 3000
+    }
+    interface {
+      name           = "si-0/1/0"
+      source_address = "192.0.2.2"
+    }
+  }
+}
+resource "junos_forwardingoptions_sampling_instance" "testacc_sampInstance2" {
+  name = "testacc_instance@2"
+  family_inet_input {
+    rate = 2
+  }
+  family_inet_output {
+    inline_jflow_source_address = "192.0.2.2"
+    flow_server {
+      hostname               = "192.0.2.1"
+      port                   = 3000
+      version_ipfix_template = junos_services_flowmonitoring_vipfix_template.testacc_sampInstance2.name
+    }
+  }
+}
+resource "junos_forwardingoptions_sampling_instance" "testacc_sampInstance3" {
+  name = "testacc_instance@3"
+  family_inet6_input {
+    rate = 2
+  }
+  family_inet6_output {
+    inline_jflow_source_address = "192.0.2.2"
+    flow_server {
+      hostname               = "192.0.2.1"
+      port                   = 3000
+      version_ipfix_template = junos_services_flowmonitoring_vipfix_template.testacc_sampInstance3.name
+    }
+  }
+}
+resource "junos_forwardingoptions_sampling_instance" "testacc_sampInstance4" {
+  name = "testacc_instance@4"
+  family_mpls_input {
+    rate = 2
+  }
+  family_mpls_output {
+    inline_jflow_source_address = "192.0.2.2"
+    flow_server {
+      hostname               = "192.0.2.1"
+      port                   = 3000
+      version_ipfix_template = junos_services_flowmonitoring_vipfix_template.testacc_sampInstance4.name
+    }
+  }
+}
+
+resource "junos_system_ntp_server" "testacc_sampInstance" {
+  address = "192.0.2.3"
+}
+resource "junos_interface_logical" "testacc_sampInstance" {
+  name = "si-0/1/0.0"
+  family_inet {}
+}
+resource "junos_services_flowmonitoring_vipfix_template" "testacc_sampInstance2" {
+  name = "testacc_sampInstance@2"
+  type = "ipv4-template"
+}
+resource "junos_services_flowmonitoring_vipfix_template" "testacc_sampInstance3" {
+  name = "testacc_sampInstance@3"
+  type = "ipv6-template"
+}
+resource "junos_services_flowmonitoring_vipfix_template" "testacc_sampInstance4" {
+  name = "testacc_sampInstance@4"
+  type = "mpls-template"
+}
+`
+}
+
+func testAccJunosForwardingOptionsSamplingInstanceConfigUpdate() string {
+	return `
+resource "junos_forwardingoptions_sampling_instance" "testacc_sampInstance" {
+  depends_on = [
+    junos_interface_logical.testacc_sampInstance,
+    junos_system_ntp_server.testacc_sampInstance,
+  ]
+
+  name    = "testacc_instance@1"
+  disable = true
+  input {
+    rate                   = 1
+    max_packets_per_second = 1000
+    maximum_packet_length  = 1500
+    run_length             = 10
+  }
+  family_inet_output {
+    flow_active_timeout = 60
+    flow_server {
+      hostname                                              = "192.0.2.1"
+      port                                                  = 3000
+      version                                               = 8
+      aggregation_autonomous_system                         = true
+      aggregation_destination_prefix                        = true
+      aggregation_protocol_port                             = true
+      aggregation_source_destination_prefix                 = true
+      aggregation_source_destination_prefix_caida_compliant = true
+      aggregation_source_prefix                             = true
+      autonomous_system_type                                = "origin"
+      source_address                                        = "192.0.2.2"
+    }
+    interface {
+      name           = "si-0/1/0"
+      source_address = "192.0.2.2"
+      engine_id      = 100
+      engine_type    = 100
+    }
+  }
+}
+resource "junos_forwardingoptions_sampling_instance" "testacc_sampInstance2" {
+  name = "testacc_instance@2"
+  family_inet_input {
+    rate                   = 3
+    max_packets_per_second = 1000
+  }
+  family_inet_output {
+    inline_jflow_export_rate    = 2
+    inline_jflow_source_address = "192.0.2.2"
+    flow_inactive_timeout       = 60
+    flow_server {
+      hostname               = "192.0.2.1"
+      port                   = 3000
+      version_ipfix_template = junos_services_flowmonitoring_vipfix_template.testacc_sampInstance2.name
+      autonomous_system_type = "peer"
+    }
+    flow_server {
+      hostname               = "192.0.2.10"
+      port                   = 3003
+      version_ipfix_template = junos_services_flowmonitoring_vipfix_template.testacc_sampInstance2.name
+      dscp                   = 10
+    }
+  }
+}
+resource "junos_forwardingoptions_sampling_instance" "testacc_sampInstance3" {
+  name = "testacc_instance@3"
+  family_inet6_input {
+    rate                   = 3
+    max_packets_per_second = 1000
+  }
+  family_inet6_output {
+    inline_jflow_export_rate    = 4
+    inline_jflow_source_address = "192.0.2.2"
+    flow_server {
+      hostname               = "192.0.2.1"
+      port                   = 3001
+      version_ipfix_template = junos_services_flowmonitoring_vipfix_template.testacc_sampInstance3.name
+      local_dump             = true
+    }
+    flow_server {
+      hostname               = "192.0.2.10"
+      port                   = 3001
+      version_ipfix_template = junos_services_flowmonitoring_vipfix_template.testacc_sampInstance3.name
+      no_local_dump          = true
+    }
+  }
+}
+
+resource "junos_system_ntp_server" "testacc_sampInstance" {
+  address = "192.0.2.3"
+}
+resource "junos_interface_logical" "testacc_sampInstance" {
+  name = "si-0/1/0.0"
+  family_inet {}
+}
+resource "junos_services_flowmonitoring_vipfix_template" "testacc_sampInstance2" {
+  name = "testacc_sampInstance@2"
+  type = "ipv4-template"
+}
+
+resource "junos_services_flowmonitoring_vipfix_template" "testacc_sampInstance3" {
+  name = "testacc_sampInstance@3"
+  type = "ipv6-template"
+}
+`
+}

--- a/junos/resource_interface_logical.go
+++ b/junos/resource_interface_logical.go
@@ -204,6 +204,14 @@ func resourceInterfaceLogical() *schema.Resource {
 								},
 							},
 						},
+						"sampling_input": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"sampling_output": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
 					},
 				},
 			},
@@ -350,6 +358,14 @@ func resourceInterfaceLogical() *schema.Resource {
 									},
 								},
 							},
+						},
+						"sampling_input": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"sampling_output": {
+							Type:     schema.TypeBool,
+							Optional: true,
 						},
 					},
 				},
@@ -798,6 +814,12 @@ func setInterfaceLogical(d *schema.ResourceData, m interface{}, jnprSess *Netcon
 					}
 				}
 			}
+			if familyInet["sampling_input"].(bool) {
+				configSet = append(configSet, setPrefix+"family inet sampling input")
+			}
+			if familyInet["sampling_output"].(bool) {
+				configSet = append(configSet, setPrefix+"family inet sampling output")
+			}
 		}
 	}
 	for _, v := range d.Get("family_inet6").([]interface{}) {
@@ -835,6 +857,12 @@ func setInterfaceLogical(d *schema.ResourceData, m interface{}, jnprSess *Netcon
 						configSet = append(configSet, setPrefix+"family inet6 rpf-check mode loose ")
 					}
 				}
+			}
+			if familyInet6["sampling_input"].(bool) {
+				configSet = append(configSet, setPrefix+"family inet6 sampling input")
+			}
+			if familyInet6["sampling_output"].(bool) {
+				configSet = append(configSet, setPrefix+"family inet6 sampling output")
 			}
 		}
 	}
@@ -893,11 +921,13 @@ func readInterfaceLogical(interFace string, m interface{}, jnprSess *NetconfObje
 			case strings.HasPrefix(itemTrim, "family inet6"):
 				if len(confRead.familyInet6) == 0 {
 					confRead.familyInet6 = append(confRead.familyInet6, map[string]interface{}{
-						"address":       make([]map[string]interface{}, 0),
-						"filter_input":  "",
-						"filter_output": "",
-						"mtu":           0,
-						"rpf_check":     make([]map[string]interface{}, 0),
+						"address":         make([]map[string]interface{}, 0),
+						"filter_input":    "",
+						"filter_output":   "",
+						"mtu":             0,
+						"rpf_check":       make([]map[string]interface{}, 0),
+						"sampling_input":  false,
+						"sampling_output": false,
 					})
 				}
 				switch {
@@ -933,15 +963,21 @@ func readInterfaceLogical(interFace string, m interface{}, jnprSess *NetconfObje
 					case itemTrim == "family inet6 rpf-check mode loose":
 						confRead.familyInet6[0]["rpf_check"].([]map[string]interface{})[0]["mode_loose"] = true
 					}
+				case itemTrim == "family inet6 sampling input":
+					confRead.familyInet6[0]["sampling_input"] = true
+				case itemTrim == "family inet6 sampling output":
+					confRead.familyInet6[0]["sampling_output"] = true
 				}
 			case strings.HasPrefix(itemTrim, "family inet"):
 				if len(confRead.familyInet) == 0 {
 					confRead.familyInet = append(confRead.familyInet, map[string]interface{}{
-						"address":       make([]map[string]interface{}, 0),
-						"mtu":           0,
-						"filter_input":  "",
-						"filter_output": "",
-						"rpf_check":     make([]map[string]interface{}, 0),
+						"address":         make([]map[string]interface{}, 0),
+						"mtu":             0,
+						"filter_input":    "",
+						"filter_output":   "",
+						"rpf_check":       make([]map[string]interface{}, 0),
+						"sampling_input":  false,
+						"sampling_output": false,
 					})
 				}
 				switch {
@@ -977,6 +1013,10 @@ func readInterfaceLogical(interFace string, m interface{}, jnprSess *NetconfObje
 					case itemTrim == "family inet rpf-check mode loose":
 						confRead.familyInet[0]["rpf_check"].([]map[string]interface{})[0]["mode_loose"] = true
 					}
+				case itemTrim == "family inet sampling input":
+					confRead.familyInet[0]["sampling_input"] = true
+				case itemTrim == "family inet sampling output":
+					confRead.familyInet[0]["sampling_output"] = true
 				}
 			case strings.HasPrefix(itemTrim, "vlan-id "):
 				var err error

--- a/junos/resource_services_flowmonitoring_vipfix_template.go
+++ b/junos/resource_services_flowmonitoring_vipfix_template.go
@@ -1,0 +1,522 @@
+package junos
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+type flowMonitoringVIPFixTemplateOptions struct {
+	flowKeyFlowDirection   bool
+	flowKeyVlanID          bool
+	nexthopLearningEnable  bool
+	nexthopLearningDisable bool
+	tunnelObservationIPv4  bool
+	tunnelObservationIPv6  bool
+	flowActiveTimeout      int
+	flowInactiveTimeout    int
+	observationDomainID    int
+	optionTemplateID       int
+	templateID             int
+	name                   string
+	typeTemplate           string
+	optionRefreshRate      []map[string]interface{}
+}
+
+func resourceServicesFlowMonitoringVIPFixTemplate() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceServicesFlowMonitoringVIPFixTemplateCreate,
+		ReadContext:   resourceServicesFlowMonitoringVIPFixTemplateRead,
+		UpdateContext: resourceServicesFlowMonitoringVIPFixTemplateUpdate,
+		DeleteContext: resourceServicesFlowMonitoringVIPFixTemplateDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceServicesFlowMonitoringVIPFixTemplateImport,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			"type": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice([]string{"ipv4-template", "ipv6-template", "mpls-template"}, false),
+			},
+			"flow_active_timeout": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(10, 600),
+			},
+			"flow_inactive_timeout": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(10, 600),
+			},
+			"flow_key_flow_direction": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"flow_key_vlan_id": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"nexthop_learning_enable": {
+				Type:          schema.TypeBool,
+				Optional:      true,
+				ConflictsWith: []string{"nexthop_learning_disable"},
+			},
+			"nexthop_learning_disable": {
+				Type:          schema.TypeBool,
+				Optional:      true,
+				ConflictsWith: []string{"nexthop_learning_enable"},
+			},
+			"observation_domain_id": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      -1,
+				ValidateFunc: validation.IntBetween(0, 255),
+			},
+			"option_refresh_rate": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"packets": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(1, 480000),
+						},
+						"seconds": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(10, 600),
+						},
+					},
+				},
+			},
+			"option_template_id": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(1024, 65535),
+			},
+			"template_id": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(1024, 65535),
+			},
+			"tunnel_observation_ipv4": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"tunnel_observation_ipv6": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceServicesFlowMonitoringVIPFixTemplateCreate(ctx context.Context,
+	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	if sess.junosFakeCreateSetFile != "" {
+		if err := setServicesFlowMonitoringVIPFixTemplate(d, m, nil); err != nil {
+			return diag.FromErr(err)
+		}
+		d.SetId(d.Get("name").(string))
+
+		return nil
+	}
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	sess.configLock(jnprSess)
+	var diagWarns diag.Diagnostics
+	flowMonitoringVIPFixTemplateExists, err :=
+		checkServicesFlowMonitoringVIPFixTemplateExists(d.Get("name").(string), m, jnprSess)
+	if err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	if flowMonitoringVIPFixTemplateExists {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns,
+			diag.FromErr(fmt.Errorf("services flow-monitoring version-ipfix template "+
+				" %v already exists", d.Get("name").(string)))...)
+	}
+
+	if err := setServicesFlowMonitoringVIPFixTemplate(d, m, jnprSess); err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	warns, err := sess.commitConf("create resource junos_services_flowmonitoring_vipfix_template", jnprSess)
+	appendDiagWarns(&diagWarns, warns)
+	if err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	flowMonitoringVIPFixTemplateExists, err =
+		checkServicesFlowMonitoringVIPFixTemplateExists(d.Get("name").(string), m, jnprSess)
+	if err != nil {
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	if flowMonitoringVIPFixTemplateExists {
+		d.SetId(d.Get("name").(string))
+	} else {
+		return append(diagWarns, diag.FromErr(fmt.Errorf("services flow-monitoring version-ipfix template %v "+
+			"not exists after commit => check your config", d.Get("name").(string)))...)
+	}
+
+	return append(diagWarns, resourceServicesFlowMonitoringVIPFixTemplateReadWJnprSess(d, m, jnprSess)...)
+}
+
+func resourceServicesFlowMonitoringVIPFixTemplateRead(ctx context.Context,
+	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+
+	return resourceServicesFlowMonitoringVIPFixTemplateReadWJnprSess(d, m, jnprSess)
+}
+
+func resourceServicesFlowMonitoringVIPFixTemplateReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
+	flowMonitoringVIPFixTemplateOptions, err :=
+		readServicesFlowMonitoringVIPFixTemplate(d.Get("name").(string), m, jnprSess)
+	mutex.Unlock()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if flowMonitoringVIPFixTemplateOptions.name == "" {
+		d.SetId("")
+	} else {
+		fillServicesFlowMonitoringVIPFixTemplateData(d, flowMonitoringVIPFixTemplateOptions)
+	}
+
+	return nil
+}
+
+func resourceServicesFlowMonitoringVIPFixTemplateUpdate(ctx context.Context,
+	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	d.Partial(true)
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	sess.configLock(jnprSess)
+	var diagWarns diag.Diagnostics
+	if err := delServicesFlowMonitoringVIPFixTemplate(d.Get("name").(string), m, jnprSess); err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	if err := setServicesFlowMonitoringVIPFixTemplate(d, m, jnprSess); err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	warns, err := sess.commitConf("update resource junos_services_flowmonitoring_vipfix_template", jnprSess)
+	appendDiagWarns(&diagWarns, warns)
+	if err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	d.Partial(false)
+
+	return append(diagWarns, resourceServicesFlowMonitoringVIPFixTemplateReadWJnprSess(d, m, jnprSess)...)
+}
+
+func resourceServicesFlowMonitoringVIPFixTemplateDelete(ctx context.Context,
+	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	sess.configLock(jnprSess)
+	var diagWarns diag.Diagnostics
+	if err := delServicesFlowMonitoringVIPFixTemplate(d.Get("name").(string), m, jnprSess); err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	warns, err := sess.commitConf("delete resource junos_services_flowmonitoring_vipfix_template", jnprSess)
+	appendDiagWarns(&diagWarns, warns)
+	if err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+
+	return diagWarns
+}
+
+func resourceServicesFlowMonitoringVIPFixTemplateImport(
+	d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return nil, err
+	}
+	defer sess.closeSession(jnprSess)
+	result := make([]*schema.ResourceData, 1)
+	flowMonitoringVIPFixTemplateExists, err := checkServicesFlowMonitoringVIPFixTemplateExists(d.Id(), m, jnprSess)
+	if err != nil {
+		return nil, err
+	}
+	if !flowMonitoringVIPFixTemplateExists {
+		return nil, fmt.Errorf("don't find services flow-monitoring version-ipfix template with "+
+			"id '%v' (id must be <name>)", d.Id())
+	}
+	flowMonitoringVIPFixTemplateOptions, err := readServicesFlowMonitoringVIPFixTemplate(d.Id(), m, jnprSess)
+	if err != nil {
+		return nil, err
+	}
+	fillServicesFlowMonitoringVIPFixTemplateData(d, flowMonitoringVIPFixTemplateOptions)
+
+	result[0] = d
+
+	return result, nil
+}
+
+func checkServicesFlowMonitoringVIPFixTemplateExists(
+	template string, m interface{}, jnprSess *NetconfObject) (bool, error) {
+	sess := m.(*Session)
+	templateConfig, err := sess.command("show configuration services flow-monitoring version-ipfix template \""+
+		template+"\" | display set", jnprSess)
+	if err != nil {
+		return false, err
+	}
+	if templateConfig == emptyWord {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func setServicesFlowMonitoringVIPFixTemplate(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) error {
+	sess := m.(*Session)
+	configSet := make([]string, 0)
+
+	setPrefix := "set services flow-monitoring version-ipfix template \"" + d.Get("name").(string) + "\" "
+	configSet = append(configSet, setPrefix+d.Get("type").(string))
+	if v := d.Get("flow_active_timeout").(int); v != 0 {
+		configSet = append(configSet, setPrefix+"flow-active-timeout "+strconv.Itoa(v))
+	}
+	if v := d.Get("flow_inactive_timeout").(int); v != 0 {
+		configSet = append(configSet, setPrefix+"flow-inactive-timeout "+strconv.Itoa(v))
+	}
+	if d.Get("flow_key_flow_direction").(bool) {
+		configSet = append(configSet, setPrefix+"flow-key flow-direction")
+	}
+	if d.Get("flow_key_vlan_id").(bool) {
+		configSet = append(configSet, setPrefix+"flow-key vlan-id")
+	}
+	if d.Get("nexthop_learning_enable").(bool) {
+		configSet = append(configSet, setPrefix+"nexthop-learning enable")
+	}
+	if d.Get("nexthop_learning_disable").(bool) {
+		configSet = append(configSet, setPrefix+"nexthop-learning disable")
+	}
+	if v := d.Get("observation_domain_id").(int); v != -1 {
+		configSet = append(configSet, setPrefix+"observation-domain-id "+strconv.Itoa(v))
+	}
+	for _, v := range d.Get("option_refresh_rate").([]interface{}) {
+		configSet = append(configSet, setPrefix+"option-refresh-rate")
+		if v != nil {
+			optRefRate := v.(map[string]interface{})
+			if v2 := optRefRate["packets"].(int); v2 != 0 {
+				configSet = append(configSet, setPrefix+"option-refresh-rate packets "+strconv.Itoa(v2))
+			}
+			if v2 := optRefRate["seconds"].(int); v2 != 0 {
+				configSet = append(configSet, setPrefix+"option-refresh-rate seconds "+strconv.Itoa(v2))
+			}
+		}
+	}
+	if v := d.Get("option_template_id").(int); v != 0 {
+		configSet = append(configSet, setPrefix+"option-template-id "+strconv.Itoa(v))
+	}
+	if v := d.Get("template_id").(int); v != 0 {
+		configSet = append(configSet, setPrefix+"template-id "+strconv.Itoa(v))
+	}
+	if d.Get("tunnel_observation_ipv4").(bool) {
+		configSet = append(configSet, setPrefix+"tunnel-observation ipv4")
+	}
+	if d.Get("tunnel_observation_ipv6").(bool) {
+		configSet = append(configSet, setPrefix+"tunnel-observation ipv6")
+	}
+
+	return sess.configSet(configSet, jnprSess)
+}
+
+func readServicesFlowMonitoringVIPFixTemplate(template string, m interface{}, jnprSess *NetconfObject) (
+	flowMonitoringVIPFixTemplateOptions, error) {
+	sess := m.(*Session)
+	var confRead flowMonitoringVIPFixTemplateOptions
+	// setup default value
+	confRead.observationDomainID = -1
+
+	templateConfig, err := sess.command("show configuration services flow-monitoring version-ipfix "+
+		" template \""+template+"\" | display set relative", jnprSess)
+	if err != nil {
+		return confRead, err
+	}
+	if templateConfig != emptyWord {
+		confRead.name = template
+		for _, item := range strings.Split(templateConfig, "\n") {
+			if strings.Contains(item, "<configuration-output>") {
+				continue
+			}
+			if strings.Contains(item, "</configuration-output>") {
+				break
+			}
+			itemTrim := strings.TrimPrefix(item, setLineStart)
+			switch {
+			case stringInSlice(itemTrim, []string{"ipv4-template", "ipv6-template", "mpls-template"}):
+				confRead.typeTemplate = itemTrim
+			case strings.HasPrefix(itemTrim, "flow-active-timeout "):
+				var err error
+				confRead.flowActiveTimeout, err = strconv.Atoi(strings.TrimPrefix(itemTrim, "flow-active-timeout "))
+				if err != nil {
+					return confRead, fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+				}
+			case strings.HasPrefix(itemTrim, "flow-inactive-timeout "):
+				var err error
+				confRead.flowInactiveTimeout, err = strconv.Atoi(strings.TrimPrefix(itemTrim, "flow-inactive-timeout "))
+				if err != nil {
+					return confRead, fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+				}
+			case itemTrim == "flow-key flow-direction":
+				confRead.flowKeyFlowDirection = true
+			case itemTrim == "flow-key vlan-id":
+				confRead.flowKeyVlanID = true
+			case itemTrim == "nexthop-learning enable":
+				confRead.nexthopLearningEnable = true
+			case itemTrim == "nexthop-learning disable":
+				confRead.nexthopLearningDisable = true
+			case strings.HasPrefix(itemTrim, "observation-domain-id "):
+				var err error
+				confRead.observationDomainID, err = strconv.Atoi(strings.TrimPrefix(itemTrim, "observation-domain-id "))
+				if err != nil {
+					return confRead, fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+				}
+			case strings.HasPrefix(itemTrim, "option-refresh-rate"):
+				if len(confRead.optionRefreshRate) == 0 {
+					confRead.optionRefreshRate = append(confRead.optionRefreshRate, map[string]interface{}{
+						"packets": 0,
+						"seconds": 0,
+					})
+				}
+				switch {
+				case strings.HasPrefix(itemTrim, "option-refresh-rate packets "):
+					var err error
+					confRead.optionRefreshRate[0]["packets"], err =
+						strconv.Atoi(strings.TrimPrefix(itemTrim, "option-refresh-rate packets "))
+					if err != nil {
+						return confRead, fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+					}
+				case strings.HasPrefix(itemTrim, "option-refresh-rate seconds "):
+					var err error
+					confRead.optionRefreshRate[0]["seconds"], err =
+						strconv.Atoi(strings.TrimPrefix(itemTrim, "option-refresh-rate seconds "))
+					if err != nil {
+						return confRead, fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+					}
+				}
+			case strings.HasPrefix(itemTrim, "option-template-id "):
+				var err error
+				confRead.optionTemplateID, err = strconv.Atoi(strings.TrimPrefix(itemTrim, "option-template-id "))
+				if err != nil {
+					return confRead, fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+				}
+			case strings.HasPrefix(itemTrim, "template-id "):
+				var err error
+				confRead.templateID, err = strconv.Atoi(strings.TrimPrefix(itemTrim, "template-id "))
+				if err != nil {
+					return confRead, fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+				}
+			case itemTrim == "tunnel-observation ipv4":
+				confRead.tunnelObservationIPv4 = true
+			case itemTrim == "tunnel-observation ipv6":
+				confRead.tunnelObservationIPv6 = true
+			}
+		}
+	}
+
+	return confRead, nil
+}
+
+func delServicesFlowMonitoringVIPFixTemplate(template string, m interface{}, jnprSess *NetconfObject) error {
+	sess := m.(*Session)
+	configSet := []string{"delete services flow-monitoring version-ipfix template \"" + template + "\""}
+
+	return sess.configSet(configSet, jnprSess)
+}
+
+func fillServicesFlowMonitoringVIPFixTemplateData(
+	d *schema.ResourceData, flowMonitoringVIPFixTemplateOptions flowMonitoringVIPFixTemplateOptions) {
+	if tfErr := d.Set("name", flowMonitoringVIPFixTemplateOptions.name); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("type", flowMonitoringVIPFixTemplateOptions.typeTemplate); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("flow_active_timeout", flowMonitoringVIPFixTemplateOptions.flowActiveTimeout); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("flow_inactive_timeout", flowMonitoringVIPFixTemplateOptions.flowInactiveTimeout); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("flow_key_flow_direction", flowMonitoringVIPFixTemplateOptions.flowKeyFlowDirection); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("flow_key_vlan_id", flowMonitoringVIPFixTemplateOptions.flowKeyVlanID); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("nexthop_learning_enable", flowMonitoringVIPFixTemplateOptions.nexthopLearningEnable); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("nexthop_learning_disable",
+		flowMonitoringVIPFixTemplateOptions.nexthopLearningDisable); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("observation_domain_id", flowMonitoringVIPFixTemplateOptions.observationDomainID); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("option_refresh_rate", flowMonitoringVIPFixTemplateOptions.optionRefreshRate); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("option_template_id", flowMonitoringVIPFixTemplateOptions.optionTemplateID); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("template_id", flowMonitoringVIPFixTemplateOptions.templateID); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("tunnel_observation_ipv4", flowMonitoringVIPFixTemplateOptions.tunnelObservationIPv4); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("tunnel_observation_ipv6", flowMonitoringVIPFixTemplateOptions.tunnelObservationIPv6); tfErr != nil {
+		panic(tfErr)
+	}
+}

--- a/junos/resource_services_flowmonitoring_vipfix_template_test.go
+++ b/junos/resource_services_flowmonitoring_vipfix_template_test.go
@@ -1,0 +1,99 @@
+package junos_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccJunosServicesFlowMonitoringVIPFixTemplate_basic(t *testing.T) {
+	if os.Getenv("TESTACC_ROUTER") != "" {
+		resource.Test(t, resource.TestCase{
+			PreCheck:  func() { testAccPreCheck(t) },
+			Providers: testAccProviders,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccJunosServicesFlowMonitoringVIPFixTemplateConfigCreate(),
+				},
+				{
+					Config: testAccJunosServicesFlowMonitoringVIPFixTemplateConfigUpdate(),
+				},
+				{
+					ResourceName:      "junos_services_flowmonitoring_vipfix_template.testacc_flow_vipfix_template_ipv4",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+				{
+					ResourceName:      "junos_services_flowmonitoring_vipfix_template.testacc_flow_vipfix_template_ipv6",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+				{
+					ResourceName:      "junos_services_flowmonitoring_vipfix_template.testacc_flow_vipfix_template_mpls",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+			},
+		})
+	}
+}
+
+func testAccJunosServicesFlowMonitoringVIPFixTemplateConfigCreate() string {
+	return `
+resource "junos_services_flowmonitoring_vipfix_template" "testacc_flow_vipfix_template_ipv4" {
+  name = "testacc_template@1"
+  type = "ipv4-template"
+}
+resource "junos_services_flowmonitoring_vipfix_template" "testacc_flow_vipfix_template_ipv6" {
+  name = "testacc_template@3"
+  type = "ipv6-template"
+}
+resource "junos_services_flowmonitoring_vipfix_template" "testacc_flow_vipfix_template_mpls" {
+  name = "testacc_template@2"
+  type = "mpls-template"
+}
+`
+}
+
+func testAccJunosServicesFlowMonitoringVIPFixTemplateConfigUpdate() string {
+	return `
+resource "junos_services_flowmonitoring_vipfix_template" "testacc_flow_vipfix_template_ipv4" {
+  name                    = "testacc_template@1"
+  type                    = "ipv4-template"
+  flow_active_timeout     = 60
+  flow_inactive_timeout   = 30
+  flow_key_flow_direction = true
+  flow_key_vlan_id        = true
+  nexthop_learning_enable = true
+  observation_domain_id   = 10
+  option_refresh_rate {}
+  option_template_id = 2000
+  template_id        = 2001
+}
+resource "junos_services_flowmonitoring_vipfix_template" "testacc_flow_vipfix_template_ipv6" {
+  name                  = "testacc_template@3"
+  type                  = "ipv6-template"
+  flow_active_timeout   = 60
+  flow_inactive_timeout = 30
+}
+resource "junos_services_flowmonitoring_vipfix_template" "testacc_flow_vipfix_template_mpls" {
+  name                    = "testacc_template@2"
+  type                    = "mpls-template"
+  flow_active_timeout     = 60
+  flow_inactive_timeout   = 30
+  flow_key_flow_direction = true
+  flow_key_vlan_id        = true
+  nexthop_learning_enable = true
+  observation_domain_id   = 10
+  option_refresh_rate {
+    packets = 100
+    seconds = 60
+  }
+  option_template_id      = 2002
+  template_id             = 2003
+  tunnel_observation_ipv4 = true
+  tunnel_observation_ipv6 = true
+}
+`
+}

--- a/website/docs/r/forwardingoptions_sampling_instance.html.markdown
+++ b/website/docs/r/forwardingoptions_sampling_instance.html.markdown
@@ -1,0 +1,93 @@
+---
+layout: "junos"
+page_title: "Junos: junos_forwardingoptions_sampling_instance"
+sidebar_current: "docs-junos-resource-forwardingoptions-sampling-instance"
+description: |-
+  Create a forwarding-options sampling-instance
+---
+
+# junos_forwardingoptions_sampling_instance
+
+Provides a forwarding-options sampling instance resource.
+
+## Example Usage
+
+```hcl
+# Add a forwarding-options sampling instance
+resource "junos_forwardingoptions_sampling_instance" "demo" {
+  name = "demo"
+  family_inet_input {
+    rate = 1
+  }
+  family_inet_output {
+    inline_jflow_source_address = "192.0.2.2"
+    flow_server {
+      hostname               = "192.0.2.1"
+      port                   = 3000
+      version_ipfix_template = "demo"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required, Forces new resource)(`String`) Name for sampling instance.
+* `disable` - (Optional)(`Bool`) Disable sampling instance
+* `family_inet_input` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare 'family inet input' configuration. See the [`input` arguments] (#input-arguments) block.
+* `family_inet_output` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare 'family inet output' configuration. See the [`output` arguments] (#output-arguments) block.
+* `family_inet6_input` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare 'family inet6 input' configuration. See the [`input` arguments] (#input-arguments) block.
+* `family_inet6_output` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare 'family inet6 output' configuration. See the [`output` arguments] (#output-arguments) block.
+* `family_mpls_input` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare 'family mpls input' configuration. See the [`input` arguments] (#input-arguments) block.
+* `family_mpls_output` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare 'family inet6 output' configuration. See the [`output` arguments] (#output-arguments) block.
+* `input` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare 'input' configuration. See the [`input` arguments] (#input-arguments) block.
+
+---
+#### input arguments
+* `max_packets_per_second` - (Optional)(`Int`) Threshold of samples per second before dropping.
+* `maximum_packet_length` - (Optional)(`Int`) Maximum length of the sampled packet (0..9192 bytes)
+* `rate` - (Optional)(`Int`) Ratio of packets to be sampled (1 out of N) (1..16000000)
+* `run_length` - (Optional)(`Int`) Number of samples after initial trigger (0..20)
+
+---
+#### output arguments
+* `aggregate_export_interval` - (Optional)(`Int`) Interval of exporting aggregate accounting information (90..1800 seconds).
+* `extension_service` - (Optional)(`ListOfString`) Define the customer specific sampling configuration. **Not available for `family mpls`**.
+* `flow_active_timeout` - (Optional)(`Int`) Interval after which an active flow is exported (60..1800 seconds).
+* `flow_inactive_timeout` - (Optional)(`Int`) Interval of inactivity that marks a flow inactive (15..1800 seconds).
+* `flow_server` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Configure sending traffic aggregates in cflowd format. Can be specified multiple times for each hostname.
+  * `hostname` - (Required)(`String`) Name of host collecting cflowd packets.
+  * `port` - (Required)(`Int`) UDP port number on host collecting cflowd packets (1..65535).
+  * `aggregation_autonomous_system` - (Optional)(`Bool`) Aggregate by autonomous system number.
+  * `aggregation_destination_prefix` - (Optional)(`Bool`) Aggregate by destination prefix
+  * `aggregation_protocol_port` - (Optional)(`Bool`) Aggregate by protocol and port number.
+  * `aggregation_source_destination_prefix` - (Optional)(`Bool`) Aggregate by source and destination prefix.
+  * `aggregation_source_destination_prefix_caida_compliant` - (Optional)(`Bool`) Compatible with Caida record format for prefix aggregation (v8).
+  * `aggregation_source_prefix` - (Optional)(`Bool`) Aggregate by source prefix
+  * `autonomous_system_type` - (Optional)(`String`) Type of autonomous system number to export. Need to be 'origin' or 'peer'.
+  * `dscp` - (Optional)(`Int`) Numeric DSCP value in the range 0 to 63 (0..63).
+  * `forwarding_class` - (Optional)(`String`) Forwarding-class for exported jflow packets, applicable only for inline-jflow.
+  * `local_dump` - (Optional)(`Bool`) Dump cflowd records to log file before exporting.
+  * `no_local_dump` - (Optional)(`Bool`) Don't dump cflowd records to log file before exporting.
+  * `routing_instance` - (Optional)(`String`) Name of routing instance on which flow collector is reachable.
+  * `source_address` - (Optional)(`String`) Source IPv4 address for cflowd packets.
+  * `version` - (Optional)(`Int`) Format of exported cflowd aggregates. Need to be '5' or '8'. **Only available for `family inet`**. 
+  * `version_ipfix_template` - (Optional)(`String`) Template to export data in version ipfix format.
+  * `version9_template` - (Optional)(`String`) Template to export data in version 9 format.
+* `inline_jflow_export_rate` - (Optional)(`Int`) Inline processing of sampled packets with flow export rate of monitored packets in kpps (1..3200)
+* `inline_jflow_source_address` - (Optional)(`String`) Inline processing of sampled packets with address to use for generating monitored packets.
+* `interface` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Configure Interfaces used to send monitored information. Can be specified multiple times for each interface.
+  * `name` - (Required)(`String`) Name of interface.
+  * `engine_id` - (Optional)(`Int`) Identity (number) of this accounting interface (0..255).
+  * `engine_type` - (Optional)(`Int`) Type (number) of this accounting interface (0..255).
+  * `source_address` - (Optional)(`String`) Address to use for generating monitored packets.
+
+## Import
+
+Junos forwarding-options sampling instance can be imported using an id made up of `<name>`, e.g.
+
+```
+$ terraform import junos_forwardingoptions_sampling_instance.demo demo
+```

--- a/website/docs/r/interface_logical.html.markdown
+++ b/website/docs/r/interface_logical.html.markdown
@@ -38,12 +38,16 @@ The following arguments are supported:
   * `filter_output` - (Optional)(`String`) Filter to be applied to transmitted packets.
   * `mtu` - (Optional)(`Int`) Maximum transmission unit.
   * `rpf_check` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once for enable reverse-path-forwarding checks on this interface. See the [`rpf_check` arguments](#rpf_check-arguments) block for optional arguments.
+  * `sampling_input` - (Optional)(`Bool`) Sample all packets input on this interface.
+  * `sampling_output` - (Optional)(`Bool`) Sample all packets output on this interface.
 * `family_inet6` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Enable family inet6 and add configurations if specified.
   * `address` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified multiple times for each ipv6 address to declare. See the [`address` arguments for family_inet6](#address-arguments-for-family_inet6) block.
   * `filter_input` - (Optional)(`String`) Filter to be applied to received packets.
   * `filter_output` - (Optional)(`String`) Filter to be applied to transmitted packets.
   * `mtu` - (Optional)(`Int`) Maximum transmission unit.
   * `rpf_check` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once for enable reverse-path-forwarding checks on this interface. See the [`rpf_check` arguments](#rpf_check-arguments) block for optional arguments. 
+  * `sampling_input` - (Optional)(`Bool`) Sample all packets input on this interface.
+  * `sampling_output` - (Optional)(`Bool`) Sample all packets output on this interface.
 * `routing_instance` - (Optional)(`String`) Add this interface in routing_instance. Need to be created before.
 * `security_inbound_protocols` - (Optional)(`ListOfString`) The inbound protocols allowed. Must be a list of Junos protocols. `security_zone` need to be set.
 * `security_inbound_services` - (Optional)(`ListOfString`) The inbound services allowed. Must be a list of Junos services. `security_zone` need to be set.

--- a/website/docs/r/services_flowmonitoring_vipfix_template.html.markdown
+++ b/website/docs/r/services_flowmonitoring_vipfix_template.html.markdown
@@ -1,0 +1,50 @@
+---
+layout: "junos"
+page_title: "Junos: junos_services_flowmonitoring_vipfix_template"
+sidebar_current: "docs-junos-resource-services-flowmonitoring-vipfix-template"
+description: |-
+  Create a services flow-monitoring version-ipfix template
+---
+
+# junos_services_flowmonitoring_vipfix_template
+
+Provides a services flow-monitoring version-ipfix template resource.
+
+## Example Usage
+
+```hcl
+# Add a services flow-monitoring version-ipfix template
+resource "junos_services_flowmonitoring_vipfix_template" "demo" {
+  name = "demo"
+  type = "ipv4-template"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required, Forces new resource)(`String`) Name of flow-monitoring ip-fix template.
+* `type` - (Required)(`String`) Type of template. Need to be 'ipv4-template', 'ipv6-template' or 'mpls-template'.
+* `flow_active_timeout` - (Optional)(`Int`) Interval after which active flow is exported (10..600).
+* `flow_inactive_timeout` - (Optional)(`Int`) Period of inactivity that marks a flow inactive (10..600).
+* `flow_key_flow_direction` - (Optional)(`Bool`) Include flow direction.
+* `flow_key_vlan_id` - (Optional)(`Bool`) Include vlan ID.
+* `nexthop_learning_enable` - (Optional)(`Bool`) Enable nexthop learning.
+* `nexthop_learning_disable` - (Optional)(`Bool`) Disable nexthop learning.
+* `observation_domain_id` - (Optional)(`Int`) Observation Domain Id (0..255).
+* `option_refresh_rate` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare 'option-refresh-rate' configuration.
+  * `packets` - (Optional)(`Int`) In number of packets (1..480000)
+  * `seconds` - (Optional)(`Int`) In number of seconds (10..600)
+* `option_template_id` - (Optional)(`Int`) Options template id (1024..65535).
+* `template_id` - (Optional)(`Int`) Template id (1024..65535).
+* `tunnel_observation_ipv4` - (Optional)(`Bool`) Tunnel observation IPv4.
+* `tunnel_observation_ipv6` - (Optional)(`Bool`) Tunnel observation IPv6.
+
+## Import
+
+Junos services flow-monitoring version-ipfix template can be imported using an id made up of `<name>`, e.g.
+
+```
+$ terraform import junos_services_flowmonitoring_vipfix_template.demo demo
+```

--- a/website/junos.erb
+++ b/website/junos.erb
@@ -42,6 +42,9 @@
           <li<%= sidebar_current("docs-junos-resource-firewall-policer") %>>
             <a href="/docs/providers/junos/r/firewall_policer.html">junos_firewall_policer</a>
           </li>
+          <li<%= sidebar_current("docs-junos-resource-forwardingoptions-sampling-instance") %>>
+            <a href="/docs/providers/junos/r/forwardingoptions_sampling_instance.html">junos_forwardingoptions_sampling_instance</a>
+          </li>
           <li<%= sidebar_current("docs-junos-resource-group-dual-system") %>>
             <a href="/docs/providers/junos/r/group_dual_system.html">junos_group_dual_system</a>
           </li>

--- a/website/junos.erb
+++ b/website/junos.erb
@@ -168,6 +168,9 @@
           <li<%= sidebar_current("docs-junos-resource-services") %>>
             <a href="/docs/providers/junos/r/services.html">junos_services</a>
           </li>
+          <li<%= sidebar_current("docs-junos-resource-services-flowmonitoring-vipfix-template") %>>
+            <a href="/docs/providers/junos/r/services_flowmonitoring_vipfix_template.html">junos_services_flowmonitoring_vipfix_template</a>
+          </li>
           <li<%= sidebar_current("docs-junos-resource-services-proxy-profile") %>>
             <a href="/docs/providers/junos/r/services_proxy_profile.html">junos_services_proxy_profile</a>
           </li>


### PR DESCRIPTION
ENHANCEMENTS:
* add `junos_services_flowmonitoring_vipfix_template` resource (Fixes parts of #165)
* add `junos_forwardingoptions_sampling_instance` resource (Fixes parts of #165)
* add `sampling_input` and `sampling_output` arguments in `family_inet` and `family_inet6` arguments of `junos_interface_logical` resource (Fixes parts of #165)