### PR TITLE
Fixes #263: r/junos_interface_logical: add `dad_disable` argument inside `family_inet6`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ENHANCEMENTS:
 
+* resource/`junos_interface_logical`: add `dad_disable` argument  inside `family_inet6` block argument (Fixes #263)
+* data-source/`junos_interface_logical`: add `dad_disable` attributes as for the resource
 * data-source/`junos_interface`, `junos_interface_logical`: `vrrp_group.*.authentication_key` is now a sensitive argument (like resource)
 * docs: rewrite style for argument name and type
 * docs: add attributes reference on resource

--- a/junos/data_source_interface_logical.go
+++ b/junos/data_source_interface_logical.go
@@ -299,6 +299,10 @@ func dataSourceInterfaceLogical() *schema.Resource {
 								},
 							},
 						},
+						"dad_disable": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
 						"filter_input": {
 							Type:     schema.TypeString,
 							Computed: true,

--- a/junos/data_source_interface_logical_test.go
+++ b/junos/data_source_interface_logical_test.go
@@ -61,6 +61,11 @@ resource junos_interface_logical testacc_datainterfaceL {
       cidr_ip = "192.0.2.1/25"
     }
   }
+  family_inet6 {
+    address {
+      cidr_ip = "2001:db8::1/64"
+    }
+  }
 }
 `
 }

--- a/junos/resource_interface_logical.go
+++ b/junos/resource_interface_logical.go
@@ -344,6 +344,10 @@ func resourceInterfaceLogical() *schema.Resource {
 								},
 							},
 						},
+						"dad_disable": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
 						"filter_input": {
 							Type:             schema.TypeString,
 							Optional:         true,
@@ -864,6 +868,9 @@ func setInterfaceLogical(d *schema.ResourceData, m interface{}, jnprSess *Netcon
 					return err
 				}
 			}
+			if familyInet6["dad_disable"].(bool) {
+				configSet = append(configSet, setPrefix+"family inet6 dad-disable")
+			}
 			if familyInet6["filter_input"].(string) != "" {
 				configSet = append(configSet, setPrefix+"family inet6 filter input "+
 					familyInet6["filter_input"].(string))
@@ -954,6 +961,7 @@ func readInterfaceLogical(interFace string, m interface{}, jnprSess *NetconfObje
 				if len(confRead.familyInet6) == 0 {
 					confRead.familyInet6 = append(confRead.familyInet6, map[string]interface{}{
 						"address":         make([]map[string]interface{}, 0),
+						"dad_disable":     false,
 						"filter_input":    "",
 						"filter_output":   "",
 						"mtu":             0,
@@ -970,6 +978,8 @@ func readInterfaceLogical(interFace string, m interface{}, jnprSess *NetconfObje
 					if err != nil {
 						return confRead, err
 					}
+				case itemTrim == "family inet6 dad-disable":
+					confRead.familyInet6[0]["dad_disable"] = true
 				case strings.HasPrefix(itemTrim, "family inet6 filter input "):
 					confRead.familyInet6[0]["filter_input"] = strings.TrimPrefix(itemTrim, "family inet6 filter input ")
 				case strings.HasPrefix(itemTrim, "family inet6 filter output "):

--- a/junos/resource_interface_logical_test.go
+++ b/junos/resource_interface_logical_test.go
@@ -256,6 +256,7 @@ resource junos_interface_logical testacc_interface_logical {
     }
   }
   family_inet6 {
+    dad_disable   = true
     mtu           = 1400
     filter_input  = junos_firewall_filter.testacc_intlogicalInet6.name
     filter_output = junos_firewall_filter.testacc_intlogicalInet6.name

--- a/website/docs/d/interface_logical.html.markdown
+++ b/website/docs/d/interface_logical.html.markdown
@@ -68,6 +68,8 @@ The following attributes are exported:
   - **address** (Block List)  
     List of address.  
     See [below for nested schema](#address-attributes-for-family_inet6).
+  - **dad_disable** (Boolean)  
+    Disable duplicate-address-detection.
   - **filter_input** (String)  
     Filter applied to received packets.
   - **filter_output** (String)  

--- a/website/docs/r/interface_logical.html.markdown
+++ b/website/docs/r/interface_logical.html.markdown
@@ -61,6 +61,8 @@ The following arguments are supported:
   - **address** (Optional, Block List)  
     For each ipv6 address to declare.  
     See [below for nested schema](#address-arguments-for-family_inet6).
+  - **dad_disable** (Optional, Boolean)  
+    Disable duplicate-address-detection.
   - **filter_input** (Optional, String)  
     Filter to be applied to received packets.
   - **filter_output** (Optional, String)  


### PR DESCRIPTION
ENHANCEMENTS:

* resource/`junos_interface_logical`: add `dad_disable` argument  inside `family_inet6` block argument (Fixes #263)
* data-source/`junos_interface_logical`: add `dad_disable` attributes as for the resource