### PR TITLE
Fixes #241: add policy to forwarding-table export directly with policy resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## upcoming release
 ENHANCEMENTS:
+* resource/`junos_policyoptions_policy_statement`: add `add_it_to_forwarding_table_export` argument (Fixes #241)
+* resource/`junos_routing_options`: add `forwarding_table_export_configure_singly` argument
 
 BUG FIXES:
 

--- a/junos/resource_policyoptions_policy_statement.go
+++ b/junos/resource_policyoptions_policy_statement.go
@@ -40,115 +40,7 @@ func resourcePolicyoptionsPolicyStatement() *schema.Resource {
 				Optional: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"aggregate_contributor": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-						"bgp_as_path": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						"bgp_as_path_group": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						"bgp_community": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						"bgp_origin": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: validation.StringInSlice([]string{"egp", "igp", "incomplete"}, false),
-						},
-						"family": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								"evpn", "inet", "inet-mdt", "inet-mvpn", "inet-vpn",
-								"inet6", "inet6-mvpn", "inet6-vpn", "iso",
-							}, false),
-						},
-						"local_preference": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-						"routing_instance": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"interface": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						"metric": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-						"neighbor": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						"next_hop": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						"ospf_area": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"policy": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						"preference": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-						"prefix_list": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						"protocol": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						"route_filter": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"route": {
-										Type:         schema.TypeString,
-										Required:     true,
-										ValidateFunc: validation.IsCIDRNetwork(0, 128),
-									},
-									"option": {
-										Type:     schema.TypeString,
-										Required: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											"address-mask", "exact", "longer", "orlonger", "prefix-length-range", "through", "upto",
-										}, false),
-									},
-									"option_value": {
-										Type:     schema.TypeString,
-										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
-									},
-								},
-							},
-						},
-					},
+					Schema: schemaPolicyoptionsPolicyStatementFrom(),
 				},
 			},
 			"then": {
@@ -156,115 +48,7 @@ func resourcePolicyoptionsPolicyStatement() *schema.Resource {
 				Optional: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"action": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: validation.StringInSlice([]string{"accept", "reject"}, false),
-						},
-						"as_path_expand": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"as_path_prepend": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"community": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"action": {
-										Type:         schema.TypeString,
-										Required:     true,
-										ValidateFunc: validation.StringInSlice([]string{addWord, deleteWord, setWord}, false),
-									},
-									"value": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-								},
-							},
-						},
-						"default_action": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: validation.StringInSlice([]string{"accept", "reject"}, false),
-						},
-						"load_balance": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: validation.StringInSlice([]string{"per-packet", "consistent-hash"}, false),
-						},
-						"local_preference": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"action": {
-										Type:         schema.TypeString,
-										Required:     true,
-										ValidateFunc: validation.StringInSlice([]string{addWord, "subtract", actionNoneWord}, false),
-									},
-									"value": {
-										Type:     schema.TypeInt,
-										Required: true,
-									},
-								},
-							},
-						},
-						"next": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: validation.StringInSlice([]string{"policy", "term"}, false),
-						},
-						"next_hop": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"metric": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"action": {
-										Type:         schema.TypeString,
-										Required:     true,
-										ValidateFunc: validation.StringInSlice([]string{"add", "subtract", actionNoneWord}, false),
-									},
-									"value": {
-										Type:     schema.TypeInt,
-										Required: true,
-									},
-								},
-							},
-						},
-						"origin": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"preference": {
-							Type:     schema.TypeList,
-							Optional: true,
-							MaxItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"action": {
-										Type:         schema.TypeString,
-										Required:     true,
-										ValidateFunc: validation.StringInSlice([]string{"add", "subtract", actionNoneWord}, false),
-									},
-									"value": {
-										Type:     schema.TypeInt,
-										Required: true,
-									},
-								},
-							},
-						},
-					},
+					Schema: schemaPolicyoptionsPolicyStatementThen(),
 				},
 			},
 			"to": {
@@ -272,81 +56,7 @@ func resourcePolicyoptionsPolicyStatement() *schema.Resource {
 				Optional: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"bgp_as_path": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						"bgp_as_path_group": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						"bgp_community": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						"bgp_origin": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							ValidateFunc: validation.StringInSlice([]string{"egp", "igp", "incomplete"}, false),
-						},
-						"family": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								"evpn", "inet", "inet-mdt", "inet-mvpn", "inet-vpn",
-								"inet6", "inet6-mvpn", "inet6-vpn", "iso",
-							}, false),
-						},
-						"local_preference": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-						"routing_instance": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"interface": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						"metric": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-						"neighbor": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						"next_hop": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						"ospf_area": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						"policy": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-						"preference": {
-							Type:     schema.TypeInt,
-							Optional: true,
-						},
-						"protocol": {
-							Type:     schema.TypeList,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-					},
+					Schema: schemaPolicyoptionsPolicyStatementTo(),
 				},
 			},
 			"term": {
@@ -364,115 +74,7 @@ func resourcePolicyoptionsPolicyStatement() *schema.Resource {
 							Optional: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"aggregate_contributor": {
-										Type:     schema.TypeBool,
-										Optional: true,
-									},
-									"bgp_as_path": {
-										Type:     schema.TypeList,
-										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
-									},
-									"bgp_as_path_group": {
-										Type:     schema.TypeList,
-										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
-									},
-									"bgp_community": {
-										Type:     schema.TypeList,
-										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
-									},
-									"bgp_origin": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ValidateFunc: validation.StringInSlice([]string{"egp", "igp", "incomplete"}, false),
-									},
-									"family": {
-										Type:     schema.TypeString,
-										Optional: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											"evpn", "inet", "inet-mdt", "inet-mvpn", "inet-vpn",
-											"inet6", "inet6-mvpn", "inet6-vpn", "iso",
-										}, false),
-									},
-									"local_preference": {
-										Type:     schema.TypeInt,
-										Optional: true,
-									},
-									"routing_instance": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-									"interface": {
-										Type:     schema.TypeList,
-										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
-									},
-									"metric": {
-										Type:     schema.TypeInt,
-										Optional: true,
-									},
-									"neighbor": {
-										Type:     schema.TypeList,
-										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
-									},
-									"next_hop": {
-										Type:     schema.TypeList,
-										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
-									},
-									"ospf_area": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-									"policy": {
-										Type:     schema.TypeList,
-										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
-									},
-									"preference": {
-										Type:     schema.TypeInt,
-										Optional: true,
-									},
-									"prefix_list": {
-										Type:     schema.TypeList,
-										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
-									},
-									"protocol": {
-										Type:     schema.TypeList,
-										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
-									},
-									"route_filter": {
-										Type:     schema.TypeList,
-										Optional: true,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"route": {
-													Type:         schema.TypeString,
-													Required:     true,
-													ValidateFunc: validation.IsCIDRNetwork(0, 128),
-												},
-												"option": {
-													Type:     schema.TypeString,
-													Required: true,
-													ValidateFunc: validation.StringInSlice([]string{
-														"address-mask", "exact", "longer", "orlonger", "prefix-length-range", "through", "upto",
-													}, false),
-												},
-												"option_value": {
-													Type:     schema.TypeString,
-													Optional: true,
-													Elem:     &schema.Schema{Type: schema.TypeString},
-												},
-											},
-										},
-									},
-								},
+								Schema: schemaPolicyoptionsPolicyStatementFrom(),
 							},
 						},
 						"then": {
@@ -480,115 +82,7 @@ func resourcePolicyoptionsPolicyStatement() *schema.Resource {
 							Optional: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"action": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ValidateFunc: validation.StringInSlice([]string{"accept", "reject"}, false),
-									},
-									"as_path_expand": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-									"as_path_prepend": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-									"community": {
-										Type:     schema.TypeList,
-										Optional: true,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"action": {
-													Type:         schema.TypeString,
-													Required:     true,
-													ValidateFunc: validation.StringInSlice([]string{addWord, deleteWord, setWord}, false),
-												},
-												"value": {
-													Type:     schema.TypeString,
-													Required: true,
-												},
-											},
-										},
-									},
-									"default_action": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ValidateFunc: validation.StringInSlice([]string{"accept", "reject"}, false),
-									},
-									"load_balance": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ValidateFunc: validation.StringInSlice([]string{"per-packet", "consistent-hash"}, false),
-									},
-									"local_preference": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"action": {
-													Type:         schema.TypeString,
-													Required:     true,
-													ValidateFunc: validation.StringInSlice([]string{"add", "subtract", actionNoneWord}, false),
-												},
-												"value": {
-													Type:     schema.TypeInt,
-													Required: true,
-												},
-											},
-										},
-									},
-									"next": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ValidateFunc: validation.StringInSlice([]string{"policy", "term"}, false),
-									},
-									"next_hop": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-									"metric": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"action": {
-													Type:         schema.TypeString,
-													Required:     true,
-													ValidateFunc: validation.StringInSlice([]string{"add", "subtract", actionNoneWord}, false),
-												},
-												"value": {
-													Type:     schema.TypeInt,
-													Required: true,
-												},
-											},
-										},
-									},
-									"origin": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-									"preference": {
-										Type:     schema.TypeList,
-										Optional: true,
-										MaxItems: 1,
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"action": {
-													Type:         schema.TypeString,
-													Required:     true,
-													ValidateFunc: validation.StringInSlice([]string{"add", "subtract", actionNoneWord}, false),
-												},
-												"value": {
-													Type:     schema.TypeInt,
-													Required: true,
-												},
-											},
-										},
-									},
-								},
+								Schema: schemaPolicyoptionsPolicyStatementThen(),
 							},
 						},
 						"to": {
@@ -596,86 +90,314 @@ func resourcePolicyoptionsPolicyStatement() *schema.Resource {
 							Optional: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"bgp_as_path": {
-										Type:     schema.TypeList,
-										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
-									},
-									"bgp_as_path_group": {
-										Type:     schema.TypeList,
-										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
-									},
-									"bgp_community": {
-										Type:     schema.TypeList,
-										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
-									},
-									"bgp_origin": {
-										Type:         schema.TypeString,
-										Optional:     true,
-										ValidateFunc: validation.StringInSlice([]string{"egp", "igp", "incomplete"}, false),
-									},
-									"family": {
-										Type:     schema.TypeString,
-										Optional: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											"evpn", "inet", "inet-mdt", "inet-mvpn", "inet-vpn",
-											"inet6", "inet6-mvpn", "inet6-vpn", "iso",
-										}, false),
-									},
-									"local_preference": {
-										Type:     schema.TypeInt,
-										Optional: true,
-									},
-									"routing_instance": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-									"interface": {
-										Type:     schema.TypeList,
-										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
-									},
-									"metric": {
-										Type:     schema.TypeInt,
-										Optional: true,
-									},
-									"neighbor": {
-										Type:     schema.TypeList,
-										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
-									},
-									"next_hop": {
-										Type:     schema.TypeList,
-										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
-									},
-									"ospf_area": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-									"policy": {
-										Type:     schema.TypeList,
-										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
-									},
-									"preference": {
-										Type:     schema.TypeInt,
-										Optional: true,
-									},
-									"protocol": {
-										Type:     schema.TypeList,
-										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
-									},
-								},
+								Schema: schemaPolicyoptionsPolicyStatementTo(),
 							},
 						},
 					},
 				},
 			},
