### PR TITLE
r/interface_logical: add vlan_no_compute argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ ENHANCEMENTS:
 * resource/`junos_system`: add `radius_options_attributes_nas_ipaddress`, `radius_options_enhanced_accounting` and `radius_options_password_protocol_mschapv2` arguments (Fixes #210)
 * resource/`junos_group_dual_system`: add `preferred` and `primary` arguments inside `family_inet_address` and `family_inet6_address` arguments inside `interface_fxp0` argument (Fixes #211)
 * resource/`junos_interface_logical`: add `preferred` and `primary` arguments inside `address` argument inside `family_inet` and `family_inet6` arguments
+* resource/`junos_interface_logical`: add `vlan_no_compute` argument to disable the automatic compute of `vlan_id`
 * data-source/`junos_interface_logical`: add `preferred` and `primary` attributes as for the resource
 
 BUG FIXES:

--- a/junos/resource_interface_logical.go
+++ b/junos/resource_interface_logical.go
@@ -414,6 +414,10 @@ func resourceInterfaceLogical() *schema.Resource {
 				Computed:     true,
 				ValidateFunc: validation.IntBetween(1, 4094),
 			},
+			"vlan_no_compute": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -727,6 +731,16 @@ func resourceInterfaceLogicalImport(d *schema.ResourceData, m interface{}) ([]*s
 	if tfErr := d.Set("name", d.Id()); tfErr != nil {
 		panic(tfErr)
 	}
+	if interfaceLogicalOpt.vlanID == 0 {
+		intCut := strings.Split(d.Id(), ".")
+		if !stringInSlice(intCut[0], []string{st0Word, "irb"}) &&
+			intCut[1] != "0" {
+			if tfErr := d.Set("vlan_no_compute", true); tfErr != nil {
+				panic(tfErr)
+			}
+		}
+	}
+
 	fillInterfaceLogicalData(d, interfaceLogicalOpt)
 
 	result[0] = d
@@ -902,7 +916,7 @@ func setInterfaceLogical(d *schema.ResourceData, m interface{}, jnprSess *Netcon
 	}
 	if d.Get("vlan_id").(int) != 0 {
 		configSet = append(configSet, setPrefix+"vlan-id "+strconv.Itoa(d.Get("vlan_id").(int)))
-	} else if !stringInSlice(intCut[0], []string{st0Word, "irb"}) && intCut[1] != "0" {
+	} else if !stringInSlice(intCut[0], []string{st0Word, "irb"}) && intCut[1] != "0" && !d.Get("vlan_no_compute").(bool) {
 		configSet = append(configSet, setPrefix+"vlan-id "+intCut[1])
 	}
 

--- a/website/docs/r/interface_logical.html.markdown
+++ b/website/docs/r/interface_logical.html.markdown
@@ -54,6 +54,8 @@ The following arguments are supported:
 * `security_zone` - (Optional)(`String`) Add this interface in security_zone. Need to be created before.
 * `vlan_id` - (Optional,Computed)(`Int`) 802.1q VLAN ID for unit interface.  
   If not set, computed with `name` of interface (ge-0/0/0.100 = 100) except if name has '.0' suffix or 'st0.', 'irb.' prefix.
+* `vlan_no_compute` - (Optional)(`Bool`) Disable the automatic compute of the `vlan_id` argument when not set.  
+  (Unnecessary if name has '.0' suffix or 'st0.', 'irb.' prefix because it's already disabled.)
 
 ---
 #### address arguments for family_inet


### PR DESCRIPTION
ENHANCEMENTS:
* resource/`junos_interface_logical`: add `vlan_no_compute` argument to disable the automatic compute of `vlan_id`