### PR TITLE
Fixes 227: r/routing_options, security, services, snmp: add clean_on_destroy argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ ENHANCEMENTS:
 * provider: add `ssh_ciphers` attribute to configure ciphers used in SSH connection
 * provider: add support of SSH agent to SSH authentication (Fixes #212)
 * resource/`junos_routing_options`: add `forwarding_table` argument (Fixes #221)
+* resource/`junos_routing_options`, `junos_security`, `junos_services`, `junos_snmp`: add `clean_on_destroy` argument to clean static configuration when destroy the resource (Fixes #227)
 
 BUG FIXES:
 

--- a/junos/resource_routing_options_test.go
+++ b/junos/resource_routing_options_test.go
@@ -44,9 +44,6 @@ func TestAccJunosRoutingOptions_basic(t *testing.T) {
 							"graceful_restart.#", "1"),
 					),
 				},
-				{
-					Config: testAccJunosRoutingOptionsConfigPostCheck(),
-				},
 			},
 		})
 	}
@@ -97,20 +94,13 @@ resource junos_routing_options "testacc_routing_options" {
 func testAccJunosRoutingOptionsConfigUpdate() string {
 	return `
 resource junos_routing_options "testacc_routing_options" {
+  clean_on_destroy = true
   forwarding_table {
     no_ecmp_fast_reroute                         = true
     no_indirect_next_hop                         = true
     no_indirect_next_hop_change_acknowledgements = true
     unicast_reverse_path                         = "feasible-paths"
   }
-  graceful_restart {}
-}
-`
-}
-
-func testAccJunosRoutingOptionsConfigPostCheck() string {
-	return `
-resource junos_routing_options "testacc_routing_options" {
   graceful_restart {}
 }
 `

--- a/junos/resource_security.go
+++ b/junos/resource_security.go
@@ -32,6 +32,10 @@ func resourceSecurity() *schema.Resource {
 			State: resourceSecurityImport,
 		},
 		Schema: map[string]*schema.Schema{
+			"clean_on_destroy": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 			"alg": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -741,6 +745,29 @@ func resourceSecurityUpdate(ctx context.Context, d *schema.ResourceData, m inter
 }
 
 func resourceSecurityDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	if d.Get("clean_on_destroy").(bool) {
+		sess := m.(*Session)
+		jnprSess, err := sess.startNewSession()
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		defer sess.closeSession(jnprSess)
+		sess.configLock(jnprSess)
+		var diagWarns diag.Diagnostics
+		if err := delSecurity(m, jnprSess); err != nil {
+			appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+			return append(diagWarns, diag.FromErr(err)...)
+		}
+		warns, err := sess.commitConf("delete resource junos_security", jnprSess)
+		appendDiagWarns(&diagWarns, warns)
+		if err != nil {
+			appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+			return append(diagWarns, diag.FromErr(err)...)
+		}
+	}
+
 	return nil
 }
 

--- a/junos/resource_services_test.go
+++ b/junos/resource_services_test.go
@@ -35,15 +35,12 @@ func TestAccJunosServices_basic(t *testing.T) {
 					ImportStateVerify: true,
 				},
 				{
-					Config: testAccJunosServicesConfigUpdate2(),
-				},
-				{
 					ResourceName:      "junos_services.testacc",
 					ImportState:       true,
 					ImportStateVerify: true,
 				},
 				{
-					Config: testAccJunosServicesConfigPostCheck(),
+					Config: testAccJunosServicesConfigUpdate2(),
 				},
 			},
 		})
@@ -238,6 +235,7 @@ resource "junos_services" "testacc" {
 func testAccJunosServicesConfigUpdate2() string {
 	return `
 resource "junos_services" "testacc" {
+  clean_on_destroy = true
   application_identification {
     no_application_system_cache = true
   }
@@ -254,11 +252,4 @@ resource "junos_services" "testacc" {
   }
 }
   `
-}
-
-func testAccJunosServicesConfigPostCheck() string {
-	return `
-resource "junos_services" "testacc" {
-}
-`
 }

--- a/junos/resource_snmp_test.go
+++ b/junos/resource_snmp_test.go
@@ -22,9 +22,6 @@ func TestAccJunosSnmp_basic(t *testing.T) {
 			{
 				Config: testAccJunosSnmpConfigUpdate(),
 			},
-			{
-				Config: testAccJunosSnmpConfigPostCheck(),
-			},
 		},
 	})
 }
