### PR TITLE
add validation to some arguments which cannot contain a space character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ BUG FIXES:
 * resource/`junos_security`: fix reading `size` argument inside `file` block inside `ike_traceoptions` block when number match a multiple of 1024 (example 1k, 1m, 1g)
 * resource/`junos_security`: fix string format for `idp_security_package.0.automatic_start_time` to `YYYY-MM-DD.HH:MM:SS` to avoid unnecessary diff for Terraform when timezone of Junos device change
 * resource/`junos_chassis_cluster`: fix possible crash in certain conditions when import this resource
+* resource/`*`: add validation to some arguments which cannot contain a space character and thus avoid bugs when reading these arguments
 
 ## 1.19.0 (July 30, 2021)
 

--- a/junos/resource_eventoptions_destination.go
+++ b/junos/resource_eventoptions_destination.go
@@ -39,8 +39,9 @@ func resourceEventoptionsDestination() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"url": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringDoesNotContainAny(" "),
 						},
 						"password": {
 							Type:      schema.TypeString,

--- a/junos/resource_eventoptions_policy.go
+++ b/junos/resource_eventoptions_policy.go
@@ -129,8 +129,9 @@ func resourceEventoptionsPolicy() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"filename": {
-										Type:     schema.TypeString,
-										Required: true,
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringDoesNotContainAny(" "),
 									},
 									"arguments": {
 										Type:     schema.TypeList,
@@ -138,12 +139,14 @@ func resourceEventoptionsPolicy() *schema.Resource {
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"name": {
-													Type:     schema.TypeString,
-													Required: true,
+													Type:         schema.TypeString,
+													Required:     true,
+													ValidateFunc: validation.StringDoesNotContainAny(" "),
 												},
 												"value": {
-													Type:     schema.TypeString,
-													Required: true,
+													Type:         schema.TypeString,
+													Required:     true,
+													ValidateFunc: validation.StringDoesNotContainAny(" "),
 												},
 											},
 										},
@@ -155,8 +158,9 @@ func resourceEventoptionsPolicy() *schema.Resource {
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"name": {
-													Type:     schema.TypeString,
-													Required: true,
+													Type:         schema.TypeString,
+													Required:     true,
+													ValidateFunc: validation.StringDoesNotContainAny(" "),
 												},
 												"retry_count": {
 													Type:         schema.TypeInt,
@@ -225,8 +229,9 @@ func resourceEventoptionsPolicy() *schema.Resource {
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"name": {
-													Type:     schema.TypeString,
-													Required: true,
+													Type:         schema.TypeString,
+													Required:     true,
+													ValidateFunc: validation.StringDoesNotContainAny(" "),
 												},
 												"retry_count": {
 													Type:         schema.TypeInt,
@@ -362,12 +367,14 @@ func resourceEventoptionsPolicy() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"filename": {
-										Type:     schema.TypeString,
-										Required: true,
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringDoesNotContainAny(" "),
 									},
 									"destination": {
-										Type:     schema.TypeString,
-										Required: true,
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringDoesNotContainAny(" "),
 									},
 									"retry_count": {
 										Type:         schema.TypeInt,
@@ -403,8 +410,9 @@ func resourceEventoptionsPolicy() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"from": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringDoesNotContainAny(" "),
 						},
 						"compare": {
 							Type:         schema.TypeString,
@@ -412,8 +420,9 @@ func resourceEventoptionsPolicy() *schema.Resource {
 							ValidateFunc: validation.StringInSlice([]string{"equals", "matches", "starts-with"}, false),
 						},
 						"to": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringDoesNotContainAny(" "),
 						},
 					},
 				},

--- a/junos/resource_security_idp_custom_attack.go
+++ b/junos/resource_security_idp_custom_attack.go
@@ -79,8 +79,9 @@ func resourceSecurityIdpCustomAttack() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"name": {
-										Type:     schema.TypeString,
-										Required: true,
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringDoesNotContainAny(" "),
 									},
 									"attack_type_anomaly": {
 										Type:     schema.TypeList,

--- a/junos/resource_security_idp_policy.go
+++ b/junos/resource_security_idp_policy.go
@@ -38,8 +38,9 @@ func resourceSecurityIdpPolicy() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringDoesNotContainAny(" "),
 						},
 						"match": {
 							Type:     schema.TypeList,
@@ -62,8 +63,9 @@ func resourceSecurityIdpPolicy() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringDoesNotContainAny(" "),
 						},
 						"match": {
 							Type:     schema.TypeList,

--- a/junos/resource_services_rpm_probe.go
+++ b/junos/resource_services_rpm_probe.go
@@ -43,8 +43,9 @@ func resourceServicesRpmProbe() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringDoesNotContainAny(" "),
 						},
 						"data_fill": {
 							Type:     schema.TypeString,

--- a/junos/resource_services_security_intelligence_policy.go
+++ b/junos/resource_services_security_intelligence_policy.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 type securityIntellPolicyOptions struct {
@@ -40,8 +41,9 @@ func resourceServicesSecurityIntellPolicy() *schema.Resource {
 							Required: true,
 						},
 						"profile_name": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringDoesNotContainAny(" "),
 						},
 					},
 				},

--- a/junos/resource_services_security_intelligence_profile.go
+++ b/junos/resource_services_security_intelligence_profile.go
@@ -45,8 +45,9 @@ func resourceServicesSecurityIntellProfile() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringDoesNotContainAny(" "),
 						},
 						"match": {
 							Type:     schema.TypeList,

--- a/junos/resource_system.go
+++ b/junos/resource_system.go
@@ -64,8 +64,9 @@ func resourceSystem() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"url": {
-										Type:     schema.TypeString,
-										Required: true,
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringDoesNotContainAny(" "),
 									},
 									"password": {
 										Type:      schema.TypeString,


### PR DESCRIPTION
BUG FIXES:

resource/`*`: add validation to some arguments which cannot contain a space character and thus avoid bugs when reading these arguments