### PR TITLE
Fixes #251: fix issue with escaping of `announcement` & `ciphers` in `junos_system`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ BUG FIXES:
 * resource/`junos_security_nat_destination`: fix order issue on `from.0.value` list
 * resource/`junos_security_nat_source`: fix order issue on `from.0.value` and `to.0.value` lists (Fixes #243)
 * resource/`junos_security_nat_static`: fix order issue on `from.0.value` list
+* resource/`junos_system`: unescape the html entities for `announcement` argument inside `login` argument (Fixes parts of #251)
 
 ## 1.17.0 (June 18, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ BUG FIXES:
 * resource/`junos_security_nat_source`: fix order issue on `from.0.value` and `to.0.value` lists (Fixes #243)
 * resource/`junos_security_nat_static`: fix order issue on `from.0.value` list
 * resource/`junos_system`: unescape the html entities for `announcement` argument inside `login` argument (Fixes parts of #251)
+* resource/`junos_system`: remove the potential double quotes for `ciphers` argument inside `services.0.ssh` argumet (Fixes parts of #251)
 
 ## 1.17.0 (June 18, 2021)
 

--- a/junos/resource_system.go
+++ b/junos/resource_system.go
@@ -3,6 +3,7 @@ package junos
 import (
 	"context"
 	"fmt"
+	"html"
 	"strconv"
 	"strings"
 
@@ -1647,7 +1648,8 @@ func readSystemLogin(confRead *systemOptions, itemTrim string) error {
 	}
 	switch {
 	case strings.HasPrefix(itemTrim, "login announcement "):
-		confRead.login[0]["announcement"] = strings.Trim(strings.TrimPrefix(itemTrim, "login announcement "), "\"")
+		confRead.login[0]["announcement"] =
+			html.UnescapeString(strings.Trim(strings.TrimPrefix(itemTrim, "login announcement "), "\""))
 	case strings.HasPrefix(itemTrim, "login deny-sources address "):
 		confRead.login[0]["deny_sources_address"] = append(confRead.login[0]["deny_sources_address"].([]string),
 			strings.TrimPrefix(itemTrim, "login deny-sources address "))

--- a/junos/resource_system.go
+++ b/junos/resource_system.go
@@ -1047,7 +1047,7 @@ func setSystemServices(d *schema.ResourceData, m interface{}, jnprSess *NetconfO
 				configSet = append(configSet, setPrefix+"ssh authentication-order "+auth.(string))
 			}
 			for _, ciphers := range servicesSSHM["ciphers"].([]interface{}) {
-				configSet = append(configSet, setPrefix+"ssh ciphers "+ciphers.(string))
+				configSet = append(configSet, setPrefix+"ssh ciphers \""+ciphers.(string)+"\"")
 			}
 			if servicesSSHM["client_alive_count_max"].(int) > -1 {
 				configSet = append(configSet, setPrefix+"ssh client-alive-count-max "+
@@ -2031,7 +2031,7 @@ func readSystemServicesSSH(confRead *systemOptions, itemTrim string) error {
 	case strings.HasPrefix(itemTrim, "services ssh ciphers "):
 		confRead.services[0]["ssh"].([]map[string]interface{})[0]["ciphers"] = append(
 			confRead.services[0]["ssh"].([]map[string]interface{})[0]["ciphers"].([]string),
-			strings.TrimPrefix(itemTrim, "services ssh ciphers "))
+			strings.Trim(strings.TrimPrefix(itemTrim, "services ssh ciphers "), "\""))
 	case strings.HasPrefix(itemTrim, "services ssh client-alive-count-max "):
 		var err error
 		confRead.services[0]["ssh"].([]map[string]interface{})[0]["client_alive_count_max"], err =


### PR DESCRIPTION
BUG FIXES:
* resource/`junos_system`: unescape the html entities for `announcement` argument inside `login` argument (Fixes parts of #251)
* resource/`junos_system`: remove the potential double quotes for `ciphers` argument inside `services.0.ssh` argumet (Fixes parts of #251)