### PR TITLE
Fix block empty with defaut int -1 and application_identification empty in junos_services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ ENHANCEMENTS:
 
 BUG FIXES:
 * fix errors not generated with certain nested blocks empty and default integer argument = -1 in these blocks
+* resource/`junos_services`: fix set/read/delete empty `application_identification` block to enable 'application-identification'
 
 ## 1.15.1 (April 23, 2021)
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ ENHANCEMENTS:
 * clean code: fix lll linter errors with a var to map
 
 BUG FIXES:
+* fix errors not generated with certain nested blocks empty and default integer argument = -1 in these blocks
 
 ## 1.15.1 (April 23, 2021)
 BUG FIXES:

--- a/junos/constants.go
+++ b/junos/constants.go
@@ -5,6 +5,7 @@ const (
 	defaultWord           = "default"
 	inetWord              = "inet"
 	inet6Word             = "inet6"
+	mplsWord              = "mpls"
 	emptyWord             = "empty"
 	matchWord             = "match"
 	permitWord            = "permit"

--- a/junos/resource_forwardingoptions_sampling_instance.go
+++ b/junos/resource_forwardingoptions_sampling_instance.go
@@ -825,9 +825,6 @@ func setForwardingoptionsSamplingInstance(d *schema.ResourceData, m interface{},
 		configSet = append(configSet, setPrefix+"disable")
 	}
 	for _, v := range d.Get("family_inet_input").([]interface{}) {
-		if v == nil {
-			return fmt.Errorf("family_inet_input block is empty")
-		}
 		if err := setForwardingoptionsSamplingInstanceInput(setPrefix,
 			v.(map[string]interface{}), inetWord, sess, jnprSess); err != nil {
 			return err
@@ -843,9 +840,6 @@ func setForwardingoptionsSamplingInstance(d *schema.ResourceData, m interface{},
 		}
 	}
 	for _, v := range d.Get("family_inet6_input").([]interface{}) {
-		if v == nil {
-			return fmt.Errorf("family_inet6_input block is empty")
-		}
 		if err := setForwardingoptionsSamplingInstanceInput(setPrefix,
 			v.(map[string]interface{}), inet6Word, sess, jnprSess); err != nil {
 			return err
@@ -861,11 +855,8 @@ func setForwardingoptionsSamplingInstance(d *schema.ResourceData, m interface{},
 		}
 	}
 	for _, v := range d.Get("family_mpls_input").([]interface{}) {
-		if v == nil {
-			return fmt.Errorf("family_mpls_input block is empty")
-		}
 		if err := setForwardingoptionsSamplingInstanceInput(setPrefix,
-			v.(map[string]interface{}), "mpls", sess, jnprSess); err != nil {
+			v.(map[string]interface{}), mplsWord, sess, jnprSess); err != nil {
 			return err
 		}
 	}
@@ -874,14 +865,11 @@ func setForwardingoptionsSamplingInstance(d *schema.ResourceData, m interface{},
 			return fmt.Errorf("family_mpls_output block is empty")
 		}
 		if err := setForwardingoptionsSamplingInstanceOutput(setPrefix,
-			v.(map[string]interface{}), "mpls", sess, jnprSess); err != nil {
+			v.(map[string]interface{}), mplsWord, sess, jnprSess); err != nil {
 			return err
 		}
 	}
 	for _, v := range d.Get("input").([]interface{}) {
-		if v == nil {
-			return fmt.Errorf("input block is empty")
-		}
 		if err := setForwardingoptionsSamplingInstanceInput(setPrefix,
 			v.(map[string]interface{}), "", sess, jnprSess); err != nil {
 			return err
@@ -899,7 +887,7 @@ func setForwardingoptionsSamplingInstanceInput(
 		setPrefix += "family inet input "
 	case inet6Word:
 		setPrefix += "family inet6 input "
-	case "mpls":
+	case mplsWord:
 		setPrefix += "family mpls input "
 	default:
 		setPrefix += "input "
@@ -916,6 +904,18 @@ func setForwardingoptionsSamplingInstanceInput(
 	if v := input["run_length"].(int); v != -1 {
 		configSet = append(configSet, setPrefix+"run-length "+strconv.Itoa(v))
 	}
+	if len(configSet) == 0 {
+		switch family {
+		case inetWord:
+			return fmt.Errorf("family_inet_input block is empty")
+		case inet6Word:
+			return fmt.Errorf("family_inet6_input block is empty")
+		case mplsWord:
+			return fmt.Errorf("family_mpls_input block is empty")
+		default:
+			return fmt.Errorf("input block is empty")
+		}
+	}
 
 	return sess.configSet(configSet, jnprSess)
 }
@@ -928,7 +928,7 @@ func setForwardingoptionsSamplingInstanceOutput(
 		setPrefix += "family inet output "
 	case inet6Word:
 		setPrefix += "family inet6 output "
-	case "mpls":
+	case mplsWord:
 		setPrefix += "family mpls output "
 	default:
 		return fmt.Errorf("internal error: setForwardingoptionsSamplingInstanceOutput call with bad family")
@@ -1151,7 +1151,7 @@ func readForwardingoptionsSamplingInstance(
 					})
 				}
 				if err := readForwardingoptionsSamplingInstanceOutput(confRead.familyMplsOutput[0],
-					strings.TrimPrefix(itemTrim, "family mpls output "), "mpls"); err != nil {
+					strings.TrimPrefix(itemTrim, "family mpls output "), mplsWord); err != nil {
 					return confRead, err
 				}
 			}

--- a/junos/resource_security.go
+++ b/junos/resource_security.go
@@ -939,21 +939,20 @@ func setSecurityFlow(flow interface{}) ([]string, error) { // nolint: gocognit
 			}
 		}
 		for _, v := range flowM["aging"].([]interface{}) {
-			if v != nil {
-				aging := v.(map[string]interface{})
-				if aging["early_ageout"].(int) != 0 {
-					configSet = append(configSet, setPrefix+"aging early-ageout "+
-						strconv.Itoa(aging["early_ageout"].(int)))
-				}
-				if aging["high_watermark"].(int) != -1 {
-					configSet = append(configSet, setPrefix+"aging high-watermark "+
-						strconv.Itoa(aging["high_watermark"].(int)))
-				}
-				if aging["low_watermark"].(int) != -1 {
-					configSet = append(configSet, setPrefix+"aging low-watermark "+
-						strconv.Itoa(aging["low_watermark"].(int)))
-				}
-			} else {
+			aging := v.(map[string]interface{})
+			if aging["early_ageout"].(int) != 0 {
+				configSet = append(configSet, setPrefix+"aging early-ageout "+
+					strconv.Itoa(aging["early_ageout"].(int)))
+			}
+			if aging["high_watermark"].(int) != -1 {
+				configSet = append(configSet, setPrefix+"aging high-watermark "+
+					strconv.Itoa(aging["high_watermark"].(int)))
+			}
+			if aging["low_watermark"].(int) != -1 {
+				configSet = append(configSet, setPrefix+"aging low-watermark "+
+					strconv.Itoa(aging["low_watermark"].(int)))
+			}
+			if len(configSet) == 0 || !strings.HasPrefix(configSet[len(configSet)-1], setPrefix+"aging ") {
 				return configSet, fmt.Errorf("flow aging block is empty")
 			}
 		}
@@ -1145,51 +1144,50 @@ func setSecurityForwOpts(forwOpts interface{}) ([]string, error) {
 func setSecurityIkeTraceOpts(ikeTrace interface{}) ([]string, error) {
 	setPrefix := "set security ike traceoptions "
 	configSet := make([]string, 0)
-	if ikeTrace != nil {
-		ikeTraceM := ikeTrace.(map[string]interface{})
-		for _, v := range ikeTraceM["file"].([]interface{}) {
-			if v != nil {
-				ikeTraceFile := v.(map[string]interface{})
-				if ikeTraceFile["name"].(string) != "" {
-					configSet = append(configSet, setPrefix+"file "+
-						ikeTraceFile["name"].(string))
-				}
-				if ikeTraceFile["files"].(int) > 0 {
-					configSet = append(configSet, setPrefix+"file files "+
-						strconv.Itoa(ikeTraceFile["files"].(int)))
-				}
-				if ikeTraceFile["match"].(string) != "" {
-					configSet = append(configSet, setPrefix+"file match \""+
-						ikeTraceFile["match"].(string)+"\"")
-				}
-				if ikeTraceFile["size"].(int) > 0 {
-					configSet = append(configSet, setPrefix+"file size "+
-						strconv.Itoa(ikeTraceFile["size"].(int)))
-				}
-				if ikeTraceFile["world_readable"].(bool) && ikeTraceFile["no_world_readable"].(bool) {
-					return configSet, fmt.Errorf("conflict between 'world_readable' and 'no_world_readable' for ike_traceoptions file")
-				}
-				if ikeTraceFile["world_readable"].(bool) {
-					configSet = append(configSet, setPrefix+"file world-readable")
-				}
-				if ikeTraceFile["no_world_readable"].(bool) {
-					configSet = append(configSet, setPrefix+"file no-world-readable")
-				}
-			} else {
-				return configSet, fmt.Errorf("ike_traceoptions file block is empty")
+	ikeTraceM := ikeTrace.(map[string]interface{})
+	for _, v := range ikeTraceM["file"].([]interface{}) {
+		if v != nil {
+			ikeTraceFile := v.(map[string]interface{})
+			if ikeTraceFile["name"].(string) != "" {
+				configSet = append(configSet, setPrefix+"file "+
+					ikeTraceFile["name"].(string))
 			}
+			if ikeTraceFile["files"].(int) > 0 {
+				configSet = append(configSet, setPrefix+"file files "+
+					strconv.Itoa(ikeTraceFile["files"].(int)))
+			}
+			if ikeTraceFile["match"].(string) != "" {
+				configSet = append(configSet, setPrefix+"file match \""+
+					ikeTraceFile["match"].(string)+"\"")
+			}
+			if ikeTraceFile["size"].(int) > 0 {
+				configSet = append(configSet, setPrefix+"file size "+
+					strconv.Itoa(ikeTraceFile["size"].(int)))
+			}
+			if ikeTraceFile["world_readable"].(bool) && ikeTraceFile["no_world_readable"].(bool) {
+				return configSet, fmt.Errorf("conflict between 'world_readable' and 'no_world_readable' for ike_traceoptions file")
+			}
+			if ikeTraceFile["world_readable"].(bool) {
+				configSet = append(configSet, setPrefix+"file world-readable")
+			}
+			if ikeTraceFile["no_world_readable"].(bool) {
+				configSet = append(configSet, setPrefix+"file no-world-readable")
+			}
+		} else {
+			return configSet, fmt.Errorf("ike_traceoptions file block is empty")
 		}
-		for _, ikeTraceFlag := range ikeTraceM["flag"].([]interface{}) {
-			configSet = append(configSet, setPrefix+"flag "+ikeTraceFlag.(string))
-		}
-		if ikeTraceM["no_remote_trace"].(bool) {
-			configSet = append(configSet, setPrefix+"no-remote-trace")
-		}
-		if ikeTraceM["rate_limit"].(int) > -1 {
-			configSet = append(configSet, setPrefix+"rate-limit "+
-				strconv.Itoa(ikeTraceM["rate_limit"].(int)))
-		}
-	} else {
+	}
+	for _, ikeTraceFlag := range ikeTraceM["flag"].([]interface{}) {
+		configSet = append(configSet, setPrefix+"flag "+ikeTraceFlag.(string))
+	}
+	if ikeTraceM["no_remote_trace"].(bool) {
+		configSet = append(configSet, setPrefix+"no-remote-trace")
+	}
+	if ikeTraceM["rate_limit"].(int) > -1 {
+		configSet = append(configSet, setPrefix+"rate-limit "+
+			strconv.Itoa(ikeTraceM["rate_limit"].(int)))
+	}
+	if len(configSet) == 0 {
 		return configSet, fmt.Errorf("ike_traceoptions block is empty")
 	}
 
@@ -1199,76 +1197,75 @@ func setSecurityIkeTraceOpts(ikeTrace interface{}) ([]string, error) {
 func setSecurityLog(log interface{}) ([]string, error) {
 	setPrefix := "set security log "
 	configSet := make([]string, 0)
-	if log != nil {
-		logM := log.(map[string]interface{})
-		if logM["disable"].(bool) {
-			configSet = append(configSet, setPrefix+"disable")
+	logM := log.(map[string]interface{})
+	if logM["disable"].(bool) {
+		configSet = append(configSet, setPrefix+"disable")
+	}
+	if logM["event_rate"].(int) != -1 {
+		configSet = append(configSet, setPrefix+"event-rate "+strconv.Itoa(logM["event_rate"].(int)))
+	}
+	if logM["facility_override"].(string) != "" {
+		configSet = append(configSet, setPrefix+"facility-override "+logM["facility_override"].(string))
+	}
+	for _, v := range logM["file"].([]interface{}) {
+		if v != nil {
+			file := v.(map[string]interface{})
+			if file["files"].(int) != 0 {
+				configSet = append(configSet, setPrefix+"file files "+strconv.Itoa(file["files"].(int)))
+			}
+			if file["name"].(string) != "" {
+				configSet = append(configSet, setPrefix+"file name "+file["name"].(string))
+			}
+			if file["path"].(string) != "" {
+				configSet = append(configSet, setPrefix+"file path "+file["path"].(string))
+			}
+			if file["size"].(int) != 0 {
+				configSet = append(configSet, setPrefix+"file size "+strconv.Itoa(file["size"].(int)))
+			}
+		} else {
+			return configSet, fmt.Errorf("log file block is empty")
 		}
-		if logM["event_rate"].(int) != -1 {
-			configSet = append(configSet, setPrefix+"event-rate "+strconv.Itoa(logM["event_rate"].(int)))
-		}
-		if logM["facility_override"].(string) != "" {
-			configSet = append(configSet, setPrefix+"facility-override "+logM["facility_override"].(string))
-		}
-		for _, v := range logM["file"].([]interface{}) {
-			if v != nil {
-				file := v.(map[string]interface{})
-				if file["files"].(int) != 0 {
-					configSet = append(configSet, setPrefix+"file files "+strconv.Itoa(file["files"].(int)))
-				}
-				if file["name"].(string) != "" {
-					configSet = append(configSet, setPrefix+"file name "+file["name"].(string))
-				}
-				if file["path"].(string) != "" {
-					configSet = append(configSet, setPrefix+"file path "+file["path"].(string))
-				}
-				if file["size"].(int) != 0 {
-					configSet = append(configSet, setPrefix+"file size "+strconv.Itoa(file["size"].(int)))
-				}
-			} else {
-				return configSet, fmt.Errorf("log file block is empty")
+	}
+	if logM["format"].(string) != "" {
+		configSet = append(configSet, setPrefix+"format "+logM["format"].(string))
+	}
+	if logM["max_database_record"].(int) != -1 {
+		configSet = append(configSet, setPrefix+"max-database-record "+strconv.Itoa(logM["max_database_record"].(int)))
+	}
+	if logM["mode"].(string) != "" {
+		configSet = append(configSet, setPrefix+"mode "+logM["mode"].(string))
+	}
+	if logM["rate_cap"].(int) != -1 {
+		configSet = append(configSet, setPrefix+"rate-cap "+strconv.Itoa(logM["rate_cap"].(int)))
+	}
+	if logM["report"].(bool) {
+		configSet = append(configSet, setPrefix+"report")
+	}
+	if logM["source_address"].(string) != "" {
+		configSet = append(configSet, setPrefix+"source-address "+logM["source_address"].(string))
+	}
+	if logM["source_interface"].(string) != "" {
+		configSet = append(configSet, setPrefix+"source-interface "+logM["source_interface"].(string))
+	}
+	for _, v := range logM["transport"].([]interface{}) {
+		configSet = append(configSet, setPrefix+"transport")
+		if v != nil {
+			trans := v.(map[string]interface{})
+			if trans["protocol"].(string) != "" {
+				configSet = append(configSet, setPrefix+"transport protocol "+trans["protocol"].(string))
+			}
+			if trans["tcp_connections"].(int) != 0 {
+				configSet = append(configSet, setPrefix+"transport tcp-connections "+strconv.Itoa(trans["tcp_connections"].(int)))
+			}
+			if trans["tls_profile"].(string) != "" {
+				configSet = append(configSet, setPrefix+"transport tls-profile "+trans["tls_profile"].(string))
 			}
 		}
-		if logM["format"].(string) != "" {
-			configSet = append(configSet, setPrefix+"format "+logM["format"].(string))
-		}
-		if logM["max_database_record"].(int) != -1 {
-			configSet = append(configSet, setPrefix+"max-database-record "+strconv.Itoa(logM["max_database_record"].(int)))
-		}
-		if logM["mode"].(string) != "" {
-			configSet = append(configSet, setPrefix+"mode "+logM["mode"].(string))
-		}
-		if logM["rate_cap"].(int) != -1 {
-			configSet = append(configSet, setPrefix+"rate-cap "+strconv.Itoa(logM["rate_cap"].(int)))
-		}
-		if logM["report"].(bool) {
-			configSet = append(configSet, setPrefix+"report")
-		}
-		if logM["source_address"].(string) != "" {
-			configSet = append(configSet, setPrefix+"source-address "+logM["source_address"].(string))
-		}
-		if logM["source_interface"].(string) != "" {
-			configSet = append(configSet, setPrefix+"source-interface "+logM["source_interface"].(string))
-		}
-		for _, v := range logM["transport"].([]interface{}) {
-			configSet = append(configSet, setPrefix+"transport")
-			if v != nil {
-				trans := v.(map[string]interface{})
-				if trans["protocol"].(string) != "" {
-					configSet = append(configSet, setPrefix+"transport protocol "+trans["protocol"].(string))
-				}
-				if trans["tcp_connections"].(int) != 0 {
-					configSet = append(configSet, setPrefix+"transport tcp-connections "+strconv.Itoa(trans["tcp_connections"].(int)))
-				}
-				if trans["tls_profile"].(string) != "" {
-					configSet = append(configSet, setPrefix+"transport tls-profile "+trans["tls_profile"].(string))
-				}
-			}
-		}
-		if logM["utc_timestamp"].(bool) {
-			configSet = append(configSet, setPrefix+"utc-timestamp")
-		}
-	} else {
+	}
+	if logM["utc_timestamp"].(bool) {
+		configSet = append(configSet, setPrefix+"utc-timestamp")
+	}
+	if len(configSet) == 0 {
 		return configSet, fmt.Errorf("log block is empty")
 	}
 

--- a/junos/resource_security_screen.go
+++ b/junos/resource_security_screen.go
@@ -784,14 +784,7 @@ func setSecurityScreen(d *schema.ResourceData, m interface{}, jnprSess *NetconfO
 		configSet = append(configSet, setSecurityScreenIcmp(icmp, setPrefix)...)
 	}
 	for _, v := range d.Get("ip").([]interface{}) {
-		if v == nil {
-			return fmt.Errorf("ip block is empty")
-		}
-		ip := v.(map[string]interface{})
-		if err := checkSetSecurityScreenIP(ip); err != nil {
-			return err
-		}
-		ipSet, err := setSecurityScreenIP(ip, setPrefix)
+		ipSet, err := setSecurityScreenIP(v.(map[string]interface{}), setPrefix)
 		if err != nil {
 			return err
 		}
@@ -870,29 +863,6 @@ func setSecurityScreenIcmp(icmp map[string]interface{}, setPrefix string) []stri
 	}
 
 	return configSet
-}
-
-func checkSetSecurityScreenIP(ip map[string]interface{}) error {
-	if !ip["bad_option"].(bool) &&
-		!ip["block_frag"].(bool) &&
-		len(ip["ipv6_extension_header"].([]interface{})) == 0 &&
-		ip["ipv6_extension_header_limit"].(int) == -1 &&
-		!ip["ipv6_malformed_header"].(bool) &&
-		!ip["loose_source_route_option"].(bool) &&
-		!ip["record_route_option"].(bool) &&
-		!ip["security_option"].(bool) &&
-		!ip["source_route_option"].(bool) &&
-		!ip["spoofing"].(bool) &&
-		!ip["stream_option"].(bool) &&
-		!ip["strict_source_route_option"].(bool) &&
-		!ip["tear_drop"].(bool) &&
-		!ip["timestamp_option"].(bool) &&
-		len(ip["tunnel"].([]interface{})) == 0 &&
-		!ip["unknown_protocol"].(bool) {
-		return fmt.Errorf("ip block is empty")
-	}
-
-	return nil
 }
 
 func setSecurityScreenIP(ip map[string]interface{}, setPrefix string) ([]string, error) {
@@ -1096,6 +1066,9 @@ func setSecurityScreenIP(ip map[string]interface{}, setPrefix string) ([]string,
 	}
 	if ip["unknown_protocol"].(bool) {
 		configSet = append(configSet, setPrefix+"unknown-protocol")
+	}
+	if len(configSet) == 0 {
+		return configSet, fmt.Errorf("ip block is empty")
 	}
 
 	return configSet, nil

--- a/junos/resource_security_utm_policy.go
+++ b/junos/resource_security_utm_policy.go
@@ -391,17 +391,17 @@ func setUtmPolicy(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject
 		}
 	}
 	for _, v := range d.Get("traffic_sessions_per_client").([]interface{}) {
-		if v != nil {
-			trafficSessPerClient := v.(map[string]interface{})
-			if trafficSessPerClient["limit"].(int) != -1 {
-				configSet = append(configSet, setPrefix+"traffic-options sessions-per-client limit "+
-					strconv.Itoa(trafficSessPerClient["limit"].(int)))
-			}
-			if trafficSessPerClient["over_limit"].(string) != "" {
-				configSet = append(configSet, setPrefix+"traffic-options sessions-per-client over-limit "+
-					trafficSessPerClient["over_limit"].(string))
-			}
-		} else {
+		trafficSessPerClient := v.(map[string]interface{})
+		if trafficSessPerClient["limit"].(int) != -1 {
+			configSet = append(configSet, setPrefix+"traffic-options sessions-per-client limit "+
+				strconv.Itoa(trafficSessPerClient["limit"].(int)))
+		}
+		if trafficSessPerClient["over_limit"].(string) != "" {
+			configSet = append(configSet, setPrefix+"traffic-options sessions-per-client over-limit "+
+				trafficSessPerClient["over_limit"].(string))
+		}
+		if len(configSet) == 0 || !strings.HasPrefix(configSet[len(configSet)-1],
+			setPrefix+"traffic-options sessions-per-client") {
 			return fmt.Errorf("traffic_sessions_per_client block is empty")
 		}
 	}

--- a/junos/resource_services.go
+++ b/junos/resource_services.go
@@ -369,6 +369,9 @@ func setServices(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject)
 	// setPrefix := "set services "
 	configSet := make([]string, 0)
 
+	if len(d.Get("application_identification").([]interface{})) == 0 {
+		configSet = append(configSet, "delete services application-identification")
+	}
 	for _, v := range d.Get("application_identification").([]interface{}) {
 		configSetApplicationIdentification, err := setServicesApplicationIdentification(v)
 		if err != nil {
@@ -391,6 +394,7 @@ func setServicesApplicationIdentification(appID interface{}) ([]string, error) {
 	setPrefix := "set services application-identification "
 	configSet := make([]string, 0)
 	appIDM := appID.(map[string]interface{})
+	configSet = append(configSet, setPrefix)
 	for _, v := range appIDM["application_system_cache"].([]interface{}) {
 		configSet = append(configSet, setPrefix+"application-system-cache")
 		if v != nil {
@@ -484,9 +488,6 @@ func setServicesApplicationIdentification(appID interface{}) ([]string, error) {
 	}
 	if v := appIDM["statistics_interval"].(int); v != 0 {
 		configSet = append(configSet, setPrefix+"statistics interval "+strconv.Itoa(v))
-	}
-	if len(configSet) == 0 {
-		return configSet, fmt.Errorf("application_identification block is empty")
 	}
 
 	return configSet, nil
@@ -595,7 +596,7 @@ func readServices(m interface{}, jnprSess *NetconfObject) (servicesOptions, erro
 			}
 			itemTrim := strings.TrimPrefix(item, setLineStart)
 			switch {
-			case checkStringHasPrefixInList(itemTrim, listLinesServicesApplicationIdentification()):
+			case strings.HasPrefix(itemTrim, "application-identification"):
 				if err := readServicesApplicationIdentification(&confRead, itemTrim); err != nil {
 					return confRead, err
 				}

--- a/junos/resource_services.go
+++ b/junos/resource_services.go
@@ -390,103 +390,102 @@ func setServices(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject)
 func setServicesApplicationIdentification(appID interface{}) ([]string, error) {
 	setPrefix := "set services application-identification "
 	configSet := make([]string, 0)
-	if appID != nil {
-		appIDM := appID.(map[string]interface{})
-		for _, v := range appIDM["application_system_cache"].([]interface{}) {
-			configSet = append(configSet, setPrefix+"application-system-cache")
-			if v != nil {
-				appSysCache := v.(map[string]interface{})
-				if appSysCache["no_miscellaneous_services"].(bool) {
-					configSet = append(configSet, setPrefix+"application-system-cache no-miscellaneous-services")
-				}
-				if appSysCache["security_services"].(bool) {
-					configSet = append(configSet, setPrefix+"application-system-cache security-services")
-				}
+	appIDM := appID.(map[string]interface{})
+	for _, v := range appIDM["application_system_cache"].([]interface{}) {
+		configSet = append(configSet, setPrefix+"application-system-cache")
+		if v != nil {
+			appSysCache := v.(map[string]interface{})
+			if appSysCache["no_miscellaneous_services"].(bool) {
+				configSet = append(configSet, setPrefix+"application-system-cache no-miscellaneous-services")
+			}
+			if appSysCache["security_services"].(bool) {
+				configSet = append(configSet, setPrefix+"application-system-cache security-services")
 			}
 		}
-		if appIDM["no_application_system_cache"].(bool) {
-			configSet = append(configSet, setPrefix+"no-application-system-cache")
+	}
+	if appIDM["no_application_system_cache"].(bool) {
+		configSet = append(configSet, setPrefix+"no-application-system-cache")
+	}
+	if v := appIDM["application_system_cache_timeout"].(int); v != -1 {
+		configSet = append(configSet, setPrefix+"application-system-cache-timeout "+strconv.Itoa(v))
+	}
+	for _, v := range appIDM["download"].([]interface{}) {
+		if v != nil {
+			download := v.(map[string]interface{})
+			if v2 := download["automatic_interval"].(int); v2 != 0 {
+				configSet = append(configSet, setPrefix+"download automatic interval "+strconv.Itoa(v2))
+			}
+			if v2 := download["automatic_start_time"].(string); v2 != "" {
+				configSet = append(configSet, setPrefix+"download automatic start-time "+v2)
+			}
+			if download["ignore_server_validation"].(bool) {
+				configSet = append(configSet, setPrefix+"download ignore-server-validation")
+			}
+			if v2 := download["proxy_profile"].(string); v2 != "" {
+				configSet = append(configSet, setPrefix+"download proxy-profile \""+v2+"\"")
+			}
+			if v2 := download["url"].(string); v2 != "" {
+				configSet = append(configSet, setPrefix+"download url \""+v2+"\"")
+			}
+		} else {
+			return configSet, fmt.Errorf("application_identification.0.download block is empty")
 		}
-		if v := appIDM["application_system_cache_timeout"].(int); v != -1 {
-			configSet = append(configSet, setPrefix+"application-system-cache-timeout "+strconv.Itoa(v))
-		}
-		for _, v := range appIDM["download"].([]interface{}) {
-			if v != nil {
-				download := v.(map[string]interface{})
-				if v2 := download["automatic_interval"].(int); v2 != 0 {
-					configSet = append(configSet, setPrefix+"download automatic interval "+strconv.Itoa(v2))
-				}
-				if v2 := download["automatic_start_time"].(string); v2 != "" {
-					configSet = append(configSet, setPrefix+"download automatic start-time "+v2)
-				}
-				if download["ignore_server_validation"].(bool) {
-					configSet = append(configSet, setPrefix+"download ignore-server-validation")
-				}
-				if v2 := download["proxy_profile"].(string); v2 != "" {
-					configSet = append(configSet, setPrefix+"download proxy-profile \""+v2+"\"")
-				}
-				if v2 := download["url"].(string); v2 != "" {
-					configSet = append(configSet, setPrefix+"download url \""+v2+"\"")
-				}
-			} else {
-				return configSet, fmt.Errorf("application_identification.0.download block is empty")
+	}
+	for _, v := range appIDM["enable_performance_mode"].([]interface{}) {
+		configSet = append(configSet, setPrefix+"enable-performance-mode")
+		if v != nil {
+			enPerfMode := v.(map[string]interface{})
+			if v := enPerfMode["max_packet_threshold"].(int); v != 0 {
+				configSet = append(configSet, setPrefix+"enable-performance-mode max-packet-threshold "+strconv.Itoa(v))
 			}
 		}
-		for _, v := range appIDM["enable_performance_mode"].([]interface{}) {
-			configSet = append(configSet, setPrefix+"enable-performance-mode")
-			if v != nil {
-				enPerfMode := v.(map[string]interface{})
-				if v := enPerfMode["max_packet_threshold"].(int); v != 0 {
-					configSet = append(configSet, setPrefix+"enable-performance-mode max-packet-threshold "+strconv.Itoa(v))
-				}
+	}
+	if v := appIDM["global_offload_byte_limit"].(int); v != -1 {
+		configSet = append(configSet, setPrefix+"global-offload-byte-limit "+strconv.Itoa(v))
+	}
+	if v := appIDM["imap_cache_size"].(int); v != 0 {
+		configSet = append(configSet, setPrefix+"imap-cache-size "+strconv.Itoa(v))
+	}
+	if v := appIDM["imap_cache_timeout"].(int); v != 0 {
+		configSet = append(configSet, setPrefix+"imap-cache-timeout "+strconv.Itoa(v))
+	}
+	for _, v := range appIDM["inspection_limit_tcp"].([]interface{}) {
+		configSet = append(configSet, setPrefix+"inspection-limit tcp")
+		if v != nil {
+			inspLimitTCP := v.(map[string]interface{})
+			if v := inspLimitTCP["byte_limit"].(int); v != -1 {
+				configSet = append(configSet, setPrefix+"inspection-limit tcp byte-limit "+strconv.Itoa(v))
+			}
+			if v := inspLimitTCP["packet_limit"].(int); v != -1 {
+				configSet = append(configSet, setPrefix+"inspection-limit tcp packet-limit "+strconv.Itoa(v))
 			}
 		}
-		if v := appIDM["global_offload_byte_limit"].(int); v != -1 {
-			configSet = append(configSet, setPrefix+"global-offload-byte-limit "+strconv.Itoa(v))
-		}
-		if v := appIDM["imap_cache_size"].(int); v != 0 {
-			configSet = append(configSet, setPrefix+"imap-cache-size "+strconv.Itoa(v))
-		}
-		if v := appIDM["imap_cache_timeout"].(int); v != 0 {
-			configSet = append(configSet, setPrefix+"imap-cache-timeout "+strconv.Itoa(v))
-		}
-		for _, v := range appIDM["inspection_limit_tcp"].([]interface{}) {
-			configSet = append(configSet, setPrefix+"inspection-limit tcp")
-			if v != nil {
-				inspLimitTCP := v.(map[string]interface{})
-				if v := inspLimitTCP["byte_limit"].(int); v != -1 {
-					configSet = append(configSet, setPrefix+"inspection-limit tcp byte-limit "+strconv.Itoa(v))
-				}
-				if v := inspLimitTCP["packet_limit"].(int); v != -1 {
-					configSet = append(configSet, setPrefix+"inspection-limit tcp packet-limit "+strconv.Itoa(v))
-				}
+	}
+	for _, v := range appIDM["inspection_limit_udp"].([]interface{}) {
+		configSet = append(configSet, setPrefix+"inspection-limit udp")
+		if v != nil {
+			inspLimitUDP := v.(map[string]interface{})
+			if v := inspLimitUDP["byte_limit"].(int); v != -1 {
+				configSet = append(configSet, setPrefix+"inspection-limit udp byte-limit "+strconv.Itoa(v))
+			}
+			if v := inspLimitUDP["packet_limit"].(int); v != -1 {
+				configSet = append(configSet, setPrefix+"inspection-limit udp packet-limit "+strconv.Itoa(v))
 			}
 		}
-		for _, v := range appIDM["inspection_limit_udp"].([]interface{}) {
-			configSet = append(configSet, setPrefix+"inspection-limit udp")
-			if v != nil {
-				inspLimitUDP := v.(map[string]interface{})
-				if v := inspLimitUDP["byte_limit"].(int); v != -1 {
-					configSet = append(configSet, setPrefix+"inspection-limit udp byte-limit "+strconv.Itoa(v))
-				}
-				if v := inspLimitUDP["packet_limit"].(int); v != -1 {
-					configSet = append(configSet, setPrefix+"inspection-limit udp packet-limit "+strconv.Itoa(v))
-				}
-			}
-		}
-		if v := appIDM["max_memory"].(int); v != 0 {
-			configSet = append(configSet, setPrefix+"max-memory "+strconv.Itoa(v))
-		}
-		if v := appIDM["max_transactions"].(int); v != -1 {
-			configSet = append(configSet, setPrefix+"max-transactions "+strconv.Itoa(v))
-		}
-		if appIDM["micro_apps"].(bool) {
-			configSet = append(configSet, setPrefix+"micro-apps")
-		}
-		if v := appIDM["statistics_interval"].(int); v != 0 {
-			configSet = append(configSet, setPrefix+"statistics interval "+strconv.Itoa(v))
-		}
-	} else {
+	}
+	if v := appIDM["max_memory"].(int); v != 0 {
+		configSet = append(configSet, setPrefix+"max-memory "+strconv.Itoa(v))
+	}
+	if v := appIDM["max_transactions"].(int); v != -1 {
+		configSet = append(configSet, setPrefix+"max-transactions "+strconv.Itoa(v))
+	}
+	if appIDM["micro_apps"].(bool) {
+		configSet = append(configSet, setPrefix+"micro-apps")
+	}
+	if v := appIDM["statistics_interval"].(int); v != 0 {
+		configSet = append(configSet, setPrefix+"statistics interval "+strconv.Itoa(v))
+	}
+	if len(configSet) == 0 {
 		return configSet, fmt.Errorf("application_identification block is empty")
 	}
 

--- a/website/docs/r/services.html.markdown
+++ b/website/docs/r/services.html.markdown
@@ -28,7 +28,7 @@ resource junos_services "services" {
 
 The following arguments are supported:
 
-* `application_identification` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare 'application-identification' configuration. See the [`application_identification` arguments] (#application_identification-arguments) block.
+* `application_identification` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to enable 'application-identification'. See the [`application_identification` arguments] (#application_identification-arguments) block.
 * `security_intelligence` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare 'security-intelligence' configuration. See the [`security_intelligence` arguments] (#security_intelligence-arguments) block.
 
 ---


### PR DESCRIPTION
BUG FIXES:
* fix errors not generated with certain nested blocks empty and default integer argument = -1 in these blocks
* resource/`junos_services`: fix set/read/delete empty `application_identification` block to enable 'application-identification'