### PR TITLE
Fix #313: add an argument to use `dhcp-client` instead of `dhcp` for client DHCP configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ ENHANCEMENTS:
 
 BUG FIXES:
 
+* resource/`junos_interface_logical`: add `srx_old_option_name` argument inside `dhcp` block argument to be able to fix the configuration of DHCP client on SRX devices with an old version of Junos (use option name `dhcp-client` instead of `dhcp` in `family inet`) (Fixes #313)
+* data-source/`junos_interface_logical`: add `srx_old_option_name` argument inside `dhcp` block argument (like resource)
+
 ## 1.22.0 (November 19, 2021)
 
 FEATURES:

--- a/junos/data_source_interface_logical.go
+++ b/junos/data_source_interface_logical.go
@@ -161,6 +161,10 @@ func dataSourceInterfaceLogical() *schema.Resource {
 							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
+									"srx_old_option_name": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
 									"client_identifier_ascii": {
 										Type:     schema.TypeString,
 										Computed: true,

--- a/website/docs/d/interface_logical.html.markdown
+++ b/website/docs/d/interface_logical.html.markdown
@@ -159,6 +159,9 @@ The following attributes are exported:
 
 ### dhcp attributes for family_inet
 
+- **srx_old_option_name** (Boolean)  
+  For configuration, use the old option name `dhcp-client` instead of `dhcp`.  
+  This is used for SRX devices with an older version of Junos.
 - **client_identifier_ascii** (String)  
   Client identifier as an ASCII string.  
 - **client_identifier_hexadecimal** (String)  

--- a/website/docs/r/interface_logical.html.markdown
+++ b/website/docs/r/interface_logical.html.markdown
@@ -172,6 +172,9 @@ The following arguments are supported:
 
 ### dhcp arguments for family_inet
 
+- **srx_old_option_name** (Optional, Boolean)  
+  For configuration, use the old option name `dhcp-client` instead of `dhcp`.  
+  This is useful for SRX devices with an older version of Junos.
 - **client_identifier_ascii** (Optional, String)  
   Client identifier as an ASCII string.  
   Conflict witch `client_identifier_hexadecimal`.


### PR DESCRIPTION
BUG FIXES:

* resource/`junos_interface_logical`: add `srx_old_option_name` argument inside `dhcp` block argument to be able to fix the configuration of DHCP client on SRX devices with an old version of Junos (use option name `dhcp-client` instead of `dhcp` in `family inet`) (Fixes #313)
* data-source/`junos_interface_logical`: add `srx_old_option_name` argument inside `dhcp` block argument (like resource)
