### PR TITLE
Fixes #189: add support for user-identification of services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ENHANCEMENTS:
 * add `junos_services_user_identification_device_identity_profile` resource (Fixes parts of #189)
 * resource/`junos_security_global_policy`: add `match_source_end_user_profile` argument inside `policy` argument
+* resource/`junos_security_policy`: add `match_source_end_user_profile` argument inside `policy` argument
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## upcoming release
 ENHANCEMENTS:
 * add `junos_services_user_identification_device_identity_profile` resource (Fixes parts of #189)
+* resource/`junos_security_global_policy`: add `match_source_end_user_profile` argument inside `policy` argument
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## upcoming release
 ENHANCEMENTS:
+* add `junos_services_user_identification_device_identity_profile` resource (Fixes parts of #189)
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## upcoming release
 ENHANCEMENTS:
+* add `junos_services_user_identification_ad_access_domain` resource
 * add `junos_services_user_identification_device_identity_profile` resource (Fixes parts of #189)
 * resource/`junos_security_global_policy`: add `match_source_end_user_profile` argument inside `policy` argument
 * resource/`junos_security_policy`: add `match_source_end_user_profile` argument inside `policy` argument

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ ENHANCEMENTS:
 * add `junos_services_user_identification_device_identity_profile` resource (Fixes parts of #189)
 * resource/`junos_security_global_policy`: add `match_source_end_user_profile` argument inside `policy` argument
 * resource/`junos_security_policy`: add `match_source_end_user_profile` argument inside `policy` argument
+* resource/`junos_services`: add `user_identification` argument (Fixes parts of #189)
 
 BUG FIXES:
 

--- a/junos/func_common.go
+++ b/junos/func_common.go
@@ -17,6 +17,7 @@ type FormatName int
 const (
 	FormatDefault FormatName = iota
 	FormatAddressName
+	FormatDefAndDots
 )
 
 func appendDiagWarns(diags *diag.Diagnostics, warns []error) {
@@ -150,12 +151,18 @@ func validateNameObjectJunos(exclude []string, length int, format FormatName) sc
 			return (r < 'a' || r > 'z') && (r < 'A' || r > 'Z') && (r < '0' || r > '9') &&
 				r != '-' && r != '_' && r != ':' && r != '.' && r != '/'
 		}
+		f3 := func(r rune) bool {
+			return (r < 'a' || r > 'z') && (r < 'A' || r > 'Z') && (r < '0' || r > '9') &&
+				r != '-' && r != '_' && r != '.'
+		}
 		resultRune := -1
 		switch format {
 		case FormatDefault:
 			resultRune = strings.IndexFunc(v, f1)
 		case FormatAddressName:
 			resultRune = strings.IndexFunc(v, f2)
+		case FormatDefAndDots:
+			resultRune = strings.IndexFunc(v, f3)
 		default:
 			diags = append(diags, diag.Diagnostic{
 				Severity:      diag.Error,

--- a/junos/provider.go
+++ b/junos/provider.go
@@ -143,6 +143,7 @@ func Provider() *schema.Provider {
 			"junos_services_proxy_profile":                               resourceServicesProxyProfile(),
 			"junos_services_security_intelligence_policy":                resourceServicesSecurityIntellPolicy(),
 			"junos_services_security_intelligence_profile":               resourceServicesSecurityIntellProfile(),
+			"junos_services_user_identification_ad_access_domain":        resourceServicesUserIdentAdAccessDomain(),
 			"junos_services_user_identification_device_identity_profile": resourceServicesUserIdentDeviceIdentityProfile(),
 			"junos_snmp":                                                 resourceSnmp(),
 			"junos_snmp_clientlist":                                      resourceSnmpClientlist(),

--- a/junos/provider.go
+++ b/junos/provider.go
@@ -143,6 +143,7 @@ func Provider() *schema.Provider {
 			"junos_services_proxy_profile":                               resourceServicesProxyProfile(),
 			"junos_services_security_intelligence_policy":                resourceServicesSecurityIntellPolicy(),
 			"junos_services_security_intelligence_profile":               resourceServicesSecurityIntellProfile(),
+			"junos_services_user_identification_device_identity_profile": resourceServicesUserIdentDeviceIdentityProfile(),
 			"junos_snmp":                                                 resourceSnmp(),
 			"junos_snmp_clientlist":                                      resourceSnmpClientlist(),
 			"junos_snmp_community":                                       resourceSnmpCommunity(),

--- a/junos/resource_security_global_policy.go
+++ b/junos/resource_security_global_policy.go
@@ -94,6 +94,11 @@ func resourceSecurityGlobalPolicy() *schema.Resource {
 							Type:     schema.TypeBool,
 							Optional: true,
 						},
+						"match_source_end_user_profile": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "profile can also be named device identity profile",
+						},
 						"permit_application_services": {
 							Type:     schema.TypeList,
 							Optional: true,
@@ -369,6 +374,9 @@ func setSecurityGlobalPolicy(d *schema.ResourceData, m interface{}, jnprSess *Ne
 		if policy["match_source_address_excluded"].(bool) {
 			configSet = append(configSet, setPrefixPolicy+" match source-address-excluded")
 		}
+		if v := policy["match_source_end_user_profile"].(string); v != "" {
+			configSet = append(configSet, setPrefixPolicy+" match source-end-user-profile \""+v+"\"")
+		}
 		if len(policy["permit_application_services"].([]interface{})) > 0 {
 			if policy["permit_application_services"].([]interface{})[0] == nil {
 				return fmt.Errorf("permit_application_services block is empty")
@@ -435,6 +443,9 @@ func readSecurityGlobalPolicy(m interface{}, jnprSess *NetconfObject) (globalPol
 						strings.TrimPrefix(itemTrimPolicy, "match dynamic-application "))
 				case strings.HasPrefix(itemTrimPolicy, "match source-address-excluded"):
 					policy["match_source_address_excluded"] = true
+				case strings.HasPrefix(itemTrimPolicy, "match source-end-user-profile "):
+					policy["match_source_end_user_profile"] = strings.Trim(strings.TrimPrefix(
+						itemTrimPolicy, "match source-end-user-profile "), "\"")
 				case strings.HasPrefix(itemTrimPolicy, "then "):
 					switch {
 					case strings.HasSuffix(itemTrimPolicy, permitWord),
@@ -491,6 +502,7 @@ func genMapGlobalPolicyWithName(name string) map[string]interface{} {
 		"match_destination_address_excluded": false,
 		"match_dynamic_application":          make([]string, 0),
 		"match_source_address_excluded":      false,
+		"match_source_end_user_profile":      "",
 		"permit_application_services":        make([]map[string]interface{}, 0),
 	}
 }

--- a/junos/resource_security_global_policy_test.go
+++ b/junos/resource_security_global_policy_test.go
@@ -63,6 +63,14 @@ resource "junos_security_address_book" "testacc_secglobpolicy" {
     value = "192.0.2.2/32"
   }
 }
+resource "junos_services_user_identification_device_identity_profile" "profile" {
+  name   = "testacc_secglobpolicy"
+  domain = "testacc_secglobpolicy"
+  attribute {
+    name  = "device-identity"
+    value = ["testacc_secglobpolicy"]
+  }
+}
 resource junos_security_global_policy "testacc_secglobpolicy" {
   depends_on = [
     junos_security_address_book.testacc_secglobpolicy
@@ -74,6 +82,7 @@ resource junos_security_global_policy "testacc_secglobpolicy" {
     match_destination_address_excluded = true
     match_application                  = ["any"]
     match_dynamic_application          = ["junos:web:wiki", "junos:web:infrastructure"]
+    match_source_end_user_profile      = junos_services_user_identification_device_identity_profile.profile.name
     match_from_zone                    = [junos_security_zone.testacc_secglobpolicy1.name]
     match_to_zone                      = [junos_security_zone.testacc_secglobpolicy2.name]
   }
@@ -97,6 +106,14 @@ resource "junos_security_address_book" "testacc_secglobpolicy" {
   network_address {
     name  = "green"
     value = "192.0.2.2/32"
+  }
+}
+resource "junos_services_user_identification_device_identity_profile" "profile" {
+  name   = "testacc_secglobpolicy"
+  domain = "testacc_secglobpolicy"
+  attribute {
+    name  = "device-identity"
+    value = ["testacc_secglobpolicy"]
   }
 }
 resource junos_security_global_policy "testacc_secglobpolicy" {

--- a/junos/resource_security_policy.go
+++ b/junos/resource_security_policy.go
@@ -96,6 +96,11 @@ func resourceSecurityPolicy() *schema.Resource {
 							Type:     schema.TypeBool,
 							Optional: true,
 						},
+						"match_source_end_user_profile": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "profile can also be named device identity profile",
+						},
 						"permit_application_services": {
 							Type:     schema.TypeList,
 							Optional: true,
@@ -415,6 +420,9 @@ func setSecurityPolicy(d *schema.ResourceData, m interface{}, jnprSess *NetconfO
 		if policy["match_source_address_excluded"].(bool) {
 			configSet = append(configSet, setPrefixPolicy+" match source-address-excluded")
 		}
+		if v := policy["match_source_end_user_profile"].(string); v != "" {
+			configSet = append(configSet, setPrefixPolicy+" match source-end-user-profile \""+v+"\"")
+		}
 		if policy["permit_tunnel_ipsec_vpn"].(string) != "" {
 			if policy["then"].(string) != permitWord {
 				return fmt.Errorf("conflict policy then %v and policy permit_tunnel_ipsec_vpn",
@@ -490,6 +498,9 @@ func readSecurityPolicy(idPolicy string, m interface{}, jnprSess *NetconfObject)
 						strings.TrimPrefix(itemTrimPolicy, "match dynamic-application "))
 				case strings.HasPrefix(itemTrimPolicy, "match source-address-excluded"):
 					policy["match_source_address_excluded"] = true
+				case strings.HasPrefix(itemTrimPolicy, "match source-end-user-profile "):
+					policy["match_source_end_user_profile"] = strings.Trim(strings.TrimPrefix(
+						itemTrimPolicy, "match source-end-user-profile "), "\"")
 				case strings.HasPrefix(itemTrimPolicy, "then "):
 					switch {
 					case strings.HasSuffix(itemTrimPolicy, permitWord),
@@ -554,6 +565,7 @@ func genMapPolicyWithName(name string) map[string]interface{} {
 		"match_destination_address_excluded": false,
 		"match_dynamic_application":          make([]string, 0),
 		"match_source_address_excluded":      false,
+		"match_source_end_user_profile":      "",
 		"permit_application_services":        make([]map[string]interface{}, 0),
 		"permit_tunnel_ipsec_vpn":            "",
 	}

--- a/junos/resource_security_policy_test.go
+++ b/junos/resource_security_policy_test.go
@@ -61,18 +61,27 @@ func TestAccJunosSecurityPolicy_basic(t *testing.T) {
 
 func testAccJunosSecurityPolicyConfigCreate() string {
 	return `
+resource "junos_services_user_identification_device_identity_profile" "profile" {
+  name   = "testacc_securityPolicy"
+  domain = "testacc_securityPolicy"
+  attribute {
+    name  = "device-identity"
+    value = ["testacc_securityPolicy"]
+  }
+}
 resource junos_security_policy testacc_securityPolicy {
   from_zone = junos_security_zone.testacc_seczonePolicy1.name
   to_zone   = junos_security_zone.testacc_seczonePolicy1.name
   policy {
-    name                      = "testacc_Policy_1"
-    match_source_address      = ["testacc_address1"]
-    match_destination_address = ["any"]
-    match_application         = ["junos-ssh"]
-    match_dynamic_application = ["junos:web:wiki", "junos:web:infrastructure"]
-    log_init                  = true
-    log_close                 = true
-    count                     = true
+    name                          = "testacc_Policy_1"
+    match_source_address          = ["testacc_address1"]
+    match_destination_address     = ["any"]
+    match_application             = ["junos-ssh"]
+    match_dynamic_application     = ["junos:web:wiki", "junos:web:infrastructure"]
+    match_source_end_user_profile = junos_services_user_identification_device_identity_profile.profile.name
+    log_init                      = true
+    log_close                     = true
+    count                         = true
   }
 }
 
@@ -88,6 +97,14 @@ resource junos_security_zone testacc_seczonePolicy1 {
 
 func testAccJunosSecurityPolicyConfigUpdate() string {
 	return `
+resource "junos_services_user_identification_device_identity_profile" "profile" {
+  name   = "testacc_securityPolicy"
+  domain = "testacc_securityPolicy"
+  attribute {
+    name  = "device-identity"
+    value = ["testacc_securityPolicy"]
+  }
+}
 resource junos_security_policy testacc_securityPolicy {
   from_zone = junos_security_zone.testacc_seczonePolicy1.name
   to_zone   = junos_security_zone.testacc_seczonePolicy1.name

--- a/junos/resource_services_test.go
+++ b/junos/resource_services_test.go
@@ -220,6 +220,17 @@ resource "junos_services" "testacc" {
   application_identification {
     no_application_system_cache = true
   }
+  user_identification {
+    ad_access {
+      auth_entry_timeout           = 30
+      filter_exclude               = ["192.0.2.3/32", "192.0.2.2/32"]
+      filter_include               = ["192.0.2.1/32", "192.0.2.0/32"]
+      firewall_auth_forced_timeout = 30
+      invalid_auth_entry_timeout   = 30
+      no_on_demand_probe           = true
+      wmi_timeout                  = 30
+    }
+  }
 }
   `
 }

--- a/junos/resource_services_test.go
+++ b/junos/resource_services_test.go
@@ -57,6 +57,17 @@ resource "junos_services_proxy_profile" "testacc_services" {
   protocol_http_host = "192.0.2.1"
   protocol_http_port = 3128
 }
+resource "junos_security_address_book" "testacc_services" {
+  name = "testacc_services"
+  network_address {
+    name  = "testacc_services_add"
+    value = "192.0.2.0/25"
+  }
+  address_set {
+    name    = "testacc_services_set"
+    address = ["testacc_services_add"]
+  }
+}
 resource "junos_services" "testacc" {
   application_identification {
     application_system_cache {}
@@ -72,6 +83,36 @@ resource "junos_services" "testacc" {
     proxy_profile        = junos_services_proxy_profile.testacc_services.name
     url                  = "https://example.com/api/manifest.xml"
     url_parameter        = "test_param"
+  }
+  user_identification {
+    device_info_auth_source = "network-access-controller"
+    identity_management {
+      connection {
+        primary_address          = "192.0.2.254"
+        primary_client_id        = "clientID"
+        primary_client_secret    = "mySecret"
+        connect_method           = "https"
+        port                     = 2000
+        primary_ca_certificate   = "ca"
+        query_api                = "user_query/v2"
+        secondary_address        = "192.0.2.253"
+        secondary_ca_certificate = "ca2"
+        secondary_client_id      = "clientID2"
+        secondary_client_secret  = "mySecret2"
+        token_api                = "oauth_token/oauth"
+      }
+      authentication_entry_timeout         = 60
+      batch_query_items_per_batch          = 100
+      batch_query_interval                 = 30
+      filter_domain                        = ["test3", "test2"]
+      filter_exclude_ip_address_book       = junos_security_address_book.testacc_services.name
+      filter_exclude_ip_address_set        = junos_security_address_book.testacc_services.address_set[0].name
+      filter_include_ip_address_book       = junos_security_address_book.testacc_services.name
+      filter_include_ip_address_set        = junos_security_address_book.testacc_services.address_set[0].name
+      invalid_authentication_entry_timeout = 60
+      ip_query_disable                     = true
+      ip_query_delay_time                  = 30
+    }
   }
 }
 `
@@ -93,6 +134,17 @@ resource "junos_services_security_intelligence_profile" "testacc_services" {
       threat_level = [1]
     }
     then_action = "permit"
+  }
+}
+resource "junos_security_address_book" "testacc_services" {
+  name = "testacc_services"
+  network_address {
+    name  = "testacc_services_add"
+    value = "192.0.2.0/25"
+  }
+  address_set {
+    name    = "testacc_services_set"
+    address = ["testacc_services_add"]
   }
 }
 resource "junos_services" "testacc" {
@@ -126,6 +178,21 @@ resource "junos_services" "testacc" {
     proxy_profile = junos_services_proxy_profile.testacc_services.name
     url           = "https://example.com/api/manifest.xml"
     url_parameter = "test_param_update"
+  }
+  user_identification {
+    device_info_auth_source = "network-access-controller"
+    identity_management {
+      connection {
+        primary_address        = "192.0.2.254"
+        primary_client_id      = "clientID"
+        primary_client_secret  = "mySecret2"
+        connect_method         = "https"
+        port                   = 2000
+        primary_ca_certificate = "ca@2"
+        query_api              = "user_query/v2"
+        token_api              = "oauth_token/oauth"
+      }
+    }
   }
 }
 `

--- a/junos/resource_services_user_identification_ad_access_domain.go
+++ b/junos/resource_services_user_identification_ad_access_domain.go
@@ -1,0 +1,497 @@
+package junos
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	jdecode "github.com/jeremmfr/junosdecode"
+)
+
+type svcUserIdentAdAccessDomainOptions struct {
+	name                      string
+	userName                  string
+	userPassword              string
+	domainController          []map[string]interface{}
+	ipUserMappingDiscoveryWmi []map[string]interface{}
+	userGroupMappingLdap      []map[string]interface{}
+}
+
+func resourceServicesUserIdentAdAccessDomain() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceServicesUserIdentAdAccessDomainCreate,
+		ReadContext:   resourceServicesUserIdentAdAccessDomainRead,
+		UpdateContext: resourceServicesUserIdentAdAccessDomainUpdate,
+		DeleteContext: resourceServicesUserIdentAdAccessDomainDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceServicesUserIdentAdAccessDomainImport,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:             schema.TypeString,
+				ForceNew:         true,
+				Required:         true,
+				ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, FormatDefAndDots),
+			},
+			"user_name": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, FormatDefAndDots),
+			},
+			"user_password": {
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
+			},
+			"domain_controller": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:             schema.TypeString,
+							Required:         true,
+							ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, FormatDefAndDots),
+						},
+						"address": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.IsIPAddress,
+						},
+					},
+				},
+			},
+			"ip_user_mapping_discovery_wmi": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"event_log_scanning_interval": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(5, 60),
+						},
+						"initial_event_log_timespan": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(1, 168),
+						},
+					},
+				},
+			},
+			"user_group_mapping_ldap": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"base": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"address": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"auth_algo_simple": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"ssl": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"user_name": {
+							Type:             schema.TypeString,
+							Optional:         true,
+							ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, FormatDefAndDots),
+						},
+						"user_password": {
+							Type:      schema.TypeString,
+							Optional:  true,
+							Sensitive: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceServicesUserIdentAdAccessDomainCreate(ctx context.Context,
+	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	if sess.junosFakeCreateSetFile != "" {
+		if err := setServicesUserIdentAdAccessDomain(d, m, nil); err != nil {
+			return diag.FromErr(err)
+		}
+		d.SetId(d.Get("name").(string))
+
+		return nil
+	}
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	sess.configLock(jnprSess)
+	var diagWarns diag.Diagnostics
+	svcUserIdentAdAccessDomainExists, err :=
+		checkServicesUserIdentAdAccessDomainExists(d.Get("name").(string), m, jnprSess)
+	if err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	if svcUserIdentAdAccessDomainExists {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns,
+			diag.FromErr(fmt.Errorf(
+				"services user-identification active-directory-access domain %v already exists", d.Get("name").(string)))...)
+	}
+
+	if err := setServicesUserIdentAdAccessDomain(d, m, jnprSess); err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	warns, err := sess.commitConf("create resource junos_services_user_identification_ad_access_domain", jnprSess)
+	appendDiagWarns(&diagWarns, warns)
+	if err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	svcUserIdentAdAccessDomainExists, err =
+		checkServicesUserIdentAdAccessDomainExists(d.Get("name").(string), m, jnprSess)
+	if err != nil {
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	if svcUserIdentAdAccessDomainExists {
+		d.SetId(d.Get("name").(string))
+	} else {
+		return append(diagWarns, diag.FromErr(fmt.Errorf(
+			"services user-identification active-directory-access domain %v "+
+				"not exists after commit => check your config", d.Get("name").(string)))...)
+	}
+
+	return append(diagWarns, resourceServicesUserIdentAdAccessDomainReadWJnprSess(d, m, jnprSess)...)
+}
+
+func resourceServicesUserIdentAdAccessDomainRead(ctx context.Context,
+	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+
+	return resourceServicesUserIdentAdAccessDomainReadWJnprSess(d, m, jnprSess)
+}
+
+func resourceServicesUserIdentAdAccessDomainReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
+	svcUserIdentAdAccessDomainOptions, err :=
+		readServicesUserIdentAdAccessDomain(d.Get("name").(string), m, jnprSess)
+	mutex.Unlock()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if svcUserIdentAdAccessDomainOptions.name == "" {
+		d.SetId("")
+	} else {
+		fillServicesUserIdentAdAccessDomainData(d, svcUserIdentAdAccessDomainOptions)
+	}
+
+	return nil
+}
+
+func resourceServicesUserIdentAdAccessDomainUpdate(ctx context.Context,
+	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	d.Partial(true)
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	sess.configLock(jnprSess)
+	var diagWarns diag.Diagnostics
+	if err := delServicesUserIdentAdAccessDomain(d.Get("name").(string), m, jnprSess); err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	if err := setServicesUserIdentAdAccessDomain(d, m, jnprSess); err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	warns, err := sess.commitConf("update resource junos_services_user_identification_ad_access_domain", jnprSess)
+	appendDiagWarns(&diagWarns, warns)
+	if err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	d.Partial(false)
+
+	return append(diagWarns, resourceServicesUserIdentAdAccessDomainReadWJnprSess(d, m, jnprSess)...)
+}
+
+func resourceServicesUserIdentAdAccessDomainDelete(ctx context.Context,
+	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	sess.configLock(jnprSess)
+	var diagWarns diag.Diagnostics
+	if err := delServicesUserIdentAdAccessDomain(d.Get("name").(string), m, jnprSess); err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	warns, err := sess.commitConf("delete resource junos_services_user_identification_ad_access_domain", jnprSess)
+	appendDiagWarns(&diagWarns, warns)
+	if err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+
+	return diagWarns
+}
+
+func resourceServicesUserIdentAdAccessDomainImport(
+	d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return nil, err
+	}
+	defer sess.closeSession(jnprSess)
+	result := make([]*schema.ResourceData, 1)
+	svcUserIdentAdAccessDomainExists, err := checkServicesUserIdentAdAccessDomainExists(d.Id(), m, jnprSess)
+	if err != nil {
+		return nil, err
+	}
+	if !svcUserIdentAdAccessDomainExists {
+		return nil, fmt.Errorf("don't find services user-identification "+
+			"active-directory-access domain with id '%v' (id must be <name>)", d.Id())
+	}
+	svcUserIdentAdAccessDomainOptions, err := readServicesUserIdentAdAccessDomain(d.Id(), m, jnprSess)
+	if err != nil {
+		return nil, err
+	}
+	fillServicesUserIdentAdAccessDomainData(d, svcUserIdentAdAccessDomainOptions)
+
+	result[0] = d
+
+	return result, nil
+}
+
+func checkServicesUserIdentAdAccessDomainExists(
+	domain string, m interface{}, jnprSess *NetconfObject) (bool, error) {
+	sess := m.(*Session)
+	profileConfig, err := sess.command("show configuration services user-identification "+
+		"active-directory-access domain "+domain+" | display set", jnprSess)
+	if err != nil {
+		return false, err
+	}
+	if profileConfig == emptyWord {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func setServicesUserIdentAdAccessDomain(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) error {
+	sess := m.(*Session)
+	configSet := make([]string, 0)
+
+	setPrefix := "set services user-identification active-directory-access domain " + d.Get("name").(string) + " "
+	configSet = append(configSet, setPrefix+"user "+d.Get("user_name").(string))
+	configSet = append(configSet, setPrefix+"user password \""+d.Get("user_password").(string)+"\"")
+	for _, v := range d.Get("domain_controller").([]interface{}) {
+		domainController := v.(map[string]interface{})
+		configSet = append(configSet, setPrefix+"domain-controller "+domainController["name"].(string)+
+			" address "+domainController["address"].(string))
+	}
+	for _, v := range d.Get("ip_user_mapping_discovery_wmi").([]interface{}) {
+		configSet = append(configSet, setPrefix+"ip-user-mapping discovery-method wmi")
+		if v != nil {
+			wmi := v.(map[string]interface{})
+			if v2 := wmi["event_log_scanning_interval"].(int); v2 != 0 {
+				configSet = append(configSet,
+					setPrefix+"ip-user-mapping discovery-method wmi event-log-scanning-interval "+strconv.Itoa(v2))
+			}
+			if v2 := wmi["initial_event_log_timespan"].(int); v2 != 0 {
+				configSet = append(configSet,
+					setPrefix+"ip-user-mapping discovery-method wmi initial-event-log-timespan "+strconv.Itoa(v2))
+			}
+		}
+	}
+	for _, v := range d.Get("user_group_mapping_ldap").([]interface{}) {
+		ldap := v.(map[string]interface{})
+		configSet = append(configSet, setPrefix+"user-group-mapping ldap base \""+ldap["base"].(string)+"\"")
+		for _, v2 := range ldap["address"].([]interface{}) {
+			configSet = append(configSet, setPrefix+"user-group-mapping ldap address "+v2.(string))
+		}
+		if ldap["auth_algo_simple"].(bool) {
+			configSet = append(configSet, setPrefix+"user-group-mapping ldap authentication-algorithm simple")
+		}
+		if ldap["ssl"].(bool) {
+			configSet = append(configSet, setPrefix+"user-group-mapping ldap ssl")
+		}
+		if v2 := ldap["user_name"].(string); v2 != "" {
+			configSet = append(configSet, setPrefix+"user-group-mapping ldap user "+v2)
+		}
+		if v2 := ldap["user_password"].(string); v2 != "" {
+			configSet = append(configSet, setPrefix+"user-group-mapping ldap user password \""+v2+"\"")
+		}
+	}
+
+	return sess.configSet(configSet, jnprSess)
+}
+
+func readServicesUserIdentAdAccessDomain(domain string, m interface{}, jnprSess *NetconfObject) (
+	svcUserIdentAdAccessDomainOptions, error) {
+	sess := m.(*Session)
+	var confRead svcUserIdentAdAccessDomainOptions
+
+	profileConfig, err := sess.command("show configuration services user-identification "+
+		"active-directory-access domain "+domain+" | display set relative", jnprSess)
+	if err != nil {
+		return confRead, err
+	}
+	if profileConfig != emptyWord {
+		confRead.name = domain
+		for _, item := range strings.Split(profileConfig, "\n") {
+			if strings.Contains(item, "<configuration-output>") {
+				continue
+			}
+			if strings.Contains(item, "</configuration-output>") {
+				break
+			}
+			itemTrim := strings.TrimPrefix(item, setLineStart)
+			switch {
+			case strings.HasPrefix(itemTrim, "user password "):
+				var err error
+				confRead.userPassword, err = jdecode.Decode(strings.Trim(strings.TrimPrefix(itemTrim, "user password "), "\""))
+				if err != nil {
+					return confRead, fmt.Errorf("failed to decode user password : %w", err)
+				}
+			case strings.HasPrefix(itemTrim, "user "):
+				confRead.userName = strings.TrimPrefix(itemTrim, "user ")
+			case strings.HasPrefix(itemTrim, "domain-controller ") &&
+				strings.Contains(itemTrim, " address "):
+				itemTrimSplit := strings.Split(itemTrim, " ")
+				confRead.domainController = append(confRead.domainController, map[string]interface{}{
+					"name":    itemTrimSplit[1],
+					"address": itemTrimSplit[3],
+				})
+			case strings.HasPrefix(itemTrim, "ip-user-mapping discovery-method wmi"):
+				if len(confRead.ipUserMappingDiscoveryWmi) == 0 {
+					confRead.ipUserMappingDiscoveryWmi = append(confRead.ipUserMappingDiscoveryWmi, map[string]interface{}{
+						"event_log_scanning_interval": 0,
+						"initial_event_log_timespan":  0,
+					})
+				}
+				switch {
+				case strings.HasPrefix(itemTrim, "ip-user-mapping discovery-method wmi event-log-scanning-interval "):
+					var err error
+					confRead.ipUserMappingDiscoveryWmi[0]["event_log_scanning_interval"], err =
+						strconv.Atoi(strings.TrimPrefix(itemTrim, "ip-user-mapping discovery-method wmi event-log-scanning-interval "))
+					if err != nil {
+						return confRead, fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+					}
+				case strings.HasPrefix(itemTrim, "ip-user-mapping discovery-method wmi initial-event-log-timespan "):
+					var err error
+					confRead.ipUserMappingDiscoveryWmi[0]["initial_event_log_timespan"], err =
+						strconv.Atoi(strings.TrimPrefix(itemTrim, "ip-user-mapping discovery-method wmi initial-event-log-timespan "))
+					if err != nil {
+						return confRead, fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+					}
+				}
+			case strings.HasPrefix(itemTrim, "user-group-mapping ldap "):
+				if len(confRead.userGroupMappingLdap) == 0 {
+					confRead.userGroupMappingLdap = append(confRead.userGroupMappingLdap, map[string]interface{}{
+						"base":             "",
+						"address":          make([]string, 0),
+						"auth_algo_simple": false,
+						"ssl":              false,
+						"user_name":        "",
+						"user_password":    "",
+					})
+				}
+				switch {
+				case strings.HasPrefix(itemTrim, "user-group-mapping ldap base "):
+					confRead.userGroupMappingLdap[0]["base"] =
+						strings.Trim(strings.TrimPrefix(itemTrim, "user-group-mapping ldap base "), "\"")
+				case strings.HasPrefix(itemTrim, "user-group-mapping ldap address "):
+					confRead.userGroupMappingLdap[0]["address"] = append(confRead.userGroupMappingLdap[0]["address"].([]string),
+						strings.TrimPrefix(itemTrim, "user-group-mapping ldap address "))
+				case itemTrim == "user-group-mapping ldap authentication-algorithm simple":
+					confRead.userGroupMappingLdap[0]["auth_algo_simple"] = true
+				case itemTrim == "user-group-mapping ldap ssl":
+					confRead.userGroupMappingLdap[0]["ssl"] = true
+				case strings.HasPrefix(itemTrim, "user-group-mapping ldap user password "):
+					var err error
+					confRead.userGroupMappingLdap[0]["user_password"], err =
+						jdecode.Decode(strings.Trim(strings.TrimPrefix(itemTrim, "user-group-mapping ldap user password "), "\""))
+					if err != nil {
+						return confRead, fmt.Errorf("failed to decode user password : %w", err)
+					}
+				case strings.HasPrefix(itemTrim, "user-group-mapping ldap user "):
+					confRead.userGroupMappingLdap[0]["user_name"] = strings.TrimPrefix(itemTrim, "user-group-mapping ldap user ")
+				}
+			}
+		}
+	}
+
+	return confRead, nil
+}
+
+func delServicesUserIdentAdAccessDomain(domain string, m interface{}, jnprSess *NetconfObject) error {
+	sess := m.(*Session)
+	configSet := []string{
+		"delete services user-identification active-directory-access domain " + domain,
+	}
+
+	return sess.configSet(configSet, jnprSess)
+}
+
+func fillServicesUserIdentAdAccessDomainData(
+	d *schema.ResourceData, svcUserIdentAdAccessDomainOptions svcUserIdentAdAccessDomainOptions) {
+	if tfErr := d.Set("name", svcUserIdentAdAccessDomainOptions.name); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("user_name", svcUserIdentAdAccessDomainOptions.userName); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("user_password", svcUserIdentAdAccessDomainOptions.userPassword); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("domain_controller", svcUserIdentAdAccessDomainOptions.domainController); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("ip_user_mapping_discovery_wmi",
+		svcUserIdentAdAccessDomainOptions.ipUserMappingDiscoveryWmi); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("user_group_mapping_ldap", svcUserIdentAdAccessDomainOptions.userGroupMappingLdap); tfErr != nil {
+		panic(tfErr)
+	}
+}

--- a/junos/resource_services_user_identification_device_identity_profile.go
+++ b/junos/resource_services_user_identification_device_identity_profile.go
@@ -1,0 +1,334 @@
+package junos
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type svcUserIdentDevIdentProfileOptions struct {
+	name      string
+	domain    string
+	attribute []map[string]interface{}
+}
+
+func resourceServicesUserIdentDeviceIdentityProfile() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceServicesUserIdentDeviceIdentityProfileCreate,
+		ReadContext:   resourceServicesUserIdentDeviceIdentityProfileRead,
+		UpdateContext: resourceServicesUserIdentDeviceIdentityProfileUpdate,
+		DeleteContext: resourceServicesUserIdentDeviceIdentityProfileDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceServicesUserIdentDeviceIdentityProfileImport,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:             schema.TypeString,
+				ForceNew:         true,
+				Required:         true,
+				ValidateDiagFunc: validateNameObjectJunos([]string{"any"}, 64, FormatDefAndDots),
+			},
+			"domain": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, FormatDefAndDots),
+			},
+			"attribute": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:             schema.TypeString,
+							Required:         true,
+							ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, FormatDefAndDots),
+						},
+						"value": {
+							Type:     schema.TypeSet,
+							Required: true,
+							MinItems: 1,
+							MaxItems: 20,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceServicesUserIdentDeviceIdentityProfileCreate(ctx context.Context,
+	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	if sess.junosFakeCreateSetFile != "" {
+		if err := setServicesUserIdentDeviceIdentityProfile(d, m, nil); err != nil {
+			return diag.FromErr(err)
+		}
+		d.SetId(d.Get("name").(string))
+
+		return nil
+	}
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	sess.configLock(jnprSess)
+	var diagWarns diag.Diagnostics
+	svcUserIdentDevIdentProfileExists, err :=
+		checkServicesUserIdentDeviceIdentityProfileExists(d.Get("name").(string), m, jnprSess)
+	if err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	if svcUserIdentDevIdentProfileExists {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns,
+			diag.FromErr(fmt.Errorf(
+				"services user-identification device-information end-user-profile %v already exists", d.Get("name").(string)))...)
+	}
+
+	if err := setServicesUserIdentDeviceIdentityProfile(d, m, jnprSess); err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	warns, err := sess.commitConf("create resource junos_services_user_identification_device_identity_profile", jnprSess)
+	appendDiagWarns(&diagWarns, warns)
+	if err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	svcUserIdentDevIdentProfileExists, err =
+		checkServicesUserIdentDeviceIdentityProfileExists(d.Get("name").(string), m, jnprSess)
+	if err != nil {
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	if svcUserIdentDevIdentProfileExists {
+		d.SetId(d.Get("name").(string))
+	} else {
+		return append(diagWarns, diag.FromErr(fmt.Errorf(
+			"services user-identification device-information end-user-profile %v "+
+				"not exists after commit => check your config", d.Get("name").(string)))...)
+	}
+
+	return append(diagWarns, resourceServicesUserIdentDeviceIdentityProfileReadWJnprSess(d, m, jnprSess)...)
+}
+
+func resourceServicesUserIdentDeviceIdentityProfileRead(ctx context.Context,
+	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+
+	return resourceServicesUserIdentDeviceIdentityProfileReadWJnprSess(d, m, jnprSess)
+}
+
+func resourceServicesUserIdentDeviceIdentityProfileReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
+	svcUserIdentDevIdentProfileOptions, err :=
+		readServicesUserIdentDeviceIdentityProfile(d.Get("name").(string), m, jnprSess)
+	mutex.Unlock()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if svcUserIdentDevIdentProfileOptions.name == "" {
+		d.SetId("")
+	} else {
+		fillServicesUserIdentDeviceIdentityProfileData(d, svcUserIdentDevIdentProfileOptions)
+	}
+
+	return nil
+}
+
+func resourceServicesUserIdentDeviceIdentityProfileUpdate(ctx context.Context,
+	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	d.Partial(true)
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	sess.configLock(jnprSess)
+	var diagWarns diag.Diagnostics
+	if err := delServicesUserIdentDeviceIdentityProfile(d.Get("name").(string), m, jnprSess); err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	if err := setServicesUserIdentDeviceIdentityProfile(d, m, jnprSess); err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	warns, err := sess.commitConf("update resource junos_services_user_identification_device_identity_profile", jnprSess)
+	appendDiagWarns(&diagWarns, warns)
+	if err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	d.Partial(false)
+
+	return append(diagWarns, resourceServicesUserIdentDeviceIdentityProfileReadWJnprSess(d, m, jnprSess)...)
+}
+
+func resourceServicesUserIdentDeviceIdentityProfileDelete(ctx context.Context,
+	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	sess.configLock(jnprSess)
+	var diagWarns diag.Diagnostics
+	if err := delServicesUserIdentDeviceIdentityProfile(d.Get("name").(string), m, jnprSess); err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	warns, err := sess.commitConf("delete resource junos_services_user_identification_device_identity_profile", jnprSess)
+	appendDiagWarns(&diagWarns, warns)
+	if err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+
+	return diagWarns
+}
+
+func resourceServicesUserIdentDeviceIdentityProfileImport(
+	d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return nil, err
+	}
+	defer sess.closeSession(jnprSess)
+	result := make([]*schema.ResourceData, 1)
+	svcUserIdentDevIdentProfileExists, err := checkServicesUserIdentDeviceIdentityProfileExists(d.Id(), m, jnprSess)
+	if err != nil {
+		return nil, err
+	}
+	if !svcUserIdentDevIdentProfileExists {
+		return nil, fmt.Errorf("don't find services user-identification "+
+			"device-information end-user-profile with id '%v' (id must be <name>)", d.Id())
+	}
+	svcUserIdentDevIdentProfileOptions, err := readServicesUserIdentDeviceIdentityProfile(d.Id(), m, jnprSess)
+	if err != nil {
+		return nil, err
+	}
+	fillServicesUserIdentDeviceIdentityProfileData(d, svcUserIdentDevIdentProfileOptions)
+
+	result[0] = d
+
+	return result, nil
+}
+
+func checkServicesUserIdentDeviceIdentityProfileExists(
+	profile string, m interface{}, jnprSess *NetconfObject) (bool, error) {
+	sess := m.(*Session)
+	profileConfig, err := sess.command("show configuration services user-identification "+
+		"device-information end-user-profile profile-name "+profile+" | display set", jnprSess)
+	if err != nil {
+		return false, err
+	}
+	if profileConfig == emptyWord {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func setServicesUserIdentDeviceIdentityProfile(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) error {
+	sess := m.(*Session)
+	configSet := make([]string, 0)
+
+	setPrefix :=
+		"set services user-identification device-information end-user-profile profile-name " + d.Get("name").(string) + " "
+	configSet = append(configSet, setPrefix+"domain-name "+d.Get("domain").(string))
+	for _, v := range d.Get("attribute").([]interface{}) {
+		attribute := v.(map[string]interface{})
+		for _, v2 := range attribute["value"].(*schema.Set).List() {
+			configSet = append(configSet, setPrefix+"attribute "+attribute["name"].(string)+
+				" string \""+v2.(string)+"\"")
+		}
+	}
+
+	return sess.configSet(configSet, jnprSess)
+}
+
+func readServicesUserIdentDeviceIdentityProfile(profile string, m interface{}, jnprSess *NetconfObject) (
+	svcUserIdentDevIdentProfileOptions, error) {
+	sess := m.(*Session)
+	var confRead svcUserIdentDevIdentProfileOptions
+
+	profileConfig, err := sess.command("show configuration services user-identification "+
+		"device-information end-user-profile profile-name "+profile+" | display set relative", jnprSess)
+	if err != nil {
+		return confRead, err
+	}
+	if profileConfig != emptyWord {
+		confRead.name = profile
+		for _, item := range strings.Split(profileConfig, "\n") {
+			if strings.Contains(item, "<configuration-output>") {
+				continue
+			}
+			if strings.Contains(item, "</configuration-output>") {
+				break
+			}
+			itemTrim := strings.TrimPrefix(item, setLineStart)
+			switch {
+			case strings.HasPrefix(itemTrim, "domain-name "):
+				confRead.domain = strings.TrimPrefix(itemTrim, "domain-name ")
+			case strings.HasPrefix(itemTrim, "attribute "):
+				itemTrimCut := strings.Split(itemTrim, " ")
+				attribute := map[string]interface{}{
+					"name":  itemTrimCut[1],
+					"value": make([]string, 0),
+				}
+				attribute, confRead.attribute = copyAndRemoveItemMapList("name", false, attribute, confRead.attribute)
+				attribute["value"] = append(attribute["value"].([]string), strings.Trim(strings.TrimPrefix(
+					itemTrim, "attribute "+itemTrimCut[1]+" string "), "\""))
+				confRead.attribute = append(confRead.attribute, attribute)
+			}
+		}
+	}
+
+	return confRead, nil
+}
+
+func delServicesUserIdentDeviceIdentityProfile(profile string, m interface{}, jnprSess *NetconfObject) error {
+	sess := m.(*Session)
+	configSet := []string{
+		"delete services user-identification device-information end-user-profile profile-name " + profile,
+	}
+
+	return sess.configSet(configSet, jnprSess)
+}
+
+func fillServicesUserIdentDeviceIdentityProfileData(
+	d *schema.ResourceData, svcUserIdentDevIdentProfileOptions svcUserIdentDevIdentProfileOptions) {
+	if tfErr := d.Set("name", svcUserIdentDevIdentProfileOptions.name); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("domain", svcUserIdentDevIdentProfileOptions.domain); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("attribute", svcUserIdentDevIdentProfileOptions.attribute); tfErr != nil {
+		panic(tfErr)
+	}
+}

--- a/junos/resource_services_user_identification_device_identity_profile_test.go
+++ b/junos/resource_services_user_identification_device_identity_profile_test.go
@@ -1,0 +1,68 @@
+package junos_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccJunosServicesUserIdentDeviceIdentityProfile_basic(t *testing.T) {
+	if os.Getenv("TESTACC_SWITCH") == "" {
+		resource.Test(t, resource.TestCase{
+			PreCheck:  func() { testAccPreCheck(t) },
+			Providers: testAccProviders,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccJunosServicesUserIdentDeviceIdentityProfileCreate(),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("junos_services_user_identification_device_identity_profile.testacc_devidProf",
+							"attribute.#", "1"),
+					),
+				},
+				{
+					Config: testAccJunosServicesUserIdentDeviceIdentityProfileUpdate(),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("junos_services_user_identification_device_identity_profile.testacc_devidProf",
+							"attribute.#", "2"),
+					),
+				},
+				{
+					ResourceName:      "junos_services_user_identification_device_identity_profile.testacc_devidProf",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+			},
+		})
+	}
+}
+
+func testAccJunosServicesUserIdentDeviceIdentityProfileCreate() string {
+	return `
+resource "junos_services_user_identification_device_identity_profile" "testacc_devidProf" {
+  name   = "testacc_devidProf.1"
+  domain = "clearpass"
+  attribute {
+    name  = "device-identity"
+    value = ["device1", "barcode scan"]
+  }
+}
+`
+}
+
+func testAccJunosServicesUserIdentDeviceIdentityProfileUpdate() string {
+	return `
+resource "junos_services_user_identification_device_identity_profile" "testacc_devidProf" {
+  name   = "testacc_devidProf.1"
+  domain = "clearpass"
+  attribute {
+    name  = "device-identity"
+    value = ["device1", "barcode scan"]
+  }
+  attribute {
+    name  = "device-category"
+    value = ["category@1"]
+  }
+}
+`
+}

--- a/website/docs/r/security_global_policy.html.markdown
+++ b/website/docs/r/security_global_policy.html.markdown
@@ -55,6 +55,7 @@ The following arguments are supported:
   * `match_destination_address_excluded` - (Optional)(`Bool`) Exclude destination addresses.
   * `match_dynamic_application` - (Optional)(`ListOfString`) List of dynamic application or group match.
   * `match_source_address_excluded` - (Optional)(`Bool`) Exclude source addresses.
+  * `match_source_end_user_profile` - (Optional)(`String`) Match source end user profile (device identity profile).
   * `permit_application_services` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare 'permit application-services' configuration. See the [`permit_application_services` arguments] (#permit_application_services-arguments) block.
 
 ---

--- a/website/docs/r/security_policy.html.markdown
+++ b/website/docs/r/security_policy.html.markdown
@@ -44,6 +44,7 @@ The following arguments are supported:
   * `match_destination_address_excluded` - (Optional)(`Bool`) Exclude destination addresses.
   * `match_dynamic_application` - (Optional)(`ListOfString`) List of dynamic application or group match.
   * `match_source_address_excluded` - (Optional)(`Bool`) Exclude source addresses.
+  * `match_source_end_user_profile` - (Optional)(`String`) Match source end user profile (device identity profile).
   * `permit_tunnel_ipsec_vpn` - (Optional)(`String`) Name of vpn to permit with a tunnel ipsec.
   * `permit_application_services` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html) Define application services for permit. See the [`permit_application_services` arguments for policy](#permit_application_services-arguments-for-policy) block. Max of 1.
 

--- a/website/docs/r/services.html.markdown
+++ b/website/docs/r/services.html.markdown
@@ -75,8 +75,16 @@ The following arguments are supported:
 
 ---
 #### user_identification arguments
+* `ad_access` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to enable 'active-directory-access'. Conflict with `identity_management`.
+  * `auth_entry_timeout` - (Optional)(`Int`) Authentication entry timeout number (0, 10-1440) (minutes).
+  * `filter_exclude` - (Optional)(`ListOfString`) Exclude addresses.
+  * `filter_include` - (Optional)(`ListOfString`) Include addresses.
+  * `firewall_auth_forced_timeout` - (Optional)(`Int`) Firewallauth fallback authentication entry forced timeout number (10-1440) (minutes).
+  * `invalid_auth_entry_timeout` - (Optional)(`Int`) Invalid authentication entry timeout number (0, 10-1440) (minutes).
+  * `no_on_demand_probe` - (Optional)(`bool`) Disable on-demand probe.
+  * `wmi_timeout` - (Optional)(`Int`) Wmi timeout number (3..120 seconds).
 * `device_info_auth_source` - (Optional)(`String`) Configure authentication-source on device information configuration. Need to be 'active-directory' or 'network-access-controller'.
-* `identity_management` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare 'identity-management' configuration. See the [`identity_management` arguments for user_identification] (#identity_management-arguments-for-user_identification) block.
+* `identity_management` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare 'identity-management' configuration. See the [`identity_management` arguments for user_identification] (#identity_management-arguments-for-user_identification) block. Conflict with `ad_access`.
 
 ---
 #### identity_management arguments for user_identification

--- a/website/docs/r/services.html.markdown
+++ b/website/docs/r/services.html.markdown
@@ -30,6 +30,7 @@ The following arguments are supported:
 
 * `application_identification` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare 'application-identification' configuration. See the [`application_identification` arguments] (#application_identification-arguments) block.
 * `security_intelligence` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare 'security-intelligence' configuration. See the [`security_intelligence` arguments] (#security_intelligence-arguments) block.
+* `user_identification` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare 'user-identification' configuration. See the [`user_identification` arguments] (#user_identification-arguments) block.
 
 ---
 #### application_identification arguments
@@ -72,6 +73,40 @@ The following arguments are supported:
 * `url` - (Optional)(`String`) Configure the url of feed server [https://<ip or hostname>:<port>/<uri>].
 * `url_parameter` - (Optional)(`String`) Configure the parameter of url.
 
+---
+#### user_identification arguments
+* `device_info_auth_source` - (Optional)(`String`) Configure authentication-source on device information configuration. Need to be 'active-directory' or 'network-access-controller'.
+* `identity_management` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare 'identity-management' configuration. See the [`identity_management` arguments for user_identification] (#identity_management-arguments-for-user_identification) block.
+
+---
+#### identity_management arguments for user_identification
+* `connection` - (Required)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare 'connection' configuration.
+  * `primary_address` - (Required)(`String`) IP address of Primary server.
+  * `primary_client_id` - (Required)(`String`) Client ID of Primary server for OAuth2 grant.
+  * `primary_client_secret` - (Required)(`String`) Client secret of Primary server for OAuth2 grant.  
+  **WARNING** Clear in tfstate.
+  * `connect_method` - (Optional)(`String`) Method of connection. Need to be 'http' or 'https'.
+  * `port` - (Optional)(`Int`) Server port (1..65535).
+  * `primary_ca_certificate` - (Optional)(`String`) Ca-certificate file name of Primary server.
+  * `query_api` - (Optional)(`String`) Query API.
+  * `secondary_address` - (Optional)(`String`) IP address of Secondary server.
+  * `secondary_ca_certificate` - (Optional)(`String`) Ca-certificate file name of Secondary server.
+  * `secondary_client_id` - (Optional)(`String`) Client ID of Secondary server for OAuth2 grant.
+  * `secondary_client_secret` - (Optional)(`String`) Client secret of Secondary server for OAuth2 grant.  
+  **WARNING** Clear in tfstate.
+  * `token_api` - (Optional)(`String`) API of acquiring token for OAuth2 authentication.
+* `authentication_entry_timeout` - (Optional)(`Int`) Authentication entry timeout number (0, 10-1440) (minutes).
+* `batch_query_items_per_batch` - (Optional)(`Int`) Items number per batch query (100..1000).
+* `batch_query_interval` - (Optional)(`Int`) Query interval for batch query (1..60 seconds).
+* `filter_domain` - (Optional)(`ListOfString`) Domain filter.
+* `filter_exclude_ip_address_book` - (Optional)(`String`) Referenced address book to exclude IP filter.
+* `filter_exclude_ip_address_set` - (Optional)(`String`) Referenced address set to exclude IP filter.
+* `filter_include_ip_address_book` - (Optional)(`String`) Referenced address book to include IP filter.
+* `filter_include_ip_address_set` - (Optional)(`String`) Referenced address set to include IP filter.
+* `invalid_authentication_entry_timeout` - (Optional)(`Int`) Invalid authentication entry timeout number (0, 10-1440) (minutes).
+* `ip_query_disable` - (Optional)(`Bool`) Disable IP query.
+* `ip_query_delay_time` - (Optional)(`Int`) Delay time to send IP query (0~60sec) (0..60 seconds).
+  
 ## Import
 
 Junos services can be imported using any id, e.g.

--- a/website/docs/r/services_user_identification_ad_access_domain.html.markdown
+++ b/website/docs/r/services_user_identification_ad_access_domain.html.markdown
@@ -1,0 +1,57 @@
+---
+layout: "junos"
+page_title: "Junos: junos_services_user_identification_ad_access_domain"
+sidebar_current: "docs-junos-resource-services-user-identification-ad-access-domain"
+description: |-
+  Create a services user-identification active-directory-access domain
+---
+
+# junos_services_user_identification_ad_access_domain
+
+Provides a services user-identification active-directory-access domain resource.
+
+## Example Usage
+
+```hcl
+# Add a services user-identification active-directory-access domain
+resource "junos_services_user_identification_ad_access_domain" "demo" {
+  name          = "example.com"
+  user_name     = "user_dom"
+  user_password = "user_pass"
+  domain_controller {
+    name    = "server1"
+    address = "192.0.2.3"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required, Forces new resource)(`String`) Domain name.
+* `user_name` - (Required)(`String`) User name.
+* `user_password` - (Required)(`String`) Password string.  
+**WARNING** Clear in tfstate.
+* `domain_controller` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Configure a domain-controller. Can be specified multiple times for each controller.
+  * `name` - (Required)(`String`) Domain controller name.
+  * `address` - (Required)(`String`) Address of domain controller.
+* `ip_user_mapping_discovery_wmi` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to enable 'ip-user-mapping discovery-method wmi'.
+  * `event_log_scanning_interval` - (Optional)(`Int`) Interval of event log scanning (5..60 seconds).
+  * `initial_event_log_timespan` - (Optional)(`Int`) Event log scanning timespan (1..168 hours).
+* `user_group_mapping_ldap` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare 'user-group-mapping ldap' configuration.
+  * `base` - (Required)(`String`) Base distinguished name.
+  * `address` - (Optional)(`ListOfString`) Address of LDAP server.
+  * `auth_algo_simple` - (Optional)(`Bool`) Authentication-algorithm simple.
+  * `ssl` - (Optional)(`Bool`) SSL.
+  * `user_name` - (Optional)(`String`) User name.
+  * `user_password` - (Optional)(`String`) Password string.  
+  **WARNING** Clear in tfstate.
+
+## Import
+
+Junos services user-identification active-directory-access domain can be imported using an id made up of `<name>`, e.g.
+
+```
+$ terraform import junos_services_user_identification_ad_access_domain.demo example.com
+```

--- a/website/docs/r/services_user_identification_device_identity_profile.html.markdown
+++ b/website/docs/r/services_user_identification_device_identity_profile.html.markdown
@@ -1,0 +1,43 @@
+---
+layout: "junos"
+page_title: "Junos: junos_services_user_identification_device_identity_profile"
+sidebar_current: "docs-junos-resource-services-user-identification-device-identity-profile"
+description: |-
+  Create a services user-identification device-information end-user-profile (also named device identity profile)
+---
+
+# junos_services_user_identification_device_identity_profile
+
+Provides a services user-identification device-information end-user-profile (also named device identity profile) resource.
+
+## Example Usage
+
+```hcl
+# Add a services user-identification device-information end-user-profile
+resource "junos_services_user_identification_device_identity_profile" "demo" {
+  name   = "demo"
+  domain = "domain"
+  attribute {
+    name  = "device-identity"
+    value = ["device1", "barcode scan"]
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required, Forces new resource)(`String`) End-user-profile profile-name.
+* `domain` - (Required)(`String`) Domain name.
+* `attribute` - (Required)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Configure a attribute. Can be specified multiple times for each attribute.
+  * `name` - (Required)(`String`) Attribute name.
+  * `value` - (Required)(`ListOfString`) A list of values.
+
+## Import
+
+Junos services user-identification device-information end-user-profile can be imported using an id made up of `<name>`, e.g.
+
+```
+$ terraform import junos_services_user_identification_device_identity_profile.demo demo
+```

--- a/website/junos.erb
+++ b/website/junos.erb
@@ -186,6 +186,9 @@
           <li<%= sidebar_current("docs-junos-resource-services-security-intelligence-profile") %>>
             <a href="/docs/providers/junos/r/services_security_intelligence_profile.html">junos_services_security_intelligence_profile</a>
           </li>
+          <li<%= sidebar_current("docs-junos-resource-services-user-identification-ad-access-domain") %>>
+            <a href="/docs/providers/junos/r/services_user_identification_ad_access_domain.html">junos_services_user_identification_ad_access_domain</a>
+          </li>
           <li<%= sidebar_current("docs-junos-resource-services-user-identification-device-identity-profile") %>>
             <a href="/docs/providers/junos/r/services_user_identification_device_identity_profile.html">junos_services_user_identification_device_identity_profile</a>
           </li>

--- a/website/junos.erb
+++ b/website/junos.erb
@@ -186,6 +186,9 @@
           <li<%= sidebar_current("docs-junos-resource-services-security-intelligence-profile") %>>
             <a href="/docs/providers/junos/r/services_security_intelligence_profile.html">junos_services_security_intelligence_profile</a>
           </li>
+          <li<%= sidebar_current("docs-junos-resource-services-user-identification-device-identity-profile") %>>
+            <a href="/docs/providers/junos/r/services_user_identification_device_identity_profile.html">junos_services_user_identification_device_identity_profile</a>
+          </li>
           <li<%= sidebar_current("docs-junos-resource-snmp") %>>
             <a href="/docs/providers/junos/r/snmp.html">junos_snmp</a>
           </li>


### PR DESCRIPTION
ENHANCEMENTS:
* add `junos_services_user_identification_ad_access_domain` resource
* add `junos_services_user_identification_device_identity_profile` resource (Fixes parts of #189)
* resource/`junos_security_global_policy`: add `match_source_end_user_profile` argument inside `policy` argument
* resource/`junos_security_policy`: add `match_source_end_user_profile` argument inside `policy` argument
* resource/`junos_services`: add `user_identification` argument (Fixes parts of #189)