### PR TITLE
gen errors for duplicate elements in the block lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ENHANCEMENTS:
 
+* resource/`*`: to avoid any confusion, the provider now detects and generates an error during `apply` when there are duplicate elements (with the same identifier, for example the same `name`) in the block lists of certain resources
+
 BUG FIXES:
 
 ## 1.20.0 (September 07, 2021)

--- a/junos/constants.go
+++ b/junos/constants.go
@@ -3,6 +3,7 @@ package junos
 const (
 	idSeparator           = "_-_"
 	defaultWord           = "default"
+	evpnWord              = "evpn"
 	inetWord              = "inet"
 	inet6Word             = "inet6"
 	mplsWord              = "mpls"

--- a/junos/func_common.go
+++ b/junos/func_common.go
@@ -257,6 +257,16 @@ func stringInSlice(str string, list []string) bool {
 	return false
 }
 
+func intInSlice(num int, list []int) bool {
+	for _, v := range list {
+		if v == num {
+			return true
+		}
+	}
+
+	return false
+}
+
 func sortSetOfString(list []interface{}) []string {
 	s := make([]string, 0)
 	for _, e := range list {

--- a/junos/func_resource_bgp.go
+++ b/junos/func_resource_bgp.go
@@ -560,15 +560,27 @@ func setBgpOptsFamily(setPrefix, familyType string, familyOptsList []interface{}
 	configSet := make([]string, 0)
 	setPrefixFamily := setPrefix + "family "
 	switch familyType {
-	case "evpn":
+	case evpnWord:
 		setPrefixFamily += "evpn "
 	case inetWord:
 		setPrefixFamily += "inet "
 	case inet6Word:
 		setPrefixFamily += "inet6 "
 	}
+	familyNlriTypeList := make([]string, 0)
 	for _, familyOpts := range familyOptsList {
 		familyOptsM := familyOpts.(map[string]interface{})
+		if stringInSlice(familyOptsM["nlri_type"].(string), familyNlriTypeList) {
+			switch familyType {
+			case evpnWord:
+				return fmt.Errorf("multiple family_evpn blocks with the same nlri_type")
+			case inetWord:
+				return fmt.Errorf("multiple family_inet blocks with the same nlri_type")
+			case inet6Word:
+				return fmt.Errorf("multiple family_inet6 blocks with the same nlri_type")
+			}
+		}
+		familyNlriTypeList = append(familyNlriTypeList, familyOptsM["nlri_type"].(string))
 		configSet = append(configSet, setPrefixFamily+familyOptsM["nlri_type"].(string))
 		for _, v := range familyOptsM["accepted_prefix_limit"].([]interface{}) {
 			mAccPrefixLimit := v.(map[string]interface{})
@@ -629,7 +641,7 @@ func readBgpOptsFamily(item, familyType string, opts []map[string]interface{}) (
 	}
 	setPrefix := "family "
 	switch familyType {
-	case "evpn":
+	case evpnWord:
 		setPrefix += "evpn "
 	case inetWord:
 		setPrefix += "inet "

--- a/junos/resource_chassis_cluster.go
+++ b/junos/resource_chassis_cluster.go
@@ -360,8 +360,13 @@ func setChassisCluster(d *schema.ResourceData, m interface{}, jnprSess *NetconfO
 			configSet = append(configSet, setChassisluster+"redundancy-group "+strconv.Itoa(i)+
 				" hold-down-interval "+strconv.Itoa(redundancyGroup["hold_down_interval"].(int)))
 		}
+		interfaceMonitorNameList := make([]string, 0)
 		for _, v2 := range redundancyGroup["interface_monitor"].([]interface{}) {
 			interfaceMonitor := v2.(map[string]interface{})
+			if stringInSlice(interfaceMonitor["name"].(string), interfaceMonitorNameList) {
+				return fmt.Errorf("multiple interface_monitor blocks with the same name")
+			}
+			interfaceMonitorNameList = append(interfaceMonitorNameList, interfaceMonitor["name"].(string))
 			configSet = append(configSet, setChassisluster+"redundancy-group "+strconv.Itoa(i)+
 				" interface-monitor "+interfaceMonitor["name"].(string)+
 				" weight "+strconv.Itoa(interfaceMonitor["weight"].(int)))

--- a/junos/resource_eventoptions_destination.go
+++ b/junos/resource_eventoptions_destination.go
@@ -251,8 +251,13 @@ func setEventoptionsDestination(d *schema.ResourceData, m interface{}, jnprSess 
 	configSet := make([]string, 0)
 	setPrefix := "set event-options destinations \"" + d.Get("name").(string) + "\" "
 
+	archiveSiteURLList := make([]string, 0)
 	for _, v := range d.Get("archive_site").([]interface{}) {
 		archiveSite := v.(map[string]interface{})
+		if stringInSlice(archiveSite["url"].(string), archiveSiteURLList) {
+			return fmt.Errorf("multiple archive_site blocks with the same url")
+		}
+		archiveSiteURLList = append(archiveSiteURLList, archiveSite["url"].(string))
 		configSet = append(configSet, setPrefix+"archive-sites \""+archiveSite["url"].(string)+"\"")
 		if v2 := archiveSite["password"].(string); v2 != "" {
 			configSet = append(configSet, setPrefix+"archive-sites \""+archiveSite["url"].(string)+"\" password \""+v2+"\"")

--- a/junos/resource_forwardingoptions_sampling_instance.go
+++ b/junos/resource_forwardingoptions_sampling_instance.go
@@ -947,8 +947,13 @@ func setForwardingoptionsSamplingInstanceOutput(
 	if v := output["flow_inactive_timeout"].(int); v != 0 {
 		configSet = append(configSet, setPrefix+"flow-inactive-timeout "+strconv.Itoa(v))
 	}
+	flowServerHostnameList := make([]string, 0)
 	for _, vFS := range output["flow_server"].([]interface{}) {
 		flowServer := vFS.(map[string]interface{})
+		if stringInSlice(flowServer["hostname"].(string), flowServerHostnameList) {
+			return fmt.Errorf("multiple flow_server blocks with the same hostname")
+		}
+		flowServerHostnameList = append(flowServerHostnameList, flowServer["hostname"].(string))
 		setPrefixFlowServer := setPrefix + "flow-server " + flowServer["hostname"].(string) + " "
 		configSet = append(configSet, setPrefixFlowServer+"port "+strconv.Itoa(flowServer["port"].(int)))
 		if flowServer["aggregation_autonomous_system"].(bool) {
@@ -1011,8 +1016,13 @@ func setForwardingoptionsSamplingInstanceOutput(
 	if v := output["inline_jflow_source_address"].(string); v != "" {
 		configSet = append(configSet, setPrefix+"inline-jflow source-address "+v)
 	}
+	interfaceNameList := make([]string, 0)
 	for _, vIF := range output["interface"].([]interface{}) {
 		interFace := vIF.(map[string]interface{})
+		if stringInSlice(interFace["name"].(string), interfaceNameList) {
+			return fmt.Errorf("multiple interface blocks with the same name")
+		}
+		interfaceNameList = append(interfaceNameList, interFace["name"].(string))
 		setPrefixInterface := setPrefix + "interface " + interFace["name"].(string) + " "
 		configSet = append(configSet, setPrefixInterface)
 		if v := interFace["engine_id"].(int); v != -1 {

--- a/junos/resource_group_dual_system.go
+++ b/junos/resource_group_dual_system.go
@@ -394,8 +394,13 @@ func setGroupDualSystem(d *schema.ResourceData, m interface{}, jnprSess *Netconf
 		if v2 := interfaceFxp0["description"].(string); v2 != "" {
 			configSet = append(configSet, setPrefix+"interfaces fxp0 description \""+v2+"\"")
 		}
+		familyInetAddressCIDRIPList := make([]string, 0)
 		for _, v2 := range interfaceFxp0["family_inet_address"].([]interface{}) {
 			familyInetAddress := v2.(map[string]interface{})
+			if stringInSlice(familyInetAddress["cidr_ip"].(string), familyInetAddressCIDRIPList) {
+				return fmt.Errorf("multiple family_inet_address blocks with the same cidr_ip")
+			}
+			familyInetAddressCIDRIPList = append(familyInetAddressCIDRIPList, familyInetAddress["cidr_ip"].(string))
 			configSet = append(configSet, setPrefix+"interfaces fxp0 unit 0 family inet address "+
 				familyInetAddress["cidr_ip"].(string))
 			if familyInetAddress["master_only"].(bool) {
@@ -411,8 +416,13 @@ func setGroupDualSystem(d *schema.ResourceData, m interface{}, jnprSess *Netconf
 					familyInetAddress["cidr_ip"].(string)+" primary")
 			}
 		}
+		familyInet6AddressCIDRIPList := make([]string, 0)
 		for _, v2 := range interfaceFxp0["family_inet6_address"].([]interface{}) {
 			familyInet6Address := v2.(map[string]interface{})
+			if stringInSlice(familyInet6Address["cidr_ip"].(string), familyInet6AddressCIDRIPList) {
+				return fmt.Errorf("multiple family_inet6_address blocks with the same cidr_ip")
+			}
+			familyInet6AddressCIDRIPList = append(familyInet6AddressCIDRIPList, familyInet6Address["cidr_ip"].(string))
 			configSet = append(configSet, setPrefix+"interfaces fxp0 unit 0 family inet6 address "+
 				familyInet6Address["cidr_ip"].(string))
 			if familyInet6Address["master_only"].(bool) {
@@ -431,8 +441,13 @@ func setGroupDualSystem(d *schema.ResourceData, m interface{}, jnprSess *Netconf
 	}
 	for _, v := range d.Get("routing_options").([]interface{}) {
 		routingOptions := v.(map[string]interface{})
+		staticRouteDestList := make([]string, 0)
 		for _, v2 := range routingOptions["static_route"].([]interface{}) {
 			staticRoute := v2.(map[string]interface{})
+			if stringInSlice(staticRoute["destination"].(string), staticRouteDestList) {
+				return fmt.Errorf("multiple static_route blocks with the same destination")
+			}
+			staticRouteDestList = append(staticRouteDestList, staticRoute["destination"].(string))
 			for _, v3 := range staticRoute["next_hop"].([]interface{}) {
 				configSet = append(configSet, setPrefix+"routing-options static route "+
 					staticRoute["destination"].(string)+" next-hop "+v3.(string))

--- a/junos/resource_ospf_area.go
+++ b/junos/resource_ospf_area.go
@@ -309,8 +309,13 @@ func setOspfArea(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject)
 		setPrefix += "routing-instances " + d.Get("routing_instance").(string) +
 			" protocols " + ospfVersion + " area " + d.Get("area_id").(string) + " "
 	}
+	interfaceNameList := make([]string, 0)
 	for _, v := range d.Get("interface").([]interface{}) {
 		ospfInterface := v.(map[string]interface{})
+		if stringInSlice(ospfInterface["name"].(string), interfaceNameList) {
+			return fmt.Errorf("multiple interface blocks with the same name")
+		}
+		interfaceNameList = append(interfaceNameList, ospfInterface["name"].(string))
 		setPrefixInterface := setPrefix + "interface " + ospfInterface["name"].(string) + " "
 		if ospfInterface["dead_interval"].(int) != 0 {
 			configSet = append(configSet, setPrefixInterface+"dead-interval "+

--- a/junos/resource_policyoptions_as_path_group.go
+++ b/junos/resource_policyoptions_as_path_group.go
@@ -246,8 +246,13 @@ func setPolicyoptionsAsPathGroup(d *schema.ResourceData, m interface{}, jnprSess
 	configSet := make([]string, 0)
 
 	setPrefix := "set policy-options as-path-group " + d.Get("name").(string)
+	asPathNameList := make([]string, 0)
 	for _, v := range d.Get("as_path").([]interface{}) {
 		asPath := v.(map[string]interface{})
+		if stringInSlice(asPath["name"].(string), asPathNameList) {
+			return fmt.Errorf("multiple as_path blocks with the same name")
+		}
+		asPathNameList = append(asPathNameList, asPath["name"].(string))
 		configSet = append(configSet, setPrefix+
 			" as-path "+asPath["name"].(string)+
 			" \""+asPath["path"].(string)+"\"")

--- a/junos/resource_security_address_book.go
+++ b/junos/resource_security_address_book.go
@@ -366,8 +366,13 @@ func setAddressBook(d *schema.ResourceData, m interface{}, jnprSess *NetconfObje
 		attachZone := v.(string)
 		configSet = append(configSet, setPrefix+" attach zone "+attachZone)
 	}
+	addressNameList := make([]string, 0)
 	for _, v := range d.Get("network_address").([]interface{}) {
 		address := v.(map[string]interface{})
+		if stringInSlice(address["name"].(string), addressNameList) {
+			return fmt.Errorf("multiple address with the same name")
+		}
+		addressNameList = append(addressNameList, address["name"].(string))
 		setPrefixAddr := setPrefix + " address " + address["name"].(string) + " "
 		configSet = append(configSet, setPrefixAddr+address["value"].(string))
 		if address["description"].(string) != "" {
@@ -376,6 +381,10 @@ func setAddressBook(d *schema.ResourceData, m interface{}, jnprSess *NetconfObje
 	}
 	for _, v := range d.Get("wildcard_address").([]interface{}) {
 		address := v.(map[string]interface{})
+		if stringInSlice(address["name"].(string), addressNameList) {
+			return fmt.Errorf("multiple address with the same name")
+		}
+		addressNameList = append(addressNameList, address["name"].(string))
 		setPrefixAddr := setPrefix + " address " + address["name"].(string)
 		configSet = append(configSet, setPrefixAddr+" wildcard-address "+address["value"].(string))
 		if address["description"].(string) != "" {
@@ -384,6 +393,10 @@ func setAddressBook(d *schema.ResourceData, m interface{}, jnprSess *NetconfObje
 	}
 	for _, v := range d.Get("dns_name").([]interface{}) {
 		address := v.(map[string]interface{})
+		if stringInSlice(address["name"].(string), addressNameList) {
+			return fmt.Errorf("multiple address with the same name")
+		}
+		addressNameList = append(addressNameList, address["name"].(string))
 		setPrefixAddr := setPrefix + " address " + address["name"].(string)
 		configSet = append(configSet, setPrefixAddr+" dns-name "+address["value"].(string))
 		if address["description"].(string) != "" {
@@ -392,6 +405,10 @@ func setAddressBook(d *schema.ResourceData, m interface{}, jnprSess *NetconfObje
 	}
 	for _, v := range d.Get("range_address").([]interface{}) {
 		address := v.(map[string]interface{})
+		if stringInSlice(address["name"].(string), addressNameList) {
+			return fmt.Errorf("multiple address with the same name")
+		}
+		addressNameList = append(addressNameList, address["name"].(string))
 		setPrefixAddr := setPrefix + " address " + address["name"].(string)
 		configSet = append(configSet, setPrefixAddr+" range-address "+address["from"].(string)+" to "+address["to"].(string))
 		if address["description"].(string) != "" {
@@ -400,6 +417,10 @@ func setAddressBook(d *schema.ResourceData, m interface{}, jnprSess *NetconfObje
 	}
 	for _, v := range d.Get("address_set").([]interface{}) {
 		addressSet := v.(map[string]interface{})
+		if stringInSlice(addressSet["name"].(string), addressNameList) {
+			return fmt.Errorf("multiple address or address_set with the same name")
+		}
+		addressNameList = append(addressNameList, addressSet["name"].(string))
 		setPrefixAddrSet := setPrefix + " address-set " + addressSet["name"].(string)
 		for _, addr := range sortSetOfString(addressSet["address"].(*schema.Set).List()) {
 			configSet = append(configSet, setPrefixAddrSet+" address "+addr)

--- a/junos/resource_security_dynamic_address_feed_server.go
+++ b/junos/resource_security_dynamic_address_feed_server.go
@@ -293,8 +293,13 @@ func setSecurityDynamicAddressFeedServer(d *schema.ResourceData, m interface{}, 
 	if v := d.Get("description").(string); v != "" {
 		configSet = append(configSet, setPrefix+"description \""+v+"\"")
 	}
+	feedNameList := make([]string, 0)
 	for _, fn := range d.Get("feed_name").([]interface{}) {
 		feedName := fn.(map[string]interface{})
+		if stringInSlice(feedName["name"].(string), feedNameList) {
+			return fmt.Errorf("multiple feed_name blocks with the same name")
+		}
+		feedNameList = append(feedNameList, feedName["name"].(string))
 		setPrefixFeedName := setPrefix + "feed-name " + feedName["name"].(string) + " "
 		configSet = append(configSet, setPrefixFeedName)
 		configSet = append(configSet, setPrefixFeedName+"path \""+feedName["path"].(string)+"\"")

--- a/junos/resource_security_dynamic_address_name.go
+++ b/junos/resource_security_dynamic_address_name.go
@@ -298,8 +298,13 @@ func setSecurityDynamicAddressName(d *schema.ResourceData, m interface{}, jnprSe
 		if v := profileCategory["feed"].(string); v != "" {
 			configSet = append(configSet, setPrefixProfileCategory+"feed "+v)
 		}
+		propertyNameList := make([]string, 0)
 		for _, pro := range profileCategory["property"].([]interface{}) {
 			property := pro.(map[string]interface{})
+			if stringInSlice(property["name"].(string), propertyNameList) {
+				return fmt.Errorf("multiple property blocks with the same name")
+			}
+			propertyNameList = append(propertyNameList, property["name"].(string))
 			for _, str := range property["string"].([]interface{}) {
 				configSet = append(configSet, setPrefixProfileCategory+"property "+
 					"\""+property["name"].(string)+"\" string \""+str.(string)+"\"")

--- a/junos/resource_security_global_policy.go
+++ b/junos/resource_security_global_policy.go
@@ -340,8 +340,13 @@ func setSecurityGlobalPolicy(d *schema.ResourceData, m interface{}, jnprSess *Ne
 	configSet := make([]string, 0)
 
 	setPrefix := "set security policies global policy "
+	policyNameList := make([]string, 0)
 	for _, v := range d.Get("policy").([]interface{}) {
 		policy := v.(map[string]interface{})
+		if stringInSlice(policy["name"].(string), policyNameList) {
+			return fmt.Errorf("multiple policy blocks with the same name")
+		}
+		policyNameList = append(policyNameList, policy["name"].(string))
 		setPrefixPolicy := setPrefix + policy["name"].(string)
 		for _, address := range sortSetOfString(policy["match_source_address"].(*schema.Set).List()) {
 			configSet = append(configSet, setPrefixPolicy+" match source-address "+address)

--- a/junos/resource_security_idp_custom_attack.go
+++ b/junos/resource_security_idp_custom_attack.go
@@ -1014,6 +1014,7 @@ func setSecurityIdpCustomAttack(d *schema.ResourceData, m interface{}, jnprSess 
 	}
 	for _, v := range d.Get("attack_type_chain").([]interface{}) {
 		attackChain := v.(map[string]interface{})
+		memberNameList := make([]string, 0)
 		for _, v2 := range attackChain["member"].([]interface{}) {
 			attackChainMember := v2.(map[string]interface{})
 			if len(attackChainMember["attack_type_anomaly"].([]interface{})) != 0 &&
@@ -1024,6 +1025,10 @@ func setSecurityIdpCustomAttack(d *schema.ResourceData, m interface{}, jnprSess 
 				len(attackChainMember["attack_type_signature"].([]interface{})) == 0 {
 				return fmt.Errorf("missing one attack type in member %s for attack_type_chain", attackChainMember["name"].(string))
 			}
+			if stringInSlice(attackChainMember["name"].(string), memberNameList) {
+				return fmt.Errorf("multiple member blocks with the same name")
+			}
+			memberNameList = append(memberNameList, attackChainMember["name"].(string))
 			for _, v3 := range attackChainMember["attack_type_anomaly"].([]interface{}) {
 				attackAnomaly := v3.(map[string]interface{})
 				configSet = append(configSet, setSecurityIdpCustomAttackTypeAnomaly(

--- a/junos/resource_security_idp_policy.go
+++ b/junos/resource_security_idp_policy.go
@@ -467,15 +467,27 @@ func setSecurityIdpPolicy(d *schema.ResourceData, m interface{}, jnprSess *Netco
 
 	setPrefix := "set security idp idp-policy \"" + d.Get("name").(string) + "\" "
 	configSet = append(configSet, setPrefix)
+	exemptRuleNameList := make([]string, 0)
 	for _, e := range d.Get("exempt_rule").([]interface{}) {
-		sets, err := setSecurityIdpPolicyExemptRule(setPrefix, e.(map[string]interface{}))
+		eM := e.(map[string]interface{})
+		if stringInSlice(eM["name"].(string), exemptRuleNameList) {
+			return fmt.Errorf("multiple exempt_rule blocks with the same name")
+		}
+		exemptRuleNameList = append(exemptRuleNameList, eM["name"].(string))
+		sets, err := setSecurityIdpPolicyExemptRule(setPrefix, eM)
 		if err != nil {
 			return err
 		}
 		configSet = append(configSet, sets...)
 	}
+	ipsRuleNameList := make([]string, 0)
 	for _, e := range d.Get("ips_rule").([]interface{}) {
-		sets, err := setSecurityIdpPolicyIpsRule(setPrefix, e.(map[string]interface{}))
+		eM := e.(map[string]interface{})
+		if stringInSlice(eM["name"].(string), ipsRuleNameList) {
+			return fmt.Errorf("multiple ips_rule blocks with the same name")
+		}
+		ipsRuleNameList = append(ipsRuleNameList, eM["name"].(string))
+		sets, err := setSecurityIdpPolicyIpsRule(setPrefix, eM)
 		if err != nil {
 			return err
 		}

--- a/junos/resource_security_ipsec_vpn.go
+++ b/junos/resource_security_ipsec_vpn.go
@@ -401,8 +401,13 @@ func setIpsecVpn(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject)
 			configSet = append(configSet, setPrefix+" ike proxy-identity service "+ike["identity_service"].(string))
 		}
 	}
+	trafficSelectorName := make([]string, 0)
 	for _, v := range d.Get("traffic_selector").([]interface{}) {
 		tS := v.(map[string]interface{})
+		if stringInSlice(tS["name"].(string), trafficSelectorName) {
+			return fmt.Errorf("multiple traffic_selector blocks with the same name")
+		}
+		trafficSelectorName = append(trafficSelectorName, tS["name"].(string))
 		configSet = append(configSet, "set security ipsec vpn "+d.Get("name").(string)+" traffic-selector "+
 			tS["name"].(string)+" local-ip "+tS["local_ip"].(string))
 		configSet = append(configSet, "set security ipsec vpn "+d.Get("name").(string)+" traffic-selector "+

--- a/junos/resource_security_nat_destination.go
+++ b/junos/resource_security_nat_destination.go
@@ -290,8 +290,13 @@ func setSecurityNatDestination(d *schema.ResourceData, m interface{}, jnprSess *
 			configSet = append(configSet, setPrefix+" from "+from["type"].(string)+" "+value)
 		}
 	}
+	ruleNameList := make([]string, 0)
 	for _, v := range d.Get("rule").([]interface{}) {
 		rule := v.(map[string]interface{})
+		if stringInSlice(rule["name"].(string), ruleNameList) {
+			return fmt.Errorf("multiple rule blocks with the same name")
+		}
+		ruleNameList = append(ruleNameList, rule["name"].(string))
 		setPrefixRule := setPrefix + " rule " + rule["name"].(string)
 		configSet = append(configSet, setPrefixRule+
 			" match destination-address "+rule["destination_address"].(string))

--- a/junos/resource_security_nat_source.go
+++ b/junos/resource_security_nat_source.go
@@ -335,8 +335,13 @@ func setSecurityNatSource(d *schema.ResourceData, m interface{}, jnprSess *Netco
 			configSet = append(configSet, setPrefix+" to "+to["type"].(string)+" "+value)
 		}
 	}
+	ruleNameList := make([]string, 0)
 	for _, v := range d.Get("rule").([]interface{}) {
 		rule := v.(map[string]interface{})
+		if stringInSlice(rule["name"].(string), ruleNameList) {
+			return fmt.Errorf("multiple rule blocks with the same name")
+		}
+		ruleNameList = append(ruleNameList, rule["name"].(string))
 		setPrefixRule := setPrefix + " rule " + rule["name"].(string)
 		for _, matchV := range rule[matchWord].([]interface{}) {
 			match := matchV.(map[string]interface{})

--- a/junos/resource_security_nat_static.go
+++ b/junos/resource_security_nat_static.go
@@ -294,8 +294,13 @@ func setSecurityNatStatic(d *schema.ResourceData, m interface{}, jnprSess *Netco
 			configSet = append(configSet, setPrefix+" from "+from["type"].(string)+" "+value)
 		}
 	}
+	ruleNameList := make([]string, 0)
 	for _, v := range d.Get("rule").([]interface{}) {
 		rule := v.(map[string]interface{})
+		if stringInSlice(rule["name"].(string), ruleNameList) {
+			return fmt.Errorf("multiple rule blocks with the same name")
+		}
+		ruleNameList = append(ruleNameList, rule["name"].(string))
 		setPrefixRule := setPrefix + " rule " + rule["name"].(string)
 		configSet = append(configSet, setPrefixRule+" match destination-address "+
 			rule["destination_address"].(string))

--- a/junos/resource_security_policy.go
+++ b/junos/resource_security_policy.go
@@ -392,8 +392,13 @@ func setSecurityPolicy(d *schema.ResourceData, m interface{}, jnprSess *NetconfO
 		" from-zone " + d.Get("from_zone").(string) +
 		" to-zone " + d.Get("to_zone").(string) +
 		" policy "
+	policyNameList := make([]string, 0)
 	for _, v := range d.Get("policy").([]interface{}) {
 		policy := v.(map[string]interface{})
+		if stringInSlice(policy["name"].(string), policyNameList) {
+			return fmt.Errorf("multiple policy blocks with the same name")
+		}
+		policyNameList = append(policyNameList, policy["name"].(string))
 		setPrefixPolicy := setPrefix + policy["name"].(string)
 		for _, address := range sortSetOfString(policy["match_source_address"].(*schema.Set).List()) {
 			configSet = append(configSet, setPrefixPolicy+" match source-address "+address)

--- a/junos/resource_security_screen.go
+++ b/junos/resource_security_screen.go
@@ -1143,6 +1143,7 @@ func setSecurityScreenTCP(tcp map[string]interface{}, setPrefix string) ([]strin
 				configSet = append(configSet, setPrefix+"syn-flood timeout "+
 					strconv.Itoa(tcpSynFlood["timeout"].(int)))
 			}
+			whitelistNameList := make([]string, 0)
 			for _, v2 := range tcpSynFlood["whitelist"].(*schema.Set).List() {
 				whitelist := v2.(map[string]interface{})
 				if len(whitelist["source_address"].(*schema.Set).List()) == 0 &&
@@ -1150,6 +1151,10 @@ func setSecurityScreenTCP(tcp map[string]interface{}, setPrefix string) ([]strin
 					return configSet, fmt.Errorf("white-list %s need to have a source or destination address set",
 						whitelist["name"].(string))
 				}
+				if stringInSlice(whitelist["name"].(string), whitelistNameList) {
+					return configSet, fmt.Errorf("multiple whitelist blocks with the same name")
+				}
+				whitelistNameList = append(whitelistNameList, whitelist["name"].(string))
 				for _, destination := range sortSetOfString(whitelist["destination_address"].(*schema.Set).List()) {
 					if err := validateCIDRNetwork(destination); err != nil {
 						return configSet, err

--- a/junos/resource_security_utm_profile_web_filtering_juniper_enhanced.go
+++ b/junos/resource_security_utm_profile_web_filtering_juniper_enhanced.go
@@ -397,12 +397,22 @@ func setUtmProfileWebFEnhanced(d *schema.ResourceData, m interface{}, jnprSess *
 			configSet = append(configSet, setPrefix+"block-message")
 		}
 	}
+	categoryNameList := make([]string, 0)
 	for _, v := range d.Get("category").([]interface{}) {
 		category := v.(map[string]interface{})
+		if stringInSlice(category["name"].(string), categoryNameList) {
+			return fmt.Errorf("multiple category blocks with the same name")
+		}
+		categoryNameList = append(categoryNameList, category["name"].(string))
 		setPrefixCategory := setPrefix + "category \"" + category["name"].(string) + "\" "
 		configSet = append(configSet, setPrefixCategory+"action "+category["action"].(string))
+		reputationActionSiteList := make([]string, 0)
 		for _, r := range category["reputation_action"].([]interface{}) {
 			reputation := r.(map[string]interface{})
+			if stringInSlice(reputation["site_reputation"].(string), reputationActionSiteList) {
+				return fmt.Errorf("multiple reputation_action blocks with the same site_reputation")
+			}
+			reputationActionSiteList = append(reputationActionSiteList, reputation["site_reputation"].(string))
 			configSet = append(configSet, setPrefixCategory+"reputation-action "+
 				reputation["site_reputation"].(string)+" "+reputation["action"].(string))
 		}
@@ -456,8 +466,13 @@ func setUtmProfileWebFEnhanced(d *schema.ResourceData, m interface{}, jnprSess *
 			configSet = append(configSet, setPrefix+"quarantine-message")
 		}
 	}
+	siteReputationNameList := make([]string, 0)
 	for _, v := range d.Get("site_reputation_action").([]interface{}) {
 		siteReputation := v.(map[string]interface{})
+		if stringInSlice(siteReputation["site_reputation"].(string), siteReputationNameList) {
+			return fmt.Errorf("multiple site_reputation_action blocks with the same site_reputation")
+		}
+		siteReputationNameList = append(siteReputationNameList, siteReputation["site_reputation"].(string))
 		configSet = append(configSet, setPrefix+"site-reputation-action "+
 			siteReputation["site_reputation"].(string)+" "+siteReputation["action"].(string))
 	}

--- a/junos/resource_services_rpm_probe.go
+++ b/junos/resource_services_rpm_probe.go
@@ -511,8 +511,13 @@ func setServicesRpmProbe(d *schema.ResourceData, m interface{}, jnprSess *Netcon
 	if d.Get("delegate_probes").(bool) {
 		configSet = append(configSet, setPrefix+"delegate-probes")
 	}
+	testNameList := make([]string, 0)
 	for _, t := range d.Get("test").([]interface{}) {
 		test := t.(map[string]interface{})
+		if stringInSlice(test["name"].(string), testNameList) {
+			return fmt.Errorf("multiple test blocks with the same name")
+		}
+		testNameList = append(testNameList, test["name"].(string))
 		setPrefixTest := setPrefix + "test \"" + test["name"].(string) + "\" "
 		configSet = append(configSet, setPrefixTest)
 		if v := test["data_fill"].(string); v != "" {

--- a/junos/resource_services_security_intelligence_policy.go
+++ b/junos/resource_services_security_intelligence_policy.go
@@ -247,8 +247,13 @@ func setServicesSecurityIntellPolicy(d *schema.ResourceData, m interface{}, jnpr
 	configSet := make([]string, 0)
 
 	setPrefix := "set services security-intelligence policy \"" + d.Get("name").(string) + "\" "
+	categoryNameList := make([]string, 0)
 	for _, v := range d.Get("category").([]interface{}) {
 		category := v.(map[string]interface{})
+		if stringInSlice(category["name"].(string), categoryNameList) {
+			return fmt.Errorf("multiple category blocks with the same name")
+		}
+		categoryNameList = append(categoryNameList, category["name"].(string))
 		configSet = append(configSet,
 			setPrefix+category["name"].(string)+" \""+category["profile_name"].(string)+"\"")
 	}

--- a/junos/resource_services_security_intelligence_profile.go
+++ b/junos/resource_services_security_intelligence_profile.go
@@ -309,8 +309,13 @@ func setServicesSecurityIntellProfile(d *schema.ResourceData, m interface{}, jnp
 
 	setPrefix := "set services security-intelligence profile \"" + d.Get("name").(string) + "\" "
 	configSet = append(configSet, setPrefix+"category "+d.Get("category").(string))
+	ruleNameList := make([]string, 0)
 	for _, v := range d.Get("rule").([]interface{}) {
 		rule := v.(map[string]interface{})
+		if stringInSlice(rule["name"].(string), ruleNameList) {
+			return fmt.Errorf("multiple rule blocks with the same name")
+		}
+		ruleNameList = append(ruleNameList, rule["name"].(string))
 		setPrefixRule := setPrefix + "rule \"" + rule["name"].(string) + "\" "
 		for _, v2 := range rule["match"].([]interface{}) {
 			match := v2.(map[string]interface{})

--- a/junos/resource_services_user_identification_ad_access_domain.go
+++ b/junos/resource_services_user_identification_ad_access_domain.go
@@ -324,8 +324,13 @@ func setServicesUserIdentAdAccessDomain(d *schema.ResourceData, m interface{}, j
 	setPrefix := "set services user-identification active-directory-access domain " + d.Get("name").(string) + " "
 	configSet = append(configSet, setPrefix+"user "+d.Get("user_name").(string))
 	configSet = append(configSet, setPrefix+"user password \""+d.Get("user_password").(string)+"\"")
+	domainControllerNameList := make([]string, 0)
 	for _, v := range d.Get("domain_controller").([]interface{}) {
 		domainController := v.(map[string]interface{})
+		if stringInSlice(domainController["name"].(string), domainControllerNameList) {
+			return fmt.Errorf("multiple domain_controller blocks with the same name")
+		}
+		domainControllerNameList = append(domainControllerNameList, domainController["name"].(string))
 		configSet = append(configSet, setPrefix+"domain-controller "+domainController["name"].(string)+
 			" address "+domainController["address"].(string))
 	}

--- a/junos/resource_services_user_identification_device_identity_profile.go
+++ b/junos/resource_services_user_identification_device_identity_profile.go
@@ -260,8 +260,13 @@ func setServicesUserIdentDeviceIdentityProfile(d *schema.ResourceData, m interfa
 	setPrefix :=
 		"set services user-identification device-information end-user-profile profile-name " + d.Get("name").(string) + " "
 	configSet = append(configSet, setPrefix+"domain-name "+d.Get("domain").(string))
+	attributeNameList := make([]string, 0)
 	for _, v := range d.Get("attribute").([]interface{}) {
 		attribute := v.(map[string]interface{})
+		if stringInSlice(attribute["name"].(string), attributeNameList) {
+			return fmt.Errorf("multiple attribute blocks with the same name")
+		}
+		attributeNameList = append(attributeNameList, attribute["name"].(string))
 		for _, v2 := range sortSetOfString(attribute["value"].(*schema.Set).List()) {
 			configSet = append(configSet, setPrefix+"attribute "+attribute["name"].(string)+
 				" string \""+v2+"\"")

--- a/junos/resource_snmp_community.go
+++ b/junos/resource_snmp_community.go
@@ -284,12 +284,17 @@ func setSnmpCommunity(d *schema.ResourceData, m interface{}, jnprSess *NetconfOb
 	for _, v := range sortSetOfString(d.Get("clients").(*schema.Set).List()) {
 		configSet = append(configSet, setPrefix+"clients "+v)
 	}
+	routingInstanceNameList := make([]string, 0)
 	for _, v := range d.Get("routing_instance").([]interface{}) {
 		routingInstance := v.(map[string]interface{})
 		if len(routingInstance["clients"].(*schema.Set).List()) > 0 && routingInstance["client_list_name"].(string) != "" {
 			return fmt.Errorf("conflict between clients and client_list_name in routing-instance %s",
 				routingInstance["name"].(string))
 		}
+		if stringInSlice(routingInstance["name"].(string), routingInstanceNameList) {
+			return fmt.Errorf("multiple routing_instance blocks with the same name")
+		}
+		routingInstanceNameList = append(routingInstanceNameList, routingInstance["name"].(string))
 		configSet = append(configSet, setPrefix+"routing-instance "+routingInstance["name"].(string))
 		if cLNname := routingInstance["client_list_name"].(string); cLNname != "" {
 			configSet = append(configSet,

--- a/junos/resource_static_route.go
+++ b/junos/resource_static_route.go
@@ -500,8 +500,13 @@ func setStaticRoute(d *schema.ResourceData, m interface{}, jnprSess *NetconfObje
 	if d.Get("preference").(int) > 0 {
 		configSet = append(configSet, setPrefix+" preference "+strconv.Itoa(d.Get("preference").(int)))
 	}
+	qualifiedNextHopList := make([]string, 0)
 	for _, qualifiedNextHop := range d.Get("qualified_next_hop").([]interface{}) {
 		qualifiedNextHopMap := qualifiedNextHop.(map[string]interface{})
+		if stringInSlice(qualifiedNextHopMap["next_hop"].(string), qualifiedNextHopList) {
+			return fmt.Errorf("multiple qualified_next_hop blocks with the same next_hop")
+		}
+		qualifiedNextHopList = append(qualifiedNextHopList, qualifiedNextHopMap["next_hop"].(string))
 		configSet = append(configSet, setPrefix+" qualified-next-hop "+qualifiedNextHopMap["next_hop"].(string))
 		if qualifiedNextHopMap["interface"] != "" {
 			configSet = append(configSet, setPrefix+

--- a/junos/resource_system.go
+++ b/junos/resource_system.go
@@ -961,8 +961,13 @@ func setSystem(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) e
 
 	for _, v := range d.Get("archival_configuration").([]interface{}) {
 		archivalConfig := v.(map[string]interface{})
+		archiveSiteURLList := make([]string, 0)
 		for _, v2 := range archivalConfig["archive_site"].([]interface{}) {
 			archiveSite := v2.(map[string]interface{})
+			if stringInSlice(archiveSite["url"].(string), archiveSiteURLList) {
+				return fmt.Errorf("multiple archive_site blocks with the same url")
+			}
+			archiveSiteURLList = append(archiveSiteURLList, archiveSite["url"].(string))
 			configSet = append(configSet, setPrefix+"archival configuration archive-sites \""+archiveSite["url"].(string)+"\"")
 			if pass := archiveSite["password"].(string); pass != "" {
 				configSet = append(configSet,

--- a/junos/resource_system_syslog_file.go
+++ b/junos/resource_system_syslog_file.go
@@ -490,8 +490,13 @@ func setSystemSyslogFile(d *schema.ResourceData, m interface{}, jnprSess *Netcon
 		configSet = append(configSet, setPrefixArchive)
 		if v != nil {
 			archive := v.(map[string]interface{})
+			sitesURLList := make([]string, 0)
 			for _, v2 := range archive["sites"].([]interface{}) {
 				sites := v2.(map[string]interface{})
+				if stringInSlice(sites["url"].(string), sitesURLList) {
+					return fmt.Errorf("multiple sites blocks with the same url")
+				}
+				sitesURLList = append(sitesURLList, sites["url"].(string))
 				setPrefixArchiveSite := setPrefixArchive + " archive-sites " + sites["url"].(string)
 				configSet = append(configSet, setPrefixArchiveSite)
 				if sites["password"].(string) != "" {

--- a/website/docs/r/eventoptions_policy.html.markdown
+++ b/website/docs/r/eventoptions_policy.html.markdown
@@ -117,7 +117,7 @@ The following arguments are supported:
 - **filename** (Required, String)  
   Local filename of the script file.
 - **arguments** (Optional, Block List)  
-  For each combination of block arguments, command line argument to the script.
+  For each name of arguments, command line argument to the script.
   - **name** (Required, String)  
     Name of the argument.
   - **value** (Required, String)  


### PR DESCRIPTION
ENHANCEMENTS:

* resource/`*`: to avoid any confusion, the provider now detects and generates an error during `apply` when there are duplicate elements (with the same identifier, for example the same `name`) in the block lists of certain resources
