### PR TITLE
Fixes #229: add support for IPFIX ipv4/6-template export-extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ ENHANCEMENTS:
 * provider: add `ssh_ciphers` attribute to configure ciphers used in SSH connection
 * provider: add support of SSH agent to SSH authentication (Fixes #212)
 * resource/`junos_routing_options`: add `forwarding_table` argument (Fixes #221)
+* resource/`junos_services_flowmonitoring_vipfix_template`: add `ip_template_export_extension` argument (Fixes #229)
 
 BUG FIXES:
 

--- a/junos/resource_services_flowmonitoring_vipfix_template_test.go
+++ b/junos/resource_services_flowmonitoring_vipfix_template_test.go
@@ -59,23 +59,25 @@ resource "junos_services_flowmonitoring_vipfix_template" "testacc_flow_vipfix_te
 func testAccJunosServicesFlowMonitoringVIPFixTemplateConfigUpdate() string {
 	return `
 resource "junos_services_flowmonitoring_vipfix_template" "testacc_flow_vipfix_template_ipv4" {
-  name                    = "testacc_template@1"
-  type                    = "ipv4-template"
-  flow_active_timeout     = 60
-  flow_inactive_timeout   = 30
-  flow_key_flow_direction = true
-  flow_key_vlan_id        = true
-  nexthop_learning_enable = true
-  observation_domain_id   = 10
+  name                         = "testacc_template@1"
+  type                         = "ipv4-template"
+  ip_template_export_extension = ["app-id", "flow-dir"]
+  flow_active_timeout          = 60
+  flow_inactive_timeout        = 30
+  flow_key_flow_direction      = true
+  flow_key_vlan_id             = true
+  nexthop_learning_enable      = true
+  observation_domain_id        = 10
   option_refresh_rate {}
   option_template_id = 2000
   template_id        = 2001
 }
 resource "junos_services_flowmonitoring_vipfix_template" "testacc_flow_vipfix_template_ipv6" {
-  name                  = "testacc_template@3"
-  type                  = "ipv6-template"
-  flow_active_timeout   = 60
-  flow_inactive_timeout = 30
+  name                         = "testacc_template@3"
+  type                         = "ipv6-template"
+  ip_template_export_extension = ["app-id", "flow-dir"]
+  flow_active_timeout          = 60
+  flow_inactive_timeout        = 30
 }
 resource "junos_services_flowmonitoring_vipfix_template" "testacc_flow_vipfix_template_mpls" {
   name                    = "testacc_template@2"

--- a/website/docs/r/services_flowmonitoring_vipfix_template.html.markdown
+++ b/website/docs/r/services_flowmonitoring_vipfix_template.html.markdown
@@ -30,6 +30,7 @@ The following arguments are supported:
 * `flow_inactive_timeout` - (Optional)(`Int`) Period of inactivity that marks a flow inactive (10..600).
 * `flow_key_flow_direction` - (Optional)(`Bool`) Include flow direction.
 * `flow_key_vlan_id` - (Optional)(`Bool`) Include vlan ID.
+* `ip_template_export_extension` - (Optional)(`ListOfString`) Export-extension for 'ipv4-template', 'ipv6-template' type.
 * `nexthop_learning_enable` - (Optional)(`Bool`) Enable nexthop learning.
 * `nexthop_learning_disable` - (Optional)(`Bool`) Disable nexthop learning.
 * `observation_domain_id` - (Optional)(`Int`) Observation Domain Id (0..255).


### PR DESCRIPTION
* resource/`junos_services_flowmonitoring_vipfix_template`: add `ip_template_export_extension` argument (Fixes #229)