### PR TITLE
Fix missing sensitive tag on some argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ ENHANCEMENTS:
 * resource/`junos_routing_options`: add `forwarding_table_export_configure_singly` argument
 * resource/`junos_interface`, `junos_interface_logical`: `vrrp_group.*.authentication_key` is now a sensitive argument
 * resource/`junos_security_ike_gateway`: `aaa.0.client_password` is now a sensitive argument
+* resource/`junos_system`: `archival_configuration.0.archive_site.*.password` is now a sensitive argument
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ ENHANCEMENTS:
 * resource/`junos_policyoptions_policy_statement`: add `add_it_to_forwarding_table_export` argument (Fixes #241)
 * resource/`junos_routing_options`: add `forwarding_table_export_configure_singly` argument
 * resource/`junos_bgp_group`: `authentication_key` is now a sensitive argument
+* resource/`junos_bgp_neighbor`: `authentication_key` is now a sensitive argument
 * resource/`junos_interface`, `junos_interface_logical`: `vrrp_group.*.authentication_key` is now a sensitive argument
 * resource/`junos_security_ike_gateway`: `aaa.0.client_password` is now a sensitive argument
 * resource/`junos_system`: `archival_configuration.0.archive_site.*.password` is now a sensitive argument

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ENHANCEMENTS:
 * resource/`junos_policyoptions_policy_statement`: add `add_it_to_forwarding_table_export` argument (Fixes #241)
 * resource/`junos_routing_options`: add `forwarding_table_export_configure_singly` argument
+* resource/`junos_interface`, `junos_interface_logical`: `vrrp_group.*.authentication_key` is now a sensitive argument
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ENHANCEMENTS:
 * resource/`junos_policyoptions_policy_statement`: add `add_it_to_forwarding_table_export` argument (Fixes #241)
 * resource/`junos_routing_options`: add `forwarding_table_export_configure_singly` argument
+* resource/`junos_bgp_group`: `authentication_key` is now a sensitive argument
 * resource/`junos_interface`, `junos_interface_logical`: `vrrp_group.*.authentication_key` is now a sensitive argument
 * resource/`junos_security_ike_gateway`: `aaa.0.client_password` is now a sensitive argument
 * resource/`junos_system`: `archival_configuration.0.archive_site.*.password` is now a sensitive argument

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ ENHANCEMENTS:
 * resource/`junos_policyoptions_policy_statement`: add `add_it_to_forwarding_table_export` argument (Fixes #241)
 * resource/`junos_routing_options`: add `forwarding_table_export_configure_singly` argument
 * resource/`junos_interface`, `junos_interface_logical`: `vrrp_group.*.authentication_key` is now a sensitive argument
+* resource/`junos_security_ike_gateway`: `aaa.0.client_password` is now a sensitive argument
 
 BUG FIXES:
 

--- a/junos/resource_bgp_group.go
+++ b/junos/resource_bgp_group.go
@@ -80,6 +80,7 @@ func resourceBgpGroup() *schema.Resource {
 			"authentication_key": {
 				Type:          schema.TypeString,
 				Optional:      true,
+				Sensitive:     true,
 				ConflictsWith: []string{"authentication_algorithm", "authentication_key_chain"},
 			},
 			"authentication_key_chain": {

--- a/junos/resource_bgp_neighbor.go
+++ b/junos/resource_bgp_neighbor.go
@@ -79,6 +79,7 @@ func resourceBgpNeighbor() *schema.Resource {
 			"authentication_key": {
 				Type:          schema.TypeString,
 				Optional:      true,
+				Sensitive:     true,
 				ConflictsWith: []string{"authentication_algorithm", "authentication_key_chain"},
 			},
 			"authentication_key_chain": {

--- a/junos/resource_interface.go
+++ b/junos/resource_interface.go
@@ -134,8 +134,9 @@ func resourceInterface() *schema.Resource {
 										ValidateFunc: validation.IntBetween(1, 15),
 									},
 									"authentication_key": {
-										Type:     schema.TypeString,
-										Optional: true,
+										Type:      schema.TypeString,
+										Optional:  true,
+										Sensitive: true,
 									},
 									"authentication_type": {
 										Type:         schema.TypeString,

--- a/junos/resource_interface_logical.go
+++ b/junos/resource_interface_logical.go
@@ -111,8 +111,9 @@ func resourceInterfaceLogical() *schema.Resource {
 													ValidateFunc: validation.IntBetween(1, 15),
 												},
 												"authentication_key": {
-													Type:     schema.TypeString,
-													Optional: true,
+													Type:      schema.TypeString,
+													Optional:  true,
+													Sensitive: true,
 												},
 												"authentication_type": {
 													Type:         schema.TypeString,

--- a/junos/resource_security_ike_gateway.go
+++ b/junos/resource_security_ike_gateway.go
@@ -167,8 +167,9 @@ func resourceIkeGateway() *schema.Resource {
 							},
 						},
 						"client_password": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:      schema.TypeString,
+							Optional:  true,
+							Sensitive: true,
 							ConflictsWith: []string{
 								"aaa.0.access_profile",
 							},

--- a/junos/resource_system.go
+++ b/junos/resource_system.go
@@ -66,8 +66,9 @@ func resourceSystem() *schema.Resource {
 										Required: true,
 									},
 									"password": {
-										Type:     schema.TypeString,
-										Optional: true,
+										Type:      schema.TypeString,
+										Optional:  true,
+										Sensitive: true,
 									},
 								},
 							},

--- a/website/docs/r/interface.html.markdown
+++ b/website/docs/r/interface.html.markdown
@@ -84,7 +84,8 @@ The following arguments are supported:
 * `accept_data` - (Optional)(`Bool`) Accept packets destined for virtual IP address. Conflict with `no_accept_data` when apply.
 * `advertise_interval` - (Optional)(`Int`) Advertisement interval (seconds)
 * `advertisements_threshold` - (Optional)(`Int`)  Number of vrrp advertisements missed before declaring master down.
-* `authentication_key` - (Optional)(`String`) Authentication key
+* `authentication_key` - (Optional)(`String`) Authentication key.  
+**WARNING** Clear in tfstate.
 * `authentication_type` - (Optional)(`String`) Authentication type. Need to be 'md5' or 'simple'.
 * `no_accept_data` - (Optional)(`Bool`) Don't accept packets destined for virtual IP address. Conflict with `accept_data` when apply.
 * `no_preempt` - (Optional)(`Bool`) Don't allow preemption. Conflict with `preempt` when apply.

--- a/website/docs/r/interface_logical.html.markdown
+++ b/website/docs/r/interface_logical.html.markdown
@@ -71,7 +71,8 @@ The following arguments are supported:
 * `accept_data` - (Optional)(`Bool`) Accept packets destined for virtual IP address. Conflict with `no_accept_data` when apply.
 * `advertise_interval` - (Optional)(`Int`) Advertisement interval (seconds)
 * `advertisements_threshold` - (Optional)(`Int`)  Number of vrrp advertisements missed before declaring master down.
-* `authentication_key` - (Optional)(`String`) Authentication key
+* `authentication_key` - (Optional)(`String`) Authentication key.  
+**WARNING** Clear in tfstate.
 * `authentication_type` - (Optional)(`String`) Authentication type. Need to be 'md5' or 'simple'.
 * `no_accept_data` - (Optional)(`Bool`) Don't accept packets destined for virtual IP address. Conflict with `accept_data` when apply.
 * `no_preempt` - (Optional)(`Bool`) Don't allow preemption. Conflict with `preempt` when apply.

--- a/website/docs/r/security_ike_gateway.html.markdown
+++ b/website/docs/r/security_ike_gateway.html.markdown
@@ -34,7 +34,8 @@ The following arguments are supported:
 * `dynamic_remote` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare dynamic configuration. See the [`dynamic_remote` arguments] (#dynamic_remote-arguments) block. Need to set one of `address` or `dynamic_remote`.
 * `aaa` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare 'aaa' configuration.
   * `access_profile` - (Optional)(`String`) Access profile that contains authentication information. Conflict with `aaa.client_*`.
-  * `client_password` - (Optional)(`String`) AAA client password with 1 to 128 characters. Conflict with `aaa.access_profile`.
+  * `client_password` - (Optional)(`String`) AAA client password with 1 to 128 characters. Conflict with `aaa.access_profile`.  
+  **WARNING** Clear in tfstate.
   * `client_username` - (Optional)(`String`) AAA client username with 1 to 128 characters. Conflict with `aaa.access_profile`.
 * `dead_peer_detection` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare RFC-3706 DPD configuration. See the [`dead_peer_detection` arguments] (#dead_peer_detection-arguments) block.
 * `general_ike_id` - (Optional)(`Bool`) Accept peer IKE-ID in general.

--- a/website/docs/r/system.html.markdown
+++ b/website/docs/r/system.html.markdown
@@ -50,7 +50,8 @@ The following arguments are supported:
 * `internet_options` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare 'internet-options' configuration. See the [`internet_options` arguments] (#internet_options-arguments) block.
 * `license` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified once to declare 'license' configuration.
   * `autoupdate` - (Optional)(`Bool`) Enable autoupdate license keys.
-  * `autoupdate_password` - (Optional)(`String`) Password for autoupdate license keys from license servers. `autoupdate_url` needs to be set.
+  * `autoupdate_password` - (Optional)(`String`) Password for autoupdate license keys from license servers. `autoupdate_url` needs to be set.  
+  **WARNING** Clear in tfstate.
   * `autoupdate_url` - (Optional)(`String`) Url for autoupdate license keys from license servers. `autoupdate` needs to be set.
   * `renew_before_expiration` - (Optional)(`Int`) License renewal lead time before expiration, in days (0..60). `renew_interval` needs to be set.
   * `renew_interval` - (Optional)(`Int`) License checking interval, in hours (1..336). `renew_before_expiration` needs to be set.
@@ -81,7 +82,8 @@ The following arguments are supported:
 #### archival_configuration arguments
 * `archive_site` - (Required)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified multiple times for each archive-site destination.
   * `url` - (Required)(`String`) URLs to receive configuration files.
-  * `password` - (Optional)(`String`) Password for login into the archive site.
+  * `password` - (Optional)(`String`) Password for login into the archive site.  
+  **WARNING** Clear in tfstate.
 * `transfer_interval` - (Optional)(`Int`) Frequency at which file transfer happens (15..2880 minutes). One of `transfer_interval` and `transfer_on_commit` arguments need to be set.
 * `transfer_on_commit` - (Optional)(`Bool`) Transfer after each commit. One of `transfer_interval` and `transfer_on_commit` arguments need to be set.
 


### PR DESCRIPTION
ENHANCEMENTS:
* resource/`junos_bgp_group`: `authentication_key` is now a sensitive argument
* resource/`junos_bgp_neighbor`: `authentication_key` is now a sensitive argument
* resource/`junos_interface`, `junos_interface_logical`: `vrrp_group.*.authentication_key` is now a sensitive argument
* resource/`junos_security_ike_gateway`: `aaa.0.client_password` is now a sensitive argument
* resource/`junos_system`: `archival_configuration.0.archive_site.*.password` is now a sensitive argument