### PR TITLE
Fixes #192: add a separate method to configure address-book in security-zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ ENHANCEMENTS:
 * resource/`junos_security_nat_source_pool`: add `address_pooling` argument (Fixes #193) Thanks @edpio19
 * resource/`junos_security_zone`: add `address_book_configure_singly` argument to disable management of address-book in this resource. (Fixes parts of #192)
 * resource/`junos_security_zone`: add `address_book_dns`, `address_book_range` and `address_book_wildcard` arguments and add `description` on existing `address_book_*` arguments
+* add `junos_security_zone_book_address` resource (Fixes parts of #192)
 * clean code: remove override of the lists of 1 map to handle directly the map
 * clean code: fix lll linter errors with a var to map
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ENHANCEMENTS:
 * resource/`junos_security`: add `policies` argument with `policy_rematch` and `policy_rematch_extensive` arguments inside (Fixes #185) Thanks @Sha-San-P
 * resource/`junos_security_nat_source_pool`: add `address_pooling` argument (Fixes #193) Thanks @edpio19
+* resource/`junos_security_zone`: add `address_book_configure_singly` argument to disable management of address-book in this resource. (Fixes parts of #192)
 * clean code: remove override of the lists of 1 map to handle directly the map
 * clean code: fix lll linter errors with a var to map
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## upcoming release
 ENHANCEMENTS:
 * resource/`junos_security`: add `policies` argument with `policy_rematch` and `policy_rematch_extensive` arguments inside (Fixes #185) Thanks @Sha-San-P
+* resource/`junos_security_address_book`: list of string for `address` argument inside `address_set` argument is now unordered
 * resource/`junos_security_nat_source_pool`: add `address_pooling` argument (Fixes #193) Thanks @edpio19
 * resource/`junos_security_zone`: add `address_book_configure_singly` argument to disable management of address-book in this resource. (Fixes parts of #192)
 * resource/`junos_security_zone`: add `address_book_dns`, `address_book_range` and `address_book_wildcard` arguments and add `description` on existing `address_book_*` arguments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ ENHANCEMENTS:
 * resource/`junos_security_nat_source_pool`: add `address_pooling` argument (Fixes #193) Thanks @edpio19
 * resource/`junos_security_zone`: add `address_book_configure_singly` argument to disable management of address-book in this resource. (Fixes parts of #192)
 * resource/`junos_security_zone`: add `address_book_dns`, `address_book_range` and `address_book_wildcard` arguments and add `description` on existing `address_book_*` arguments
+* resource/`junos_security_zone`: list of string for `address` argument inside `address_book_set` argument is now unordered
 * add `junos_security_zone_book_address` resource (Fixes parts of #192)
 * add `junos_security_zone_book_address_set` resource (Fixes parts of #192)
 * clean code: remove override of the lists of 1 map to handle directly the map

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ ENHANCEMENTS:
 * resource/`junos_security`: add `policies` argument with `policy_rematch` and `policy_rematch_extensive` arguments inside (Fixes #185) Thanks @Sha-San-P
 * resource/`junos_security_nat_source_pool`: add `address_pooling` argument (Fixes #193) Thanks @edpio19
 * resource/`junos_security_zone`: add `address_book_configure_singly` argument to disable management of address-book in this resource. (Fixes parts of #192)
+* resource/`junos_security_zone`: add `address_book_dns`, `address_book_range` and `address_book_wildcard` arguments and add `description` on existing `address_book_*` arguments
 * clean code: remove override of the lists of 1 map to handle directly the map
 * clean code: fix lll linter errors with a var to map
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ ENHANCEMENTS:
 * resource/`junos_security_zone`: add `address_book_configure_singly` argument to disable management of address-book in this resource. (Fixes parts of #192)
 * resource/`junos_security_zone`: add `address_book_dns`, `address_book_range` and `address_book_wildcard` arguments and add `description` on existing `address_book_*` arguments
 * add `junos_security_zone_book_address` resource (Fixes parts of #192)
+* add `junos_security_zone_book_address_set` resource (Fixes parts of #192)
 * clean code: remove override of the lists of 1 map to handle directly the map
 * clean code: fix lll linter errors with a var to map
 

--- a/junos/provider.go
+++ b/junos/provider.go
@@ -139,6 +139,7 @@ func Provider() *schema.Provider {
 			"junos_security_utm_profile_web_filtering_websense_redirect": resourceSecurityUtmProfileWebFilteringWebsense(),
 			"junos_security_zone":                                        resourceSecurityZone(),
 			"junos_security_zone_book_address":                           resourceSecurityZoneBookAddress(),
+			"junos_security_zone_book_address_set":                       resourceSecurityZoneBookAddressSet(),
 			"junos_services":                                             resourceServices(),
 			"junos_services_flowmonitoring_vipfix_template":              resourceServicesFlowMonitoringVIPFixTemplate(),
 			"junos_services_proxy_profile":                               resourceServicesProxyProfile(),

--- a/junos/provider.go
+++ b/junos/provider.go
@@ -138,6 +138,7 @@ func Provider() *schema.Provider {
 			"junos_security_utm_profile_web_filtering_juniper_local":     resourceSecurityUtmProfileWebFilteringLocal(),
 			"junos_security_utm_profile_web_filtering_websense_redirect": resourceSecurityUtmProfileWebFilteringWebsense(),
 			"junos_security_zone":                                        resourceSecurityZone(),
+			"junos_security_zone_book_address":                           resourceSecurityZoneBookAddress(),
 			"junos_services":                                             resourceServices(),
 			"junos_services_flowmonitoring_vipfix_template":              resourceServicesFlowMonitoringVIPFixTemplate(),
 			"junos_services_proxy_profile":                               resourceServicesProxyProfile(),

--- a/junos/resource_interface.go
+++ b/junos/resource_interface.go
@@ -513,7 +513,7 @@ func resourceInterfaceCreate(ctx context.Context, d *schema.ResourceData, m inte
 			appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
 
 			return append(diagWarns,
-				diag.FromErr(fmt.Errorf("security zones %v doesn't exist", d.Get("security_zone").(string)))...)
+				diag.FromErr(fmt.Errorf("security zone %v doesn't exist", d.Get("security_zone").(string)))...)
 		}
 	}
 	if d.Get("routing_instance").(string) != "" {
@@ -719,7 +719,7 @@ func resourceInterfaceUpdate(ctx context.Context, d *schema.ResourceData, m inte
 			if !zonesExists {
 				appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
 
-				return append(diagWarns, diag.FromErr(fmt.Errorf("security zones %v doesn't exist", nSecurityZone.(string)))...)
+				return append(diagWarns, diag.FromErr(fmt.Errorf("security zone %v doesn't exist", nSecurityZone.(string)))...)
 			}
 		}
 		if oSecurityZone.(string) != "" {

--- a/junos/resource_interface_logical.go
+++ b/junos/resource_interface_logical.go
@@ -457,7 +457,7 @@ func resourceInterfaceLogicalCreate(ctx context.Context, d *schema.ResourceData,
 			appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
 
 			return append(diagWarns,
-				diag.FromErr(fmt.Errorf("security zones %v doesn't exist", d.Get("security_zone").(string)))...)
+				diag.FromErr(fmt.Errorf("security zone %v doesn't exist", d.Get("security_zone").(string)))...)
 		}
 	}
 	if d.Get("routing_instance").(string) != "" {
@@ -592,7 +592,7 @@ func resourceInterfaceLogicalUpdate(ctx context.Context, d *schema.ResourceData,
 			if !zonesExists {
 				appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
 
-				return append(diagWarns, diag.FromErr(fmt.Errorf("security zones %v doesn't exist", nSecurityZone.(string)))...)
+				return append(diagWarns, diag.FromErr(fmt.Errorf("security zone %v doesn't exist", nSecurityZone.(string)))...)
 			}
 		}
 		if oSecurityZone.(string) != "" {

--- a/junos/resource_security_address_book.go
+++ b/junos/resource_security_address_book.go
@@ -149,7 +149,7 @@ func resourceSecurityAddressBook() *schema.Resource {
 							ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, FormatAddressName),
 						},
 						"address": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Required: true,
 							MinItems: 1,
 							Elem:     &schema.Schema{Type: schema.TypeString},
@@ -404,7 +404,7 @@ func setAddressBook(d *schema.ResourceData, m interface{}, jnprSess *NetconfObje
 		if addressSet["description"].(string) != "" {
 			configSet = append(configSet, setPrefixAddrSet+"description \""+addressSet["description"].(string)+"\"")
 		}
-		for _, addr := range addressSet["address"].([]interface{}) {
+		for _, addr := range addressSet["address"].(*schema.Set).List() {
 			configSet = append(configSet, setPrefixAddrSet+" address "+addr.(string))
 		}
 	}

--- a/junos/resource_security_zone.go
+++ b/junos/resource_security_zone.go
@@ -145,7 +145,7 @@ func resourceSecurityZone() *schema.Resource {
 							ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, FormatAddressName),
 						},
 						"address": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Required: true,
 							MinItems: 1,
 							Elem:     &schema.Schema{Type: schema.TypeString},
@@ -470,7 +470,7 @@ func setSecurityZone(d *schema.ResourceData, m interface{}, jnprSess *NetconfObj
 		}
 		for _, v := range d.Get("address_book_set").([]interface{}) {
 			addressBookSet := v.(map[string]interface{})
-			for _, addressBookSetAddress := range addressBookSet["address"].([]interface{}) {
+			for _, addressBookSetAddress := range addressBookSet["address"].(*schema.Set).List() {
 				configSet = append(configSet, setPrefix+" address-book address-set "+addressBookSet["name"].(string)+
 					" address "+addressBookSetAddress.(string))
 			}

--- a/junos/resource_security_zone.go
+++ b/junos/resource_security_zone.go
@@ -23,7 +23,10 @@ type zoneOptions struct {
 	inboundProtocols                 []string
 	inboundServices                  []string
 	addressBook                      []map[string]interface{}
+	addressBookDNS                   []map[string]interface{}
+	addressBookRange                 []map[string]interface{}
 	addressBookSet                   []map[string]interface{}
+	addressBookWildcard              []map[string]interface{}
 }
 
 func resourceSecurityZone() *schema.Resource {
@@ -57,13 +60,79 @@ func resourceSecurityZone() *schema.Resource {
 							Required:     true,
 							ValidateFunc: validation.IsCIDRNetwork(0, 128),
 						},
+						"description": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 					},
 				},
 			},
 			"address_book_configure_singly": {
-				Type:          schema.TypeBool,
-				Optional:      true,
-				ConflictsWith: []string{"address_book", "address_book_set"},
+				Type:     schema.TypeBool,
+				Optional: true,
+				ConflictsWith: []string{
+					"address_book",
+					"address_book_dns",
+					"address_book_range",
+					"address_book_set",
+					"address_book_wildcard",
+				},
+			},
+			"address_book_dns": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:             schema.TypeString,
+							Required:         true,
+							ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, FormatAddressName),
+						},
+						"fqdn": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"ipv4_only": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"ipv6_only": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"address_book_range": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:             schema.TypeString,
+							Required:         true,
+							ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, FormatAddressName),
+						},
+						"from": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.IsIPAddress,
+						},
+						"to": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.IsIPAddress,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
 			},
 			"address_book_set": {
 				Type:     schema.TypeList,
@@ -80,6 +149,32 @@ func resourceSecurityZone() *schema.Resource {
 							Required: true,
 							MinItems: 1,
 							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"address_book_wildcard": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:             schema.TypeString,
+							Required:         true,
+							ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, FormatAddressName),
+						},
+						"network": {
+							Type:             schema.TypeString,
+							Required:         true,
+							ValidateDiagFunc: validateWildcardFunc(),
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Optional: true,
 						},
 					},
 				},
@@ -342,12 +437,55 @@ func setSecurityZone(d *schema.ResourceData, m interface{}, jnprSess *NetconfObj
 			addressBook := v.(map[string]interface{})
 			configSet = append(configSet, setPrefix+" address-book address "+
 				addressBook["name"].(string)+" "+addressBook["network"].(string))
+			if v2 := addressBook["description"].(string); v2 != "" {
+				configSet = append(configSet, setPrefix+" address-book address "+
+					addressBook["name"].(string)+" description \""+v2+"\"")
+			}
+		}
+		for _, v := range d.Get("address_book_dns").([]interface{}) {
+			addressBook := v.(map[string]interface{})
+			setLine := setPrefix + " address-book address " + addressBook["name"].(string) +
+				" dns-name " + addressBook["fqdn"].(string)
+			configSet = append(configSet, setLine)
+			if addressBook["ipv4_only"].(bool) {
+				configSet = append(configSet, setLine+" ipv4-only")
+			}
+			if addressBook["ipv6_only"].(bool) {
+				configSet = append(configSet, setLine+" ipv6-only")
+			}
+			if v2 := addressBook["description"].(string); v2 != "" {
+				configSet = append(configSet, setPrefix+" address-book address "+
+					addressBook["name"].(string)+" description \""+v2+"\"")
+			}
+		}
+		for _, v := range d.Get("address_book_range").([]interface{}) {
+			addressBook := v.(map[string]interface{})
+			configSet = append(configSet, setPrefix+" address-book address "+
+				addressBook["name"].(string)+" range-address "+addressBook["from"].(string)+
+				" to "+addressBook["to"].(string))
+			if v2 := addressBook["description"].(string); v2 != "" {
+				configSet = append(configSet, setPrefix+" address-book address "+
+					addressBook["name"].(string)+" description \""+v2+"\"")
+			}
 		}
 		for _, v := range d.Get("address_book_set").([]interface{}) {
 			addressBookSet := v.(map[string]interface{})
 			for _, addressBookSetAddress := range addressBookSet["address"].([]interface{}) {
 				configSet = append(configSet, setPrefix+" address-book address-set "+addressBookSet["name"].(string)+
 					" address "+addressBookSetAddress.(string))
+			}
+			if v2 := addressBookSet["description"].(string); v2 != "" {
+				configSet = append(configSet, setPrefix+" address-book address-set "+
+					addressBookSet["name"].(string)+" description \""+v2+"\"")
+			}
+		}
+		for _, v := range d.Get("address_book_wildcard").([]interface{}) {
+			addressBook := v.(map[string]interface{})
+			configSet = append(configSet, setPrefix+" address-book address "+
+				addressBook["name"].(string)+" wildcard-address "+addressBook["network"].(string))
+			if v2 := addressBook["description"].(string); v2 != "" {
+				configSet = append(configSet, setPrefix+" address-book address "+
+					addressBook["name"].(string)+" description \""+v2+"\"")
 			}
 		}
 	}
@@ -392,6 +530,7 @@ func readSecurityZone(zone string, m interface{}, jnprSess *NetconfObject) (zone
 	if err != nil {
 		return confRead, err
 	}
+	descAddressBookMap := make(map[string]string)
 	if zoneConfig != emptyWord {
 		confRead.name = zone
 		for _, item := range strings.Split(zoneConfig, "\n") {
@@ -404,28 +543,66 @@ func readSecurityZone(zone string, m interface{}, jnprSess *NetconfObject) (zone
 			itemTrim := strings.TrimPrefix(item, setLineStart)
 			switch {
 			case strings.HasPrefix(itemTrim, "address-book address "):
-				address := strings.TrimPrefix(itemTrim, "address-book address ")
-				addressWords := strings.Split(address, " ")
-				// addressWords[0] = name of address
-				// addressWords[1] = network
-				confRead.addressBook = append(confRead.addressBook, map[string]interface{}{
-					"name":    addressWords[0],
-					"network": addressWords[1],
-				})
+				addressSplit := strings.Split(strings.TrimPrefix(itemTrim, "address-book address "), " ")
+				itemTrimAddress := strings.TrimPrefix(itemTrim, "address-book address "+addressSplit[0]+" ")
+				switch {
+				case strings.HasPrefix(itemTrimAddress, "description "):
+					descAddressBookMap[addressSplit[0]] = strings.Trim(strings.TrimPrefix(itemTrimAddress, "description "), "\"")
+				case strings.HasPrefix(itemTrimAddress, "dns-name "):
+					dnsValue := strings.TrimPrefix(itemTrimAddress, "dns-name ")
+					var ipv4Only, ipv6Only bool
+					switch {
+					case strings.HasSuffix(itemTrimAddress, " ipv4-only"):
+						ipv4Only = true
+						dnsValue = strings.TrimSuffix(strings.TrimPrefix(itemTrimAddress, "dns-name "), " ipv4-only")
+					case strings.HasSuffix(itemTrimAddress, " ipv6-only"):
+						ipv6Only = true
+						dnsValue = strings.TrimSuffix(strings.TrimPrefix(itemTrimAddress, "dns-name "), " ipv6-only")
+					}
+					confRead.addressBookDNS = append(confRead.addressBookDNS, map[string]interface{}{
+						"name":        addressSplit[0],
+						"description": descAddressBookMap[addressSplit[0]],
+						"fqdn":        dnsValue,
+						"ipv4_only":   ipv4Only,
+						"ipv6_only":   ipv6Only,
+					})
+				case strings.HasPrefix(itemTrimAddress, "range-address "):
+					rangeAddress := strings.Split(strings.TrimPrefix(itemTrimAddress, "range-address "), " ")
+					confRead.addressBookRange = append(confRead.addressBookRange, map[string]interface{}{
+						"name":        addressSplit[0],
+						"description": descAddressBookMap[addressSplit[0]],
+						"from":        rangeAddress[0],
+						"to":          rangeAddress[2],
+					})
+				case strings.HasPrefix(itemTrimAddress, "wildcard-address "):
+					confRead.addressBookWildcard = append(confRead.addressBookWildcard, map[string]interface{}{
+						"name":        addressSplit[0],
+						"description": descAddressBookMap[addressSplit[0]],
+						"network":     strings.TrimPrefix(itemTrimAddress, "wildcard-address "),
+					})
+				default:
+					confRead.addressBook = append(confRead.addressBook, map[string]interface{}{
+						"name":        addressSplit[0],
+						"description": descAddressBookMap[addressSplit[0]],
+						"network":     itemTrimAddress,
+					})
+				}
 			case strings.HasPrefix(itemTrim, "address-book address-set "):
-				address := strings.TrimPrefix(itemTrim, "address-book address-set ")
-				addressWords := strings.Split(address, " ")
-				// addressWords[0] = name of address-set
-				// addressWords[1] = "address"
-				// addressWords[2] = name of address
+				addressSetSplit := strings.Split(strings.TrimPrefix(itemTrim, "address-book address-set "), " ")
 				adSet := map[string]interface{}{
-					"name":    addressWords[0],
-					"address": make([]string, 0),
+					"name":        addressSetSplit[0],
+					"address":     make([]string, 0),
+					"description": "",
 				}
 				// search if name of address-set already create
 				adSet, confRead.addressBookSet = copyAndRemoveItemMapList("name", false, adSet, confRead.addressBookSet)
 				// append new address find
-				adSet["address"] = append(adSet["address"].([]string), addressWords[2])
+				if addressSetSplit[1] == "description" {
+					adSet["description"] = strings.Trim(strings.TrimPrefix(
+						itemTrim, "address-book address-set "+addressSetSplit[0]+" description "), "\"")
+				} else {
+					adSet["address"] = append(adSet["address"].([]string), addressSetSplit[2])
+				}
 				confRead.addressBookSet = append(confRead.addressBookSet, adSet)
 			case strings.HasPrefix(itemTrim, "advance-policy-based-routing-profile "):
 				confRead.advancePolicyBasedRoutingProfile = strings.Trim(strings.TrimPrefix(itemTrim,
@@ -496,7 +673,16 @@ func fillSecurityZoneData(d *schema.ResourceData, zoneOptions zoneOptions) {
 		if tfErr := d.Set("address_book", zoneOptions.addressBook); tfErr != nil {
 			panic(tfErr)
 		}
+		if tfErr := d.Set("address_book_dns", zoneOptions.addressBookDNS); tfErr != nil {
+			panic(tfErr)
+		}
+		if tfErr := d.Set("address_book_range", zoneOptions.addressBookRange); tfErr != nil {
+			panic(tfErr)
+		}
 		if tfErr := d.Set("address_book_set", zoneOptions.addressBookSet); tfErr != nil {
+			panic(tfErr)
+		}
+		if tfErr := d.Set("address_book_wildcard", zoneOptions.addressBookWildcard); tfErr != nil {
 			panic(tfErr)
 		}
 	}

--- a/junos/resource_security_zone_book_address.go
+++ b/junos/resource_security_zone_book_address.go
@@ -1,0 +1,427 @@
+package junos
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+type zoneBookAddressOptions struct {
+	dnsIPv4Only bool
+	dnsIPv6Only bool
+	cidr        string
+	description string
+	dnsName     string
+	name        string
+	rangeFrom   string
+	rangeTo     string
+	wildcard    string
+	zone        string
+}
+
+func resourceSecurityZoneBookAddress() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSecurityZoneBookAddressCreate,
+		ReadContext:   resourceSecurityZoneBookAddressRead,
+		UpdateContext: resourceSecurityZoneBookAddressUpdate,
+		DeleteContext: resourceSecurityZoneBookAddressDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceSecurityZoneBookAddressImport,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:             schema.TypeString,
+				ForceNew:         true,
+				Required:         true,
+				ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, FormatAddressName),
+			},
+			"zone": {
+				Type:             schema.TypeString,
+				ForceNew:         true,
+				Required:         true,
+				ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, FormatDefault),
+			},
+			"cidr": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.IsCIDRNetwork(0, 128),
+				ExactlyOneOf: []string{"cidr", "dns_name", "range_from", "wildcard"},
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"dns_ipv4_only": {
+				Type:          schema.TypeBool,
+				Optional:      true,
+				RequiredWith:  []string{"dns_name"},
+				ConflictsWith: []string{"dns_ipv6_only"},
+			},
+			"dns_ipv6_only": {
+				Type:          schema.TypeBool,
+				Optional:      true,
+				RequiredWith:  []string{"dns_name"},
+				ConflictsWith: []string{"dns_ipv4_only"},
+			},
+			"dns_name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ExactlyOneOf: []string{"cidr", "dns_name", "range_from", "wildcard"},
+			},
+			"range_from": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.IsIPAddress,
+				RequiredWith: []string{"range_to"},
+				ExactlyOneOf: []string{"cidr", "dns_name", "range_from", "wildcard"},
+			},
+			"range_to": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.IsIPAddress,
+				RequiredWith: []string{"range_from"},
+			},
+			"wildcard": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateDiagFunc: validateWildcardFunc(),
+				ExactlyOneOf:     []string{"cidr", "dns_name", "range_from", "wildcard"},
+			},
+		},
+	}
+}
+
+func resourceSecurityZoneBookAddressCreate(ctx context.Context,
+	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	if sess.junosFakeCreateSetFile != "" {
+		if err := setSecurityZoneBookAddress(d, m, nil); err != nil {
+			return diag.FromErr(err)
+		}
+		d.SetId(d.Get("zone").(string) + idSeparator + d.Get("name").(string))
+
+		return nil
+	}
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	if !checkCompatibilitySecurity(jnprSess) {
+		return diag.FromErr(fmt.Errorf("security zone address-book address not compatible with Junos device %s",
+			jnprSess.SystemInformation.HardwareModel))
+	}
+	sess.configLock(jnprSess)
+	var diagWarns diag.Diagnostics
+	zonesExists, err := checkSecurityZonesExists(d.Get("zone").(string), m, jnprSess)
+	if err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	if !zonesExists {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns,
+			diag.FromErr(fmt.Errorf("security zone %v doesn't exist", d.Get("zone").(string)))...)
+	}
+	securityZoneBookAddressExists, err := checkSecurityZoneBookAddresssExists(
+		d.Get("zone").(string), d.Get("name").(string), m, jnprSess)
+	if err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	if securityZoneBookAddressExists {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(fmt.Errorf(
+			"security zone address-book address %v already exists in zone %s",
+			d.Get("name").(string), d.Get("zone").(string)))...)
+	}
+
+	if err := setSecurityZoneBookAddress(d, m, jnprSess); err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	warns, err := sess.commitConf("create resource junos_security_zone_book_address", jnprSess)
+	appendDiagWarns(&diagWarns, warns)
+	if err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	securityZoneBookAddressExists, err =
+		checkSecurityZoneBookAddresssExists(d.Get("zone").(string), d.Get("name").(string), m, jnprSess)
+	if err != nil {
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	if securityZoneBookAddressExists {
+		d.SetId(d.Get("zone").(string) + idSeparator + d.Get("name").(string))
+	} else {
+		return append(diagWarns, diag.FromErr(fmt.Errorf(
+			"security zone address-book address %v not exists in zone %s after commit "+
+				"=> check your config", d.Get("name").(string), d.Get("zone").(string)))...)
+	}
+
+	return append(diagWarns, resourceSecurityZoneBookAddressReadWJnprSess(d, m, jnprSess)...)
+}
+
+func resourceSecurityZoneBookAddressRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+
+	return resourceSecurityZoneBookAddressReadWJnprSess(d, m, jnprSess)
+}
+
+func resourceSecurityZoneBookAddressReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
+	zoneBookAddressOptions, err := readSecurityZoneBookAddress(d.Get("zone").(string), d.Get("name").(string), m, jnprSess)
+	mutex.Unlock()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if zoneBookAddressOptions.name == "" {
+		d.SetId("")
+	} else {
+		fillSecurityZoneBookAddressData(d, zoneBookAddressOptions)
+	}
+
+	return nil
+}
+
+func resourceSecurityZoneBookAddressUpdate(ctx context.Context,
+	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	d.Partial(true)
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	sess.configLock(jnprSess)
+	var diagWarns diag.Diagnostics
+	if err := delSecurityZoneBookAddress(d.Get("zone").(string), d.Get("name").(string), m, jnprSess); err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	if err := setSecurityZoneBookAddress(d, m, jnprSess); err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	warns, err := sess.commitConf("update resource junos_security_zone_book_address", jnprSess)
+	appendDiagWarns(&diagWarns, warns)
+	if err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	d.Partial(false)
+
+	return append(diagWarns, resourceSecurityZoneBookAddressReadWJnprSess(d, m, jnprSess)...)
+}
+
+func resourceSecurityZoneBookAddressDelete(ctx context.Context,
+	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	sess.configLock(jnprSess)
+	var diagWarns diag.Diagnostics
+	if err := delSecurityZoneBookAddress(d.Get("zone").(string), d.Get("name").(string), m, jnprSess); err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	warns, err := sess.commitConf("delete resource junos_security_zone_book_address", jnprSess)
+	appendDiagWarns(&diagWarns, warns)
+	if err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+
+	return diagWarns
+}
+
+func resourceSecurityZoneBookAddressImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return nil, err
+	}
+	defer sess.closeSession(jnprSess)
+	result := make([]*schema.ResourceData, 1)
+	idList := strings.Split(d.Id(), idSeparator)
+	if len(idList) < 2 {
+		return nil, fmt.Errorf("missing element(s) in id with separator %v", idSeparator)
+	}
+	securityZoneBookAddressExists, err := checkSecurityZoneBookAddresssExists(idList[0], idList[1], m, jnprSess)
+	if err != nil {
+		return nil, err
+	}
+	if !securityZoneBookAddressExists {
+		return nil, fmt.Errorf(
+			"don't find zone address-book address with id '%v' (id must be <zone>"+idSeparator+"<name>)", d.Id())
+	}
+	zoneBookAddressOptions, err := readSecurityZoneBookAddress(idList[0], idList[1], m, jnprSess)
+	if err != nil {
+		return nil, err
+	}
+	fillSecurityZoneBookAddressData(d, zoneBookAddressOptions)
+
+	result[0] = d
+
+	return result, nil
+}
+
+func checkSecurityZoneBookAddresssExists(zone, address string, m interface{}, jnprSess *NetconfObject) (bool, error) {
+	sess := m.(*Session)
+	zoneConfig, err := sess.command("show configuration security zones security-zone "+
+		zone+" address-book address "+address+" | display set", jnprSess)
+	if err != nil {
+		return false, err
+	}
+	if zoneConfig == emptyWord {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func setSecurityZoneBookAddress(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) error {
+	sess := m.(*Session)
+	configSet := make([]string, 0)
+
+	setPrefix := "set security zones security-zone " +
+		d.Get("zone").(string) + " address-book address " + d.Get("name").(string) + " "
+
+	if v := d.Get("cidr").(string); v != "" {
+		configSet = append(configSet, setPrefix+v)
+	}
+	if v := d.Get("description").(string); v != "" {
+		configSet = append(configSet, setPrefix+"description \""+v+"\"")
+	}
+	if v := d.Get("dns_name").(string); v != "" {
+		configSet = append(configSet, setPrefix+"dns-name "+v)
+		if d.Get("dns_ipv4_only").(bool) {
+			configSet = append(configSet, setPrefix+"dns-name "+v+" ipv4-only")
+		}
+		if d.Get("dns_ipv6_only").(bool) {
+			configSet = append(configSet, setPrefix+"dns-name "+v+" ipv6-only")
+		}
+	}
+	if v := d.Get("range_from").(string); v != "" {
+		configSet = append(configSet, setPrefix+"range-address "+v+" to "+d.Get("range_to").(string))
+	}
+	if v := d.Get("wildcard").(string); v != "" {
+		configSet = append(configSet, setPrefix+"wildcard-address "+v)
+	}
+
+	return sess.configSet(configSet, jnprSess)
+}
+
+func readSecurityZoneBookAddress(
+	zone, address string, m interface{}, jnprSess *NetconfObject) (zoneBookAddressOptions, error) {
+	sess := m.(*Session)
+	var confRead zoneBookAddressOptions
+
+	zoneConfig, err := sess.command("show configuration"+
+		" security zones security-zone "+zone+" address-book address "+address+" | display set relative", jnprSess)
+	if err != nil {
+		return confRead, err
+	}
+	if zoneConfig != emptyWord {
+		confRead.name = address
+		confRead.zone = zone
+		for _, item := range strings.Split(zoneConfig, "\n") {
+			if strings.Contains(item, "<configuration-output>") {
+				continue
+			}
+			if strings.Contains(item, "</configuration-output>") {
+				break
+			}
+			itemTrim := strings.TrimPrefix(item, setLineStart)
+			switch {
+			case strings.HasPrefix(itemTrim, "description "):
+				confRead.description = strings.Trim(strings.TrimPrefix(itemTrim, "description "), "\"")
+			case strings.HasPrefix(itemTrim, "dns-name "):
+				dnsValue := strings.TrimPrefix(itemTrim, "dns-name ")
+				switch {
+				case strings.HasSuffix(itemTrim, " ipv4-only"):
+					confRead.dnsIPv4Only = true
+					dnsValue = strings.TrimSuffix(strings.TrimPrefix(itemTrim, "dns-name "), " ipv4-only")
+				case strings.HasSuffix(itemTrim, " ipv6-only"):
+					confRead.dnsIPv6Only = true
+					dnsValue = strings.TrimSuffix(strings.TrimPrefix(itemTrim, "dns-name "), " ipv6-only")
+				}
+				confRead.dnsName = dnsValue
+			case strings.HasPrefix(itemTrim, "range-address "):
+				itemTrimSplit := strings.Split(strings.TrimPrefix(itemTrim, "range-address "), " ")
+				confRead.rangeFrom = itemTrimSplit[0]
+				confRead.rangeTo = itemTrimSplit[2]
+			case strings.HasPrefix(itemTrim, "wildcard-address "):
+				confRead.wildcard = strings.TrimPrefix(itemTrim, "wildcard-address ")
+			case strings.Contains(itemTrim, "/"):
+				confRead.cidr = itemTrim
+			}
+		}
+	}
+
+	return confRead, nil
+}
+
+func delSecurityZoneBookAddress(zone, address string, m interface{}, jnprSess *NetconfObject) error {
+	sess := m.(*Session)
+	configSet := []string{"delete security zones security-zone " + zone + " address-book address " + address}
+
+	return sess.configSet(configSet, jnprSess)
+}
+
+func fillSecurityZoneBookAddressData(d *schema.ResourceData, zoneBookAddressOptions zoneBookAddressOptions) {
+	if tfErr := d.Set("name", zoneBookAddressOptions.name); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("zone", zoneBookAddressOptions.zone); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("cidr", zoneBookAddressOptions.cidr); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("description", zoneBookAddressOptions.description); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("dns_ipv4_only", zoneBookAddressOptions.dnsIPv4Only); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("dns_ipv6_only", zoneBookAddressOptions.dnsIPv6Only); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("dns_name", zoneBookAddressOptions.dnsName); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("range_from", zoneBookAddressOptions.rangeFrom); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("range_to", zoneBookAddressOptions.rangeTo); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("wildcard", zoneBookAddressOptions.wildcard); tfErr != nil {
+		panic(tfErr)
+	}
+}

--- a/junos/resource_security_zone_book_address_set.go
+++ b/junos/resource_security_zone_book_address_set.go
@@ -1,0 +1,336 @@
+package junos
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type zoneBookAddressSetOptions struct {
+	description string
+	name        string
+	zone        string
+	address     []string
+}
+
+func resourceSecurityZoneBookAddressSet() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSecurityZoneBookAddressSetCreate,
+		ReadContext:   resourceSecurityZoneBookAddressSetRead,
+		UpdateContext: resourceSecurityZoneBookAddressSetUpdate,
+		DeleteContext: resourceSecurityZoneBookAddressSetDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceSecurityZoneBookAddressSetImport,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:             schema.TypeString,
+				ForceNew:         true,
+				Required:         true,
+				ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, FormatAddressName),
+			},
+			"zone": {
+				Type:             schema.TypeString,
+				ForceNew:         true,
+				Required:         true,
+				ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, FormatDefault),
+			},
+			"address": {
+				Type:     schema.TypeSet,
+				Required: true,
+				MinItems: 1,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceSecurityZoneBookAddressSetCreate(ctx context.Context,
+	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	if sess.junosFakeCreateSetFile != "" {
+		if err := setSecurityZoneBookAddressSet(d, m, nil); err != nil {
+			return diag.FromErr(err)
+		}
+		d.SetId(d.Get("zone").(string) + idSeparator + d.Get("name").(string))
+
+		return nil
+	}
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	if !checkCompatibilitySecurity(jnprSess) {
+		return diag.FromErr(fmt.Errorf("security zone address-book address-set not compatible with Junos device %s",
+			jnprSess.SystemInformation.HardwareModel))
+	}
+	sess.configLock(jnprSess)
+	var diagWarns diag.Diagnostics
+	zonesExists, err := checkSecurityZonesExists(d.Get("zone").(string), m, jnprSess)
+	if err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	if !zonesExists {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns,
+			diag.FromErr(fmt.Errorf("security zone %v doesn't exist", d.Get("zone").(string)))...)
+	}
+	securityZoneBookAddressSetExists, err := checkSecurityZoneBookAddressSetsExists(
+		d.Get("zone").(string), d.Get("name").(string), m, jnprSess)
+	if err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	if securityZoneBookAddressSetExists {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(fmt.Errorf(
+			"security zone address-book address-set %v already exists in zone %s",
+			d.Get("name").(string), d.Get("zone").(string)))...)
+	}
+
+	if err := setSecurityZoneBookAddressSet(d, m, jnprSess); err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	warns, err := sess.commitConf("create resource junos_security_zone_book_address_set", jnprSess)
+	appendDiagWarns(&diagWarns, warns)
+	if err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	securityZoneBookAddressSetExists, err =
+		checkSecurityZoneBookAddressSetsExists(d.Get("zone").(string), d.Get("name").(string), m, jnprSess)
+	if err != nil {
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	if securityZoneBookAddressSetExists {
+		d.SetId(d.Get("zone").(string) + idSeparator + d.Get("name").(string))
+	} else {
+		return append(diagWarns, diag.FromErr(fmt.Errorf(
+			"security zone address-book address-set %v not exists in zone %s after commit "+
+				"=> check your config", d.Get("name").(string), d.Get("zone").(string)))...)
+	}
+
+	return append(diagWarns, resourceSecurityZoneBookAddressSetReadWJnprSess(d, m, jnprSess)...)
+}
+
+func resourceSecurityZoneBookAddressSetRead(ctx context.Context,
+	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+
+	return resourceSecurityZoneBookAddressSetReadWJnprSess(d, m, jnprSess)
+}
+
+func resourceSecurityZoneBookAddressSetReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
+	zoneBookAddressSetOptions, err := readSecurityZoneBookAddressSet(
+		d.Get("zone").(string), d.Get("name").(string), m, jnprSess)
+	mutex.Unlock()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if zoneBookAddressSetOptions.name == "" {
+		d.SetId("")
+	} else {
+		fillSecurityZoneBookAddressSetData(d, zoneBookAddressSetOptions)
+	}
+
+	return nil
+}
+
+func resourceSecurityZoneBookAddressSetUpdate(ctx context.Context,
+	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	d.Partial(true)
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	sess.configLock(jnprSess)
+	var diagWarns diag.Diagnostics
+	if err := delSecurityZoneBookAddressSet(d.Get("zone").(string), d.Get("name").(string), m, jnprSess); err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	if err := setSecurityZoneBookAddressSet(d, m, jnprSess); err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	warns, err := sess.commitConf("update resource junos_security_zone_book_address_set", jnprSess)
+	appendDiagWarns(&diagWarns, warns)
+	if err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	d.Partial(false)
+
+	return append(diagWarns, resourceSecurityZoneBookAddressSetReadWJnprSess(d, m, jnprSess)...)
+}
+
+func resourceSecurityZoneBookAddressSetDelete(ctx context.Context,
+	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	sess.configLock(jnprSess)
+	var diagWarns diag.Diagnostics
+	if err := delSecurityZoneBookAddressSet(d.Get("zone").(string), d.Get("name").(string), m, jnprSess); err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	warns, err := sess.commitConf("delete resource junos_security_zone_book_address_set", jnprSess)
+	appendDiagWarns(&diagWarns, warns)
+	if err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+
+	return diagWarns
+}
+
+func resourceSecurityZoneBookAddressSetImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return nil, err
+	}
+	defer sess.closeSession(jnprSess)
+	result := make([]*schema.ResourceData, 1)
+	idList := strings.Split(d.Id(), idSeparator)
+	if len(idList) < 2 {
+		return nil, fmt.Errorf("missing element(s) in id with separator %v", idSeparator)
+	}
+	securityZoneBookAddressSetExists, err := checkSecurityZoneBookAddressSetsExists(idList[0], idList[1], m, jnprSess)
+	if err != nil {
+		return nil, err
+	}
+	if !securityZoneBookAddressSetExists {
+		return nil, fmt.Errorf(
+			"don't find zone address-book address-set with id '%v' (id must be <zone>"+idSeparator+"<name>)", d.Id())
+	}
+	zoneBookAddressSetOptions, err := readSecurityZoneBookAddressSet(idList[0], idList[1], m, jnprSess)
+	if err != nil {
+		return nil, err
+	}
+	fillSecurityZoneBookAddressSetData(d, zoneBookAddressSetOptions)
+
+	result[0] = d
+
+	return result, nil
+}
+
+func checkSecurityZoneBookAddressSetsExists(
+	zone, addressSet string, m interface{}, jnprSess *NetconfObject) (bool, error) {
+	sess := m.(*Session)
+	zoneConfig, err := sess.command("show configuration security zones security-zone "+
+		zone+" address-book address-set "+addressSet+" | display set", jnprSess)
+	if err != nil {
+		return false, err
+	}
+	if zoneConfig == emptyWord {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func setSecurityZoneBookAddressSet(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) error {
+	sess := m.(*Session)
+	configSet := make([]string, 0)
+
+	setPrefix := "set security zones security-zone " +
+		d.Get("zone").(string) + " address-book address-set " + d.Get("name").(string) + " "
+	for _, v := range d.Get("address").(*schema.Set).List() {
+		configSet = append(configSet, setPrefix+"address "+v.(string))
+	}
+	if v := d.Get("description").(string); v != "" {
+		configSet = append(configSet, setPrefix+"description \""+v+"\"")
+	}
+
+	return sess.configSet(configSet, jnprSess)
+}
+
+func readSecurityZoneBookAddressSet(
+	zone, addressSet string, m interface{}, jnprSess *NetconfObject) (zoneBookAddressSetOptions, error) {
+	sess := m.(*Session)
+	var confRead zoneBookAddressSetOptions
+
+	zoneConfig, err := sess.command("show configuration"+
+		" security zones security-zone "+zone+" address-book address-set "+addressSet+" | display set relative", jnprSess)
+	if err != nil {
+		return confRead, err
+	}
+	if zoneConfig != emptyWord {
+		confRead.name = addressSet
+		confRead.zone = zone
+		for _, item := range strings.Split(zoneConfig, "\n") {
+			if strings.Contains(item, "<configuration-output>") {
+				continue
+			}
+			if strings.Contains(item, "</configuration-output>") {
+				break
+			}
+			itemTrim := strings.TrimPrefix(item, setLineStart)
+			switch {
+			case strings.HasPrefix(itemTrim, "description "):
+				confRead.description = strings.Trim(strings.TrimPrefix(itemTrim, "description "), "\"")
+			case strings.HasPrefix(itemTrim, "address "):
+				confRead.address = append(confRead.address, strings.TrimPrefix(itemTrim, "address "))
+			}
+		}
+	}
+
+	return confRead, nil
+}
+
+func delSecurityZoneBookAddressSet(zone, addressSet string, m interface{}, jnprSess *NetconfObject) error {
+	sess := m.(*Session)
+	configSet := []string{"delete security zones security-zone " + zone + " address-book address-set " + addressSet}
+
+	return sess.configSet(configSet, jnprSess)
+}
+
+func fillSecurityZoneBookAddressSetData(d *schema.ResourceData, zoneBookAddressSetOptions zoneBookAddressSetOptions) {
+	if tfErr := d.Set("name", zoneBookAddressSetOptions.name); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("zone", zoneBookAddressSetOptions.zone); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("address", zoneBookAddressSetOptions.address); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("description", zoneBookAddressSetOptions.description); tfErr != nil {
+		panic(tfErr)
+	}
+}

--- a/junos/resource_security_zone_book_address_set_test.go
+++ b/junos/resource_security_zone_book_address_set_test.go
@@ -1,0 +1,79 @@
+package junos_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccJunosSecurityZoneBookAddressSet_basic(t *testing.T) {
+	if os.Getenv("TESTACC_SWITCH") == "" {
+		resource.Test(t, resource.TestCase{
+			PreCheck:  func() { testAccPreCheck(t) },
+			Providers: testAccProviders,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccJunosSecurityZoneBookAddressSetConfigCreate(),
+				},
+				{
+					ResourceName:      "junos_security_zone_book_address_set.testacc_szone_bookaddress_set",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+				{
+					Config: testAccJunosSecurityZoneBookAddressSetConfigUpdate(),
+				},
+			},
+		})
+	}
+}
+
+func testAccJunosSecurityZoneBookAddressSetConfigCreate() string {
+	return `
+resource junos_security_zone "testacc_szone_bookaddressset" {
+  name                          = "testacc_szone_bookaddressset"
+  address_book_configure_singly = true
+}
+resource junos_security_zone_book_address "testacc_szone_bookaddress_set" {
+  name = "testacc_szone_bookaddress_set1"
+  zone = junos_security_zone.testacc_szone_bookaddressset.name
+  cidr = "192.0.2.0/25"
+}
+resource junos_security_zone_book_address_set "testacc_szone_bookaddress_set" {
+  name = "testacc_szone_bookaddress_set"
+  zone = junos_security_zone.testacc_szone_bookaddressset.name
+  address = [
+    junos_security_zone_book_address.testacc_szone_bookaddress_set.name,
+  ]
+  description = "testacc szone bookaddress set"
+}
+`
+}
+
+func testAccJunosSecurityZoneBookAddressSetConfigUpdate() string {
+	return `
+resource junos_security_zone "testacc_szone_bookaddressset" {
+  name                          = "testacc_szone_bookaddressset"
+  address_book_configure_singly = true
+}
+resource junos_security_zone_book_address "testacc_szone_bookaddress_set" {
+  name = "testacc_szone_bookaddress_set1"
+  zone = junos_security_zone.testacc_szone_bookaddressset.name
+  cidr = "192.0.2.0/25"
+}
+resource junos_security_zone_book_address "testacc_szone_bookaddress_set2" {
+  name = "testacc_szone_bookaddress_set2"
+  zone = junos_security_zone.testacc_szone_bookaddressset.name
+  cidr = "192.0.2.128/25"
+}
+resource junos_security_zone_book_address_set "testacc_szone_bookaddress_set" {
+  name = "testacc_szone_bookaddress_set"
+  zone = junos_security_zone.testacc_szone_bookaddressset.name
+  address = [
+    junos_security_zone_book_address.testacc_szone_bookaddress_set.name,
+    junos_security_zone_book_address.testacc_szone_bookaddress_set2.name,
+  ]
+}
+`
+}

--- a/junos/resource_security_zone_book_address_test.go
+++ b/junos/resource_security_zone_book_address_test.go
@@ -1,0 +1,138 @@
+package junos_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccJunosSecurityZoneBookAddress_basic(t *testing.T) {
+	if os.Getenv("TESTACC_SWITCH") == "" {
+		resource.Test(t, resource.TestCase{
+			PreCheck:  func() { testAccPreCheck(t) },
+			Providers: testAccProviders,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccJunosSecurityZoneBookAddressConfigCreate(),
+				},
+				{
+					ResourceName:      "junos_security_zone_book_address.testacc_szone_bookaddress1",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+				{
+					ResourceName:      "junos_security_zone_book_address.testacc_szone_bookaddress2",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+				{
+					ResourceName:      "junos_security_zone_book_address.testacc_szone_bookaddress3",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+				{
+					ResourceName:      "junos_security_zone_book_address.testacc_szone_bookaddress5",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+				{
+					ResourceName:      "junos_security_zone_book_address.testacc_szone_bookaddress6",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+				{
+					Config: testAccJunosSecurityZoneBookAddressConfigUpdate(),
+				},
+			},
+		})
+	}
+}
+
+func testAccJunosSecurityZoneBookAddressConfigCreate() string {
+	return `
+resource junos_security_zone "testacc_szone_bookaddress" {
+  name                          = "testacc_szone_bookaddress"
+  address_book_configure_singly = true
+}
+resource junos_security_zone_book_address "testacc_szone_bookaddress1" {
+  name        = "testacc_szone_bookaddress1"
+  zone        = junos_security_zone.testacc_szone_bookaddress.name
+  cidr        = "192.0.2.0/25"
+  description = "testacc szone bookaddress1"
+}
+resource junos_security_zone_book_address "testacc_szone_bookaddress2" {
+  name        = "testacc_szone_bookaddress2"
+  zone        = junos_security_zone.testacc_szone_bookaddress.name
+  dns_name    = "test.com"
+  description = "testacc szone bookaddress2"
+}
+resource junos_security_zone_book_address "testacc_szone_bookaddress3" {
+  name          = "testacc_szone_bookaddress3"
+  zone          = junos_security_zone.testacc_szone_bookaddress.name
+  dns_name      = "test.com"
+  description   = "testacc szone bookaddress3"
+  dns_ipv4_only = true
+}
+resource junos_security_zone_book_address "testacc_szone_bookaddress4" {
+  name          = "testacc_szone_bookaddress4"
+  zone          = junos_security_zone.testacc_szone_bookaddress.name
+  dns_name      = "test.com"
+  description   = "testacc szone bookaddress4"
+  dns_ipv6_only = true
+}
+resource junos_security_zone_book_address "testacc_szone_bookaddress5" {
+  name        = "testacc_szone_bookaddress5"
+  zone        = junos_security_zone.testacc_szone_bookaddress.name
+  range_from  = "192.0.2.10"
+  range_to    = "192.0.2.12"
+  description = "testacc szone bookaddress5"
+}
+resource junos_security_zone_book_address "testacc_szone_bookaddress6" {
+  name        = "testacc_szone_bookaddress6"
+  zone        = junos_security_zone.testacc_szone_bookaddress.name
+  wildcard    = "192.0.2.0/255.0.255.255"
+  description = "testacc szone bookaddress6"
+}
+`
+}
+
+func testAccJunosSecurityZoneBookAddressConfigUpdate() string {
+	return `
+resource junos_security_zone "testacc_szone_bookaddress" {
+  name                          = "testacc_szone_bookaddress"
+  address_book_configure_singly = true
+}
+resource junos_security_zone_book_address "testacc_szone_bookaddress1" {
+  name        = "testacc_szone_bookaddress1"
+  zone        = junos_security_zone.testacc_szone_bookaddress.name
+  cidr        = "192.0.2.128/25"
+  description = "testacc szone address1"
+}
+resource junos_security_zone_book_address "testacc_szone_bookaddress2" {
+  name        = "testacc_szone_bookaddress2"
+  zone        = junos_security_zone.testacc_szone_bookaddress.name
+  dns_name    = "test.fr"
+  description = "testacc szone address2"
+}
+resource junos_security_zone_book_address "testacc_szone_bookaddress3" {
+  name        = "testacc_szone_bookaddress3"
+  zone        = junos_security_zone.testacc_szone_bookaddress.name
+  dns_name    = "test.net"
+  description = "testacc szone address3"
+}
+resource junos_security_zone_book_address "testacc_szone_bookaddress5" {
+  name        = "testacc_szone_bookaddress5"
+  zone        = junos_security_zone.testacc_szone_bookaddress.name
+  range_from  = "192.0.2.20"
+  range_to    = "192.0.2.22"
+  description = "testacc szone ddress5"
+}
+resource junos_security_zone_book_address "testacc_szone_bookaddress6" {
+  name        = "testacc_szone_bookaddress6"
+  zone        = junos_security_zone.testacc_szone_bookaddress.name
+  wildcard    = "192.0.4.0/255.0.255.255"
+  description = "testacc szone address6"
+}
+`
+}

--- a/junos/resource_security_zone_test.go
+++ b/junos/resource_security_zone_test.go
@@ -25,15 +25,15 @@ func TestAccJunosSecurityZone_basic(t *testing.T) {
 						resource.TestCheckResourceAttr("junos_security_zone.testacc_securityZone",
 							"address_book.#", "1"),
 						resource.TestCheckResourceAttr("junos_security_zone.testacc_securityZone",
-							"address_book.0.name", "testacc_address1"),
+							"address_book.0.name", "testacc_zone1"),
 						resource.TestCheckResourceAttr("junos_security_zone.testacc_securityZone",
 							"address_book_set.#", "1"),
 						resource.TestCheckResourceAttr("junos_security_zone.testacc_securityZone",
-							"address_book_set.0.name", "testacc_addressSet"),
+							"address_book_set.0.name", "testacc_zoneSet"),
 						resource.TestCheckResourceAttr("junos_security_zone.testacc_securityZone",
 							"address_book_set.0.address.#", "1"),
 						resource.TestCheckResourceAttr("junos_security_zone.testacc_securityZone",
-							"address_book_set.0.address.0", "testacc_address1"),
+							"address_book_set.0.address.0", "testacc_zone1"),
 						resource.TestCheckResourceAttr("junos_security_zone.testacc_securityZone",
 							"application_tracking", "true"),
 						resource.TestCheckResourceAttr("junos_security_zone.testacc_securityZone",
@@ -51,26 +51,26 @@ func TestAccJunosSecurityZone_basic(t *testing.T) {
 					),
 				},
 				{
+					ResourceName:      "junos_security_zone.testacc_securityZone",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+				{
 					Config: testAccJunosSecurityZoneConfigUpdate(testaccInterface),
 					Check: resource.ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr("junos_security_zone.testacc_securityZone",
 							"address_book.#", "2"),
 						resource.TestCheckResourceAttr("junos_security_zone.testacc_securityZone",
-							"address_book.1.name", "testacc_address2"),
+							"address_book.1.name", "testacc_zone2"),
 						resource.TestCheckResourceAttr("junos_security_zone.testacc_securityZone",
 							"address_book_set.0.address.#", "2"),
 						resource.TestCheckResourceAttr("junos_security_zone.testacc_securityZone",
-							"address_book_set.0.address.1", "testacc_address2"),
+							"address_book_set.0.address.1", "testacc_zone2"),
 						resource.TestCheckResourceAttr("junos_security_zone.testacc_securityZone",
 							"inbound_services.#", "1"),
 						resource.TestCheckResourceAttr("junos_security_zone.testacc_securityZone",
 							"inbound_services.0", "ssh"),
 					),
-				},
-				{
-					ResourceName:      "junos_security_zone.testacc_securityZone",
-					ImportState:       true,
-					ImportStateVerify: true,
 				},
 				{
 					Config: testAccJunosSecurityZoneConfigUpdate2(testaccInterface),
@@ -93,12 +93,42 @@ resource junos_security_screen "testaccZone" {
 resource junos_security_zone "testacc_securityZone" {
   name = "testacc_securityZone"
   address_book {
-    name    = "testacc_address1"
-    network = "192.0.2.0/25"
+    name        = "testacc_zone1"
+    description = "testacc_zone 1"
+    network     = "192.0.2.0/25"
+  }
+  address_book_dns {
+    name        = "testacc_zone2"
+    description = "testacc_zone 2"
+    fqdn        = "test.com"
+  }
+  address_book_dns {
+    name        = "testacc_zone2b"
+    description = "testacc_zone 2b"
+    fqdn        = "test.com"
+    ipv4_only   = true
+  }
+  address_book_dns {
+    name        = "testacc_zone2c"
+    description = "testacc_zone 2c"
+    fqdn        = "test.com"
+    ipv6_only   = true
+  }
+  address_book_range {
+    name        = "testacc_zone3"
+    description = "testacc_zone 3"
+    from        = "192.0.2.10"
+    to          = "192.0.2.12"
   }
   address_book_set {
-    name    = "testacc_addressSet"
-    address = ["testacc_address1"]
+    name        = "testacc_zoneSet"
+    description = "testacc_zone Set"
+    address     = ["testacc_zone1"]
+  }
+  address_book_wildcard {
+    name        = "testacc_zone4"
+    description = "testacc_zone 4"
+    network     = "192.0.2.0/255.0.255.255"
   }
   application_tracking = true
   inbound_protocols    = ["bgp"]
@@ -120,16 +150,16 @@ resource junos_security_screen "testaccZone" {
 resource junos_security_zone "testacc_securityZone" {
   name = "testacc_securityZone"
   address_book {
-    name    = "testacc_address1"
+    name    = "testacc_zone1"
     network = "192.0.2.0/25"
   }
   address_book {
-    name    = "testacc_address2"
+    name    = "testacc_zone2"
     network = "192.0.2.128/25"
   }
   address_book_set {
-    name    = "testacc_addressSet"
-    address = ["testacc_address1", "testacc_address2"]
+    name    = "testacc_zoneSet"
+    address = ["testacc_zone1", "testacc_zone2"]
   }
   inbound_protocols = ["bgp"]
   inbound_services  = ["ssh"]

--- a/website/docs/r/security_zone.html.markdown
+++ b/website/docs/r/security_zone.html.markdown
@@ -32,6 +32,7 @@ The following arguments are supported:
 * `address_book` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified multiple times for each address to declare.
   * `name` - (Required)(`String`) Name of address.
   * `network` - (Required)(`String`) CIDR of address.
+* `address_book_configure_singly` - (Optional)(`Bool`) Disable management of address-book in this resource to be able to manage them with specific resources. Conflict with `address_book_*`.
 * `address_book_set` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified multiple times for each address-set to declare.
   * `name` - (Required)(`String`) Name of address-set.
   * `address` - (Required)(`ListOfString`) List of address names.

--- a/website/docs/r/security_zone.html.markdown
+++ b/website/docs/r/security_zone.html.markdown
@@ -32,10 +32,27 @@ The following arguments are supported:
 * `address_book` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified multiple times for each address to declare.
   * `name` - (Required)(`String`) Name of address.
   * `network` - (Required)(`String`) CIDR of address.
+  * `description` - (Optional)(`String`) Description of address.
 * `address_book_configure_singly` - (Optional)(`Bool`) Disable management of address-book in this resource to be able to manage them with specific resources. Conflict with `address_book_*`.
+* `address_book_dns` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified multiple times for each dns-name address to declare.
+  * `name` - (Required)(`String`) Name of address.
+  * `fqdn` - (Required)(`String`) Fully qualified domain name.
+  * `description` - (Optional)(`String`) Description of address.
+  * `ipv4_only` - (Optional)(`Bool`) IPv4 dns address.
+  * `ipv6_only` - (Optional)(`Bool`) IPv6 dns address.
+* `address_book_range` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified multiple times for each range-address to declare.
+  * `name` - (Required)(`String`) Name of address.
+  * `from` - (Required)(`String`) Lower limit of address range.
+  * `to` - (Required)(`String`) Upper limit of address range.
+  * `description` - (Optional)(`String`) Description of address.
 * `address_book_set` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified multiple times for each address-set to declare.
   * `name` - (Required)(`String`) Name of address-set.
   * `address` - (Required)(`ListOfString`) List of address names.
+  * `description` - (Optional)(`String`) Description of address-set.
+* `address_book_wildcard` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified multiple times for each wildcard-address to declare.
+  * `name` - (Required)(`String`) Name of address.
+  * `network` - (Required)(`String`) Numeric IPv4 wildcard address with in the form of a.d.d.r/netmask.
+  * `description` - (Optional)(`String`) Description of address.
 * `advance_policy_based_routing_profile` - (Optional)(`String`) Enable Advance Policy Based Routing on this zone with a profile.
 * `application_tracking` - (Optional)(`Bool`) Enable Application tracking support for this zone.
 * `description` - (Optional)(`String`) Text description of zone.

--- a/website/docs/r/security_zone_book_address.html.markdown
+++ b/website/docs/r/security_zone_book_address.html.markdown
@@ -1,0 +1,49 @@
+---
+layout: "junos"
+page_title: "Junos: junos_security_zone_book_address"
+sidebar_current: "docs-junos-resource-security-zone-book-address"
+description: |-
+  Create a address in address-book of security zone (when Junos device supports it)
+---
+
+# junos_security_zone_book_address
+
+Provides a address resource in address-book of security zone.
+
+-> **Note:** The `security_zone` resource need to be have `address_book_configure_singly` to true otherwise there will be a conflict between resources.
+
+## Example Usage
+
+```hcl
+# Add a address
+resource junos_security_zone_book_address "demo" {
+  name = "address1"
+  zone = "theZone"
+  cidr = "192.0.2.0/25"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required, Forces new resource)(`String`) The name of address.
+* `zone` - (Required, Forces new resource)(`String`) The name of security zone.
+* `cidr` - (Optional)(`String`) CIDR of address.
+* `description` - (Optional)(`String`) Description of address.
+* `dns_ipv4_only` - (Optional)(`Bool`) IPv4 dns address.
+* `dns_ipv6_only` - (Optional)(`Bool`) IPv6 dns address.
+* `dns_name` - (Optional)(`String`) DNS address name.
+* `range_from` - (Optional)(`String`) Lower limit of address range.
+* `range_to` - (Optional)(`String`) Upper limit of address range.
+* `wildcard` - (Optional)(`String`) Numeric IPv4 wildcard address with in the form of a.d.d.r/netmask.
+
+-> **Note:** One of `cidr`, `dns_name`, `range_from` or `wildcard` argument need to be set.
+
+## Import
+
+Junos address in address-book of security zone can be imported using an id made up of `<zone>_-_<name>`, e.g.
+
+```
+$ terraform import junos_security_zone_book_address.demo theZone_-_address1
+```

--- a/website/docs/r/security_zone_book_address_set.html.markdown
+++ b/website/docs/r/security_zone_book_address_set.html.markdown
@@ -1,0 +1,41 @@
+---
+layout: "junos"
+page_title: "Junos: junos_security_zone_book_address_set"
+sidebar_current: "docs-junos-resource-security-zone-book-address-set"
+description: |-
+  Create a address-set in address-book of security zone (when Junos device supports it)
+---
+
+# junos_security_zone_book_address_set
+
+Provides a address-set resource in address-book of security zone.
+
+-> **Note:** The `security_zone` resource need to be have `address_book_configure_singly` to true otherwise there will be a conflict between resources.
+
+## Example Usage
+
+```hcl
+# Add a address-set
+resource junos_security_zone_book_address_set "demo" {
+  name    = "addressSet1"
+  zone    = "theZone"
+  address = ["address1"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required, Forces new resource)(`String`) The name of address-set.
+* `zone` - (Required, Forces new resource)(`String`) The name of security zone.
+* `address` - (Required)(`ListOfString`) Address to be included in this set.
+* `description` - (Optional)(`String`) Description of address-set.
+
+## Import
+
+Junos address-set in address-book of security zone can be imported using an id made up of `<zone>_-_<name>`, e.g.
+
+```
+$ terraform import junos_security_zone_book_address_set.demo theZone_-_addressSet1
+```

--- a/website/junos.erb
+++ b/website/junos.erb
@@ -171,6 +171,9 @@
           <li<%= sidebar_current("docs-junos-resource-security-zone") %>>
             <a href="/docs/providers/junos/r/security_zone.html">junos_security_zone</a>
           </li>
+          <li<%= sidebar_current("docs-junos-resource-security-zone-book-address") %>>
+            <a href="/docs/providers/junos/r/security_zone_book_address.html">junos_security_zone_book_address</a>
+          </li>
           <li<%= sidebar_current("docs-junos-resource-services") %>>
             <a href="/docs/providers/junos/r/services.html">junos_services</a>
           </li>

--- a/website/junos.erb
+++ b/website/junos.erb
@@ -174,6 +174,9 @@
           <li<%= sidebar_current("docs-junos-resource-security-zone-book-address") %>>
             <a href="/docs/providers/junos/r/security_zone_book_address.html">junos_security_zone_book_address</a>
           </li>
+          <li<%= sidebar_current("docs-junos-resource-security-zone-book-address-set") %>>
+            <a href="/docs/providers/junos/r/security_zone_book_address_set.html">junos_security_zone_book_address_set</a>
+          </li>
           <li<%= sidebar_current("docs-junos-resource-services") %>>
             <a href="/docs/providers/junos/r/services.html">junos_services</a>
           </li>


### PR DESCRIPTION
ENHANCEMENTS:
* resource/`junos_security_address_book`: list of string for `address` argument inside `address_set` argument is now unordered
* resource/`junos_security_zone`: add `address_book_configure_singly` argument to disable management of address-book in this resource. (Fixes parts of #192)
* resource/`junos_security_zone`: add `address_book_dns`, `address_book_range` and `address_book_wildcard` arguments and add `description` on existing `address_book_*` arguments
* resource/`junos_security_zone`: list of string for `address` argument inside `address_book_set` argument is now unordered
* add `junos_security_zone_book_address` resource (Fixes parts of #192)
* add `junos_security_zone_book_address_set` resource (Fixes parts of #192)