### PR TITLE
Fixes #131: add evpn resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ ENHANCEMENTS:
 * resource/`junos_system`: `archival_configuration.0.archive_site.*.password` is now a sensitive argument
 * resource/`junos_routing_instance`: add `description`, `route_distinguisher`, `vrf_export`, `vrf_import`, `vrf_target`, `vrf_target_auto`, `vrf_target_export`, `vrf_target_import`, `vtep_source_interface`, `configure_rd_vrfopts_singly` and `configure_type_singly` arguments
 * add `junos_switch_options` resource (Fixes parts of #131)
+* add `junos_evpn` resource (Fixes parts of #131)
 
 BUG FIXES:
 * resource/`junos_ospf`: fix missing mutex unlocking when read resource and checking routing-instance existence

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ ENHANCEMENTS:
 * resource/`junos_security_ike_gateway`: `aaa.0.client_password` is now a sensitive argument
 * resource/`junos_system`: `archival_configuration.0.archive_site.*.password` is now a sensitive argument
 * resource/`junos_routing_instance`: add `description`, `route_distinguisher`, `vrf_export`, `vrf_import`, `vrf_target`, `vrf_target_auto`, `vrf_target_export`, `vrf_target_import`, `vtep_source_interface`, `configure_rd_vrfopts_singly` and `configure_type_singly` arguments
+* add `junos_switch_options` resource (Fixes parts of #131)
 
 BUG FIXES:
 * resource/`junos_ospf`: fix missing mutex unlocking when read resource and checking routing-instance existence

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ ENHANCEMENTS:
 * resource/`junos_interface`, `junos_interface_logical`: `vrrp_group.*.authentication_key` is now a sensitive argument
 * resource/`junos_security_ike_gateway`: `aaa.0.client_password` is now a sensitive argument
 * resource/`junos_system`: `archival_configuration.0.archive_site.*.password` is now a sensitive argument
+* resource/`junos_routing_instance`: add `description`, `route_distinguisher`, `vrf_export`, `vrf_import`, `vrf_target`, `vrf_target_auto`, `vrf_target_export`, `vrf_target_import`, `vtep_source_interface`, `configure_rd_vrfopts_singly` and `configure_type_singly` arguments
 
 BUG FIXES:
 * resource/`junos_ospf`: fix missing mutex unlocking when read resource and checking routing-instance existence

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ENHANCEMENTS:
 * resource/`junos_policyoptions_policy_statement`: add `add_it_to_forwarding_table_export` argument (Fixes #241)
 * resource/`junos_routing_options`: add `forwarding_table_export_configure_singly` argument
+* resource/`junos_routing_options`: add `router_id` argument
 * resource/`junos_bgp_group`: `authentication_key` is now a sensitive argument
 * resource/`junos_bgp_neighbor`: `authentication_key` is now a sensitive argument
 * resource/`junos_interface`, `junos_interface_logical`: `vrrp_group.*.authentication_key` is now a sensitive argument

--- a/junos/provider.go
+++ b/junos/provider.go
@@ -164,6 +164,7 @@ func Provider() *schema.Provider {
 			"junos_snmp_community":                                       resourceSnmpCommunity(),
 			"junos_snmp_view":                                            resourceSnmpView(),
 			"junos_static_route":                                         resourceStaticRoute(),
+			"junos_switch_options":                                       resourceSwitchOptions(),
 			"junos_system":                                               resourceSystem(),
 			"junos_system_login_class":                                   resourceSystemLoginClass(),
 			"junos_system_login_user":                                    resourceSystemLoginUser(),

--- a/junos/provider.go
+++ b/junos/provider.go
@@ -99,6 +99,7 @@ func Provider() *schema.Provider {
 			"junos_bgp_group":                                            resourceBgpGroup(),
 			"junos_bgp_neighbor":                                         resourceBgpNeighbor(),
 			"junos_chassis_cluster":                                      resourceChassisCluster(),
+			"junos_evpn":                                                 resourceEvpn(),
 			"junos_firewall_filter":                                      resourceFirewallFilter(),
 			"junos_firewall_policer":                                     resourceFirewallPolicer(),
 			"junos_forwardingoptions_sampling_instance":                  resourceForwardingoptionsSamplingInstance(),

--- a/junos/resource_evpn.go
+++ b/junos/resource_evpn.go
@@ -1,0 +1,502 @@
+package junos
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+type evpnOptions struct {
+	routingInstanceEvpn bool
+	encapsulation       string
+	multicastMode       string
+	routingInstance     string
+	switchOrRIOptions   []map[string]interface{}
+}
+
+func resourceEvpn() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceEvpnCreate,
+		ReadContext:   resourceEvpnRead,
+		UpdateContext: resourceEvpnUpdate,
+		DeleteContext: resourceEvpnDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceEvpnImport,
+		},
+		Schema: map[string]*schema.Schema{
+			"routing_instance": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ForceNew:         true,
+				Default:          defaultWord,
+				ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatDefault),
+			},
+			"routing_instance_evpn": {
+				Type:         schema.TypeBool,
+				Optional:     true,
+				ForceNew:     true,
+				RequiredWith: []string{"routing_instance", "switch_or_ri_options"},
+			},
+			"encapsulation": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice([]string{"mpls", "vxlan"}, false),
+			},
+			"multicast_mode": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"ingress-replication"}, false),
+			},
+			"switch_or_ri_options": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"route_distinguisher": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringMatch(regexp.MustCompile(
+								`^(\d|\.)+L?:\d+$`), "must have valid route distinguisher. Use format 'x:y'"),
+						},
+						"vrf_export": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"vrf_import": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"vrf_target": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ValidateFunc: validation.StringMatch(regexp.MustCompile(
+								`^target:(\d|\.)+L?:\d+$`), "must have valid target. Use format 'target:x:y'"),
+						},
+						"vrf_target_auto": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"vrf_target_export": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ValidateFunc: validation.StringMatch(regexp.MustCompile(
+								`^target:(\d|\.)+L?:\d+$`), "must have valid target. Use format 'target:x:y'"),
+						},
+						"vrf_target_import": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ValidateFunc: validation.StringMatch(regexp.MustCompile(
+								`^target:(\d|\.)+L?:\d+$`), "must have valid target. Use format 'target:x:y'"),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceEvpnCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	if sess.junosFakeCreateSetFile != "" {
+		if err := setEvpn(d, m, nil); err != nil {
+			return diag.FromErr(err)
+		}
+		d.SetId(d.Get("routing_instance").(string))
+
+		return nil
+	}
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	sess.configLock(jnprSess)
+	var diagWarns diag.Diagnostics
+	if d.Get("routing_instance").(string) != defaultWord {
+		instanceExists, err := checkRoutingInstanceExists(d.Get("routing_instance").(string), m, jnprSess)
+		if err != nil {
+			appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+			return append(diagWarns, diag.FromErr(err)...)
+		}
+		if !instanceExists {
+			appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+			return append(diagWarns,
+				diag.FromErr(fmt.Errorf("routing instance %v doesn't exist", d.Get("routing_instance").(string)))...)
+		}
+	}
+	if err := setEvpn(d, m, jnprSess); err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	warns, err := sess.commitConf("create resource junos_evpn", jnprSess)
+	appendDiagWarns(&diagWarns, warns)
+	if err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	d.SetId(d.Get("routing_instance").(string))
+
+	return append(diagWarns, resourceEvpnReadWJnprSess(d, m, jnprSess)...)
+}
+
+func resourceEvpnRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+
+	return resourceEvpnReadWJnprSess(d, m, jnprSess)
+}
+
+func resourceEvpnReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
+	if d.Get("routing_instance").(string) != defaultWord {
+		instanceExists, err := checkRoutingInstanceExists(d.Get("routing_instance").(string), m, jnprSess)
+		if err != nil {
+			mutex.Unlock()
+
+			return diag.FromErr(err)
+		}
+		if !instanceExists {
+			mutex.Unlock()
+
+			d.SetId("")
+
+			return nil
+		}
+	}
+	evpnOptions, err := readEvpn(d.Get("routing_instance").(string), m, jnprSess)
+	mutex.Unlock()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	fillEvpnData(d, evpnOptions)
+
+	return nil
+}
+
+func resourceEvpnUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	d.Partial(true)
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	sess.configLock(jnprSess)
+	var diagWarns diag.Diagnostics
+	if err := delEvpn(false, d, m, jnprSess); err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	if err := setEvpn(d, m, jnprSess); err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	warns, err := sess.commitConf("update resource junos_evpn", jnprSess)
+	appendDiagWarns(&diagWarns, warns)
+	if err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	d.Partial(false)
+
+	return append(diagWarns, resourceEvpnReadWJnprSess(d, m, jnprSess)...)
+}
+
+func resourceEvpnDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	sess.configLock(jnprSess)
+	var diagWarns diag.Diagnostics
+	if err := delEvpn(true, d, m, jnprSess); err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	warns, err := sess.commitConf("delete resource junos_evpn", jnprSess)
+	appendDiagWarns(&diagWarns, warns)
+	if err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+
+	return diagWarns
+}
+
+func resourceEvpnImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return nil, err
+	}
+	defer sess.closeSession(jnprSess)
+	result := make([]*schema.ResourceData, 1)
+	idList := strings.Split(d.Id(), idSeparator)
+	if idList[0] != defaultWord {
+		instanceExists, err := checkRoutingInstanceExists(idList[0], m, jnprSess)
+		if err != nil {
+			return nil, err
+		}
+		if !instanceExists {
+			return nil, fmt.Errorf("routing instance %v doesn't exist", d.Get("routing_instance").(string))
+		}
+	}
+	evpnOptions, err := readEvpn(idList[0], m, jnprSess)
+	if err != nil {
+		return nil, err
+	}
+	fillEvpnData(d, evpnOptions)
+	if len(idList) > 1 || idList[0] == defaultWord {
+		if tfErr := d.Set("switch_or_ri_options", evpnOptions.switchOrRIOptions); tfErr != nil {
+			panic(tfErr)
+		}
+	}
+	result[0] = d
+
+	return result, nil
+}
+
+func setEvpn(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) error {
+	sess := m.(*Session)
+	configSet := make([]string, 0)
+	setPrefix := setLineStart
+	setPrefixSwitchRIVRF := setLineStart
+	if d.Get("routing_instance").(string) == defaultWord {
+		if len(d.Get("switch_or_ri_options").([]interface{})) == 0 {
+			return fmt.Errorf("`switch_or_ri_options` required if `routing_instance` = %s", defaultWord)
+		}
+		if d.Get("routing_instance_evpn").(bool) {
+			return fmt.Errorf("`routing_instance_evpn` incompatible if `routing_instance` = %s", defaultWord)
+		}
+		setPrefix += "protocols evpn "
+		setPrefixSwitchRIVRF += "switch-options "
+	} else {
+		setPrefix += "routing-instances " + d.Get("routing_instance").(string) + " protocols evpn "
+		setPrefixSwitchRIVRF += "routing-instances " + d.Get("routing_instance").(string) + " "
+	}
+	if d.Get("routing_instance_evpn").(bool) {
+		if len(d.Get("switch_or_ri_options").([]interface{})) == 0 {
+			return fmt.Errorf("`switch_or_ri_options` required if routing_instance_evpn = true")
+		}
+		configSet = append(configSet, setPrefixSwitchRIVRF+"instance-type evpn")
+	}
+	if v := d.Get("encapsulation").(string); v != "" {
+		configSet = append(configSet, setPrefix+"encapsulation "+v)
+	}
+	if v := d.Get("multicast_mode").(string); v != "" {
+		configSet = append(configSet, setPrefix+"multicast-mode "+v)
+	}
+	for _, v := range d.Get("switch_or_ri_options").([]interface{}) {
+		swOpts := v.(map[string]interface{})
+		configSet = append(configSet, setPrefixSwitchRIVRF+"route-distinguisher "+swOpts["route_distinguisher"].(string))
+		for _, v2 := range swOpts["vrf_export"].([]interface{}) {
+			configSet = append(configSet, setPrefixSwitchRIVRF+"vrf-export \""+v2.(string)+"\"")
+		}
+		for _, v2 := range swOpts["vrf_import"].([]interface{}) {
+			configSet = append(configSet, setPrefixSwitchRIVRF+"vrf-import \""+v2.(string)+"\"")
+		}
+		if v2 := swOpts["vrf_target"].(string); v2 != "" {
+			configSet = append(configSet, setPrefixSwitchRIVRF+"vrf-target "+v2)
+		}
+		if swOpts["vrf_target_auto"].(bool) {
+			configSet = append(configSet, setPrefixSwitchRIVRF+"vrf-target auto")
+		}
+		if v2 := swOpts["vrf_target_export"].(string); v2 != "" {
+			configSet = append(configSet, setPrefixSwitchRIVRF+"vrf-target export "+v2)
+		}
+		if v2 := swOpts["vrf_target_import"].(string); v2 != "" {
+			configSet = append(configSet, setPrefixSwitchRIVRF+"vrf-target import "+v2)
+		}
+	}
+
+	return sess.configSet(configSet, jnprSess)
+}
+
+func readEvpn(routingInstance string,
+	m interface{}, jnprSess *NetconfObject) (evpnOptions, error) {
+	sess := m.(*Session)
+	var confRead evpnOptions
+	var evpnConfig string
+	var switchRIConfig string
+
+	if routingInstance == defaultWord {
+		var err error
+		evpnConfig, err = sess.command("show configuration protocols evpn | display set relative", jnprSess)
+		if err != nil {
+			return confRead, err
+		}
+		switchRIConfig, err = sess.command("show configuration switch-options | display set relative", jnprSess)
+		if err != nil {
+			return confRead, err
+		}
+	} else {
+		var err error
+		evpnConfig, err = sess.command("show configuration routing-instances "+
+			routingInstance+" protocols evpn | display set relative", jnprSess)
+		if err != nil {
+			return confRead, err
+		}
+		switchRIConfig, err = sess.command("show configuration routing-instances "+
+			routingInstance+" | display set relative", jnprSess)
+		if err != nil {
+			return confRead, err
+		}
+	}
+
+	if evpnConfig != emptyWord {
+		confRead.routingInstance = routingInstance
+		for _, item := range strings.Split(evpnConfig, "\n") {
+			if strings.Contains(item, "<configuration-output>") {
+				continue
+			}
+			if strings.Contains(item, "</configuration-output>") {
+				break
+			}
+			itemTrim := strings.TrimPrefix(item, setLineStart)
+			switch {
+			case strings.HasPrefix(itemTrim, "encapsulation "):
+				confRead.encapsulation = strings.TrimPrefix(itemTrim, "encapsulation ")
+			case strings.HasPrefix(itemTrim, "multicast-mode "):
+				confRead.multicastMode = strings.TrimPrefix(itemTrim, "multicast-mode ")
+			}
+		}
+	}
+	if switchRIConfig != emptyWord {
+		for _, item := range strings.Split(switchRIConfig, "\n") {
+			if strings.Contains(item, "<configuration-output>") {
+				continue
+			}
+			if strings.Contains(item, "</configuration-output>") {
+				break
+			}
+			itemTrim := strings.TrimPrefix(item, setLineStart)
+			switch {
+			case itemTrim == "instance-type evpn":
+				confRead.routingInstanceEvpn = true
+			case strings.HasPrefix(itemTrim, "route-distinguisher ") ||
+				strings.HasPrefix(itemTrim, "vrf-export") ||
+				strings.HasPrefix(itemTrim, "vrf-import") ||
+				strings.HasPrefix(itemTrim, "vrf-target"):
+				if len(confRead.switchOrRIOptions) == 0 {
+					confRead.switchOrRIOptions = append(confRead.switchOrRIOptions, map[string]interface{}{
+						"route_distinguisher": "",
+						"vrf_export":          make([]string, 0),
+						"vrf_import":          make([]string, 0),
+						"vrf_target":          "",
+						"vrf_target_auto":     false,
+						"vrf_target_export":   "",
+						"vrf_target_import":   "",
+					})
+				}
+				switch {
+				case strings.HasPrefix(itemTrim, "route-distinguisher "):
+					confRead.switchOrRIOptions[0]["route_distinguisher"] = strings.TrimPrefix(itemTrim, "route-distinguisher ")
+				case strings.HasPrefix(itemTrim, "vrf-export "):
+					confRead.switchOrRIOptions[0]["vrf_export"] = append(confRead.switchOrRIOptions[0]["vrf_export"].([]string),
+						strings.Trim(strings.TrimPrefix(itemTrim, "vrf-export "), "\""))
+				case strings.HasPrefix(itemTrim, "vrf-import "):
+					confRead.switchOrRIOptions[0]["vrf_import"] = append(confRead.switchOrRIOptions[0]["vrf_import"].([]string),
+						strings.Trim(strings.TrimPrefix(itemTrim, "vrf-import "), "\""))
+				case itemTrim == "vrf-target auto":
+					confRead.switchOrRIOptions[0]["vrf_target_auto"] = true
+				case strings.HasPrefix(itemTrim, "vrf-target export "):
+					confRead.switchOrRIOptions[0]["vrf_target_export"] = strings.TrimPrefix(itemTrim, "vrf-target export ")
+				case strings.HasPrefix(itemTrim, "vrf-target import "):
+					confRead.switchOrRIOptions[0]["vrf_target_import"] = strings.TrimPrefix(itemTrim, "vrf-target import ")
+				case strings.HasPrefix(itemTrim, "vrf-target "):
+					confRead.switchOrRIOptions[0]["vrf_target"] = strings.TrimPrefix(itemTrim, "vrf-target ")
+				}
+			}
+		}
+	}
+
+	return confRead, nil
+}
+
+func delEvpn(destroy bool, d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) error {
+	sess := m.(*Session)
+	configSet := make([]string, 0, 1)
+	delPrefix := deleteWord + " "
+	delPrefixSwitchRIVRF := deleteWord + " "
+
+	if d.Get("routing_instance").(string) == defaultWord {
+		delPrefix += "protocols evpn "
+		delPrefixSwitchRIVRF += "switch-options "
+	} else {
+		delPrefix += "routing-instances " + d.Get("routing_instance").(string) + " protocols evpn "
+		delPrefixSwitchRIVRF += "routing-instances " + d.Get("routing_instance").(string) + " "
+	}
+	listLinesToDelete := []string{
+		"encapsulation",
+		"multicast-mode",
+	}
+	// to remove line "set protocols evpn" without options when destroy resource
+	if destroy && d.Get("routing_instance").(string) != defaultWord {
+		listLinesToDelete = append(listLinesToDelete, "")
+	}
+	for _, line := range listLinesToDelete {
+		configSet = append(configSet, delPrefix+line)
+	}
+
+	listLinesToDelete = listLinesToDelete[:0]
+	if d.Get("routing_instance_evpn").(bool) {
+		listLinesToDelete = append(listLinesToDelete, "instance-type")
+	}
+	if len(d.Get("switch_or_ri_options").([]interface{})) != 0 {
+		listLinesToDelete = append(listLinesToDelete,
+			"route-distinguisher",
+			"vrf-export",
+			"vrf-import",
+			"vrf-target",
+		)
+	}
+	for _, line := range listLinesToDelete {
+		configSet = append(configSet, delPrefixSwitchRIVRF+line)
+	}
+
+	return sess.configSet(configSet, jnprSess)
+}
+
+func fillEvpnData(d *schema.ResourceData, evpnOptions evpnOptions) {
+	if tfErr := d.Set("routing_instance", evpnOptions.routingInstance); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("routing_instance_evpn", evpnOptions.routingInstanceEvpn); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("encapsulation", evpnOptions.encapsulation); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("multicast_mode", evpnOptions.multicastMode); tfErr != nil {
+		panic(tfErr)
+	}
+	if _, s := d.GetOk("switch_or_ri_options"); s {
+		if tfErr := d.Set("switch_or_ri_options", evpnOptions.switchOrRIOptions); tfErr != nil {
+			panic(tfErr)
+		}
+	}
+}

