### PR TITLE
Fixes #262: r/system: add netconf_traceoptions block inside services argument 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ENHANCEMENTS:
 
+* resource/`junos_system`: add `netconf_traceoptions` block argument inside `services` block argument (Fixes #262)
 * data-source/`junos_interface`, `junos_interface_logical`: `vrrp_group.*.authentication_key` is now a sensitive argument (like resource)
 * docs: rewrite style for argument name and type
 * docs: add attributes reference on resource

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ ENHANCEMENTS:
 
 BUG FIXES:
 
+* resource/`junos_security`: fix reading `size` argument inside `file` block inside `ike_traceoptions` block when number match a multiple of 1024 (example 1k, 1m, 1g)
+
 ## 1.19.0 (July 30, 2021)
 
 FEATURES:

--- a/junos/resource_security.go
+++ b/junos/resource_security.go
@@ -2364,8 +2364,26 @@ func readSecurityIkeTraceOptions(confRead *securityOptions, itemTrimIkeTraceOpts
 				strings.TrimPrefix(itemTrim, "file match "), "\"")
 		case strings.HasPrefix(itemTrim, "file size"):
 			var err error
-			confRead.ikeTraceoptions[0]["file"].([]map[string]interface{})[0]["size"], err = strconv.Atoi(
-				strings.TrimPrefix(itemTrim, "file size "))
+			switch {
+			case strings.HasSuffix(itemTrim, "k"):
+				confRead.ikeTraceoptions[0]["file"].([]map[string]interface{})[0]["size"], err =
+					strconv.Atoi(strings.TrimSuffix(strings.TrimPrefix(itemTrim, "file size "), "k"))
+				confRead.ikeTraceoptions[0]["file"].([]map[string]interface{})[0]["size"] =
+					confRead.ikeTraceoptions[0]["file"].([]map[string]interface{})[0]["size"].(int) * 1024
+			case strings.HasSuffix(itemTrim, "m"):
+				confRead.ikeTraceoptions[0]["file"].([]map[string]interface{})[0]["size"], err =
+					strconv.Atoi(strings.TrimSuffix(strings.TrimPrefix(itemTrim, "file size "), "m"))
+				confRead.ikeTraceoptions[0]["file"].([]map[string]interface{})[0]["size"] =
+					confRead.ikeTraceoptions[0]["file"].([]map[string]interface{})[0]["size"].(int) * 1024 * 1024
+			case strings.HasSuffix(itemTrim, "g"):
+				confRead.ikeTraceoptions[0]["file"].([]map[string]interface{})[0]["size"], err =
+					strconv.Atoi(strings.TrimSuffix(strings.TrimPrefix(itemTrim, "file size "), "g"))
+				confRead.ikeTraceoptions[0]["file"].([]map[string]interface{})[0]["size"] =
+					confRead.ikeTraceoptions[0]["file"].([]map[string]interface{})[0]["size"].(int) * 1024 * 1024 * 1024
+			default:
+				confRead.ikeTraceoptions[0]["file"].([]map[string]interface{})[0]["size"], err =
+					strconv.Atoi(strings.TrimPrefix(itemTrim, "file size "))
+			}
 			if err != nil {
 				return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
 			}

--- a/junos/resource_security_test.go
+++ b/junos/resource_security_test.go
@@ -125,7 +125,7 @@ func TestAccJunosSecurity_basic(t *testing.T) {
 						resource.TestCheckResourceAttr("junos_security.testacc_security",
 							"ike_traceoptions.0.file.0.match", "test"),
 						resource.TestCheckResourceAttr("junos_security.testacc_security",
-							"ike_traceoptions.0.file.0.size", "100000"),
+							"ike_traceoptions.0.file.0.size", "102400"),
 						resource.TestCheckResourceAttr("junos_security.testacc_security",
 							"ike_traceoptions.0.file.0.world_readable", "true"),
 						resource.TestCheckResourceAttr("junos_security.testacc_security",
@@ -398,7 +398,7 @@ resource junos_security "testacc_security" {
       name           = "ike.log"
       files          = 5
       match          = "test"
-      size           = 100000
+      size           = 102400
       world_readable = true
     }
     flag            = ["all"]

--- a/junos/resource_system.go
+++ b/junos/resource_system.go
@@ -501,6 +501,56 @@ func resourceSystem() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"netconf_traceoptions": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"file_name": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"file_files": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(2, 1000),
+									},
+									"file_match": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"file_no_world_readable": {
+										Type:          schema.TypeBool,
+										Optional:      true,
+										ConflictsWith: []string{"services.0.netconf_traceoptions.0.file_world_readable"},
+									},
+									"file_size": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(10240, 1073741824),
+									},
+									"file_world_readable": {
+										Type:          schema.TypeBool,
+										Optional:      true,
+										ConflictsWith: []string{"services.0.netconf_traceoptions.0.file_no_world_readable"},
+									},
+									"flag": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"no_remote_trace": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"on_demand": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+								},
+							},
+						},
 						"ssh": {
 							Type:     schema.TypeList,
 							Optional: true,
@@ -1041,6 +1091,39 @@ func setSystemServices(d *schema.ResourceData, m interface{}, jnprSess *NetconfO
 			return fmt.Errorf("services block is empty")
 		}
 		servicesM := services.(map[string]interface{})
+		for _, servicesNetconfTraceOpts := range servicesM["netconf_traceoptions"].([]interface{}) {
+			if servicesNetconfTraceOpts == nil {
+				return fmt.Errorf("services.0.netconf_traceoptions block is empty")
+			}
+			netconfTraceOpts := servicesNetconfTraceOpts.(map[string]interface{})
+			if v := netconfTraceOpts["file_name"].(string); v != "" {
+				configSet = append(configSet, setPrefix+"netconf traceoptions file \""+v+"\"")
+			}
+			if v := netconfTraceOpts["file_files"].(int); v != 0 {
+				configSet = append(configSet, setPrefix+"netconf traceoptions file files "+strconv.Itoa(v))
+			}
+			if v := netconfTraceOpts["file_match"].(string); v != "" {
+				configSet = append(configSet, setPrefix+"netconf traceoptions file match \""+v+"\"")
+			}
+			if v := netconfTraceOpts["file_size"].(int); v != 0 {
+				configSet = append(configSet, setPrefix+"netconf traceoptions file size "+strconv.Itoa(v))
+			}
+			if netconfTraceOpts["file_no_world_readable"].(bool) {
+				configSet = append(configSet, setPrefix+"netconf traceoptions file no-world-readable")
+			}
+			if netconfTraceOpts["file_world_readable"].(bool) {
+				configSet = append(configSet, setPrefix+"netconf traceoptions file world-readable")
+			}
+			for _, v := range netconfTraceOpts["flag"].(*schema.Set).List() {
+				configSet = append(configSet, setPrefix+"netconf traceoptions flag "+v.(string))
+			}
+			if netconfTraceOpts["no_remote_trace"].(bool) {
+				configSet = append(configSet, setPrefix+"netconf traceoptions no-remote-trace")
+			}
+			if netconfTraceOpts["on_demand"].(bool) {
+				configSet = append(configSet, setPrefix+"netconf traceoptions on-demand")
+			}
+		}
 		for _, servicesSSH := range servicesM["ssh"].([]interface{}) {
 			servicesSSHM := servicesSSH.(map[string]interface{})
 			for _, auth := range servicesSSHM["authentication_order"].([]interface{}) {
@@ -1389,6 +1472,7 @@ func listLinesLicense() []string {
 
 func listLinesServices() []string {
 	ls := make([]string, 0)
+	ls = append(ls, "services netconf traceoptions")
 	ls = append(ls, listLinesServicesSSH()...)
 	ls = append(ls, listLinesServicesWebManagement()...)
 
@@ -1604,10 +1688,16 @@ func readSystem(m interface{}, jnprSess *NetconfObject) (systemOptions, error) {
 			case checkStringHasPrefixInList(itemTrim, listLinesServices()):
 				if len(confRead.services) == 0 {
 					confRead.services = append(confRead.services, map[string]interface{}{
+						"netconf_traceoptions": make([]map[string]interface{}, 0),
 						"ssh":                  make([]map[string]interface{}, 0),
 						"web_management_http":  make([]map[string]interface{}, 0),
 						"web_management_https": make([]map[string]interface{}, 0),
 					})
+				}
+				if strings.HasPrefix(itemTrim, "services netconf traceoptions ") {
+					if err := readSystemServicesNetconfTraceOpts(&confRead, itemTrim); err != nil {
+						return confRead, err
+					}
 				}
 				if checkStringHasPrefixInList(itemTrim, listLinesServicesSSH()) {
 					if err := readSystemServicesSSH(&confRead, itemTrim); err != nil {
@@ -1992,6 +2082,72 @@ func readSystemLicense(confRead *systemOptions, itemTrim string) error {
 		if err != nil {
 			return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
 		}
+	}
+
+	return nil
+}
+
+func readSystemServicesNetconfTraceOpts(confRead *systemOptions, itemTrimNetconfTraceOpts string) error {
+	if len(confRead.services[0]["netconf_traceoptions"].([]map[string]interface{})) == 0 {
+		confRead.services[0]["netconf_traceoptions"] = append(
+			confRead.services[0]["netconf_traceoptions"].([]map[string]interface{}),
+			map[string]interface{}{
+				"file_name":              "",
+				"file_files":             0,
+				"file_match":             "",
+				"file_no_world_readable": false,
+				"file_size":              0,
+				"file_world_readable":    false,
+				"flag":                   make([]string, 0),
+				"no_remote_trace":        false,
+				"on_demand":              false,
+			})
+	}
+	netconfTraceOpts := confRead.services[0]["netconf_traceoptions"].([]map[string]interface{})[0]
+	itemTrim := strings.TrimPrefix(itemTrimNetconfTraceOpts, "services netconf traceoptions ")
+	switch {
+	case strings.HasPrefix(itemTrim, "file files "):
+		var err error
+		netconfTraceOpts["file_files"], err = strconv.Atoi(strings.TrimPrefix(itemTrim, "file files "))
+		if err != nil {
+			return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+		}
+	case strings.HasPrefix(itemTrim, "file match "):
+		netconfTraceOpts["file_match"] = strings.Trim(strings.TrimPrefix(itemTrim, "file match "), "\"")
+	case itemTrim == "file no-world-readable":
+		netconfTraceOpts["file_no_world_readable"] = true
+	case strings.HasPrefix(itemTrim, "file size "):
+		var err error
+		switch {
+		case strings.HasSuffix(itemTrim, "k"):
+			netconfTraceOpts["file_size"], err =
+				strconv.Atoi(strings.TrimSuffix(strings.TrimPrefix(itemTrim, "file size "), "k"))
+			netconfTraceOpts["file_size"] = netconfTraceOpts["file_size"].(int) * 1024
+		case strings.HasSuffix(itemTrim, "m"):
+			netconfTraceOpts["file_size"], err =
+				strconv.Atoi(strings.TrimSuffix(strings.TrimPrefix(itemTrim, "file size "), "m"))
+			netconfTraceOpts["file_size"] = netconfTraceOpts["file_size"].(int) * 1024 * 1024
+		case strings.HasSuffix(itemTrim, "g"):
+			netconfTraceOpts["file_size"], err =
+				strconv.Atoi(strings.TrimSuffix(strings.TrimPrefix(itemTrim, "file size "), "g"))
+			netconfTraceOpts["file_size"] = netconfTraceOpts["file_size"].(int) * 1024 * 1024 * 1024
+		default:
+			netconfTraceOpts["file_size"], err =
+				strconv.Atoi(strings.TrimPrefix(itemTrim, "file size "))
+		}
+		if err != nil {
+			return fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
+		}
+	case itemTrim == "file world-readable":
+		netconfTraceOpts["file_world_readable"] = true
+	case strings.HasPrefix(itemTrim, "file "):
+		netconfTraceOpts["file_name"] = strings.Trim(strings.TrimPrefix(itemTrim, "file "), "\"")
+	case strings.HasPrefix(itemTrim, "flag "):
+		netconfTraceOpts["flag"] = append(netconfTraceOpts["flag"].([]string), strings.TrimPrefix(itemTrim, "flag "))
+	case itemTrim == "no-remote-trace":
+		netconfTraceOpts["no_remote_trace"] = true
+	case itemTrim == "on-demand":
+		netconfTraceOpts["on_demand"] = true
 	}
 
 	return nil

--- a/junos/resource_system_test.go
+++ b/junos/resource_system_test.go
@@ -335,6 +335,15 @@ resource junos_system "testacc_system" {
   radius_options_enhanced_accounting        = true
   radius_options_password_protocol_mschapv2 = true
   services {
+    netconf_traceoptions {
+      file_name           = "testacc_netconf"
+      file_match          = "test"
+      file_world_readable = true
+      file_size           = 20480
+      flag                = ["all"]
+      no_remote_trace     = true
+      on_demand           = true
+    }
     ssh {
       authentication_order           = ["password"]
       ciphers                        = ["aes256-ctr", "aes256-cbc"]
@@ -406,6 +415,12 @@ resource junos_system "testacc_system" {
     no_tcp_rfc1323_paws           = true
   }
   services {
+    netconf_traceoptions {
+      file_name              = "testacc_netconf"
+      file_no_world_readable = true
+      file_size              = 40960
+      flag                   = ["incoming", "outgoing"]
+    }
     ssh {
       ciphers           = ["aes256-ctr"]
       no_tcp_forwarding = true

--- a/website/docs/r/system.html.markdown
+++ b/website/docs/r/system.html.markdown
@@ -106,6 +106,9 @@ The following arguments are supported:
   MSCHAP version 2 for password protocol used in RADIUS packets.
 - **services** (Optional, Block)  
   Declare `services` configuration.
+  - **netconf_traceoptions** (Optional, Block)  
+    Declare `netconf traceoptions` configuration.  
+    See [below for nested schema](#netconf_traceoptions-arguments-for-services).
   - **ssh** (Optional, Block)  
     Declare `ssh` configuration.  
     See [below for nested schema](#ssh-arguments-for-services).
@@ -266,6 +269,29 @@ The following arguments are supported:
     Minimum total connection time if all attempts fail (20..60).
   - **tries_before_disconnect** (Optional, Number)  
     Number of times user is allowed to try password (2..10).
+
+---
+
+### netconf_traceoptions arguments for services
+
+- **file_name** (Optional, String)  
+  Name of file in which to write trace information.
+- **file_files** (Optional, Number)  
+  Maximum number of trace files (2..1000).
+- **file_match** (Optional, String)  
+  Regular expression for lines to be logged.
+- **file_no_world_readable** (Optional, Boolean)  
+  Don't allow any user to read the log file.
+- **file_size** (Optional, Number)  
+  Maximum trace file size (10240..1073741824).
+- **file_world_readable** (Optional, Boolean)  
+  Allow any user to read the log file.
+- **flag** (Optional, Set of String)  
+  Tracing parameters.
+- **no_remote_trace** (Optional, Boolean)  
+  Disable remote tracing.
+- **on_demand** (Optional, Boolean)  
+  Enable on-demand tracing.
 
 ---
 


### PR DESCRIPTION
ENHANCEMENTS:

* resource/`junos_system`: add `netconf_traceoptions` block argument inside `services` block argument (Fixes #262)

BUG FIXES:

* resource/`junos_security`: fix reading `size` argument inside `file` block inside `ike_traceoptions` block when number match a multiple of 1024 (example 1k, 1m, 1g)