### PR TITLE
Fixes #193: Add support for address-pooling to nat source pool

### DIFF
--- a/junos/resource_security_nat_source_test.go
+++ b/junos/resource_security_nat_source_test.go
@@ -128,7 +128,7 @@ resource junos_security_nat_source_pool testacc_securitySNATPool {
   name                                   = "testacc_securitySNATPool"
   address                                = ["192.0.2.1/32", "192.0.2.64/27"]
   routing_instance                       = junos_routing_instance.testacc_securitySNAT.name
-  address_pooling_paired                 = true 
+  address_pooling_paired                 = true
   port_no_translation                    = true
   pool_utilization_alarm_raise_threshold = 80
   pool_utilization_alarm_clear_threshold = 60

--- a/junos/resource_security_nat_source_test.go
+++ b/junos/resource_security_nat_source_test.go
@@ -61,7 +61,7 @@ func TestAccJunosSecurityNatSource_basic(t *testing.T) {
 						resource.TestCheckResourceAttr("junos_security_nat_source_pool.testacc_securitySNATPool",
 							"routing_instance", "testacc_securitySNAT"),
 						resource.TestCheckResourceAttr("junos_security_nat_source_pool.testacc_securitySNATPool",
-							"address_pooling_paired", "true"),
+							"address_pooling", "paired"),
 						resource.TestCheckResourceAttr("junos_security_nat_source_pool.testacc_securitySNATPool",
 							"port_no_translation", "true"),
 						resource.TestCheckResourceAttr("junos_security_nat_source_pool.testacc_securitySNATPool",
@@ -82,7 +82,7 @@ func TestAccJunosSecurityNatSource_basic(t *testing.T) {
 						resource.TestCheckResourceAttr("junos_security_nat_source.testacc_securitySNAT",
 							"rule.1.then.0.type", "off"),
 						resource.TestCheckResourceAttr("junos_security_nat_source_pool.testacc_securitySNATPool",
-							"address_pooling_no_paired", "true"),
+							"address_pooling", "no-paired"),
 						resource.TestCheckResourceAttr("junos_security_nat_source_pool.testacc_securitySNATPool",
 							"port_no_translation", "false"),
 						resource.TestCheckResourceAttr("junos_security_nat_source_pool.testacc_securitySNATPool",
@@ -128,7 +128,7 @@ resource junos_security_nat_source_pool testacc_securitySNATPool {
   name                                   = "testacc_securitySNATPool"
   address                                = ["192.0.2.1/32", "192.0.2.64/27"]
   routing_instance                       = junos_routing_instance.testacc_securitySNAT.name
-  address_pooling_paired                 = true
+  address_pooling                        = "paired"
   port_no_translation                    = true
   pool_utilization_alarm_raise_threshold = 80
   pool_utilization_alarm_clear_threshold = 60
@@ -180,11 +180,11 @@ resource junos_security_nat_source testacc_securitySNAT {
   }
 }
 resource junos_security_nat_source_pool testacc_securitySNATPool {
-  name                      = "testacc_securitySNATPool"
-  address                   = ["192.0.2.1/32"]
-  routing_instance          = junos_routing_instance.testacc_securitySNAT.name
-  address_pooling_no_paired = true
-  port_overloading_factor   = 3
+  name                    = "testacc_securitySNATPool"
+  address                 = ["192.0.2.1/32"]
+  routing_instance        = junos_routing_instance.testacc_securitySNAT.name
+  address_pooling         = "no-paired"
+  port_overloading_factor = 3
 }
 
 resource junos_security_zone testacc_securitySNAT {

--- a/junos/resource_security_nat_source_test.go
+++ b/junos/resource_security_nat_source_test.go
@@ -61,6 +61,8 @@ func TestAccJunosSecurityNatSource_basic(t *testing.T) {
 						resource.TestCheckResourceAttr("junos_security_nat_source_pool.testacc_securitySNATPool",
 							"routing_instance", "testacc_securitySNAT"),
 						resource.TestCheckResourceAttr("junos_security_nat_source_pool.testacc_securitySNATPool",
+							"address_pooling_paired", "true"),
+						resource.TestCheckResourceAttr("junos_security_nat_source_pool.testacc_securitySNATPool",
 							"port_no_translation", "true"),
 						resource.TestCheckResourceAttr("junos_security_nat_source_pool.testacc_securitySNATPool",
 							"pool_utilization_alarm_raise_threshold", "80"),
@@ -79,6 +81,8 @@ func TestAccJunosSecurityNatSource_basic(t *testing.T) {
 							"rule.1.then.#", "1"),
 						resource.TestCheckResourceAttr("junos_security_nat_source.testacc_securitySNAT",
 							"rule.1.then.0.type", "off"),
+						resource.TestCheckResourceAttr("junos_security_nat_source_pool.testacc_securitySNATPool",
+							"address_pooling_no_paired", "true"),
 						resource.TestCheckResourceAttr("junos_security_nat_source_pool.testacc_securitySNATPool",
 							"port_no_translation", "false"),
 						resource.TestCheckResourceAttr("junos_security_nat_source_pool.testacc_securitySNATPool",
@@ -124,6 +128,7 @@ resource junos_security_nat_source_pool testacc_securitySNATPool {
   name                                   = "testacc_securitySNATPool"
   address                                = ["192.0.2.1/32", "192.0.2.64/27"]
   routing_instance                       = junos_routing_instance.testacc_securitySNAT.name
+  address_pooling_paired                 = true 
   port_no_translation                    = true
   pool_utilization_alarm_raise_threshold = 80
   pool_utilization_alarm_clear_threshold = 60
@@ -175,10 +180,11 @@ resource junos_security_nat_source testacc_securitySNAT {
   }
 }
 resource junos_security_nat_source_pool testacc_securitySNATPool {
-  name                    = "testacc_securitySNATPool"
-  address                 = ["192.0.2.1/32"]
-  routing_instance        = junos_routing_instance.testacc_securitySNAT.name
-  port_overloading_factor = 3
+  name                      = "testacc_securitySNATPool"
+  address                   = ["192.0.2.1/32"]
+  routing_instance          = junos_routing_instance.testacc_securitySNAT.name
+  address_pooling_no_paired = true
+  port_overloading_factor   = 3
 }
 
 resource junos_security_zone testacc_securitySNAT {

--- a/website/docs/r/security_nat_source_pool.html.markdown
+++ b/website/docs/r/security_nat_source_pool.html.markdown
@@ -26,6 +26,8 @@ The following arguments are supported:
 
 * `name` - (Required, Forces new resource)(`String`) The name of source nat pool.
 * `address` - (Required)(`ListofString`) List of CIDR for source nat pool.
+* `address_pooling_no_paired` - (Optional)(`Bool`) Allow address-pooling no-paired. Conflict with `address_pooling_paired`.
+* `address_pooling_paired` - (Optional)(`Bool`) Allow address-pooling paired. Conflict with `address_pooling_no_paired`.
 * `pool_utilization_alarm_raise_threshold` - (Optional)(`Int`) Upper threshold at which an SNMP trap is triggered. Range 50 through 100.
 * `pool_utilization_alarm_clear_threshold` - (Optional)(`Int`) Lower threshold at which an SNMP trap is triggered. Range 40 through 100.
 * `port_no_translation` - (Optional)(`Bool`) Do not perform port translation.

--- a/website/docs/r/security_nat_source_pool.html.markdown
+++ b/website/docs/r/security_nat_source_pool.html.markdown
@@ -26,8 +26,7 @@ The following arguments are supported:
 
 * `name` - (Required, Forces new resource)(`String`) The name of source nat pool.
 * `address` - (Required)(`ListofString`) List of CIDR for source nat pool.
-* `address_pooling_no_paired` - (Optional)(`Bool`) Allow address-pooling no-paired. Conflict with `address_pooling_paired`.
-* `address_pooling_paired` - (Optional)(`Bool`) Allow address-pooling paired. Conflict with `address_pooling_no_paired`.
+* `address_pooling` - (Optional)(`String`) Type of address pooling. Need to be 'paired' or 'no-paired'.
 * `pool_utilization_alarm_raise_threshold` - (Optional)(`Int`) Upper threshold at which an SNMP trap is triggered. Range 50 through 100.
 * `pool_utilization_alarm_clear_threshold` - (Optional)(`Int`) Lower threshold at which an SNMP trap is triggered. Range 40 through 100.
 * `port_no_translation` - (Optional)(`Bool`) Do not perform port translation.


### PR DESCRIPTION
* add `address-pooling paired | no-paired` argument to `security_nat_source_pool` resource 