+		},
+	}
+}
+
+func schemaPolicyoptionsPolicyStatementFrom() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"aggregate_contributor": {
+			Type:     schema.TypeBool,
+			Optional: true,
+		},
+		"bgp_as_path": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+		},
+		"bgp_as_path_group": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+		},
+		"bgp_community": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+		},
+		"bgp_origin": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringInSlice([]string{"egp", "igp", "incomplete"}, false),
+		},
+		"family": {
+			Type:     schema.TypeString,
+			Optional: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				"evpn", "inet", "inet-mdt", "inet-mvpn", "inet-vpn",
+				"inet6", "inet6-mvpn", "inet6-vpn", "iso",
+			}, false),
+		},
+		"local_preference": {
+			Type:     schema.TypeInt,
+			Optional: true,
+		},
+		"routing_instance": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"interface": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+		},
+		"metric": {
+			Type:     schema.TypeInt,
+			Optional: true,
+		},
+		"neighbor": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+		},
+		"next_hop": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+		},
+		"ospf_area": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"policy": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+		},
+		"preference": {
+			Type:     schema.TypeInt,
+			Optional: true,
+		},
+		"prefix_list": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+		},
+		"protocol": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+		},
+		"route_filter": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"route": {
+						Type:         schema.TypeString,
+						Required:     true,
+						ValidateFunc: validation.IsCIDRNetwork(0, 128),
+					},
+					"option": {
+						Type:     schema.TypeString,
+						Required: true,
+						ValidateFunc: validation.StringInSlice([]string{
+							"address-mask", "exact", "longer", "orlonger", "prefix-length-range", "through", "upto",
+						}, false),
+					},
+					"option_value": {
+						Type:     schema.TypeString,
+						Optional: true,
+						Elem:     &schema.Schema{Type: schema.TypeString},
+					},
+				},
+			},
+		},
+	}
+}
+
+func schemaPolicyoptionsPolicyStatementThen() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"action": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringInSlice([]string{"accept", "reject"}, false),
+		},
+		"as_path_expand": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"as_path_prepend": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"community": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"action": {
+						Type:         schema.TypeString,
+						Required:     true,
+						ValidateFunc: validation.StringInSlice([]string{addWord, deleteWord, setWord}, false),
+					},
+					"value": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+				},
+			},
+		},
+		"default_action": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringInSlice([]string{"accept", "reject"}, false),
+		},
+		"load_balance": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringInSlice([]string{"per-packet", "consistent-hash"}, false),
+		},
+		"local_preference": {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"action": {
+						Type:         schema.TypeString,
+						Required:     true,
+						ValidateFunc: validation.StringInSlice([]string{addWord, "subtract", actionNoneWord}, false),
+					},
+					"value": {
+						Type:     schema.TypeInt,
+						Required: true,
+					},
+				},
+			},
+		},
+		"next": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringInSlice([]string{"policy", "term"}, false),
+		},
+		"next_hop": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"metric": {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"action": {
+						Type:         schema.TypeString,
+						Required:     true,
+						ValidateFunc: validation.StringInSlice([]string{"add", "subtract", actionNoneWord}, false),
+					},
+					"value": {
+						Type:     schema.TypeInt,
+						Required: true,
+					},
+				},
+			},
+		},
+		"origin": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"preference": {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"action": {
+						Type:         schema.TypeString,
+						Required:     true,
+						ValidateFunc: validation.StringInSlice([]string{"add", "subtract", actionNoneWord}, false),
+					},
+					"value": {
+						Type:     schema.TypeInt,
+						Required: true,
+					},
+				},
+			},
+		},
+	}
+}
+
+func schemaPolicyoptionsPolicyStatementTo() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"bgp_as_path": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+		},
+		"bgp_as_path_group": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+		},
+		"bgp_community": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+		},
+		"bgp_origin": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringInSlice([]string{"egp", "igp", "incomplete"}, false),
+		},
+		"family": {
+			Type:     schema.TypeString,
+			Optional: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				"evpn", "inet", "inet-mdt", "inet-mvpn", "inet-vpn",
+				"inet6", "inet6-mvpn", "inet6-vpn", "iso",
+			}, false),
+		},
+		"local_preference": {
+			Type:     schema.TypeInt,
+			Optional: true,
+		},
+		"routing_instance": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"interface": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+		},
+		"metric": {
+			Type:     schema.TypeInt,
+			Optional: true,
+		},
+		"neighbor": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+		},
+		"next_hop": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+		},
+		"ospf_area": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"policy": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+		},
+		"preference": {
+			Type:     schema.TypeInt,
+			Optional: true,
+		},
+		"protocol": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
 		},
 	}
 }
