### PR TITLE
Fix #294: add support for system ports settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ENHANCEMENTS:
 
+* resource/`junos_system`: add `ports` block argument (Fixes #294)
+
 BUG FIXES:
 
 ## 1.21.1 (October 22, 2021)

--- a/junos/resource_system_test.go
+++ b/junos/resource_system_test.go
@@ -339,6 +339,18 @@ resource junos_system "testacc_system" {
     threshold_action         = "accept"
     threshold_value          = 30
   }
+  ports {
+    auxiliary_authentication_order = ["password", "radius"]
+    auxiliary_disable              = true
+    auxiliary_insecure             = true
+    auxiliary_logout_on_disconnect = true
+    auxiliary_type                 = "vt100"
+    console_authentication_order   = ["radius", "password"]
+    console_disable                = true
+    console_insecure               = true
+    console_logout_on_disconnect   = true
+    console_type                   = "vt100"
+  }
   radius_options_attributes_nas_ipaddress   = "192.0.2.12"
   radius_options_enhanced_accounting        = true
   radius_options_password_protocol_mschapv2 = true

--- a/website/docs/r/system.html.markdown
+++ b/website/docs/r/system.html.markdown
@@ -118,6 +118,28 @@ The following arguments are supported:
   - **threshold_value** (Optional, Number)  
     Set the maximum threshold(sec) allowed for NTP adjustment (1..600).
     `threshold_action` needs to be set.
+- **ports** (Optional, Block)  
+  Declare `ports` configuration.
+  - **auxiliary_authentication_order** (Optional, List of String)  
+    Order in which authentication methods are invoked on auxiliary port.
+  - **auxiliary_disable** (Optional, Boolean)  
+    Disable console on auxiliary port.
+  - **auxiliary_insecure** (Optional, Boolean)  
+    Disallow superuser access on auxiliary port.
+  - **auxiliary_logout_on_disconnect** (Optional, Boolean)  
+    Log out the console session when cable is unplugged.
+  - **auxiliary_type** (Optional, String)  
+    Terminal type on auxiliary port.
+  - **console_authentication_order** (Optional, List of String)  
+    Order in which authentication methods are invoked on console port.
+  - **console_disable** (Optional, Boolean)  
+    Disable console on console port.
+  - **console_insecure** (Optional, Boolean)  
+    Disallow superuser access on console port.
+  - **console_logout_on_disconnect** (Optional, Boolean)  
+    Log out the console session when cable is unplugged.
+  - **console_type** (Optional, String)  
+    Terminal type on console port.
 - **radius_options_attributes_nas_ipaddress** (Optional, String)  
   Value of NAS-IP-Address in outgoing RADIUS packets.
 - **radius_options_enhanced_accounting** (Optional, Boolean)  


### PR DESCRIPTION
ENHANCEMENTS:

* resource/`junos_system`: add `ports` block argument (Fixes #294)