### PR TITLE
add family_inet6_address argument in junos_group_dual_system resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ ENHANCEMENTS:
 * add `vni_extend_evpn` argument on `vxlan` argument in `junos_vlan` resource (Fixes parts of #132) Thanks @dejongm
 * add `forwarding_process` argument in `junos_security` resource (Fixes parts of #158)
 * clean code: remove useless type/func exporting, and fixes formating golang code
+* add `family_inet6_address` argument inside `interface_fxp0` argument in `junos_group_dual_system` resource (Fixes #177)
 
 BUG FIXES:
 * fix panic when candidate config clear or unlock generate Junos error(s)

--- a/junos/resource_group_dual_system_test.go
+++ b/junos/resource_group_dual_system_test.go
@@ -56,6 +56,9 @@ resource "junos_group_dual_system" "testacc_node0" {
     family_inet_address {
       cidr_ip = "192.0.2.193/26"
     }
+    family_inet6_address {
+      cidr_ip = "fe80::2/64"
+    }
   }
   routing_options {
     static_route {
@@ -93,6 +96,10 @@ resource "junos_group_dual_system" "testacc_node0" {
     }
     family_inet_address {
       cidr_ip     = "192.0.2.194/26"
+      master_only = true
+    }
+    family_inet6_address {
+      cidr_ip     = "fe80::2/64"
       master_only = true
     }
   }

--- a/website/docs/r/group_dual_system.html.markdown
+++ b/website/docs/r/group_dual_system.html.markdown
@@ -62,6 +62,9 @@ Can be specified only once for configure `system` block.
 * `family_inet_address` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified multiple times for each ip address to declare.
   * `cidr_ip` - (Required)(`String`) Address IP/Mask v4.
   * `master_only` - (Optional)(`Bool`) Master management IP address.
+* `family_inet6_address` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified multiple times for each ip v6 address to declare.
+  * `cidr_ip` - (Required)(`String`) Address IP/Mask v6.
+  * `master_only` - (Optional)(`Bool`) Master management IP address.
 
 ---
 #### routing_options arguments


### PR DESCRIPTION
ENHANCEMENTS:
* add `family_inet6_address` argument inside `interface_fxp0` argument in `junos_group_dual_system` resource (Fixes #177)