### PR TITLE
Release v1.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 ENHANCEMENTS:
 
 BUG FIXES:
+* resource/`junos_security_global_policy`: fix `match_application` argument not required if `match_dynamic_application` is set and Junos version is > 19.1R1 (Fixes #188)
+* resource/`junos_security_policy`: fix `match_application` argument not required if `match_dynamic_application` is set and Junos version is > 19.1R1 (Fixes #188)
 
 ## 1.15.0 (April 20, 2021)
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ENHANCEMENTS:
 
 BUG FIXES:
+
+## 1.15.1 (April 23, 2021)
+BUG FIXES:
 * resource/`junos_security_global_policy`: fix `match_application` argument not required if `match_dynamic_application` is set and Junos version is > 19.1R1 (Fixes #188)
 * resource/`junos_security_policy`: fix `match_application` argument not required if `match_dynamic_application` is set and Junos version is > 19.1R1 (Fixes #188)
 

--- a/junos/resource_security_policy.go
+++ b/junos/resource_security_policy.go
@@ -60,12 +60,6 @@ func resourceSecurityPolicy() *schema.Resource {
 							MinItems: 1,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
-						"match_application": {
-							Type:     schema.TypeList,
-							Required: true,
-							MinItems: 1,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
 						"then": {
 							Type:         schema.TypeString,
 							Optional:     true,
@@ -83,6 +77,11 @@ func resourceSecurityPolicy() *schema.Resource {
 						"log_close": {
 							Type:     schema.TypeBool,
 							Optional: true,
+						},
+						"match_application": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 						"match_destination_address_excluded": {
 							Type:     schema.TypeBool,
@@ -383,26 +382,11 @@ func setSecurityPolicy(d *schema.ResourceData, m interface{}, jnprSess *NetconfO
 	for _, v := range d.Get("policy").([]interface{}) {
 		policy := v.(map[string]interface{})
 		setPrefixPolicy := setPrefix + policy["name"].(string)
-		if len(policy["match_source_address"].([]interface{})) != 0 {
-			for _, address := range policy["match_source_address"].([]interface{}) {
-				configSet = append(configSet, setPrefixPolicy+" match source-address "+address.(string))
-			}
-		} else {
-			configSet = append(configSet, setPrefixPolicy+" match source-address any")
+		for _, address := range policy["match_source_address"].([]interface{}) {
+			configSet = append(configSet, setPrefixPolicy+" match source-address "+address.(string))
 		}
-		if len(policy["match_destination_address"].([]interface{})) != 0 {
-			for _, address := range policy["match_destination_address"].([]interface{}) {
-				configSet = append(configSet, setPrefixPolicy+" match destination-address "+address.(string))
-			}
-		} else {
-			configSet = append(configSet, setPrefixPolicy+" match destination-address any")
-		}
-		if len(policy["match_application"].([]interface{})) != 0 {
-			for _, app := range policy["match_application"].([]interface{}) {
-				configSet = append(configSet, setPrefixPolicy+" match application "+app.(string))
-			}
-		} else {
-			configSet = append(configSet, setPrefixPolicy+" match application any")
+		for _, address := range policy["match_destination_address"].([]interface{}) {
+			configSet = append(configSet, setPrefixPolicy+" match destination-address "+address.(string))
 		}
 		configSet = append(configSet, setPrefixPolicy+" then "+policy["then"].(string))
 		if policy["count"].(bool) {
@@ -413,6 +397,14 @@ func setSecurityPolicy(d *schema.ResourceData, m interface{}, jnprSess *NetconfO
 		}
 		if policy["log_close"].(bool) {
 			configSet = append(configSet, setPrefixPolicy+" then log session-close")
+		}
+		if len(policy["match_application"].([]interface{})) == 0 &&
+			len(policy["match_dynamic_application"].([]interface{})) == 0 {
+			return fmt.Errorf("1 minimum item must be set in 'match_application' or 'match_dynamic_application' "+
+				"argument in '%s' policy", policy["name"].(string))
+		}
+		for _, app := range policy["match_application"].([]interface{}) {
+			configSet = append(configSet, setPrefixPolicy+" match application "+app.(string))
 		}
 		if policy["match_destination_address_excluded"].(bool) {
 			configSet = append(configSet, setPrefixPolicy+" match destination-address-excluded")

--- a/website/docs/r/security_global_policy.html.markdown
+++ b/website/docs/r/security_global_policy.html.markdown
@@ -45,13 +45,13 @@ The following arguments are supported:
   * `name` - (Required)(`String`) Security policy name.
   * `match_source_address` - (Required)(`ListOfString`) List of source address match.
   * `match_destination_address` - (Required)(`ListOfString`) List of destination address match.
-  * `match_application` - (Required)(`ListOfString`) List of applications match.
   * `match_from_zone` - (Required)(`ListOfString`) Match multiple source zone.
   * `match_to_zone` - (Required)(`ListOfString`) Match multiple destination zone.
   * `then` - (Optional)(`String`) Action of policy. Defaults to `permit`.
   * `count` - (Optional)(`Bool`) Enable count.
   * `log_init` - (Optional)(`Bool`) Log at session init time.
   * `log_close` - (Optional)(`Bool`) Log at session close time.
+  * `match_application` - (Optional)(`ListOfString`) List of applications match.
   * `match_destination_address_excluded` - (Optional)(`Bool`) Exclude destination addresses.
   * `match_dynamic_application` - (Optional)(`ListOfString`) List of dynamic application or group match.
   * `match_source_address_excluded` - (Optional)(`Bool`) Exclude source addresses.

--- a/website/docs/r/security_policy.html.markdown
+++ b/website/docs/r/security_policy.html.markdown
@@ -36,11 +36,11 @@ The following arguments are supported:
   * `name`  - (Required)(`String`) The name of policy.
   * `match_source_address` - (Required)(`ListOfString`) List of source address match.
   * `match_destination_address` - (Required)(`ListOfString`) List of destination address match.
-  * `match_application` - (Required)(`ListOfString`) List of applications match.
   * `then` - (Optional)(`String`) Action of policy. Defaults to `permit`.
   * `count` - (Optional)(`Bool`) Enable count.
   * `log_init` - (Optional)(`Bool`) Log at session init time.
   * `log_close` - (Optional)(`Bool`) Log at session close time.
+  * `match_application` - (Optional)(`ListOfString`) List of applications match.
   * `match_destination_address_excluded` - (Optional)(`Bool`) Exclude destination addresses.
   * `match_dynamic_application` - (Optional)(`ListOfString`) List of dynamic application or group match.
   * `match_source_address_excluded` - (Optional)(`Bool`) Exclude source addresses.


### PR DESCRIPTION
BUG FIXES:
* resource/`junos_security_global_policy`: fix `match_application` argument not required if `match_dynamic_application` is set and Junos version is > 19.1R1 (Fixes #188)
* resource/`junos_security_policy`: fix `match_application` argument not required if `match_dynamic_application` is set and Junos version is > 19.1R1 (Fixes #188)