@@ -915,18 +637,18 @@ func setPolicyStatement(d *schema.ResourceData, m interface{}, jnprSess *Netconf
 	return sess.configSet(configSet, jnprSess)
 }
 
-func readPolicyStatement(policyStatement string,
+func readPolicyStatement(policyName string,
 	m interface{}, jnprSess *NetconfObject) (policyStatementOptions, error) {
 	sess := m.(*Session)
 	var confRead policyStatementOptions
 
 	policyStatementConfig, err := sess.command("show configuration "+
-		"policy-options policy-statement "+policyStatement+" | display set relative", jnprSess)
+		"policy-options policy-statement "+policyName+" | display set relative", jnprSess)
 	if err != nil {
 		return confRead, err
 	}
 	if policyStatementConfig != emptyWord {
-		confRead.name = policyStatement
+		confRead.name = policyName
 		for _, item := range strings.Split(policyStatementConfig, "\n") {
 			if strings.Contains(item, "<configuration-output>") {
 				continue
@@ -1004,10 +726,10 @@ func readPolicyStatement(policyStatement string,
 	return confRead, nil
 }
 
-func delPolicyStatement(policyStatement string, m interface{}, jnprSess *NetconfObject) error {
+func delPolicyStatement(policyName string, m interface{}, jnprSess *NetconfObject) error {
 	sess := m.(*Session)
-	configSet := make([]string, 0, 1)
-	configSet = append(configSet, "delete policy-options policy-statement "+policyStatement)
+	configSet := []string{"delete policy-options policy-statement " + policyName}
+
 
 	return sess.configSet(configSet, jnprSess)
 }

--- a/junos/resource_policyoptions_test.go
+++ b/junos/resource_policyoptions_test.go
@@ -701,6 +701,19 @@ resource junos_policyoptions_policy_statement "testacc_policyOptions2" {
     }
   }
 }
+resource junos_policyoptions_policy_statement "testacc_policyOptions3" {
+  name                              = "testacc_policyOptions3"
+  add_it_to_forwarding_table_export = true
+  from {
+    route_filter {
+      route  = "192.0.2.0/25"
+      option = "orlonger"
+    }
+  }
+  then {
+    load_balance = "per-packet"
+  }
+}
 `
 }
 

--- a/junos/resource_routing_options_test.go
+++ b/junos/resource_routing_options_test.go
@@ -94,7 +94,8 @@ resource junos_routing_options "testacc_routing_options" {
 func testAccJunosRoutingOptionsConfigUpdate() string {
 	return `
 resource junos_routing_options "testacc_routing_options" {
-  clean_on_destroy = true
+  clean_on_destroy                         = true
+  forwarding_table_export_configure_singly = true
   forwarding_table {
     no_ecmp_fast_reroute                         = true
     no_indirect_next_hop                         = true
@@ -102,6 +103,19 @@ resource junos_routing_options "testacc_routing_options" {
     unicast_reverse_path                         = "feasible-paths"
   }
   graceful_restart {}
+}
+resource junos_policyoptions_policy_statement "testacc_routing_options" {
+  name                              = "testacc_routing_options"
+  add_it_to_forwarding_table_export = true
+  from {
+    route_filter {
+      route  = "192.0.2.0/25"
+      option = "orlonger"
+    }
+  }
+  then {
+    load_balance = "per-packet"
+  }
 }
 `
 }

--- a/website/docs/r/policyoptions_policy_statement.html.markdown
+++ b/website/docs/r/policyoptions_policy_statement.html.markdown
@@ -45,6 +45,7 @@ resource junos_policyoptions_policy_statement "demo_policy" {
 The following arguments are supported:
 
 * `name` - (Required, Forces new resource)(`String`) The name of routing policy.
+* `add_it_to_forwarding_table_export` - (Optional)(`Bool`) Add this policy in `routing-options forwarding-table export` list.
 * `from` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Declare from filter. See the [`from` arguments](#from-arguments) block. Max of 1.
 * `to` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Declare to filter. See the [`to` arguments](#to-arguments) block. Max of 1.
 * `then` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Declare then actions. See the [`then` arguments](#then-arguments) block. Max of 1.

--- a/website/docs/r/policyoptions_policy_statement.html.markdown
+++ b/website/docs/r/policyoptions_policy_statement.html.markdown
@@ -50,12 +50,12 @@ The following arguments are supported:
 * `then` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Declare then actions. See the [`then` arguments](#then-arguments) block. Max of 1.
 * `term` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified multiple times for each term declaration.
   * `name`(Required)(`String`) Name of policy
-  * `from` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Declare from filter. See the [`from` arguments for term](#from-arguments-for-term) block. Max of 1.
-  * `to` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Declare to filter. See the [`to` arguments for term](#to-arguments-for-term) block. Max of 1.
-  * `then` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Declare then actions. See the [`then` arguments for term](#then-arguments-for-term) block. Max of 1.
+  * `from` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Declare from filter. See the [`from` arguments](#from-arguments) block. Max of 1.
+  * `to` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Declare to filter. See the [`to` arguments](#to-arguments) block. Max of 1.
+  * `then` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Declare then actions. See the [`then` arguments](#then-arguments) block. Max of 1.
 
 ---
-#### from arguments for term
+#### from arguments
 * `aggregate_contributor` - (Optional)(`Bool`) Match more specifics of an aggregate.
 * `bgp_as_path` - (Optional)(`ListOfString`) Name of AS path regular expression. See resource `junos_policyoptions_as_path`.
 * `bgp_as_path_group` - (Optional)(`ListOfString`) Name of AS path group. See resource `junos_policyoptions_as_path_group`.
@@ -79,7 +79,7 @@ The following arguments are supported:
   * `option_value` - (Optional)(`String`) For options that need an argument
 
 ---
-#### to arguments for term
+#### to arguments
 * `bgp_as_path` - (Optional)(`ListOfString`) Name of AS path regular expression. See resource `junos_policyoptions_as_path`.
 * `bgp_as_path_group` - (Optional)(`ListOfString`) Name of AS path group. See resource `junos_policyoptions_as_path_group`.
 * `bgp_community` - (Optional)(`ListOfString`) BGP community. See resource `junos_policyoptions_community`.
@@ -97,7 +97,7 @@ The following arguments are supported:
 * `protocol` - (Optional)(`ListOfString`) Protocol from which route was learned
 
 ---
-#### then arguments for term
+#### then arguments
 * `action` - (Optional)(`String`) Action 'accept' or 'reject'.
 * `as_path_expand` - (Optional)(`String`) Prepend AS numbers prior to adding local-as.
 * `as_path_prepend` - (Optional)(`String`) Prepend AS numbers to an AS path.

--- a/website/docs/r/routing_options.html.markdown
+++ b/website/docs/r/routing_options.html.markdown
@@ -48,6 +48,7 @@ The following arguments are supported:
   * `krt_nexthop_ack_timeout` - (Optional)(`Int`) Kernel nexthop ack timeout interval (1..400).
   * `remnant_holdtime` - (Optional)(`Int`) Time to hold inherited routes from FIB (0..10000).
   * `unicast_reverse_path` - (Optional)(`String`)  Unicast reverse path (RP) verification. Need to be 'active-paths' or 'feasible-paths'.
+* `forwarding_table_export_configure_singly` - (Optional)(`Bool`) Disable management of `forwarding-table export` in this resource to be able to manage them directly from `junos_policyoptions_policy_statement` resources with `add_it_to_forwarding_table_export` argument. Conflict with `forwarding_table.0.export`.
 * `graceful_restart` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare 'graceful-restart' configuration.
   * `disable` - (Optional)(`Bool`) Disable graceful restart.
   * `restart_duration` - (Optional)(`Int`) Maximum time for which router is in graceful restart (120..10000).


### PR DESCRIPTION
ENHANCEMENTS:
* resource/`junos_policyoptions_policy_statement`: add `add_it_to_forwarding_table_export` argument (Fixes #241)
* resource/`junos_routing_options`: add `forwarding_table_export_configure_singly` argument