### PR TITLE
Fixes #211: add preferred and primary arguments on interface address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ENHANCEMENTS:
 * resource/`junos_group_dual_system`: add `preferred` and `primary` arguments inside `family_inet_address` and `family_inet6_address` arguments inside `interface_fxp0` argument (Fixes #211)
 * resource/`junos_interface_logical`: add `preferred` and `primary` arguments inside `address` argument inside `family_inet` and `family_inet6` arguments
+* data-source/`junos_interface_logical`: add `preferred` and `primary` attributes as for the resource
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## upcoming release
 ENHANCEMENTS:
 * resource/`junos_group_dual_system`: add `preferred` and `primary` arguments inside `family_inet_address` and `family_inet6_address` arguments inside `interface_fxp0` argument (Fixes #211)
+* resource/`junos_interface_logical`: add `preferred` and `primary` arguments inside `address` argument inside `family_inet` and `family_inet6` arguments
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## upcoming release
 ENHANCEMENTS:
+* resource/`junos_group_dual_system`: add `preferred` and `primary` arguments inside `family_inet_address` and `family_inet6_address` arguments inside `interface_fxp0` argument (Fixes #211)
 
 BUG FIXES:
 

--- a/junos/data_source_interface_logical.go
+++ b/junos/data_source_interface_logical.go
@@ -53,6 +53,14 @@ func dataSourceInterfaceLogical() *schema.Resource {
 										Type:     schema.TypeString,
 										Computed: true,
 									},
+									"preferred": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"primary": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
 									"vrrp_group": {
 										Type:     schema.TypeList,
 										Computed: true,
@@ -196,6 +204,14 @@ func dataSourceInterfaceLogical() *schema.Resource {
 								Schema: map[string]*schema.Schema{
 									"cidr_ip": {
 										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"preferred": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
+									"primary": {
+										Type:     schema.TypeBool,
 										Computed: true,
 									},
 									"vrrp_group": {

--- a/junos/resource_group_dual_system_test.go
+++ b/junos/resource_group_dual_system_test.go
@@ -97,10 +97,14 @@ resource "junos_group_dual_system" "testacc_node0" {
     family_inet_address {
       cidr_ip     = "192.0.2.194/26"
       master_only = true
+      primary     = true
+      preferred   = true
     }
     family_inet6_address {
       cidr_ip     = "fe80::2/64"
       master_only = true
+      primary     = true
+      preferred   = true
     }
   }
   routing_options {

--- a/junos/resource_interface.go
+++ b/junos/resource_interface.go
@@ -1148,7 +1148,7 @@ func readInterface(interFace string, m interface{}, jnprSess *NetconfObject) (in
 				confRead.inet6 = true
 				switch {
 				case strings.HasPrefix(itemTrim, "family inet6 address "):
-					inet6Address, err = fillFamilyInetAddressOld(itemTrim, inet6Address, inet6Word)
+					inet6Address, err = readFamilyInetAddressOld(itemTrim, inet6Address, inet6Word)
 					if err != nil {
 						return confRead, err
 					}
@@ -1180,7 +1180,7 @@ func readInterface(interFace string, m interface{}, jnprSess *NetconfObject) (in
 				confRead.inet = true
 				switch {
 				case strings.HasPrefix(itemTrim, "family inet address "):
-					inetAddress, err = fillFamilyInetAddressOld(itemTrim, inetAddress, inetWord)
+					inetAddress, err = readFamilyInetAddressOld(itemTrim, inetAddress, inetWord)
 					if err != nil {
 						return confRead, err
 					}
@@ -1543,7 +1543,7 @@ func fillInterfaceData(d *schema.ResourceData, interfaceOpt interfaceOptions) {
 	}
 }
 
-func fillFamilyInetAddressOld(item string, inetAddress []map[string]interface{},
+func readFamilyInetAddressOld(item string, inetAddress []map[string]interface{},
 	family string) ([]map[string]interface{}, error) {
 	var addressConfig []string
 	var itemTrim string

--- a/junos/resource_interface_logical.go
+++ b/junos/resource_interface_logical.go
@@ -933,7 +933,7 @@ func readInterfaceLogical(interFace string, m interface{}, jnprSess *NetconfObje
 				switch {
 				case strings.HasPrefix(itemTrim, "family inet6 address "):
 					var err error
-					confRead.familyInet6[0]["address"], err = fillFamilyInetAddress(
+					confRead.familyInet6[0]["address"], err = readFamilyInetAddress(
 						itemTrim, confRead.familyInet6[0]["address"].([]map[string]interface{}), inet6Word)
 					if err != nil {
 						return confRead, err
@@ -983,7 +983,7 @@ func readInterfaceLogical(interFace string, m interface{}, jnprSess *NetconfObje
 				switch {
 				case strings.HasPrefix(itemTrim, "family inet address "):
 					var err error
-					confRead.familyInet[0]["address"], err = fillFamilyInetAddress(
+					confRead.familyInet[0]["address"], err = readFamilyInetAddress(
 						itemTrim, confRead.familyInet[0]["address"].([]map[string]interface{}), inetWord)
 					if err != nil {
 						return confRead, err
@@ -1183,7 +1183,7 @@ func fillInterfaceLogicalData(d *schema.ResourceData, interfaceLogicalOpt interf
 	}
 }
 
-func fillFamilyInetAddress(item string, inetAddress []map[string]interface{},
+func readFamilyInetAddress(item string, inetAddress []map[string]interface{},
 	family string) ([]map[string]interface{}, error) {
 	var addressConfig []string
 	var itemTrim string

--- a/junos/resource_interface_logical_test.go
+++ b/junos/resource_interface_logical_test.go
@@ -336,7 +336,9 @@ resource junos_interface_logical testacc_interface_logical {
       mode_loose = true
     }
     address {
-      cidr_ip = "192.0.2.1/25"
+      cidr_ip   = "192.0.2.1/25"
+      primary   = true
+      preferred = true
       vrrp_group {
         identifier               = 100
         virtual_address          = ["192.0.2.2"]
@@ -355,7 +357,9 @@ resource junos_interface_logical testacc_interface_logical {
     filter_input  = junos_firewall_filter.testacc_intlogicalInet6.name
     filter_output = junos_firewall_filter.testacc_intlogicalInet6.name
     address {
-      cidr_ip = "2001:db8::1/64"
+      cidr_ip   = "2001:db8::1/64"
+      primary   = true
+      preferred = true
       vrrp_group {
         identifier                 = 100
         virtual_address            = ["2001:db8::2"]

--- a/website/docs/d/interface_logical.html.markdown
+++ b/website/docs/d/interface_logical.html.markdown
@@ -62,6 +62,8 @@ The following arguments are supported:
 ---
 #### address attributes for family_inet
 * `cidr_ip` - Address IP/Mask v4.
+* `preferred` - Preferred address on interface.
+* `primary` - Candidate for primary address in system.
 * `vrrp_group` - List of vrrp group configurations. See the [`vrrp_group` attributes for address in family_inet](#vrrp_group-attributes-for-address-in-family_inet) block.
 
 ---
@@ -88,6 +90,8 @@ The following arguments are supported:
 ---
 #### address attributes for family_inet6
 * `cidr_ip` - Address IP/Mask v6.
+* `preferred` - Preferred address on interface.
+* `primary` - Candidate for primary address in system.
 * `vrrp_group` - List of vrrp group configurations. See the [`vrrp_group` attributes for address in family_inet6](#vrrp_group-attributes-for-address-in-family_inet6) block.
 
 ---

--- a/website/docs/r/group_dual_system.html.markdown
+++ b/website/docs/r/group_dual_system.html.markdown
@@ -62,9 +62,13 @@ Can be specified only once for configure `system` block.
 * `family_inet_address` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified multiple times for each ip address to declare.
   * `cidr_ip` - (Required)(`String`) Address IP/Mask v4.
   * `master_only` - (Optional)(`Bool`) Master management IP address.
+  * `preferred` - (Optional)(`Bool`) Preferred address on interface.
+  * `primary` - (Optional)(`Bool`) Candidate for primary address in system.
 * `family_inet6_address` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified multiple times for each ip v6 address to declare.
   * `cidr_ip` - (Required)(`String`) Address IP/Mask v6.
   * `master_only` - (Optional)(`Bool`) Master management IP address.
+  * `preferred` - (Optional)(`Bool`) Preferred address on interface.
+  * `primary` - (Optional)(`Bool`) Candidate for primary address in system.
 
 ---
 #### routing_options arguments

--- a/website/docs/r/interface_logical.html.markdown
+++ b/website/docs/r/interface_logical.html.markdown
@@ -57,6 +57,8 @@ The following arguments are supported:
 ---
 #### address arguments for family_inet
 * `cidr_ip` - (Required)(`String`) Address IP/Mask v4.
+* `preferred` - (Optional)(`Bool`) Preferred address on interface.
+* `primary` - (Optional)(`Bool`) Candidate for primary address in system.
 * `vrrp_group` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified multiple times for each vrrp group to declare. See the [`vrrp_group` arguments for address in family_inet](#vrrp_group-arguments-for-address-in-family_inet) block.
 
 ---
@@ -83,6 +85,8 @@ The following arguments are supported:
 ---
 #### address arguments for family_inet6
 * `cidr_ip` - (Required)(`String`) Address IP/Mask v6.
+* `preferred` - (Optional)(`Bool`) Preferred address on interface.
+* `primary` - (Optional)(`Bool`) Candidate for primary address in system.
 * `vrrp_group` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified multiple times for each vrrp group to declare. See the [`vrrp_group` arguments for address in family_inet6](#vrrp_group-arguments-for-address-in-family_inet6) block.
 
 ---


### PR DESCRIPTION
ENHANCEMENTS:
* resource/`junos_group_dual_system`: add `preferred` and `primary` arguments inside `family_inet_address` and `family_inet6_address` arguments inside `interface_fxp0` argument (Fixes #211)
* resource/`junos_interface_logical`: add `preferred` and `primary` arguments inside `address` argument inside `family_inet` and `family_inet6` arguments