### PR TITLE
r/ospf_area: fix missing set interface when `interface` block have only `name`set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ ENHANCEMENTS:
 
 BUG FIXES:
 
+* resource/`junos_ospf_area`: fix missing set interface when `interface` block have only `name` set
 * resource/`junos_security_nat_source`: fix panic when `match` block inside `rule` block is empty
 
 ## 1.20.0 (September 07, 2021)

--- a/junos/provider_test.go
+++ b/junos/provider_test.go
@@ -18,7 +18,10 @@ var (
 	testAccProvider = junos.Provider() // nolint: gochecknoglobals
 )
 
-const defaultInterfaceTestAcc = "ge-0/0/3"
+const (
+	defaultInterfaceTestAcc  = "ge-0/0/3"
+	defaultInterfaceTestAcc2 = "ge-0/0/4"
+)
 
 func TestProvider(t *testing.T) {
 	if err := junos.Provider().InternalValidate(); err != nil {

--- a/junos/resource_chassis_cluster_test.go
+++ b/junos/resource_chassis_cluster_test.go
@@ -21,7 +21,7 @@ func TestAccJunosCluster_basic(t *testing.T) {
 	if os.Getenv("TESTACC_INTERFACE2") != "" {
 		testaccInterface2 = os.Getenv("TESTACC_INTERFACE2")
 	} else {
-		testaccInterface2 = "ge-0/0/4"
+		testaccInterface2 = defaultInterfaceTestAcc2
 	}
 	if os.Getenv("TESTACC_SWITCH") == "" && os.Getenv("TESTACC_ROUTER") == "" {
 		resource.Test(t, resource.TestCase{

--- a/junos/resource_interface_physical_test.go
+++ b/junos/resource_interface_physical_test.go
@@ -26,7 +26,7 @@ func TestAccJunosInterfacePhysical_basic(t *testing.T) {
 	if os.Getenv("TESTACC_INTERFACE2") != "" {
 		testaccInterface2 = os.Getenv("TESTACC_INTERFACE2")
 	} else {
-		testaccInterface2 = "ge-0/0/4"
+		testaccInterface2 = defaultInterfaceTestAcc2
 	}
 	if os.Getenv("TESTACC_SWITCH") != "" {
 		resource.Test(t, resource.TestCase{

--- a/junos/resource_ospf_area.go
+++ b/junos/resource_ospf_area.go
@@ -317,6 +317,7 @@ func setOspfArea(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject)
 		}
 		interfaceNameList = append(interfaceNameList, ospfInterface["name"].(string))
 		setPrefixInterface := setPrefix + "interface " + ospfInterface["name"].(string) + " "
+		configSet = append(configSet, setPrefixInterface)
 		if ospfInterface["dead_interval"].(int) != 0 {
 			configSet = append(configSet, setPrefixInterface+"dead-interval "+
 				strconv.Itoa(ospfInterface["dead_interval"].(int)))


### PR DESCRIPTION
BUG FIXES:

* resource/`junos_ospf_area`: fix missing set interface when `interface` block have only `name` set