### PR TITLE
Release v1.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ENHANCEMENTS:
 
 BUG FIXES:
+* resource/`junos_interface_logical`: disable set vlan-id on 'vlan.*' interface (Fixes parts of #222)
 * resource/`junos_vlan`: allow 'vlan.*' interface in `l3_interface` argument (Fixes parts of #222)
 
 ## 1.16.1 (May 26, 2021)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 ENHANCEMENTS:
 
 BUG FIXES:
-* provider: fix XML error on commit with RPC reply without `<commit-results>` but different from `<ok/>` (Fixes #223)
-* resource/`junos_interface_logical`: disable set vlan-id on 'vlan.*' interface (Fixes parts of #222)
-* resource/`junos_vlan`: allow 'vlan.*' interface in `l3_interface` argument (Fixes parts of #222)
+
+## 1.16.2 (May 28, 2021)
+BUG FIXES:
+* provider: fix XML error on commit with RPC reply without `<commit-results>` but different from `<ok/>` (Fixes [#223](https://github.com/jeremmfr/terraform-provider-junos/issues/223))
+* resource/`junos_interface_logical`: disable set vlan-id on 'vlan.*' interface (Fixes parts of [#222](https://github.com/jeremmfr/terraform-provider-junos/issues/222))
+* resource/`junos_vlan`: allow 'vlan.*' interface in `l3_interface` argument (Fixes parts of [#222](https://github.com/jeremmfr/terraform-provider-junos/issues/222))
 
 ## 1.16.1 (May 26, 2021)
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ENHANCEMENTS:
 
 BUG FIXES:
+* resource/`junos_vlan`: allow 'vlan.*' interface in `l3_interface` argument (Fixes parts of #222)
 
 ## 1.16.1 (May 26, 2021)
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ENHANCEMENTS:
 
 BUG FIXES:
+* provider: fix XML error on commit with RPC reply without `<commit-results>` but different from `<ok/>` (Fixes #223)
 * resource/`junos_interface_logical`: disable set vlan-id on 'vlan.*' interface (Fixes parts of #222)
 * resource/`junos_vlan`: allow 'vlan.*' interface in `l3_interface` argument (Fixes parts of #222)
 

--- a/junos/netconf.go
+++ b/junos/netconf.go
@@ -276,7 +276,6 @@ func (j *NetconfObject) netconfConfigClear() []error {
 
 // netconfCommit commits the configuration.
 func (j *NetconfObject) netconfCommit(logMessage string) (_warn []error, _err error) {
-	var errs commitResults
 	reply, err := j.Session.Exec(netconf.RawMethod(fmt.Sprintf(rpcCommit, logMessage)))
 	if err != nil {
 		return []error{}, fmt.Errorf("failed to netconf commit : %w", err)
@@ -294,7 +293,8 @@ func (j *NetconfObject) netconfCommit(logMessage string) (_warn []error, _err er
 		return warnings, nil
 	}
 
-	if reply.Data != "\n<ok/>\n" {
+	var errs commitResults
+	if strings.Contains(reply.Data, "<commit-results>") {
 		err = xml.Unmarshal([]byte(reply.Data), &errs)
 		if err != nil {
 			return []error{}, fmt.Errorf("failed to xml unmarshal reply %s : %w", reply.Data, err)

--- a/junos/resource_interface_logical.go
+++ b/junos/resource_interface_logical.go
@@ -886,7 +886,7 @@ func setInterfaceLogical(d *schema.ResourceData, m interface{}, jnprSess *Netcon
 	}
 	if d.Get("vlan_id").(int) != 0 {
 		configSet = append(configSet, setPrefix+"vlan-id "+strconv.Itoa(d.Get("vlan_id").(int)))
-	} else if !stringInSlice(intCut[0], []string{st0Word, "irb"}) && intCut[1] != "0" {
+	} else if !stringInSlice(intCut[0], []string{st0Word, "irb", "vlan"}) && intCut[1] != "0" {
 		configSet = append(configSet, setPrefix+"vlan-id "+intCut[1])
 	}
 

--- a/junos/resource_vlan.go
+++ b/junos/resource_vlan.go
@@ -77,9 +77,9 @@ func resourceVlan() *schema.Resource {
 				Optional: true,
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 					value := v.(string)
-					if !strings.HasPrefix(value, "irb.") {
+					if !checkStringHasPrefixInList(value, []string{"irb.", "vlan."}) {
 						errors = append(errors, fmt.Errorf(
-							"%q for %q is not start with 'irb.'", value, k))
+							"%q for %q is not start with 'irb.' or 'vlan.'", value, k))
 					}
 
 					return

--- a/junos/resource_vlan_test.go
+++ b/junos/resource_vlan_test.go
@@ -75,12 +75,15 @@ resource junos_firewall_filter "testacc_vlansw" {
     }
   }
 }
+resource junos_interface_logical "testacc_vlansw" {
+  name = "irb.1000"
+}
 resource junos_vlan "testacc_vlansw" {
   name                  = "testacc_vlansw"
   description           = "testacc_vlansw"
   vlan_id               = 1000
   service_id            = 1000
-  l3_interface          = "irb.1000"
+  l3_interface          = junos_interface_logical.testacc_vlansw.name
   forward_filter_input  = junos_firewall_filter.testacc_vlansw.name
   forward_filter_output = junos_firewall_filter.testacc_vlansw.name
   forward_flood_input   = junos_firewall_filter.testacc_vlansw.name
@@ -90,6 +93,9 @@ resource junos_vlan "testacc_vlansw" {
 
 func testAccJunosVlanSwConfigUpdate() string {
 	return `
+resource junos_interface_logical "testacc_vlansw" {
+  name = "irb.1000"
+}
 resource junos_firewall_filter "testacc_vlansw" {
   name   = "testacc_vlansw"
   family = "ethernet-switching"

--- a/website/docs/r/interface_logical.html.markdown
+++ b/website/docs/r/interface_logical.html.markdown
@@ -53,7 +53,7 @@ The following arguments are supported:
 * `security_inbound_services` - (Optional)(`ListOfString`) The inbound services allowed. Must be a list of Junos services. `security_zone` need to be set.
 * `security_zone` - (Optional)(`String`) Add this interface in security_zone. Need to be created before.
 * `vlan_id` - (Optional,Computed)(`Int`) 802.1q VLAN ID for unit interface.  
-  If not set, computed with `name` of interface (ge-0/0/0.100 = 100) except if name has '.0' suffix or 'st0.', 'irb.' prefix.
+  If not set, computed with `name` of interface (ge-0/0/0.100 = 100) except if name has '.0' suffix or 'st0.', 'irb.', 'vlan.' prefix.
 
 ---
 #### address arguments for family_inet

--- a/website/docs/r/vlan.html.markdown
+++ b/website/docs/r/vlan.html.markdown
@@ -31,7 +31,7 @@ The following arguments are supported:
 * `forward_filter_input` - (Optional)(`String`) input filter to apply for forwarded packets (when Junos device supports it).
 * `forward_filter_output` - (Optional)(`String`) output filter to apply for forwarded packets (when Junos device supports it).
 * `forward_flood_input` - (Optional)(`String`) input filter to apply for ethernet switching flood packets (when Junos device supports it).
-* `l3_interface` - (Optional)(`String`) L3 interface name for this vlans. Must be start with irb.
+* `l3_interface` - (Optional)(`String`) L3 interface name for this vlans. Must be start with 'irb.' or 'vlan.'.
 * `isolated-vlan` - (Optional)(`Int`) declare ID isolated vlan for primary vlan (when Junos device supports it).
 * `private_vlan` - (Optional)(`String`) Type of secondary vlan for private vlan. Must be 'community' or 'isolated' (when Junos device supports it).
 * `service_id` - (Optional)(`Int`) Service id (when Junos device supports it).


### PR DESCRIPTION
BUG FIXES:
* provider: fix XML error on commit with RPC reply without `<commit-results>` but different from `<ok/>` (Fixes [#223](https://github.com/jeremmfr/terraform-provider-junos/issues/223))
* resource/`junos_interface_logical`: disable set vlan-id on 'vlan.*' interface (Fixes parts of [#222](https://github.com/jeremmfr/terraform-provider-junos/issues/222))
* resource/`junos_vlan`: allow 'vlan.*' interface in `l3_interface` argument (Fixes parts of [#222](https://github.com/jeremmfr/terraform-provider-junos/issues/222))