### PR TITLE
Release v1.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ ENHANCEMENTS:
 
 BUG FIXES:
 
+* resource/`junos_interface_logical`: add `srx_old_option_name` argument inside `dhcp` block argument to be able to fix the configuration of DHCP client on SRX devices with an old version of Junos (use option name `dhcp-client` instead of `dhcp` in `family inet`) (Fixes #313)
+* data-source/`junos_interface_logical`: add `srx_old_option_name` argument inside `dhcp` block argument (like resource)
+
 ## 1.22.0 (November 19, 2021)
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ ENHANCEMENTS:
 
 BUG FIXES:
 
-* resource/`junos_interface_logical`: add `srx_old_option_name` argument inside `dhcp` block argument to be able to fix the configuration of DHCP client on SRX devices with an old version of Junos (use option name `dhcp-client` instead of `dhcp` in `family inet`) (Fixes #313)
+## 1.22.1 (November 30, 2021)
+
+BUG FIXES:
+
+* resource/`junos_interface_logical`: add `srx_old_option_name` argument inside `dhcp` block argument to be able to fix the configuration of DHCP client on SRX devices with an old version of Junos (use option name `dhcp-client` instead of `dhcp` in `family inet`) (Fixes [#313](https://github.com/jeremmfr/terraform-provider-junos/issues/313))
 * data-source/`junos_interface_logical`: add `srx_old_option_name` argument inside `dhcp` block argument (like resource)
 
 ## 1.22.0 (November 19, 2021)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,17 +3,25 @@
 
 ENHANCEMENTS:
 
-* add `junos_access_address_assignment_pool` resource (Fixes parts of #301)
-* add `junos_system_services_dhcp_localserver_group` resource (Fixes parts of #301)
-* resource/`junos_interface_logical`: add `dhcp` and `dhcpv6_client` block arguments inside `family_inet` and `family_inet6` block arguments (Fixes parts of #301)
-* data-source/`junos_interface_logical`: add `dhcp` and `dhcpv6_client` block attributes inside `family_inet` and `family_inet6` block attributes
-* add `junos_interface_physical_disable` resource (Fixes #305)
+BUG FIXES:
+
+## 1.22.0 (November 19, 2021)
+
+FEATURES:
+
+* add `junos_access_address_assignment_pool` resource (Fixes parts of [#301](https://github.com/jeremmfr/terraform-provider-junos/issues/301))
+* add `junos_interface_physical_disable` resource (Fixes [#305](https://github.com/jeremmfr/terraform-provider-junos/issues/305))
 * add `junos_interfaces_physical_present` data-source
-* resource/`junos_system`: add `ports` block argument (Fixes #294)
-* resource/`junos_application`: add `term` block argument (Fixes #296)
-* resource/`junos_chassis_cluster`: add `control_ports` block argument (Fixes #304)
-* resource/`junos_application`: add `term` block argument (Fixes #296), add `inactivity_timeout_never` argument (Fixes #308)
-* resource/`junos_group_dual_system`: add `system.0.inet6_backup_router_address` and `system.0.inet6_backup_router_destination` arguments, add validation on `system.0.backup_router_address` and list of string for `system.0.backup_router_destination` is now unordered (Fixes #302)
+* add `junos_system_services_dhcp_localserver_group` resource (Fixes parts of [#301](https://github.com/jeremmfr/terraform-provider-junos/issues/301))
+
+ENHANCEMENTS:
+
+* resource/`junos_application`: add `term` block argument (Fixes [#296](https://github.com/jeremmfr/terraform-provider-junos/issues/296)), add `inactivity_timeout_never` argument (Fixes [#308](https://github.com/jeremmfr/terraform-provider-junos/issues/308))
+* resource/`junos_chassis_cluster`: add `control_ports` block argument (Fixes [#304](https://github.com/jeremmfr/terraform-provider-junos/issues/304))
+* resource/`junos_group_dual_system`: add `system.0.inet6_backup_router_address` and `system.0.inet6_backup_router_destination` arguments, add validation on `system.0.backup_router_address` and list of string for `system.0.backup_router_destination` is now unordered (Fixes [#302](https://github.com/jeremmfr/terraform-provider-junos/issues/302))
+* resource/`junos_interface_logical`: add `dhcp` and `dhcpv6_client` block arguments inside `family_inet` and `family_inet6` block arguments (Fixes parts of [#301](https://github.com/jeremmfr/terraform-provider-junos/issues/301))
+* data-source/`junos_interface_logical`: add `dhcp` and `dhcpv6_client` block attributes inside `family_inet` and `family_inet6` block attributes
+* resource/`junos_system`: add `ports` block argument (Fixes [#294](https://github.com/jeremmfr/terraform-provider-junos/issues/294))
 
 BUG FIXES:
 

--- a/junos/data_source_interface_logical.go
+++ b/junos/data_source_interface_logical.go
@@ -161,6 +161,10 @@ func dataSourceInterfaceLogical() *schema.Resource {
 							Computed: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
+									"srx_old_option_name": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
 									"client_identifier_ascii": {
 										Type:     schema.TypeString,
 										Computed: true,

--- a/website/docs/d/interface_logical.html.markdown
+++ b/website/docs/d/interface_logical.html.markdown
@@ -159,6 +159,9 @@ The following attributes are exported:
 
 ### dhcp attributes for family_inet
 
+- **srx_old_option_name** (Boolean)  
+  For configuration, use the old option name `dhcp-client` instead of `dhcp`.  
+  This is used for SRX devices with an older version of Junos.
 - **client_identifier_ascii** (String)  
   Client identifier as an ASCII string.  
 - **client_identifier_hexadecimal** (String)  

--- a/website/docs/r/interface_logical.html.markdown
+++ b/website/docs/r/interface_logical.html.markdown
@@ -172,6 +172,9 @@ The following arguments are supported:
 
 ### dhcp arguments for family_inet
 
+- **srx_old_option_name** (Optional, Boolean)  
+  For configuration, use the old option name `dhcp-client` instead of `dhcp`.  
+  This is useful for SRX devices with an older version of Junos.
 - **client_identifier_ascii** (Optional, String)  
   Client identifier as an ASCII string.  
   Conflict witch `client_identifier_hexadecimal`.


### PR DESCRIPTION
BUG FIXES:

* resource/`junos_interface_logical`: add `srx_old_option_name` argument inside `dhcp` block argument to be able to fix the configuration of DHCP client on SRX devices with an old version of Junos (use option name `dhcp-client` instead of `dhcp` in `family inet`) (Fixes [#313](https://github.com/jeremmfr/terraform-provider-junos/issues/313))
* data-source/`junos_interface_logical`: add `srx_old_option_name` argument inside `dhcp` block argument (like resource)