### PR TITLE
Fix #280: add instance_export, instance_import arguments to routing-options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ENHANCEMENTS:
 
 * resource/`*`: to avoid any confusion, the provider now detects and generates an error during `apply` when there are duplicate elements (with the same identifier, for example the same `name`) in the block lists of certain resources
+* resource/`junos_routing_instance`: add `instance_export` and `instance_import` arguments (Fixes #280)
 * resource/`junos_routing_options`: add `instance_export` and `instance_import` arguments
 * resource/`junos_security_nat_destination`: add multiple arguments, `application`, `destination_...`, `protocol`, `source_...` in `rule` block and `description`
 * resource/`junos_security_nat_destination_pool`: add `description` argument

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ENHANCEMENTS:
 
 * resource/`*`: to avoid any confusion, the provider now detects and generates an error during `apply` when there are duplicate elements (with the same identifier, for example the same `name`) in the block lists of certain resources
+* resource/`junos_routing_options`: add `instance_export` and `instance_import` arguments
 * resource/`junos_security_nat_destination`: add multiple arguments, `application`, `destination_...`, `protocol`, `source_...` in `rule` block and `description`
 * resource/`junos_security_nat_destination_pool`: add `description` argument
 * resource/`junos_security_nat_source`: add multiple arguments, `application`, `destination_...`, `protocol`, `source_...` in `match` block inside `rule` block and `description`

--- a/junos/resource_routing_instance.go
+++ b/junos/resource_routing_instance.go
@@ -22,6 +22,8 @@ type instanceOptions struct {
 	vrfTargetExport    string
 	vrfTargetImport    string
 	vtepSourceIf       string
+	instanceExport     []string
+	instanceImport     []string
 	vrfExport          []string
 	vrfImport          []string
 }
@@ -73,6 +75,16 @@ func resourceRoutingInstance() *schema.Resource {
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
+			},
+			"instance_export": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"instance_import": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"route_distinguisher": {
 				Type:     schema.TypeString,
@@ -349,6 +361,12 @@ func setRoutingInstance(d *schema.ResourceData, m interface{}, jnprSess *Netconf
 	if v := d.Get("description").(string); v != "" {
 		configSet = append(configSet, setPrefix+"description \""+v+"\"")
 	}
+	for _, v := range d.Get("instance_export").([]interface{}) {
+		configSet = append(configSet, setPrefix+"routing-options instance-export "+v.(string))
+	}
+	for _, v := range d.Get("instance_import").([]interface{}) {
+		configSet = append(configSet, setPrefix+"routing-options instance-import "+v.(string))
+	}
 	if v := d.Get("vtep_source_interface").(string); v != "" {
 		configSet = append(configSet, setPrefix+"vtep-source-interface "+v)
 	}
@@ -383,6 +401,12 @@ func readRoutingInstance(instance string, m interface{}, jnprSess *NetconfObject
 				confRead.routeDistinguisher = strings.TrimPrefix(itemTrim, "route-distinguisher ")
 			case strings.HasPrefix(itemTrim, "routing-options autonomous-system "):
 				confRead.as = strings.TrimPrefix(itemTrim, "routing-options autonomous-system ")
+			case strings.HasPrefix(itemTrim, "routing-options instance-export "):
+				confRead.instanceExport = append(confRead.instanceExport,
+					strings.TrimPrefix(itemTrim, "routing-options instance-export "))
+			case strings.HasPrefix(itemTrim, "routing-options instance-import "):
+				confRead.instanceImport = append(confRead.instanceImport,
+					strings.TrimPrefix(itemTrim, "routing-options instance-import "))
 			case strings.HasPrefix(itemTrim, "vrf-export "):
 				confRead.vrfExport = append(confRead.vrfExport, strings.Trim(strings.TrimPrefix(itemTrim, "vrf-export "), "\""))
 			case strings.HasPrefix(itemTrim, "vrf-import "):
@@ -411,6 +435,8 @@ func delRoutingInstanceOpts(d *schema.ResourceData, m interface{}, jnprSess *Net
 	configSet = append(configSet,
 		setPrefix+"description",
 		setPrefix+"routing-options autonomous-system",
+		setPrefix+"routing-options instance-export",
+		setPrefix+"routing-options instance-import",
 		setPrefix+"vtep-source-interface",
 	)
 	if !d.Get("configure_type_singly").(bool) {
@@ -444,6 +470,12 @@ func fillRoutingInstanceData(d *schema.ResourceData, instanceOptions instanceOpt
 		panic(tfErr)
 	}
 	if tfErr := d.Set("description", instanceOptions.description); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("instance_export", instanceOptions.instanceExport); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("instance_import", instanceOptions.instanceImport); tfErr != nil {
 		panic(tfErr)
 	}
 	if tfErr := d.Set("vtep_source_interface", instanceOptions.vtepSourceIf); tfErr != nil {

--- a/junos/resource_routing_instance_test.go
+++ b/junos/resource_routing_instance_test.go
@@ -47,9 +47,11 @@ func TestAccJunosRoutingInstance_basic(t *testing.T) {
 func testAccJunosRoutingInstanceConfigCreate() string {
 	return `
 resource junos_routing_instance "testacc_routingInst" {
-  name        = "testacc_routingInst"
-  as          = "65000"
-  description = "testacc routingInst"
+  name            = "testacc_routingInst"
+  as              = "65000"
+  description     = "testacc routingInst"
+  instance_export = [junos_policyoptions_policy_statement.testacc_routingInst2.name]
+  instance_import = [junos_policyoptions_policy_statement.testacc_routingInst2.name]
 }
 resource junos_policyoptions_community "testacc_routingInst2" {
   name    = "testacc_routingInst2"
@@ -105,6 +107,14 @@ func testAccJunosRoutingInstanceConfigUpdate() string {
 resource junos_routing_instance "testacc_routingInst" {
   name = "testacc_routingInst"
   as   = "65001"
+  instance_export = [
+    junos_policyoptions_policy_statement.testacc_routingInst3.name,
+    junos_policyoptions_policy_statement.testacc_routingInst2.name,
+  ]
+  instance_import = [
+    junos_policyoptions_policy_statement.testacc_routingInst3.name,
+    junos_policyoptions_policy_statement.testacc_routingInst2.name,
+  ]
 }
 resource junos_policyoptions_community "testacc_routingInst2" {
   name    = "testacc_routingInst2"

--- a/junos/resource_routing_options.go
+++ b/junos/resource_routing_options.go
@@ -14,6 +14,8 @@ import (
 
 type routingOptionsOptions struct {
 	routerID         string
+	instanceExport   []string
+	instanceImport   []string
 	autonomousSystem []map[string]interface{}
 	forwardingTable  []map[string]interface{}
 	gracefulRestart  []map[string]interface{}
@@ -156,6 +158,16 @@ func resourceRoutingOptions() *schema.Resource {
 						},
 					},
 				},
+			},
+			"instance_export": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"instance_import": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"router_id": {
 				Type:         schema.TypeString,
@@ -402,6 +414,12 @@ func setRoutingOptions(d *schema.ResourceData, m interface{}, jnprSess *NetconfO
 			}
 		}
 	}
+	for _, v := range d.Get("instance_export").([]interface{}) {
+		configSet = append(configSet, setPrefix+"instance-export "+v.(string))
+	}
+	for _, v := range d.Get("instance_import").([]interface{}) {
+		configSet = append(configSet, setPrefix+"instance-import "+v.(string))
+	}
 	if v := d.Get("router_id").(string); v != "" {
 		configSet = append(configSet, setPrefix+"router-id "+v)
 	}
@@ -413,6 +431,8 @@ func delRoutingOptions(fwTableExportConfigSingly bool, m interface{}, jnprSess *
 	listLinesToDelete := []string{
 		"autonomous-system",
 		"graceful-restart",
+		"instance-export",
+		"instance-import",
 		"router-id",
 	}
 	if fwTableExportConfigSingly {
@@ -573,6 +593,10 @@ func readRoutingOptions(m interface{}, jnprSess *NetconfObject) (routingOptionsO
 						return confRead, fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
 					}
 				}
+			case strings.HasPrefix(itemTrim, "instance-export "):
+				confRead.instanceExport = append(confRead.instanceExport, strings.TrimPrefix(itemTrim, "instance-export "))
+			case strings.HasPrefix(itemTrim, "instance-import "):
+				confRead.instanceImport = append(confRead.instanceImport, strings.TrimPrefix(itemTrim, "instance-import "))
 			case strings.HasPrefix(itemTrim, "router-id "):
 				confRead.routerID = strings.TrimPrefix(itemTrim, "router-id ")
 			}
@@ -596,6 +620,12 @@ func fillRoutingOptions(d *schema.ResourceData, routingOptionsOptions routingOpt
 		panic(tfErr)
 	}
 	if tfErr := d.Set("graceful_restart", routingOptionsOptions.gracefulRestart); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("instance_export", routingOptionsOptions.instanceExport); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("instance_import", routingOptionsOptions.instanceImport); tfErr != nil {
 		panic(tfErr)
 	}
 	if tfErr := d.Set("router_id", routingOptionsOptions.routerID); tfErr != nil {

--- a/junos/resource_routing_options_test.go
+++ b/junos/resource_routing_options_test.go
@@ -67,6 +67,31 @@ resource "junos_policyoptions_policy_statement" "testacc_routing_options" {
     load_balance = "per-packet"
   }
 }
+resource "junos_policyoptions_policy_statement" "testacc_routing_options2" {
+  name = "testacc_routing_options2"
+  from {
+    route_filter {
+      route  = "192.0.2.0/28"
+      option = "orlonger"
+    }
+  }
+  then {
+    action = "accept"
+  }
+}
+resource "junos_policyoptions_policy_statement" "testacc_routing_options3" {
+  name = "testacc_routing_options3"
+  from {
+    route_filter {
+      route  = "192.0.2.16/28"
+      option = "orlonger"
+    }
+  }
+  then {
+    action = "accept"
+  }
+}
+
 resource junos_routing_options "testacc_routing_options" {
   autonomous_system {
     number         = "65000"
@@ -87,13 +112,40 @@ resource junos_routing_options "testacc_routing_options" {
     restart_duration = 120
     disable          = true
   }
-  router_id = "192.0.2.4"
+  instance_export = [junos_policyoptions_policy_statement.testacc_routing_options2.name]
+  instance_import = [junos_policyoptions_policy_statement.testacc_routing_options3.name]
+  router_id       = "192.0.2.4"
 }
 `
 }
 
 func testAccJunosRoutingOptionsConfigUpdate() string {
 	return `
+resource "junos_policyoptions_policy_statement" "testacc_routing_options2" {
+  name = "testacc_routing_options2"
+  from {
+    route_filter {
+      route  = "192.0.2.0/28"
+      option = "orlonger"
+    }
+  }
+  then {
+    action = "accept"
+  }
+}
+resource "junos_policyoptions_policy_statement" "testacc_routing_options3" {
+  name = "testacc_routing_options3"
+  from {
+    route_filter {
+      route  = "192.0.2.16/28"
+      option = "orlonger"
+    }
+  }
+  then {
+    action = "accept"
+  }
+}
+
 resource junos_routing_options "testacc_routing_options" {
   clean_on_destroy                         = true
   forwarding_table_export_configure_singly = true
@@ -104,6 +156,14 @@ resource junos_routing_options "testacc_routing_options" {
     unicast_reverse_path                         = "feasible-paths"
   }
   graceful_restart {}
+  instance_export = [
+    junos_policyoptions_policy_statement.testacc_routing_options3.name,
+    junos_policyoptions_policy_statement.testacc_routing_options2.name,
+  ]
+  instance_import = [
+    junos_policyoptions_policy_statement.testacc_routing_options2.name,
+    junos_policyoptions_policy_statement.testacc_routing_options3.name,
+  ]
 }
 resource junos_policyoptions_policy_statement "testacc_routing_options" {
   name                              = "testacc_routing_options"

--- a/website/docs/r/routing_instance.html.markdown
+++ b/website/docs/r/routing_instance.html.markdown
@@ -37,6 +37,10 @@ The following arguments are supported:
   Autonomous system number in plain number or `higher 16bits`.`lower 16 bits` (asdot notation) format.
 - **description** (Optional, String)  
   Text description of routing instance.
+- **instance_export** (Optional, List of String)  
+  Export policy for instance RIBs
+- **instance_import** (Optional, List of String)  
+  Import policy for instance RIBs
 - **route_distinguisher** (Optional, String)  
   Route distinguisher for this instance.
 - **vrf_export** (Optional, List of String)  

--- a/website/docs/r/routing_options.html.markdown
+++ b/website/docs/r/routing_options.html.markdown
@@ -82,6 +82,10 @@ The following arguments are supported:
     Disable graceful restart.
   - **restart_duration** (Optional, Number)  
     Maximum time for which router is in graceful restart (120..10000).
+- **instance_export** (Optional, List of String)  
+  Export policy for instance RIBs
+- **instance_import** (Optional, List of String)  
+  Import policy for instance RIBs
 - **router_id** (Optional, String)  
   Router identifier.
 


### PR DESCRIPTION
ENHANCEMENTS:

* resource/`junos_routing_instance`: add `instance_export` and `instance_import` arguments (Fixes #280)
* resource/`junos_routing_options`: add `instance_export` and `instance_import` arguments