### PR TITLE
Fix 316,169: block arguments to address-book unordered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ENHANCEMENTS:
 
 * resource/`junos_security_address_book`: `network_address`, `wildcard_address`, `dns_name`, `range_address` and `address_set` block arguments are now unordered blocks. (Fixes #316)
+* resource/`junos_security_zone`: `address_book`, `address_book_dns`, `address_book_range`, `address_book_set` and `address_book_wildcard` block arguments are now unordered blocks. (Fixes #169)
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ENHANCEMENTS:
 
+* resource/`junos_security_address_book`: `network_address`, `wildcard_address`, `dns_name`, `range_address` and `address_set` block arguments are now unordered blocks. (Fixes #316)
+
 BUG FIXES:
 
 ## 1.22.1 (November 30, 2021)

--- a/junos/resource_security_address_book.go
+++ b/junos/resource_security_address_book.go
@@ -48,7 +48,7 @@ func resourceSecurityAddressBook() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"network_address": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -65,12 +65,13 @@ func resourceSecurityAddressBook() *schema.Resource {
 						"description": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Default:  "",
 						},
 					},
 				},
 			},
 			"wildcard_address": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -87,12 +88,13 @@ func resourceSecurityAddressBook() *schema.Resource {
 						"description": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Default:  "",
 						},
 					},
 				},
 			},
 			"dns_name": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -108,12 +110,13 @@ func resourceSecurityAddressBook() *schema.Resource {
 						"description": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Default:  "",
 						},
 					},
 				},
 			},
 			"range_address": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -135,12 +138,13 @@ func resourceSecurityAddressBook() *schema.Resource {
 						"description": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Default:  "",
 						},
 					},
 				},
 			},
 			"address_set": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -162,6 +166,7 @@ func resourceSecurityAddressBook() *schema.Resource {
 						"description": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Default:  "",
 						},
 					},
 				},
@@ -372,7 +377,7 @@ func setSecurityAddressBook(d *schema.ResourceData, m interface{}, jnprSess *Net
 		configSet = append(configSet, setPrefix+" attach zone "+attachZone)
 	}
 	addressNameList := make([]string, 0)
-	for _, v := range d.Get("network_address").([]interface{}) {
+	for _, v := range d.Get("network_address").(*schema.Set).List() {
 		address := v.(map[string]interface{})
 		if bchk.StringInSlice(address["name"].(string), addressNameList) {
 			return fmt.Errorf("multiple addresses with the same name %s", address["name"].(string))
@@ -384,7 +389,7 @@ func setSecurityAddressBook(d *schema.ResourceData, m interface{}, jnprSess *Net
 			configSet = append(configSet, setPrefixAddr+"description \""+address["description"].(string)+"\"")
 		}
 	}
-	for _, v := range d.Get("wildcard_address").([]interface{}) {
+	for _, v := range d.Get("wildcard_address").(*schema.Set).List() {
 		address := v.(map[string]interface{})
 		if bchk.StringInSlice(address["name"].(string), addressNameList) {
 			return fmt.Errorf("multiple addresses with the same name %s", address["name"].(string))
@@ -396,7 +401,7 @@ func setSecurityAddressBook(d *schema.ResourceData, m interface{}, jnprSess *Net
 			configSet = append(configSet, setPrefixAddr+"description \""+address["description"].(string)+"\"")
 		}
 	}
-	for _, v := range d.Get("dns_name").([]interface{}) {
+	for _, v := range d.Get("dns_name").(*schema.Set).List() {
 		address := v.(map[string]interface{})
 		if bchk.StringInSlice(address["name"].(string), addressNameList) {
 			return fmt.Errorf("multiple addresses with the same name %s", address["name"].(string))
@@ -408,7 +413,7 @@ func setSecurityAddressBook(d *schema.ResourceData, m interface{}, jnprSess *Net
 			configSet = append(configSet, setPrefixAddr+"description \""+address["description"].(string)+"\"")
 		}
 	}
-	for _, v := range d.Get("range_address").([]interface{}) {
+	for _, v := range d.Get("range_address").(*schema.Set).List() {
 		address := v.(map[string]interface{})
 		if bchk.StringInSlice(address["name"].(string), addressNameList) {
 			return fmt.Errorf("multiple addresses with the same name %s", address["name"].(string))
@@ -420,7 +425,7 @@ func setSecurityAddressBook(d *schema.ResourceData, m interface{}, jnprSess *Net
 			configSet = append(configSet, setPrefixAddr+"description \""+address["description"].(string)+"\"")
 		}
 	}
-	for _, v := range d.Get("address_set").([]interface{}) {
+	for _, v := range d.Get("address_set").(*schema.Set).List() {
 		addressSet := v.(map[string]interface{})
 		if bchk.StringInSlice(addressSet["name"].(string), addressNameList) {
 			return fmt.Errorf("multiple addresses or address-sets with the same name %s", addressSet["name"].(string))

--- a/junos/resource_security_zone.go
+++ b/junos/resource_security_zone.go
@@ -47,7 +47,7 @@ func resourceSecurityZone() *schema.Resource {
 				ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatDefault),
 			},
 			"address_book": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -64,6 +64,7 @@ func resourceSecurityZone() *schema.Resource {
 						"description": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Default:  "",
 						},
 					},
 				},
@@ -80,7 +81,7 @@ func resourceSecurityZone() *schema.Resource {
 				},
 			},
 			"address_book_dns": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -96,20 +97,23 @@ func resourceSecurityZone() *schema.Resource {
 						"description": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Default:  "",
 						},
 						"ipv4_only": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							Default:  false,
 						},
 						"ipv6_only": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							Default:  false,
 						},
 					},
 				},
 			},
 			"address_book_range": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -131,12 +135,13 @@ func resourceSecurityZone() *schema.Resource {
 						"description": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Default:  "",
 						},
 					},
 				},
 			},
 			"address_book_set": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -158,12 +163,13 @@ func resourceSecurityZone() *schema.Resource {
 						"description": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Default:  "",
 						},
 					},
 				},
 			},
 			"address_book_wildcard": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -180,6 +186,7 @@ func resourceSecurityZone() *schema.Resource {
 						"description": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Default:  "",
 						},
 					},
 				},