--- a/junos/resource_evpn_test.go
+++ b/junos/resource_evpn_test.go
@@ -108,6 +108,7 @@ resource "junos_routing_instance" "testacc_evpn_ri2" {
 resource "junos_evpn" "testacc_evpn_ri2" {
   routing_instance = junos_routing_instance.testacc_evpn_ri2.name
   encapsulation    = "vxlan"
+  default_gateway  = "advertise"
   switch_or_ri_options {
     route_distinguisher = "10:1"
     vrf_import          = [junos_policyoptions_policy_statement.testacc_evpn.name]

--- a/junos/resource_evpn_test.go
+++ b/junos/resource_evpn_test.go
@@ -1,0 +1,179 @@
+package junos_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccJunosEvpn_basic(t *testing.T) {
+	if os.Getenv("TESTACC_ROUTER") != "" {
+		resource.Test(t, resource.TestCase{
+			PreCheck:  func() { testAccPreCheck(t) },
+			Providers: testAccProviders,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccJunosEvpnConfigCreate(),
+				},
+				{
+					ResourceName:      "junos_evpn.testacc_evpn_default",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+				{
+					ResourceName:      "junos_evpn.testacc_evpn_ri1",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+				{
+					Config: testAccJunosEvpnConfigUpdate(),
+				},
+			},
+		})
+	}
+}
+
+func testAccJunosEvpnConfigCreate() string {
+	return `
+resource "junos_interface_logical" "testacc_evpn" {
+  depends_on = [
+    junos_routing_options.testacc_evpn,
+  ]
+  name        = "lo0.0"
+  description = "testacc_evpn"
+  family_inet {
+    address {
+      cidr_ip = "192.0.2.18/32"
+    }
+  }
+}
+resource "junos_routing_options" "testacc_evpn" {
+  router_id = "192.0.2.18"
+}
+resource "junos_switch_options" "testacc_evpn" {
+  clean_on_destroy      = true
+  vtep_source_interface = junos_interface_logical.testacc_evpn.name
+}
+resource "junos_policyoptions_community" "testacc_evpn" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  name    = "testacc_evpn"
+  members = ["target:65000:100"]
+}
+resource "junos_policyoptions_policy_statement" "testacc_evpn" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  name = "testacc_evpn1"
+  from {
+    bgp_community = [junos_policyoptions_community.testacc_evpn.name]
+  }
+  then {
+    action = "accept"
+  }
+}
+resource "junos_evpn" "testacc_evpn_default" {
+  depends_on = [
+    junos_switch_options.testacc_evpn,
+  ]
+  encapsulation = "vxlan"
+  switch_or_ri_options {
+    route_distinguisher = "20:1"
+    vrf_target          = "target:20:2"
+    vrf_import          = [junos_policyoptions_policy_statement.testacc_evpn.name]
+    vrf_export          = [junos_policyoptions_policy_statement.testacc_evpn.name]
+  }
+}
+resource "junos_routing_instance" "testacc_evpn_ri1" {
+  name                  = "testacc_evpn_ri1"
+  type                  = "virtual-switch"
+  route_distinguisher   = "1:1"
+  vrf_target            = "target:1:2"
+  vrf_import            = [junos_policyoptions_policy_statement.testacc_evpn.name]
+  vrf_export            = [junos_policyoptions_policy_statement.testacc_evpn.name]
+  vtep_source_interface = junos_interface_logical.testacc_evpn.name
+}
+resource "junos_evpn" "testacc_evpn_ri1" {
+  routing_instance = junos_routing_instance.testacc_evpn_ri1.name
+  encapsulation    = "vxlan"
+}
+resource "junos_routing_instance" "testacc_evpn_ri2" {
+  name                        = "testacc_evpn_ri2"
+  type                        = "virtual-switch"
+  configure_rd_vrfopts_singly = true
+  vtep_source_interface       = junos_interface_logical.testacc_evpn.name
+}
+resource "junos_evpn" "testacc_evpn_ri2" {
+  routing_instance = junos_routing_instance.testacc_evpn_ri2.name
+  encapsulation    = "vxlan"
+  switch_or_ri_options {
+    route_distinguisher = "10:1"
+    vrf_import          = [junos_policyoptions_policy_statement.testacc_evpn.name]
+    vrf_export          = [junos_policyoptions_policy_statement.testacc_evpn.name]
+    vrf_target          = "target:10:2"
+  }
+}
+`
+}
+
+func testAccJunosEvpnConfigUpdate() string {
+	return `
+resource "junos_interface_logical" "testacc_evpn" {
+  depends_on = [
+    junos_routing_options.testacc_evpn,
+  ]
+  name        = "lo0.0"
+  description = "testacc_evpn"
+  family_inet {
+    address {
+      cidr_ip = "192.0.2.18/32"
+    }
+  }
+}
+resource "junos_routing_options" "testacc_evpn" {
+  clean_on_destroy = true
+  router_id        = "192.0.2.18"
+}
+resource "junos_switch_options" "testacc_evpn" {
+  clean_on_destroy      = true
+  vtep_source_interface = junos_interface_logical.testacc_evpn.name
+}
+resource "junos_evpn" "testacc_evpn_default" {
+  depends_on = [
+    junos_switch_options.testacc_evpn,
+  ]
+  encapsulation = "vxlan"
+  switch_or_ri_options {
+    route_distinguisher = "201:1"
+    vrf_target          = "target:201:2"
+  }
+}
+resource "junos_routing_instance" "testacc_evpn_ri1" {
+  name                  = "testacc_evpn_ri1"
+  type                  = "virtual-switch"
+  route_distinguisher   = "11:1"
+  vrf_target            = "target:11:2"
+  vtep_source_interface = junos_interface_logical.testacc_evpn.name
+}
+resource "junos_evpn" "testacc_evpn_ri1" {
+  routing_instance = junos_routing_instance.testacc_evpn_ri1.name
+  encapsulation    = "vxlan"
+}
+resource "junos_routing_instance" "testacc_evpn_ri2" {
+  name                        = "testacc_evpn_ri2"
+  type                        = "virtual-switch"
+  configure_rd_vrfopts_singly = true
+  vtep_source_interface       = junos_interface_logical.testacc_evpn.name
+}
+resource "junos_evpn" "testacc_evpn_ri2" {
+  routing_instance = junos_routing_instance.testacc_evpn_ri2.name
+  encapsulation    = "vxlan"
+  switch_or_ri_options {
+    route_distinguisher = "101:1"
+    vrf_target          = "target:101:2"
+  }
+}
+`
+}

--- a/junos/resource_ospf.go
+++ b/junos/resource_ospf.go
@@ -844,7 +844,7 @@ func readOspf(version, routingInstance string,
 func delOspf(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) error {
 	sess := m.(*Session)
 	configSet := make([]string, 0, 1)
-	delPrefix := "delete "
+	delPrefix := deleteWord + " "
 	ospfVersion := ospfV2
 	if d.Get("version").(string) == "v3" {
 		ospfVersion = ospfV3

--- a/junos/resource_routing_instance_test.go
+++ b/junos/resource_routing_instance_test.go
@@ -34,6 +34,11 @@ func TestAccJunosRoutingInstance_basic(t *testing.T) {
 					ImportState:       true,
 					ImportStateVerify: true,
 				},
+				{
+					ResourceName:      "junos_routing_instance.testacc_routingInst2",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
 			},
 		})
 	}
@@ -42,8 +47,55 @@ func TestAccJunosRoutingInstance_basic(t *testing.T) {
 func testAccJunosRoutingInstanceConfigCreate() string {
 	return `
 resource junos_routing_instance "testacc_routingInst" {
-  name = "testacc_routingInst"
-  as   = "65000"
+  name        = "testacc_routingInst"
+  as          = "65000"
+  description = "testacc routingInst"
+}
+resource junos_policyoptions_community "testacc_routingInst2" {
+  name    = "testacc_routingInst2"
+  members = ["target:65000:100"]
+}
+resource junos_policyoptions_policy_statement "testacc_routingInst2" {
+  name = "testacc_routingInst2"
+  from {
+    bgp_community = [junos_policyoptions_community.testacc_routingInst2.name]
+  }
+  then {
+    action = "accept"
+  }
+}
+resource junos_interface_logical "testacc_routingInst2" {
+  name = "lo0.1"
+  family_inet {
+    address {
+      cidr_ip = "192.0.2.15/32"
+    }
+  }
+}
+resource junos_routing_instance "testacc_routingInst2" {
+  name                  = "testacc_routingInst2"
+  type                  = "l2vpn"
+  route_distinguisher   = "1:2"
+  vrf_export            = [junos_policyoptions_policy_statement.testacc_routingInst2.name]
+  vrf_import            = [junos_policyoptions_policy_statement.testacc_routingInst2.name]
+  vrf_target            = "target:2:3"
+  vrf_target_export     = "target:4:5"
+  vrf_target_import     = "target:6:7"
+  vtep_source_interface = junos_interface_logical.testacc_routingInst2.name
+}
+
+resource junos_routing_instance "testacc_routingInst3" {
+  name                  = "testacc_routingInst3"
+  configure_type_singly = true
+  type                  = ""
+  vtep_source_interface = junos_interface_logical.testacc_routingInst2.name
+}
+resource junos_routing_instance "testacc_routingInst4" {
+  name                = "testacc_routingInst4"
+  type                = "vrf"
+  route_distinguisher = "8:9"
+  vrf_export          = [junos_policyoptions_policy_statement.testacc_routingInst2.name]
+  vrf_target_auto     = true
 }
 `
 }
@@ -53,6 +105,71 @@ func testAccJunosRoutingInstanceConfigUpdate() string {
 resource junos_routing_instance "testacc_routingInst" {
   name = "testacc_routingInst"
   as   = "65001"
+}
+resource junos_policyoptions_community "testacc_routingInst2" {
+  name    = "testacc_routingInst2"
+  members = ["target:65000:100"]
+}
+resource junos_policyoptions_community "testacc_routingInst3" {
+  name    = "testacc_routingInst3"
+  members = ["target:65000:200"]
+}
+resource junos_policyoptions_policy_statement "testacc_routingInst2" {
+  name = "testacc_routingInst2"
+  from {
+    bgp_community = [junos_policyoptions_community.testacc_routingInst2.name]
+  }
+  then {
+    action = "accept"
+  }
+}
+resource junos_policyoptions_policy_statement "testacc_routingInst3" {
+  name = "testacc_routingInst3"
+  from {
+    bgp_community = [junos_policyoptions_community.testacc_routingInst3.name]
+  }
+  then {
+    action = "accept"
+  }
+}
+resource junos_interface_logical "testacc_routingInst2" {
+  name = "lo0.1"
+  family_inet {
+    address {
+      cidr_ip = "192.0.2.15/32"
+    }
+  }
+}
+resource junos_routing_instance "testacc_routingInst2" {
+  name                = "testacc_routingInst2"
+  type                = "l2vpn"
+  route_distinguisher = "1:2"
+  vrf_export = [
+    junos_policyoptions_policy_statement.testacc_routingInst3.name,
+    junos_policyoptions_policy_statement.testacc_routingInst2.name,
+  ]
+  vrf_import = [
+    junos_policyoptions_policy_statement.testacc_routingInst3.name,
+    junos_policyoptions_policy_statement.testacc_routingInst2.name,
+  ]
+  vrf_target            = "target:2:3"
+  vrf_target_export     = "target:4:5"
+  vrf_target_import     = "target:8:7"
+  vtep_source_interface = junos_interface_logical.testacc_routingInst2.name
+}
+
+resource junos_routing_instance "testacc_routingInst3" {
+  name                  = "testacc_routingInst3"
+  configure_type_singly = true
+  type                  = ""
+  vtep_source_interface = junos_interface_logical.testacc_routingInst2.name
+}
+resource junos_routing_instance "testacc_routingInst4" {
+  name                = "testacc_routingInst4"
+  type                = "vrf"
+  route_distinguisher = "10:11"
+  vrf_export          = [junos_policyoptions_policy_statement.testacc_routingInst2.name]
+  vrf_target_auto     = true
 }
 `
 }

--- a/junos/resource_routing_options_test.go
+++ b/junos/resource_routing_options_test.go
@@ -87,6 +87,7 @@ resource junos_routing_options "testacc_routing_options" {
     restart_duration = 120
     disable          = true
   }
+  router_id = "192.0.2.4"
 }
 `
 }

--- a/junos/resource_switch_options.go
+++ b/junos/resource_switch_options.go
@@ -1,0 +1,241 @@
+package junos
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type switchOptionsOptions struct {
+	vtepSourceIf string
+}
+
+func resourceSwitchOptions() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSwitchOptionsCreate,
+		ReadContext:   resourceSwitchOptionsRead,
+		UpdateContext: resourceSwitchOptionsUpdate,
+		DeleteContext: resourceSwitchOptionsDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceSwitchOptionsImport,
+		},
+		Schema: map[string]*schema.Schema{
+			"clean_on_destroy": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"vtep_source_interface": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(string)
+					if strings.Count(value, ".") != 1 {
+						errors = append(errors, fmt.Errorf(
+							"%q in %q need to have 1 dot", value, k))
+					}
+
+					return
+				},
+			},
+		},
+	}
+}
+
+func resourceSwitchOptionsCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	if sess.junosFakeCreateSetFile != "" {
+		if err := setSwitchOptions(d, m, nil); err != nil {
+			return diag.FromErr(err)
+		}
+		d.SetId("switch_options")
+
+		return nil
+	}
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	sess.configLock(jnprSess)
+	var diagWarns diag.Diagnostics
+	if err := setSwitchOptions(d, m, jnprSess); err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	warns, err := sess.commitConf("create resource junos_switch_options", jnprSess)
+	appendDiagWarns(&diagWarns, warns)
+	if err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	d.SetId("switch_options")
+
+	return append(diagWarns, resourceSwitchOptionsReadWJnprSess(d, m, jnprSess)...)
+}
+
+func resourceSwitchOptionsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+
+	return resourceSwitchOptionsReadWJnprSess(d, m, jnprSess)
+}
+
+func resourceSwitchOptionsReadWJnprSess(
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	mutex.Lock()
+	switchOptionsOptions, err := readSwitchOptions(m, jnprSess)
+	mutex.Unlock()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	fillSwitchOptions(d, switchOptionsOptions)
+
+	return nil
+}
+
+func resourceSwitchOptionsUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	d.Partial(true)
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	defer sess.closeSession(jnprSess)
+	sess.configLock(jnprSess)
+	var diagWarns diag.Diagnostics
+	if err := delSwitchOptions(m, jnprSess); err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	if err := setSwitchOptions(d, m, jnprSess); err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	warns, err := sess.commitConf("update resource junos_switch_options", jnprSess)
+	appendDiagWarns(&diagWarns, warns)
+	if err != nil {
+		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+		return append(diagWarns, diag.FromErr(err)...)
+	}
+	d.Partial(false)
+
+	return append(diagWarns, resourceSwitchOptionsReadWJnprSess(d, m, jnprSess)...)
+}
+
+func resourceSwitchOptionsDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	if d.Get("clean_on_destroy").(bool) {
+		sess := m.(*Session)
+		jnprSess, err := sess.startNewSession()
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		defer sess.closeSession(jnprSess)
+		sess.configLock(jnprSess)
+		var diagWarns diag.Diagnostics
+		if err := delSwitchOptions(m, jnprSess); err != nil {
+			appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+			return append(diagWarns, diag.FromErr(err)...)
+		}
+		warns, err := sess.commitConf("delete resource junos_switch_options", jnprSess)
+		appendDiagWarns(&diagWarns, warns)
+		if err != nil {
+			appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+			return append(diagWarns, diag.FromErr(err)...)
+		}
+	}
+
+	return nil
+}
+
+func resourceSwitchOptionsImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	sess := m.(*Session)
+	jnprSess, err := sess.startNewSession()
+	if err != nil {
+		return nil, err
+	}
+	defer sess.closeSession(jnprSess)
+	result := make([]*schema.ResourceData, 1)
+	switchOptionsOptions, err := readSwitchOptions(m, jnprSess)
+	if err != nil {
+		return nil, err
+	}
+	fillSwitchOptions(d, switchOptionsOptions)
+	d.SetId("switch_options")
+	result[0] = d
+
+	return result, nil
+}
+
+func setSwitchOptions(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) error {
+	sess := m.(*Session)
+
+	setPrefix := "set switch-options "
+	configSet := make([]string, 0)
+
+	if v := d.Get("vtep_source_interface").(string); v != "" {
+		configSet = append(configSet, setPrefix+"vtep-source-interface "+v)
+	}
+
+	return sess.configSet(configSet, jnprSess)
+}
+
+func delSwitchOptions(m interface{}, jnprSess *NetconfObject) error {
+	listLinesToDelete := []string{"vtep-source-interface"}
+
+	sess := m.(*Session)
+	configSet := make([]string, 0)
+	delPrefix := "delete switch-options "
+	for _, line := range listLinesToDelete {
+		configSet = append(configSet,
+			delPrefix+line)
+	}
+
+	return sess.configSet(configSet, jnprSess)
+}
+
+func readSwitchOptions(m interface{}, jnprSess *NetconfObject) (switchOptionsOptions, error) {
+	sess := m.(*Session)
+	var confRead switchOptionsOptions
+
+	switchOptionsConfig, err := sess.command("show configuration switch-options"+
+		" | display set relative", jnprSess)
+	if err != nil {
+		return confRead, err
+	}
+	if switchOptionsConfig != emptyWord {
+		for _, item := range strings.Split(switchOptionsConfig, "\n") {
+			if strings.Contains(item, "<configuration-output>") {
+				continue
+			}
+			if strings.Contains(item, "</configuration-output>") {
+				break
+			}
+			itemTrim := strings.TrimPrefix(item, setLineStart)
+			if strings.HasPrefix(itemTrim, "vtep-source-interface ") {
+				confRead.vtepSourceIf = strings.TrimPrefix(itemTrim, "vtep-source-interface ")
+			}
+		}
+	}
+
+	return confRead, nil
+}
+
+func fillSwitchOptions(d *schema.ResourceData, switchOptionsOptions switchOptionsOptions) {
+	if tfErr := d.Set("vtep_source_interface", switchOptionsOptions.vtepSourceIf); tfErr != nil {
+		panic(tfErr)
+	}
+}

