### PR TITLE
Fix #318: system_login_user: fix validation of name with a dot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ ENHANCEMENTS:
 
 BUG FIXES:
 
+* resource/`junos_system_login_user`: fix validation of `name` with a dot that is acceptable for Junos (Fixes #318)
+
 ## 1.22.1 (November 30, 2021)
 
 BUG FIXES:

--- a/junos/resource_system_login_user.go
+++ b/junos/resource_system_login_user.go
@@ -35,7 +35,7 @@ func resourceSystemLoginUser() *schema.Resource {
 				Type:             schema.TypeString,
 				ForceNew:         true,
 				Required:         true,
-				ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatDefault),
+				ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatDefAndDots),
 			},
 			"class": {
 				Type:     schema.TypeString,

--- a/junos/resource_system_login_user_test.go
+++ b/junos/resource_system_login_user_test.go
@@ -59,6 +59,10 @@ resource "junos_system_login_user" "testacc" {
     no_public_keys     = true
   }
 }
+resource "junos_system_login_user" "testacc2" {
+  name  = "test.acc2"
+  class = "unauthorized"
+}
 `
 }
 


### PR DESCRIPTION
BUG FIXES:

* resource/`junos_system_login_user`: fix validation of `name` with a dot that is acceptable for Junos (Fixes #318)