### PR TITLE
enhances security nat 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,13 @@
 
 ENHANCEMENTS:
 
+* resource/`junos_security_nat_destination`: add multiple arguments, `application`, `destination_...`, `protocol`, `source_...` in `rule` block
+* resource/`junos_security_nat_source`: add multiple arguments, `application`, `destination_...`, `protocol`, `source_...` in `match` block inside `rule` block
+* resource/`junos_security_nat_static`: add multiple arguments, `destination_...`, `source_...` in `rule` block and `mapped_port...` in `then` block. also add possibility to use `prefix-name` in `then.0.type`
+
 BUG FIXES:
+
+* resource/`junos_security_nat_source`: fix panic when `match` block inside `rule` block is empty
 
 ## 1.20.0 (September 07, 2021)
 

--- a/junos/constants.go
+++ b/junos/constants.go
@@ -11,6 +11,7 @@ const (
 	permitWord            = "permit"
 	thenWord              = "then"
 	prefixWord            = "prefix"
+	prefixNameWord        = "prefix-name"
 	actionNoneWord        = "none"
 	addWord               = "add"
 	deleteWord            = "delete"

--- a/junos/resource_security_nat_destination_test.go
+++ b/junos/resource_security_nat_destination_test.go
@@ -50,9 +50,9 @@ func TestAccJunosSecurityNatDestination_basic(t *testing.T) {
 					Config: testAccJunosSecurityNatDestinationConfigUpdate(),
 					Check: resource.ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr("junos_security_nat_destination.testacc_securityDNAT",
-							"rule.#", "2"),
+							"rule.#", "3"),
 						resource.TestCheckResourceAttr("junos_security_nat_destination.testacc_securityDNAT",
-							"rule.1.destination_address", "192.0.2.2/32"),
+							"rule.1.destination_address_name", "testacc_securityDNAT"),
 						resource.TestCheckResourceAttr("junos_security_nat_destination.testacc_securityDNAT",
 							"rule.1.then.#", "1"),
 						resource.TestCheckResourceAttr("junos_security_nat_destination.testacc_securityDNAT",
@@ -111,6 +111,9 @@ resource junos_routing_instance testacc_securityDNAT {
 func testAccJunosSecurityNatDestinationConfigUpdate() string {
 	return `
 resource junos_security_nat_destination testacc_securityDNAT {
+  depends_on = [
+    junos_security_address_book.testacc_securityDNAT
+  ]
   name = "testacc_securityDNAT"
   from {
     type  = "zone"
@@ -119,14 +122,37 @@ resource junos_security_nat_destination testacc_securityDNAT {
   rule {
     name                = "testacc_securityDNATRule"
     destination_address = "192.0.2.1/32"
+    source_address_name = [
+      "testacc_securityDNAT-src",
+    ]
+    protocol = ["tcp", "50"]
     then {
       type = "pool"
       pool = junos_security_nat_destination_pool.testacc_securityDNATPool.name
     }
   }
   rule {
-    name                = "testacc_securityDNATRule2"
-    destination_address = "192.0.2.2/32"
+    name                     = "testacc_securityDNATRule2"
+    destination_address_name = "testacc_securityDNAT"
+    destination_port = [
+      "81",
+      "82 to 83",
+    ]
+    source_address = [
+      "192.0.2.128/26",
+    ]
+    then {
+      type = "pool"
+      pool = junos_security_nat_destination_pool.testacc_securityDNATPool2.name
+    }
+  }
+  rule {
+    name                = "testacc_securityDNATRule3"
+    destination_address = "192.0.2.1/32"
+    application = [
+      "junos-ssh", "junos-http",
+    ]
+
     then {
       type = "pool"
       pool = junos_security_nat_destination_pool.testacc_securityDNATPool2.name
@@ -151,6 +177,16 @@ resource junos_security_zone testacc_securityDNAT {
 }
 resource junos_routing_instance testacc_securityDNAT {
   name = "testacc_securityDNAT"
+}
+resource "junos_security_address_book" "testacc_securityDNAT" {
+  network_address {
+    name  = "testacc_securityDNAT"
+    value = "192.0.2.128/27"
+  }
+  network_address {
+    name  = "testacc_securityDNAT-src"
+    value = "192.0.2.160/27"
+  }
 }
 `
 }

--- a/junos/resource_security_nat_source.go
+++ b/junos/resource_security_nat_source.go
@@ -361,6 +361,9 @@ func setSecurityNatSource(d *schema.ResourceData, m interface{}, jnprSess *Netco
 		rule := v.(map[string]interface{})
 		setPrefixRule := setPrefix + " rule " + rule["name"].(string)
 		for _, matchV := range rule[matchWord].([]interface{}) {
+			if matchV == nil {
+				return fmt.Errorf("match block in rule %s need to have an argument", rule["name"].(string))
+			}
 			match := matchV.(map[string]interface{})
 			for _, address := range sortSetOfString(match["destination_address"].(*schema.Set).List()) {
 				err := validateCIDRNetwork(address)

--- a/junos/resource_security_nat_source.go
+++ b/junos/resource_security_nat_source.go
@@ -365,6 +365,13 @@ func setSecurityNatSource(d *schema.ResourceData, m interface{}, jnprSess *Netco
 				return fmt.Errorf("match block in rule %s need to have an argument", rule["name"].(string))
 			}
 			match := matchV.(map[string]interface{})
+			if len(match["destination_address"].(*schema.Set).List()) == 0 &&
+				len(match["destination_address_name"].(*schema.Set).List()) == 0 &&
+				len(match["source_address"].(*schema.Set).List()) == 0 &&
+				len(match["source_address_name"].(*schema.Set).List()) == 0 {
+				return fmt.Errorf("one of destination_address, destination_address_name, " +
+					"source_address or source_address_name arguments must be set")
+			}
 			for _, address := range sortSetOfString(match["destination_address"].(*schema.Set).List()) {
 				err := validateCIDRNetwork(address)
 				if err != nil {

--- a/junos/resource_security_nat_source_test.go
+++ b/junos/resource_security_nat_source_test.go
@@ -74,7 +74,7 @@ func TestAccJunosSecurityNatSource_basic(t *testing.T) {
 					Config: testAccJunosSecurityNatSourceConfigUpdate(),
 					Check: resource.ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr("junos_security_nat_source.testacc_securitySNAT",
-							"rule.#", "2"),
+							"rule.#", "3"),
 						resource.TestCheckResourceAttr("junos_security_nat_source.testacc_securitySNAT",
 							"rule.1.match.#", "1"),
 						resource.TestCheckResourceAttr("junos_security_nat_source.testacc_securitySNAT",
@@ -180,6 +180,17 @@ resource junos_security_nat_source testacc_securitySNAT {
       source_address      = ["192.0.2.0/25"]
       destination_address = ["192.0.2.128/25"]
       protocol            = ["udp"]
+    }
+    then {
+      type = "off"
+    }
+  }
+  rule {
+    name = "testacc_securitySNATRule3"
+    match {
+      source_address      = ["192.0.2.0/25"]
+      destination_address = ["192.0.2.128/25"]
+      application         = ["junos-ssh", "junos-http"]
     }
     then {
       type = "off"

--- a/junos/resource_security_nat_source_test.go
+++ b/junos/resource_security_nat_source_test.go
@@ -146,6 +146,9 @@ resource junos_routing_instance testacc_securitySNAT {
 func testAccJunosSecurityNatSourceConfigUpdate() string {
 	return `
 resource junos_security_nat_source testacc_securitySNAT {
+  depends_on = [
+    junos_security_address_book.testacc_securitySNAT
+  ]
   name = "testacc_securitySNAT"
   from {
     type  = "zone"
@@ -158,9 +161,13 @@ resource junos_security_nat_source testacc_securitySNAT {
   rule {
     name = "testacc_securitySNATRule"
     match {
-      source_address      = ["192.0.2.0/25"]
-      destination_address = ["192.0.2.128/25"]
-      protocol            = ["tcp"]
+      source_address           = ["192.0.2.0/25"]
+      source_address_name      = ["testacc_securitySNAT2"]
+      source_port              = ["1024", "1021 to 1022"]
+      destination_address      = ["192.0.2.128/25"]
+      destination_address_name = ["testacc_securitySNAT"]
+      destination_port         = ["80", "82 to 83"]
+      protocol                 = ["tcp"]
     }
     then {
       type = "pool"
@@ -192,6 +199,16 @@ resource junos_security_zone testacc_securitySNAT {
 }
 resource junos_routing_instance testacc_securitySNAT {
   name = "testacc_securitySNAT"
+}
+resource "junos_security_address_book" "testacc_securitySNAT" {
+  network_address {
+    name  = "testacc_securitySNAT"
+    value = "192.0.2.128/27"
+  }
+  network_address {
+    name  = "testacc_securitySNAT2"
+    value = "192.0.2.160/27"
+  }
 }
 `
 }

--- a/junos/resource_security_nat_static_test.go
+++ b/junos/resource_security_nat_static_test.go
@@ -44,17 +44,17 @@ func TestAccJunosSecurityNatStatic_basic(t *testing.T) {
 					Config: testAccJunosSecurityNatStaticConfigUpdate(),
 					Check: resource.ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr("junos_security_nat_static.testacc_securityNATStt",
-							"rule.#", "2"),
+							"rule.#", "3"),
 						resource.TestCheckResourceAttr("junos_security_nat_static.testacc_securityNATStt",
 							"rule.0.destination_address", "192.0.2.0/26"),
 						resource.TestCheckResourceAttr("junos_security_nat_static.testacc_securityNATStt",
 							"rule.0.then.0.prefix", "192.0.2.64/26"),
 						resource.TestCheckResourceAttr("junos_security_nat_static.testacc_securityNATStt",
-							"rule.1.destination_address", "192.0.2.128/26"),
+							"rule.1.destination_address_name", "testacc_securityNATSttRule2"),
 						resource.TestCheckResourceAttr("junos_security_nat_static.testacc_securityNATStt",
-							"rule.1.then.#", "1"),
+							"rule.1.source_address.#", "1"),
 						resource.TestCheckResourceAttr("junos_security_nat_static.testacc_securityNATStt",
-							"rule.1.then.0.type", "prefix"),
+							"rule.1.source_port.#", "2"),
 					),
 				},
 				{
@@ -97,7 +97,10 @@ resource junos_routing_instance testacc_securityNATStt {
 
 func testAccJunosSecurityNatStaticConfigUpdate() string {
 	return `
-resource junos_security_nat_static testacc_securityNATStt {
+resource "junos_security_nat_static" "testacc_securityNATStt" {
+  depends_on = [
+    junos_security_address_book.testacc_securityNATStt
+  ]
   name = "testacc_securityNATStt"
   from {
     type  = "zone"
@@ -113,21 +116,59 @@ resource junos_security_nat_static testacc_securityNATStt {
     }
   }
   rule {
-    name                = "testacc_securityNATSttRule2"
-    destination_address = "192.0.2.128/26"
+    name                     = "testacc_securityNATSttRule2"
+    destination_address_name = "testacc_securityNATSttRule2"
+    source_address = [
+      "192.0.2.128/26"
+    ]
+    source_port = [
+      "1024",
+      "1025 to 1026",
+    ]
+    then {
+      routing_instance = junos_routing_instance.testacc_securityNATStt.name
+      type             = "prefix-name"
+      prefix           = "testacc_securityNATStt-prefix"
+    }
+  }
+  rule {
+    name                = "testacc_securityNATSttRule3"
+    destination_address = "192.0.3.1/32"
+    source_address_name = [
+      "testacc_securityNATStt-src"
+    ]
+    destination_port    = 81
+    destination_port_to = 82
     then {
       routing_instance = junos_routing_instance.testacc_securityNATStt.name
       type             = "prefix"
-      prefix           = "192.0.2.192/26"
+      prefix           = "192.0.3.2/32"
+      mapped_port      = 8081
+      mapped_port_to   = 8082
     }
   }
 }
 
-resource junos_security_zone testacc_securityNATStt {
+resource "junos_security_zone" "testacc_securityNATStt" {
   name = "testacc_securityNATStt"
 }
-resource junos_routing_instance testacc_securityNATStt {
+resource "junos_routing_instance" "testacc_securityNATStt" {
   name = "testacc_securityNATStt"
+}
+
+resource "junos_security_address_book" "testacc_securityNATStt" {
+  network_address {
+    name  = "testacc_securityNATSttRule2"
+    value = "192.0.2.128/27"
+  }
+  network_address {
+    name  = "testacc_securityNATStt-prefix"
+    value = "192.0.2.160/27"
+  }
+  network_address {
+    name  = "testacc_securityNATStt-src"
+    value = "192.0.2.224/27"
+  }
 }
 `
 }

--- a/website/docs/r/security_nat_destination.html.markdown
+++ b/website/docs/r/security_nat_destination.html.markdown
@@ -52,10 +52,25 @@ The following arguments are supported:
 
 ### rule arguments
 
+-> **Note:** One of `destination_address` or `destination_address_name` arguments is required.
+
 - **name** (Required, String)  
   Name of rule
-- **destination_address** (Required, String)  
+- **destination_address** (Optional, String)  
   CIDR for match destination address
+- **destination_address_name** (Optional, String)  
+  Destination address from address book for rule match.
+- **application** (Optional, Set of String)  
+  Specify application or application-set name for rule match.
+- **destination_port** (Optional, Set of String)  
+  List of destination port for rule match.  
+  Format need to be `x` or `x to y`.
+- **protocol** (Optional, Set of String)  
+  IP Protocol for rule match.
+- **source_address** (Optional, Set of String)  
+  List of CIDR source address for rule match.
+- **source_address_name** (Optional, Set of String)  
+  List of source address from address book for rule match.
 - **then** (Required, Block)  
   Declare `then` action.
   - **type** (Required, String)  

--- a/website/docs/r/security_nat_source.html.markdown
+++ b/website/docs/r/security_nat_source.html.markdown
@@ -69,6 +69,8 @@ The following arguments are supported:
   Name of rule.
 - **match** (Required, Block)  
   Declare `match` configuration.
+  - **application** (Optional, Set of String)  
+    Specify application or application-set name to match.
   - **destination_address** (Optional, Set of String)  
     List of CIDR destination address to match.
   - **destination_address_name** (Optional, Set of String)  

--- a/website/docs/r/security_nat_source.html.markdown
+++ b/website/docs/r/security_nat_source.html.markdown
@@ -70,11 +70,21 @@ The following arguments are supported:
 - **match** (Required, Block)  
   Declare `match` configuration.
   - **destination_address** (Optional, Set of String)  
-    CIDR list to match destination address.
+    List of CIDR destination address to match.
+  - **destination_address_name** (Optional, Set of String)  
+    List of destination address from address book to match.
+  - **destination_port** (Optional, Set of String)  
+    List of destination port to match.  
+    Format need to be `x` or `x to y`.
   - **protocol** (Optional, Set of String)  
-    Protocol list to match.
+    List of protocol to match.
   - **source_address** (Optional, Set of String)  
-    CIDR list to match source address.
+    List of CIDR source address to match.
+  - **source_address_name** (Optional, Set of String)  
+    List of source address from address book to match.
+  - **source_port** (Optional, Set of String)  
+    List of source port to match.  
+    Format need to be `x` or `x to y`.
 - **then** (Required, Block)  
   Declare `then` configuration.
   - **type** (Required, String)  

--- a/website/docs/r/security_nat_static.html.markdown
+++ b/website/docs/r/security_nat_static.html.markdown
@@ -52,17 +52,40 @@ The following arguments are supported:
 
 ### rule arguments
 
+-> **Note:** One of `destination_address` or `destination_address_name` arguments is required.
+
 - **name** (Required, String)  
   Name of rule.
-- **destination_address** (Required, String)  
-  CIDR of destination address for rule.
+- **destination_address** (Optional, String)  
+  CIDR of destination address for rule match.
+- **destination_address_name** (Optional, String)  
+  Destination address from address book for rule match.
+- **destination_port** (Optional, Number)  
+  Destination port or lower limit of port range for rule match.
+- **destination_port_to** (Optional, Number)  
+  Port range upper limit for rule match.
+- **source_address** (Optional, Set of String)  
+  List of CIDR source address for rule match.
+- **source_address_name** (Optional, Set of String)  
+  List of source address from address book for rule match.
+- **source_port** (Optional, Set of String)  
+  List of source port for rule match.  
+  Format need to be `x` or `x to y`.
 - **then** (Required, Block)  
   Declare `then` configuration.
   - **type** (Required, String)  
     Type of static nat.  
-    Need to be `inet` or `prefix`.
+    Need to be `inet`, `prefix` or `prefix-name`.
+  - **mapped_port** (Optional, Number)  
+    Port or lower limit of port range to mapped port.  
+    `type` need to be `prefix` or `prefix-name`.
+  - **mapped_port_to** (Optional, Number)  
+    Port range upper limit to mapped port.  
+    `type` need to be `prefix` or `prefix-name`.
   - **prefix** (Optional, String)  
-    CIDR for prefix static nat.
+    CIDR or address from address book to prefix static nat.  
+    `type` need to be `prefix` or `prefix-name`.  
+    CIDR is required if `type` = `prefix`.
   - **routing_instance** (Optional, String)  
     Change routing_instance with nat.
 


### PR DESCRIPTION
ENHANCEMENTS:

* resource/`junos_security_nat_destination`: add multiple arguments, `application`, `destination_...`, `protocol`, `source_...` in `rule` block
* resource/`junos_security_nat_source`: add multiple arguments, `application`, `destination_...`, `protocol`, `source_...` in `match` block inside `rule` block
* resource/`junos_security_nat_static`: add multiple arguments, `destination_...`, `source_...` in `rule` block and `mapped_port...` in `then` block. also add possibility to use `prefix-name` in `then.0.type`

BUG FIXES:

* resource/`junos_security_nat_source`: fix panic when `match` block inside `rule` block is empty