### PR TITLE
Fix #302: add inet6-backup-router support on `junos_group_dual_system`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ENHANCEMENTS:
 
+* resource/`junos_group_dual_system`: add validation on `system.0.backup_router_address` and list of string for `system.0.backup_router_destination` is now unordered
+
 BUG FIXES:
 
 ## 1.21.1 (October 22, 2021)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ENHANCEMENTS:
 
-* resource/`junos_group_dual_system`: add validation on `system.0.backup_router_address` and list of string for `system.0.backup_router_destination` is now unordered
+* resource/`junos_group_dual_system`: add `system.0.inet6_backup_router_address` and `system.0.inet6_backup_router_destination` arguments, add validation on `system.0.backup_router_address` and list of string for `system.0.backup_router_destination` is now unordered (Fixes #302)
 
 BUG FIXES:
 

--- a/junos/resource_group_dual_system.go
+++ b/junos/resource_group_dual_system.go
@@ -155,11 +155,12 @@ func resourceGroupDualSystem() *schema.Resource {
 							Optional: true,
 						},
 						"backup_router_address": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.IsIPv4Address,
 						},
 						"backup_router_destination": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Optional: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
@@ -474,8 +475,8 @@ func setGroupDualSystem(d *schema.ResourceData, m interface{}, jnprSess *Netconf
 		if v2 := system["backup_router_address"].(string); v2 != "" {
 			configSet = append(configSet, setPrefix+" system backup-router "+v2)
 		}
-		for _, v2 := range system["backup_router_destination"].([]interface{}) {
-			configSet = append(configSet, setPrefix+" system backup-router destination "+v2.(string))
+		for _, v2 := range sortSetOfString(system["backup_router_destination"].(*schema.Set).List()) {
+			configSet = append(configSet, setPrefix+" system backup-router destination "+v2)
 		}
 	}
 

--- a/junos/resource_group_dual_system_test.go
+++ b/junos/resource_group_dual_system_test.go
@@ -33,8 +33,8 @@ func TestAccJunosGroupDualSystem_basic(t *testing.T) {
 							"system.0.backup_router_destination.#", "2"),
 						resource.TestCheckResourceAttr("junos_group_dual_system.testacc_node0",
 							"system.#", "1"),
-						resource.TestCheckResourceAttr("junos_group_dual_system.testacc_node0",
-							"system.0.backup_router_destination.1", "192.0.2.0/26"),
+						resource.TestCheckTypeSetElemAttr("junos_group_dual_system.testacc_node0",
+							"system.0.backup_router_destination.*", "192.0.2.0/26"),
 					),
 				},
 				{

--- a/junos/resource_group_dual_system_test.go
+++ b/junos/resource_group_dual_system_test.go
@@ -79,6 +79,10 @@ resource "junos_group_dual_system" "testacc_node0" {
     backup_router_destination = [
       "192.0.2.0/26",
     ]
+    inet6_backup_router_address = "fe80::1"
+    inet6_backup_router_destination = [
+      "fe80:a::/48",
+    ]
   }
 }
 `
@@ -122,7 +126,11 @@ resource "junos_group_dual_system" "testacc_node0" {
     backup_router_destination = [
       "192.0.2.64/26",
       "192.0.2.0/26",
-
+    ]
+    inet6_backup_router_address = "fe80::1"
+    inet6_backup_router_destination = [
+      "fe80:b::/48",
+      "fe80:a::/48",
     ]
   }
 }

--- a/website/docs/r/group_dual_system.html.markdown
+++ b/website/docs/r/group_dual_system.html.markdown
@@ -65,8 +65,8 @@ The following arguments are supported:
     Hostname.
   - **backup_router_address** (Optional, String)  
     IPv4 address backup router.
-  - **backup_router_destination** (Optional, List of String)  
-    Destinations network reachable through the router.
+  - **backup_router_destination** (Optional, Set of String)  
+    Destinations network reachable through the IPv4 router.
 
 ---
 

--- a/website/docs/r/group_dual_system.html.markdown
+++ b/website/docs/r/group_dual_system.html.markdown
@@ -67,6 +67,10 @@ The following arguments are supported:
     IPv4 address backup router.
   - **backup_router_destination** (Optional, Set of String)  
     Destinations network reachable through the IPv4 router.
+  - **inet6_backup_router_address** (Optional, String)  
+    IPv6 address backup router.
+  - **inet6_backup_router_destination** (Optional, Set of String)  
+    Destinations network reachable through the IPv6 router.
 
 ---
 


### PR DESCRIPTION
ENHANCEMENTS:

* resource/`junos_group_dual_system`: add `system.0.inet6_backup_router_address` and `system.0.inet6_backup_router_destination` arguments, add validation on `system.0.backup_router_address` and list of string for `system.0.backup_router_destination` is now unordered (Fixes #302)