### PR TITLE
Fix #304: add support of chassis cluster control-ports 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ ENHANCEMENTS:
 
 * resource/`junos_system`: add `ports` block argument (Fixes #294)
 * resource/`junos_application`: add `term` block argument (Fixes #296)
+* resource/`junos_chassis_cluster`: add `control_ports` block argument (Fixes #304)
 * resource/`junos_group_dual_system`: add `system.0.inet6_backup_router_address` and `system.0.inet6_backup_router_destination` arguments, add validation on `system.0.backup_router_address` and list of string for `system.0.backup_router_destination` is now unordered (Fixes #302)
 
 BUG FIXES:

--- a/website/docs/r/chassis_cluster.html.markdown
+++ b/website/docs/r/chassis_cluster.html.markdown
@@ -85,6 +85,14 @@ The following arguments are supported:
   Number of redundant ethernet interfaces (1..128)
 - **config_sync_no_secondary_bootup_auto** (Optional, Boolean)  
   Disable auto configuration synchronize on secondary bootup.
+- **control_ports** (Optional, Set of Block)  
+  For each combination of block arguments,
+  enable the specific control port to use as a control link for the chassis cluster.  
+  Only available for some higher end Juniper SRX devices.
+  - **fpc** (Required, Number)  
+    Flexible PIC Concentrator (FPC) slot number.
+  - **port** (Required, Number)  
+    Port number on which to configure the control port.
 - **control_link_recovery** (Optional, Boolean)  
   Enable automatic control link recovery.
 - **heartbeat_interval** (Optional, Number)  


### PR DESCRIPTION
ENHANCEMENTS:

* resource/`junos_chassis_cluster`: add `control_ports` block argument (Fixes #304)