--- a/junos/resource_switch_options_test.go
+++ b/junos/resource_switch_options_test.go
@@ -1,0 +1,56 @@
+package junos_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccJunosSwitchOptions_basic(t *testing.T) {
+	if os.Getenv("TESTACC_SWITCH") == "" {
+		resource.Test(t, resource.TestCase{
+			PreCheck:  func() { testAccPreCheck(t) },
+			Providers: testAccProviders,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccJunosSwitchOptionsConfigCreate(),
+				},
+				{
+					ResourceName:      "junos_switch_options.testacc_switchOpts",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+				{
+					Config: testAccJunosSwitchOptionsConfigUpdate(),
+				},
+			},
+		})
+	}
+}
+
+func testAccJunosSwitchOptionsConfigCreate() string {
+	return `
+resource junos_interface_logical "testacc_switchOpts" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  name = "lo0.0"
+  family_inet {
+    address {
+      cidr_ip = "192.0.2.16/32"
+    }
+  }
+}
+resource "junos_switch_options" "testacc_switchOpts" {
+  vtep_source_interface = junos_interface_logical.testacc_switchOpts.name
+}
+`
+}
+
+func testAccJunosSwitchOptionsConfigUpdate() string {
+	return `
+resource "junos_switch_options" "testacc_switchOpts" {
+}
+`
+}