@@ -439,7 +446,7 @@ func setSecurityZone(d *schema.ResourceData, m interface{}, jnprSess *NetconfObj
 	configSet = append(configSet, setPrefix)
 	if !d.Get("address_book_configure_singly").(bool) {
 		addressNameList := make([]string, 0)
-		for _, v := range d.Get("address_book").([]interface{}) {
+		for _, v := range d.Get("address_book").(*schema.Set).List() {
 			addressBook := v.(map[string]interface{})
 			if bchk.StringInSlice(addressBook["name"].(string), addressNameList) {
 				return fmt.Errorf("multiple addresses with the same name %s", addressBook["name"].(string))
@@ -452,7 +459,7 @@ func setSecurityZone(d *schema.ResourceData, m interface{}, jnprSess *NetconfObj
 					addressBook["name"].(string)+" description \""+v2+"\"")
 			}
 		}
-		for _, v := range d.Get("address_book_dns").([]interface{}) {
+		for _, v := range d.Get("address_book_dns").(*schema.Set).List() {
 			addressBook := v.(map[string]interface{})
 			if bchk.StringInSlice(addressBook["name"].(string), addressNameList) {
 				return fmt.Errorf("multiple addresses with the same name %s", addressBook["name"].(string))
@@ -472,7 +479,7 @@ func setSecurityZone(d *schema.ResourceData, m interface{}, jnprSess *NetconfObj
 					addressBook["name"].(string)+" description \""+v2+"\"")
 			}
 		}
-		for _, v := range d.Get("address_book_range").([]interface{}) {
+		for _, v := range d.Get("address_book_range").(*schema.Set).List() {
 			addressBook := v.(map[string]interface{})
 			if bchk.StringInSlice(addressBook["name"].(string), addressNameList) {
 				return fmt.Errorf("multiple addresses with the same name %s", addressBook["name"].(string))
@@ -486,7 +493,7 @@ func setSecurityZone(d *schema.ResourceData, m interface{}, jnprSess *NetconfObj
 					addressBook["name"].(string)+" description \""+v2+"\"")
 			}
 		}
-		for _, v := range d.Get("address_book_wildcard").([]interface{}) {
+		for _, v := range d.Get("address_book_wildcard").(*schema.Set).List() {
 			addressBook := v.(map[string]interface{})
 			if bchk.StringInSlice(addressBook["name"].(string), addressNameList) {
 				return fmt.Errorf("multiple addresses with the same name %s", addressBook["name"].(string))
@@ -499,7 +506,7 @@ func setSecurityZone(d *schema.ResourceData, m interface{}, jnprSess *NetconfObj
 					addressBook["name"].(string)+" description \""+v2+"\"")
 			}
 		}
-		for _, v := range d.Get("address_book_set").([]interface{}) {
+		for _, v := range d.Get("address_book_set").(*schema.Set).List() {
 			addressBookSet := v.(map[string]interface{})
 			if bchk.StringInSlice(addressBookSet["name"].(string), addressNameList) {
 				return fmt.Errorf("multiple addresses or address-sets with the same name %s", addressBookSet["name"].(string))

--- a/website/docs/d/interfaces_physical_present.html.markdown
+++ b/website/docs/d/interfaces_physical_present.html.markdown
@@ -40,7 +40,7 @@ The following attributes are exported:
   An identifier for the resource.
 - **interface_names** (List of String)  
   List of interface names found.
-- **interface_statuses** (List of Block)  
+- **interface_statuses** (Block List)  
   For each interface name.
   - **name** (String)  
     Interface name.

--- a/website/docs/r/access_address_assignment_pool.html.markdown
+++ b/website/docs/r/access_address_assignment_pool.html.markdown
@@ -58,7 +58,7 @@ The following arguments are supported:
 - **excluded_address** (Optional, Set of String)  
   Excluded Addresses.  
   Need to be valid IP addresses.
-- **excluded_range** (Optional, List of Block)  
+- **excluded_range** (Optional, Block List)  
   For each name of excluded address range to declare.
   - **name** (Required, String)  
     Range name.
@@ -68,7 +68,7 @@ The following arguments are supported:
   - **high** (Required, String)  
     Upper limit of excluded address range.  
     Need to be a valid IP address.
-- **host** (Optional, List of Block)  
+- **host** (Optional, Block List)  
   For each name of host to declare.  
   `type` need to be `inet`.
   - **name** (Required, String)  
@@ -79,7 +79,7 @@ The following arguments are supported:
   - **Reserved address** (Required, String)  
     Hardware address.  
     Need to be a valid IPv4 address.
-- **inet_range** (Optional, List of Block)  
+- **inet_range** (Optional, Block List)  
   For each name of address range to declare.  
   `type` need to be `inet`.
   - **name** (Required, String)  
@@ -90,7 +90,7 @@ The following arguments are supported:
   - **high** (Required, String)  
     Upper limit of address range.  
     Need to be a valid IPv4 address.
-- **inet6_range** (Optional, List of Block)  
+- **inet6_range** (Optional, Block List)  
   For each name of address range to declare.  
   Need to set one of `prefix_length` or `low` + `high`.  
   `type` need to be `inet6`.
@@ -159,13 +159,13 @@ The following arguments are supported:
   DHCP option.  
   Format need to match `^\d+ (array )?(byte|flag|hex-string|integer|ip-address|short|string|unsigned-integer|unsigned-short) .*$`.
 <!-- markdownlint-restore -->
-- **option_match_82_circuit_id** (Optional, List of Block)  
+- **option_match_82_circuit_id** (Optional, Block List)  
   For each value to declare, circuit ID portion of the option 82.
   - **value** (Required, String)  
     Match value.
   - **range** (Required, String)  
     Range name.
-- **option_match_82_remote_id** (Optional, List of Block)  
+- **option_match_82_remote_id** (Optional, Block List)  
   For each value to declare, remote ID portion of the option 82.
   - **value** (Required, String)  
     Match value.

--- a/website/docs/r/chassis_cluster.html.markdown
+++ b/website/docs/r/chassis_cluster.html.markdown
@@ -85,7 +85,7 @@ The following arguments are supported:
   Number of redundant ethernet interfaces (1..128)
 - **config_sync_no_secondary_bootup_auto** (Optional, Boolean)  
   Disable auto configuration synchronize on secondary bootup.
-- **control_ports** (Optional, Set of Block)  
+- **control_ports** (Optional, Block Set)  
   For each combination of block arguments,
   enable the specific control port to use as a control link for the chassis cluster.  
   Only available for some higher end Juniper SRX devices.

--- a/website/docs/r/security_address_book.html.markdown
+++ b/website/docs/r/security_address_book.html.markdown
@@ -59,7 +59,7 @@ The following arguments are supported:
 - **attach_zone** (Optional, List of String)  
   List of zones to attach address book to.  
   **NOTE:** Cannot be set on global address book.
-- **network_address** (Optional, Block List)  
+- **network_address** (Optional, Block Set)  
   For each name of network address.
   - **name** (Required, String)  
     Name of network address.
@@ -67,7 +67,7 @@ The following arguments are supported:
     CIDR value of network address (`192.0.0.0/24`).
   - **description** (Optional, String)  
     Description of network address.
-- **wildcard_address** (Optional, Block List)  
+- **wildcard_address** (Optional, Block Set)  
   For each name of wildcard address.
   - **name** (Required, String)  
     Name of wildcard address.
@@ -75,7 +75,7 @@ The following arguments are supported:
     Network and mask of wildcard address (`192.0.0.0/255.255.0.255`).
   - **description** (Optional, String)  
     Description of network address.
-- **dns_name** (Optional, Block List)  
+- **dns_name** (Optional, Block Set)  
   For each name of dns name address.
   - **name** (Required, String)  
     Name of dns name address.
@@ -83,7 +83,7 @@ The following arguments are supported:
     DNS name string value (`juniper.net`).
   - **description** (Optional, String)  
     Description of dns name address.
-- **range_address** (Optional, Block List)  
+- **range_address** (Optional, Block Set)  
    For each name of range address.
   - **name** (Required, String)  
     Name of range address.
@@ -93,7 +93,7 @@ The following arguments are supported:
     IP address of end of range.
   - **description** (Optional, String)  
     Description of range address.
-- **address_set** (Optional, Block List)  
+- **address_set** (Optional, Block Set)  
   For each name of address-set to declare.
   - **name** (Required, String)  
     Name of address-set.

--- a/website/docs/r/security_zone.html.markdown
+++ b/website/docs/r/security_zone.html.markdown
@@ -30,7 +30,7 @@ The following arguments are supported:
 
 - **name** (Required, String, Forces new resource)  
   The name of security zone.
-- **address_book** (Optional, Block List)  
+- **address_book** (Optional, Block Set)  
   For each name of address to declare.
   - **name** (Required, String)  
     Name of address.
@@ -42,7 +42,7 @@ The following arguments are supported:
   Disable management of address-book in this resource to be able to manage them with specific
   resources.  
   Conflict with `address_book_*`.
-- **address_book_dns** (Optional, Block List)  
+- **address_book_dns** (Optional, Block Set)  
   For each name of dns-name address to declare.
   - **name** (Required, String)  
     Name of address.
@@ -54,7 +54,7 @@ The following arguments are supported:
     IPv4 dns address.
   - **ipv6_only** (Optional, Boolean)  
     IPv6 dns address.
-- **address_book_range** (Optional, Block List)  
+- **address_book_range** (Optional, Block Set)  
   For each name of range-address to declare.
   - **name** (Required, String)  
     Name of address.
@@ -64,7 +64,7 @@ The following arguments are supported:
     Upper limit of address range.
   - **description** (Optional, String)  
     Description of address.
-- **address_book_set** (Optional, Block List)  
+- **address_book_set** (Optional, Block Set)  
   For each name of address-set to declare.
   - **name** (Required, String)  
     Name of address-set.
@@ -74,7 +74,7 @@ The following arguments are supported:
     List of address-set names.
   - **description** (Optional, String)  
     Description of address-set.
-- **address_book_wildcard** (Optional, Block List)  
+- **address_book_wildcard** (Optional, Block Set)  
   For each name of wildcard-address to declare.
   - **name** (Required, String)  
     Name of address.

--- a/website/docs/r/system_services_dhcp_localserver_group.html.markdown
+++ b/website/docs/r/system_services_dhcp_localserver_group.html.markdown
@@ -109,7 +109,7 @@ The following arguments are supported:
   Merge or replace the client dynamic profiles.  
   Need to be `merge` or `replace`.  
   `dynamic_profile_aggregate_clients` need to be true.
-- **interface** (Optional, Set of Block)  
+- **interface** (Optional, Block Set)  
   For each name of interface to declare.  
   See [below for nested schema](#interface-arguments).
 - **lease_time_validation** (Optional, Block)  
@@ -253,7 +253,7 @@ The following arguments are supported:
 - **client_discover_match** (Optional, String)  
   Use incoming interface or option 60 and option 82 match criteria for DISCOVER PDU.  
   Need to be `incoming-interface` or `option60-and-option82`.
-- **delay_offer_based_on** (Optional, Set of Block)  
+- **delay_offer_based_on** (Optional, Block Set)  
   For each combination of block arguments, filter options for dhcp-server.
   - **option** (Required, String)  
     Option.  
@@ -298,7 +298,7 @@ The following arguments are supported:
   Use a reduced prefix lease time for the client. In seconds (600..86400 seconds).
 - **client_negotiation_match_incoming_interface** (Optional, Boolean)  
   Use incoming interface match criteria for SOLICIT PDU
-- **delay_advertise_based_on** (Optional, Set of Block)  
+- **delay_advertise_based_on** (Optional, Block Set)  
   For each combination of block arguments, filter options for dhcp-server.
   - **option** (Required, String)  
     Option.  


### PR DESCRIPTION
ENHANCEMENTS:

* resource/`junos_security_address_book`: `network_address`, `wildcard_address`, `dns_name`, `range_address` and `address_set` block arguments are now unordered blocks. (Fixes #316)
* resource/`junos_security_zone`: `address_book`, `address_book_dns`, `address_book_range`, `address_book_set` and `address_book_wildcard` block arguments are now unordered blocks. (Fixes #169)
