### PR TITLE
Release v1.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ENHANCEMENTS:
 
 BUG FIXES:
+* resource/`junos_interface_logical`: disable set vlan-id on 'irb.*' interface (Fixes #217)
 
 ## 1.16.0 (May 17, 2021)
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 ENHANCEMENTS:
 
 BUG FIXES:
-* resource/`junos_interface_logical`: disable set vlan-id on 'irb.*' interface (Fixes #217)
+
+## 1.16.1 (May 26, 2021)
+BUG FIXES:
+* resource/`junos_interface_logical`: disable set vlan-id on 'irb.*' interface (Fixes [#217](https://github.com/jeremmfr/terraform-provider-junos/issues/217))
 
 ## 1.16.0 (May 17, 2021)
 FEATURES:

--- a/junos/resource_interface_logical.go
+++ b/junos/resource_interface_logical.go
@@ -886,7 +886,7 @@ func setInterfaceLogical(d *schema.ResourceData, m interface{}, jnprSess *Netcon
 	}
 	if d.Get("vlan_id").(int) != 0 {
 		configSet = append(configSet, setPrefix+"vlan-id "+strconv.Itoa(d.Get("vlan_id").(int)))
-	} else if intCut[0] != st0Word && intCut[1] != "0" {
+	} else if !stringInSlice(intCut[0], []string{st0Word, "irb"}) && intCut[1] != "0" {
 		configSet = append(configSet, setPrefix+"vlan-id "+intCut[1])
 	}
 

--- a/website/docs/r/interface_logical.html.markdown
+++ b/website/docs/r/interface_logical.html.markdown
@@ -52,7 +52,8 @@ The following arguments are supported:
 * `security_inbound_protocols` - (Optional)(`ListOfString`) The inbound protocols allowed. Must be a list of Junos protocols. `security_zone` need to be set.
 * `security_inbound_services` - (Optional)(`ListOfString`) The inbound services allowed. Must be a list of Junos services. `security_zone` need to be set.
 * `security_zone` - (Optional)(`String`) Add this interface in security_zone. Need to be created before.
-* `vlan_id` - (Optional,Computed)(`Int`) 802.1q VLAN ID for unit interface. If not set, computed with `name` of interface (ge-0/0/0.100 = 100) except if name has '.0' suffix or 'st0.' prefix.
+* `vlan_id` - (Optional,Computed)(`Int`) 802.1q VLAN ID for unit interface.  
+  If not set, computed with `name` of interface (ge-0/0/0.100 = 100) except if name has '.0' suffix or 'st0.', 'irb.' prefix.
 
 ---
 #### address arguments for family_inet


### PR DESCRIPTION
BUG FIXES:
* resource/`junos_interface_logical`: disable set vlan-id on 'irb.*' interface (Fixes [#217](https://github.com/jeremmfr/terraform-provider-junos/issues/217))