--- a/website/docs/r/evpn.html.markdown
+++ b/website/docs/r/evpn.html.markdown
@@ -32,6 +32,7 @@ The following arguments are supported:
 * `routing_instance` - (Optional)(`String`) Routing instance. Need to be 'default' (for root level) or the name of routing instance. Defaults to `default`.
 * `routing_instance_evpn` - (Optional)(`Bool`) Configure routing-instance is an evpn instance-type.
 * `encapsulation` - (Required)(`String`) Encapsulation type for EVPN. Need to be `mpls` or `vxlan`.
+* `default_gateway` - (Optional)(`String`) Default gateway mode. Need to be `advertise`, `do-not-advertise` or `no-gateway-community`.
 * `multicast_mode` - (Optional)(`String`) Multicast mode for EVPN.
 * `switch_or_ri_options` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare `switch-options` or `routing-instance` configuration. Need to be set if `routing_instance` = `default` or `routing_instance_evpn` = true. To avoid conflict with same options on `routing_instance` resource, add him `configure_rd_vrfopts_singly`.
   * `route_distinguisher` - (Required)(`String`) Route distinguisher for this instance.

--- a/website/docs/r/evpn.html.markdown
+++ b/website/docs/r/evpn.html.markdown
@@ -1,0 +1,57 @@
+---
+layout: "junos"
+page_title: "Junos: junos_evpn"
+sidebar_current: "docs-junos-resource-evpn"
+description: |-
+  Configure static configuration in protocols evpn block in root or routing-instance level and options potentially required in switch-options or on routing-instance.
+---
+
+# junos_evpn
+
+-> **Note:** This resource should only be created **once** for root level or each routing-instance. It's used to configure static (not object) options in `protocols evpn` block in root or routing-instance level, in `switch-options` and potentially also in `routing-instance` level directly.
+
+Configure static configuration in `protocols evpn` block for root ou routing-instance level and the various options potentially required in `switch-options` or on the `routing-instance` in same commit.
+
+## Example Usage
+
+```hcl
+# Configure evpn
+resource junos_evpn "default" {
+  encapsulation = "vxlan"
+  switch_or_ri_options {
+    route_distinguisher = "20:1"
+    vrf_target          = "target:20:2"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `routing_instance` - (Optional)(`String`) Routing instance. Need to be 'default' (for root level) or the name of routing instance. Defaults to `default`.
+* `routing_instance_evpn` - (Optional)(`Bool`) Configure routing-instance is an evpn instance-type.
+* `encapsulation` - (Required)(`String`) Encapsulation type for EVPN. Need to be `mpls` or `vxlan`.
+* `multicast_mode` - (Optional)(`String`) Multicast mode for EVPN.
+* `switch_or_ri_options` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare `switch-options` or `routing-instance` configuration. Need to be set if `routing_instance` = `default` or `routing_instance_evpn` = true. To avoid conflict with same options on `routing_instance` resource, add him `configure_rd_vrfopts_singly`.
+  * `route_distinguisher` - (Required)(`String`) Route distinguisher for this instance.
+  * `vrf_export` - (Optional)(`ListOfString`) Export policy for VRF instance RIBs.
+  * `vrf_import` - (Optional)(`ListOfString`) Import policy for VRF instance RIBs.
+  * `vrf_target` - (Optional)(`String`) VRF target community configuration.
+  * `vrf_target_auto` - (Optional)(`Bool`) Auto derive import and export target community from BGP AS & L2.
+  * `vrf_target_export` - (Optional)(`String`) Target community to use when marking routes on export.
+  * `vrf_target_import` - (Optional)(`String`) Target community to use when filtering on import.
+
+## Import
+
+Junos evpn can be imported using an id made up of `<routing_instance>`, e.g.
+
+```shell
+$ terraform import junos_evpn.default default
+```
+
+If `routing_instance` != `default`, `switch_or_ri_options` is not imported. Add the internal delimiter and a random word to import it, e.g.
+
+```shell
+$ terraform import junos_evpn.ri ri_name_-_random
+```

--- a/website/docs/r/routing_instance.html.markdown
+++ b/website/docs/r/routing_instance.html.markdown
@@ -24,8 +24,19 @@ resource junos_routing_instance "demo_ri" {
 The following arguments are supported:
 
 * `name` - (Required, Forces new resource)(`String`) The name of routing instance.
-* `type` - (Optional)(`String`) Type of routing instance. Defaults to `virtual-router`
+* `configure_rd_vrfopts_singly` - (Optional, Forces new resource)(`Bool`) Configure `route-distinguisher` and `vrf-*` options in other resource (like `junos_evpn`).
+* `configure_type_singly` - (Optional, Forces new resource)(`Bool`) Configure `instance-type` option in other resource (like `junos_evpn`). `type` argument need to be set to "" when true (to avoid confusion).
+* `type` - (Optional)(`String`) Type of routing instance. Defaults to `virtual-router`.
 * `as` - (Optional)(`String`) Autonomous system number in plain number or 'higher 16bits'.'Lower 16 bits' (asdot notation) format.
+* `description` - (Optional)(`String`) Text description of routing instance.
+* `route_distinguisher` - (Optional)(`String`) Route distinguisher for this instance.
+* `vrf_export` - (Optional)(`ListOfString`) Export policy for VRF instance RIBs;
+* `vrf_import` - (Optional)(`ListOfString`) Import policy for VRF instance RIBs.
+* `vrf_target` - (Optional)(`String`) Target community to use in import and export.
+* `vrf_target_auto` - (Optional)(`Bool`) Auto derive import and export target community from BGP AS & L2.
+* `vrf_target_export` - (Optional)(`String`) Target community to use when marking routes on export.
+* `vrf_target_import` - (Optional)(`String`) Target community to use when filtering on import.
+* `vtep_source_interface` - (Optional)(`String`) Source layer-3 IFL for VXLAN.
 
 ## Import
 

--- a/website/docs/r/routing_options.html.markdown
+++ b/website/docs/r/routing_options.html.markdown
@@ -47,11 +47,12 @@ The following arguments are supported:
   * `no_indirect_next_hop_change_acknowledgements` - (Optional)(`Bool`) Don't request acknowledgements for Indirect next hop changes.
   * `krt_nexthop_ack_timeout` - (Optional)(`Int`) Kernel nexthop ack timeout interval (1..400).
   * `remnant_holdtime` - (Optional)(`Int`) Time to hold inherited routes from FIB (0..10000).
-  * `unicast_reverse_path` - (Optional)(`String`)  Unicast reverse path (RP) verification. Need to be 'active-paths' or 'feasible-paths'.
+  * `unicast_reverse_path` - (Optional)(`String`) Unicast reverse path (RP) verification. Need to be 'active-paths' or 'feasible-paths'.
 * `forwarding_table_export_configure_singly` - (Optional)(`Bool`) Disable management of `forwarding-table export` in this resource to be able to manage them directly from `junos_policyoptions_policy_statement` resources with `add_it_to_forwarding_table_export` argument. Conflict with `forwarding_table.0.export`.
 * `graceful_restart` - (Optional)([attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html)) Can be specified only once to declare 'graceful-restart' configuration.
   * `disable` - (Optional)(`Bool`) Disable graceful restart.
   * `restart_duration` - (Optional)(`Int`) Maximum time for which router is in graceful restart (120..10000).
+* `router_id` - (Optional)(`String`) Router identifier.
 
 ## Import
 

--- a/website/docs/r/switch_options.html.markdown
+++ b/website/docs/r/switch_options.html.markdown
@@ -1,0 +1,37 @@
+---
+layout: "junos"
+page_title: "Junos: junos_switch_options"
+sidebar_current: "docs-junos-resource-switch-options"
+description: |-
+  Configure static configuration in switch-options block
+---
+
+# junos_switch_options
+
+-> **Note:** This resource should only be created **once**. It's used to configure static (not object) options in `switch-options` block. By default (without `clean_on_destroy`= true), destroy this resource has no effect on the Junos configuration.
+
+Configure static configuration in `switch-options` block
+
+## Example Usage
+
+```hcl
+# Configure switch-options
+resource junos_switch_options "switch_options" {
+  vtep_source_interface = "lo0.0"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `clean_on_destroy` - (Optional)(`Bool`) Clean supported lines when destroy this resource.
+* `vtep_source_interface` - (Optional)(`String`) Source layer-3 IFL for VXLAN.
+
+## Import
+
+Junos switch_options can be imported using any id, e.g.
+
+```
+$ terraform import junos_switch_options.switch_options random
+```

--- a/website/junos.erb
+++ b/website/junos.erb
@@ -231,6 +231,9 @@
           <li<%= sidebar_current("docs-junos-resource-static-route") %>>
             <a href="/docs/providers/junos/r/static_route.html">junos_static_route</a>
           </li>
+          <li<%= sidebar_current("docs-junos-resource-switch-options") %>>
+            <a href="/docs/providers/junos/r/switch_options.html">junos_switch_options</a>
+          </li>
           <li<%= sidebar_current("docs-junos-resource-system") %>>
             <a href="/docs/providers/junos/r/system.html">junos_system</a>
           </li>

--- a/website/junos.erb
+++ b/website/junos.erb
@@ -36,6 +36,9 @@
           <li<%= sidebar_current("docs-junos-resource-chassis-cluster") %>>
             <a href="/docs/providers/junos/r/chassis_cluster.html">junos_chassis_cluster</a>
           </li>
+          <li<%= sidebar_current("docs-junos-resource-evpn") %>>
+            <a href="/docs/providers/junos/r/evpn.html">junos_evpn</a>
+          </li>
           <li<%= sidebar_current("docs-junos-resource-firewall-filter") %>>
             <a href="/docs/providers/junos/r/firewall_filter.html">junos_firewall_filter</a>
           </li>


### PR DESCRIPTION
ENHANCEMENTS:
* resource/`junos_routing_options`: add `router_id` argument
* resource/`junos_routing_instance`: add `description`, `route_distinguisher`, `vrf_export`, `vrf_import`, `vrf_target`, `vrf_target_auto`, `vrf_target_export`, `vrf_target_import`, `vtep_source_interface`, `configure_rd_vrfopts_singly` and `configure_type_singly` arguments
* add `junos_switch_options` resource (Fixes parts of #131)
* add `junos_evpn` resource (Fixes parts of #131)