### PR TITLE
Provider: try key and password on SSH authentication and add support of SSH agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ENHANCEMENTS:
 * provider: try multiple SSH authentication methods (key + password)
 * provider: add `ssh_ciphers` attribute to configure ciphers used in SSH connection
+* provider: add support of SSH agent to SSH authentication (Fixes #212)
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## upcoming release
 ENHANCEMENTS:
+* provider: try multiple SSH authentication methods (key + password)
+* provider: add `ssh_ciphers` attribute to configure ciphers used in SSH connection
 
 BUG FIXES:
 

--- a/junos/config.go
+++ b/junos/config.go
@@ -23,6 +23,7 @@ type configProvider struct {
 	junosFilePermission      string
 	junosDebugNetconfLogPath string
 	junosFakeCreateSetFile   string
+	junosSSHCiphers          []string
 }
 
 // prepareSession : prepare information to connect to Junos Device and more.
@@ -38,6 +39,7 @@ func (c *configProvider) prepareSession() (*Session, diag.Diagnostics) {
 		junosSleepLock:      c.junosCmdSleepLock,
 		junosSleepShort:     c.junosCmdSleepShort,
 		junosSleepSSHClosed: c.junosSSHSleepClosed,
+		junosSSHCiphers:     c.junosSSHCiphers,
 	}
 	// junosSSHKeyFile
 	sshKeyFile := c.junosSSHKeyFile

--- a/junos/provider.go
+++ b/junos/provider.go
@@ -69,6 +69,12 @@ func Provider() *schema.Provider {
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("JUNOS_SLEEP_SSH_CLOSED", 0),
 			},
+			"ssh_ciphers": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				DefaultFunc: defaultSSHCiphers(),
+			},
 			"file_permission": {
 				Type:             schema.TypeString,
 				Optional:         true,
@@ -190,6 +196,9 @@ func configureProvider(ctx context.Context, d *schema.ResourceData) (interface{}
 		junosFilePermission:      d.Get("file_permission").(string),
 		junosDebugNetconfLogPath: d.Get("debug_netconf_log_path").(string),
 		junosFakeCreateSetFile:   d.Get("fake_create_with_setfile").(string),
+	}
+	for _, v := range d.Get("ssh_ciphers").([]interface{}) {
+		c.junosSSHCiphers = append(c.junosSSHCiphers, v.(string))
 	}
 
 	return c.prepareSession()

--- a/junos/provider_test.go
+++ b/junos/provider_test.go
@@ -36,11 +36,12 @@ func TestProvider_impl(t *testing.T) {
 
 func testAccPreCheck(t *testing.T) {
 	t.Helper()
-	if os.Getenv("JUNOS_HOST") == "" && os.Getenv("JUNOS_KEYFILE") == "" {
+	if os.Getenv("JUNOS_HOST") == "" {
 		t.Fatal("JUNOS_HOST must be set for acceptance tests")
 	}
-	if os.Getenv("JUNOS_KEYFILE") == "" && os.Getenv("JUNOS_PASSWORD") == "" && os.Getenv("JUNOS_KEYPEM") == "" {
-		t.Fatal("JUNOS_KEYPEM, JUNOS_KEYFILE or JUNOS_PASSWORD must be set for acceptance tests")
+	if os.Getenv("JUNOS_KEYFILE") == "" && os.Getenv("JUNOS_PASSWORD") == "" && os.Getenv("SSH_AUTH_SOCK") == "" &&
+		os.Getenv("JUNOS_KEYPEM") == "" {
+		t.Fatal("JUNOS_KEYPEM, JUNOS_KEYFILE, SSH_AUTH_SOCK or JUNOS_PASSWORD must be set for acceptance tests")
 	}
 	if os.Getenv("JUNOS_FAKECREATE_SETFILE") != "" {
 		t.Fatal("can't run testacc with JUNOS_FAKECREATE_SETFILE")

--- a/junos/session.go
+++ b/junos/session.go
@@ -27,11 +27,13 @@ type Session struct {
 	junosGroupIntDel       string
 	junosLogFile           string
 	junosFakeCreateSetFile string
+	junosSSHCiphers        []string
 }
 
 func (sess *Session) startNewSession() (*NetconfObject, error) {
 	var auth netconfAuthMethod
 	auth.Username = sess.junosUserName
+	auth.Ciphers = sess.junosSSHCiphers
 	if sess.junosSSHKeyPEM != "" {
 		auth.PrivateKeyPEM = sess.junosSSHKeyPEM
 		if sess.junosKeyPass != "" {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -90,8 +90,7 @@ The following arguments are supported in the `provider` block:
   It can also be sourced from the `JUNOS_KEYFILE` environment variable.  
   Defaults is empty.
 
-* `password` - (Optional) This is a password for ssh connection.  
-  Used only if `sshkey_pem` and `sshkeyfile` is empty.  
+* `password` - (Optional) This is a password for ssh connection.   
   It can also be sourced from the `JUNOS_PASSWORD` environment variable.  
   Defaults is empty.
 
@@ -108,6 +107,8 @@ The following arguments are supported in the `provider` block:
   It can also be sourced from the `JUNOS_GROUP_INTERFACE_DELETE` environment variable.  
   Defaults to empty.
 
+-> **Note:** Two SSH authentication methods (keys / password) is possible and tried with the `sshkey_pem` or `sshkeyfile` and `password` attributes.
+
 ---
 #### Command options
 * `cmd_sleep_short` - (Optional) Number of milliseconds to wait after Terraform provider executes an action on the Junos device.  
@@ -123,6 +124,9 @@ The following arguments are supported in the `provider` block:
 * `ssh_sleep_closed` - (Optional) Number of seconds to wait after Terraform provider closed a ssh connection.  
   It can also be sourced from the `JUNOS_SLEEP_SSH_CLOSED` environment variable.  
   Defaults to `0`.
+
+* `ssh_ciphers` - (Optional) List of ciphers used in SSH connection.  
+  Defaults to `["aes128-gcm@openssh.com", "chacha20-poly1305@openssh.com", "aes128-ctr", "aes192-ctr", "aes256-ctr", "aes128-cbc"]`
 
 ---
 #### Debug & workaround options

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -107,7 +107,8 @@ The following arguments are supported in the `provider` block:
   It can also be sourced from the `JUNOS_GROUP_INTERFACE_DELETE` environment variable.  
   Defaults to empty.
 
--> **Note:** Two SSH authentication methods (keys / password) is possible and tried with the `sshkey_pem` or `sshkeyfile` and `password` attributes.
+-> **Note:** Two SSH authentication methods (keys / password) are possible and tried with the `sshkey_pem`, `sshkeyfile` attributes or the keys provided by a SSH agent through the `SSH_AUTH_SOCK` environnement variable and `password` attribute.  
+  The keys provided by a SSH agent are only read if `sshkey_pem` and `sshkeyfile` attributes aren't set.
 
 ---
 #### Command options


### PR DESCRIPTION
ENHANCEMENTS:
* provider: try multiple SSH authentication methods (key + password)
* provider: add `ssh_ciphers` attribute to configure ciphers used in SSH connection
* provider: add support of SSH agent to SSH authentication (Fixes #212)