### PR TITLE
Fixes #270: `junos_chassis_cluster` add preempt settings arguments for redundancy_group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ BUG FIXES:
 
 * resource/`junos_security`: fix reading `size` argument inside `file` block inside `ike_traceoptions` block when number match a multiple of 1024 (example 1k, 1m, 1g)
 * resource/`junos_security`: fix string format for `idp_security_package.0.automatic_start_time` to `YYYY-MM-DD.HH:MM:SS` to avoid unnecessary diff for Terraform when timezone of Junos device change
+* resource/`junos_chassis_cluster`: fix possible crash in certain conditions when import this resource
 
 ## 1.19.0 (July 30, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ENHANCEMENTS:
 
+* resource/`junos_chassis_cluster`: add `preempt_delay`, `preempt_limit` and `preempt_period` arguments inside `redundancy_group` block list argument (Fixes #270)
 * resource/`junos_system`: add `ntp` block argument (Fixes #261)
 * resource/`junos_interface_logical`: add `dad_disable` argument  inside `family_inet6` block argument (Fixes #263)
 * data-source/`junos_interface_logical`: add `dad_disable` attributes as for the resource

--- a/junos/resource_chassis_cluster.go
+++ b/junos/resource_chassis_cluster.go
@@ -418,14 +418,16 @@ func readChassisCluster(m interface{}, jnprSess *NetconfObject) (chassisClusterO
 					return confRead, fmt.Errorf("failed to convert value from '%s' to integer : %w", itemRGTrimSplit[0], err)
 				}
 				if len(confRead.redundancyGroup) < number+1 {
-					confRead.redundancyGroup = append(confRead.redundancyGroup, map[string]interface{}{
-						"node0_priority":       0,
-						"node1_priority":       0,
-						"gratuitous_arp_count": 0,
-						"hold_down_interval":   -1,
-						"interface_monitor":    make([]map[string]interface{}, 0),
-						"preempt":              false,
-					})
+					for i := len(confRead.redundancyGroup); i < number+1; i++ {
+						confRead.redundancyGroup = append(confRead.redundancyGroup, map[string]interface{}{
+							"node0_priority":       0,
+							"node1_priority":       0,
+							"gratuitous_arp_count": 0,
+							"hold_down_interval":   -1,
+							"interface_monitor":    make([]map[string]interface{}, 0),
+							"preempt":              false,
+						})
+					}
 				}
 				itemRGNbTrim := strings.TrimPrefix(itemRGTrim, strconv.Itoa(number)+" ")
 				switch {

--- a/junos/resource_chassis_cluster_test.go
+++ b/junos/resource_chassis_cluster_test.go
@@ -53,7 +53,7 @@ func TestAccJunosCluster_basic(t *testing.T) {
 					Config: testAccJunosClusterConfigUpdate(testaccInterface, testaccInterface2),
 					Check: resource.ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr("junos_chassis_cluster.testacc_cluster",
-							"redundancy_group.#", "2"),
+							"redundancy_group.#", "3"),
 						resource.TestCheckResourceAttr("junos_chassis_cluster.testacc_cluster",
 							"redundancy_group.1.node0_priority", "100"),
 						resource.TestCheckResourceAttr("junos_chassis_cluster.testacc_cluster",
@@ -94,6 +94,7 @@ resource "junos_chassis_cluster" "testacc_cluster" {
       name   = junos_interface_physical.testacc_cluster_int2.name
       weight = 255
     }
+    preempt = true
   }
   reth_count = 2
 }
@@ -124,6 +125,14 @@ resource "junos_chassis_cluster" "testacc_cluster" {
       name   = junos_interface_physical.testacc_cluster_int2.name
       weight = 255
     }
+  }
+  redundancy_group {
+    node0_priority = 100
+    node1_priority = 99
+    preempt        = true
+    preempt_delay  = 2
+    preempt_limit  = 3
+    preempt_period = 4
   }
   reth_count = 3
 }

--- a/website/docs/r/chassis_cluster.html.markdown
+++ b/website/docs/r/chassis_cluster.html.markdown
@@ -72,6 +72,15 @@ The following arguments are supported:
     See [below for nested schema](#interface_monitor-arguments-for-redundancy_group).
   - **preempt** (Optional, Boolean)  
     Allow preemption of primaryship based on priority.
+  - **preempt_delay** (Optional, Number)  
+    Time to wait before taking over mastership (1..21600 seconds).  
+    `preempt` need to be true.
+  - **preempt_limit** (Optional, Number)  
+    Max number of preemptive failovers allowed (1..50).  
+    `preempt` need to be true.
+  - **preempt_period** (Optional, Number)  
+    Time period during which the limit is applied (1..1400 seconds).  
+    `preempt` need to be true.
 - **reth_count** (Required, Number)  
   Number of redundant ethernet interfaces (1..128)
 - **config_sync_no_secondary_bootup_auto** (Optional, Boolean)  


### PR DESCRIPTION
ENHANCEMENTS:

* resource/`junos_chassis_cluster`: add `preempt_delay`, `preempt_limit` and `preempt_period` arguments inside `redundancy_group` block list argument (Fixes #270)