@@ -65,16 +62,11 @@ resource "junos_routing_instance" "testacc_snmp" {
 func testAccJunosSnmpConfigUpdate() string {
 	return `
 resource "junos_snmp" "testacc_snmp" {
+  clean_on_destroy         = true
   arp                      = true
   arp_host_name_resolution = true
   health_monitor {}
   routing_instance_access = true
 }
-`
-}
-
-func testAccJunosSnmpConfigPostCheck() string {
-	return `
-resource "junos_snmp" "testacc_snmp" {}
 `
 }

--- a/website/docs/r/routing_options.html.markdown
+++ b/website/docs/r/routing_options.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # junos_routing_options
 
--> **Note:** This resource should only be created **once**. It's used to configure static (not object) options in `routing-options` block. Destroy this resource has no effect on the Junos configuration.
+-> **Note:** This resource should only be created **once**. It's used to configure static (not object) options in `routing-options` block. By default (without `clean_on_destroy`= true), destroy this resource has no effect on the Junos configuration.
 
 Configure static configuration in `routing-options` block
 
@@ -28,6 +28,7 @@ resource junos_routing_options "routing_options" {
 
 The following arguments are supported:
 
+* `clean_on_destroy` - (Optional)(`Bool`) Clean supported lines when destroy this resource.
 * `autonomous_system` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare 'autonomous-system' configuration.
   * `number` - (Required)(`String`) Autonomous system number in plain number or 'higher 16bits'.'Lower 16 bits' (asdot notation) format.
   * `asdot_notation` - (Optional)(`Bool`) Use AS-Dot notation to display true 4 byte AS numbers.

--- a/website/docs/r/security.html.markdown
+++ b/website/docs/r/security.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # junos_security
 
--> **Note:** This resource should only be created **once**. It's used to configure static (not object) options in `security` block. Destroy this resource has no effect on the Junos configuration.
+-> **Note:** This resource should only be created **once**. It's used to configure static (not object) options in `security` block. By default (without `clean_on_destroy`= true), destroy this resource has no effect on the Junos configuration.
 
 Configure static configuration in `security` block
 
@@ -30,6 +30,7 @@ resource junos_security "security" {
 
 The following arguments are supported:
 
+* `clean_on_destroy` - (Optional)(`Bool`) Clean supported lines when destroy this resource.
 * `alg` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare 'alg' configuration. See the [`alg` arguments] (#alg-arguments) block.
 * `flow` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare 'flow' configuration. See the [`flow` arguments] (#flow-arguments) block.
 * `forwarding_options` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare 'forwarding-options' configuration. See the [`forwarding_options` arguments] (#forwarding_options-arguments) block.

--- a/website/docs/r/services.html.markdown
+++ b/website/docs/r/services.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # junos_services
 
--> **Note:** This resource should only be created **once**. It's used to configure static (not object) options in `services` block. Destroy this resource has no effect on the Junos configuration.
+-> **Note:** This resource should only be created **once**. It's used to configure static (not object) options in `services` block. By default (without `clean_on_destroy`= true), destroy this resource has no effect on the Junos configuration.
 
 Configure static configuration in `services` block
 
@@ -28,6 +28,7 @@ resource junos_services "services" {
 
 The following arguments are supported:
 
+* `clean_on_destroy` - (Optional)(`Bool`) Clean supported lines when destroy this resource.
 * `advanced_anti_malware` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare 'advanced-anti-malware' static configuration. See the [`advanced_anti_malware` arguments] (#advanced_anti_malware-arguments) block.
 * `application_identification` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to enable 'application-identification'. See the [`application_identification` arguments] (#application_identification-arguments) block.
 * `security_intelligence` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare 'security-intelligence' configuration. See the [`security_intelligence` arguments] (#security_intelligence-arguments) block.

--- a/website/docs/r/snmp.html.markdown
+++ b/website/docs/r/snmp.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # junos_snmp
 
--> **Note:** This resource should only be created **once**. It's used to configure static (not object) options in `snmp` block. Destroy this resource has no effect on the Junos configuration.  
+-> **Note:** This resource should only be created **once**. It's used to configure static (not object) options in `snmp` block. By default (without `clean_on_destroy`= true), destroy this resource has no effect on the Junos configuration.  
 
 Configure static configuration in `snmp` block
 
@@ -28,6 +28,7 @@ resource junos_snmp "snmp" {
 
 The following arguments are supported:
 
+* `clean_on_destroy` - (Optional)(`Bool`) Clean supported lines when destroy this resource.
 * `arp` - (Optional)(`Bool`) JVision ARP.
 * `arp_host_name_resolution` - (Optional)(`Bool`) Enable host name resolution for JVision ARP.
 * `contact` - (Optional)(`String`) Contact information for administrator.


### PR DESCRIPTION
ENHANCEMENTS:
* resource/`junos_routing_options`, `junos_security`, `junos_services`, `junos_snmp`: add `clean_on_destroy` argument to clean static configuration when destroy the resource (Fixes #227)