### PR TITLE
security_policy: read the config lines with `then allow tunnel pair-policy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ ENHANCEMENTS:
 
 BUG FIXES:
 
+* resource/`junos_security_policy`: read the config lines with `then allow tunnel pair-policy` to add them when updating the resource and thus avoid modifying the `junos_security_policy_tunnel_pair_policy` resource lines
+
 ## 1.23.0 (December 17, 2021)
 
 ENHANCEMENTS:

--- a/junos/resource_security_ike_ipsec_test.go
+++ b/junos/resource_security_ike_ipsec_test.go
@@ -411,24 +411,32 @@ resource junos_security_zone testacc_secIkeIpsec_remote {
   }
 }
 resource junos_security_policy testacc_policyIpsecLocToRem {
+  depends_on = [
+    junos_security_zone.testacc_secIkeIpsec_local,
+    junos_security_zone.testacc_secIkeIpsec_remote
+  ]
   from_zone = junos_security_zone.testacc_secIkeIpsec_local.name
   to_zone   = junos_security_zone.testacc_secIkeIpsec_remote.name
   policy {
     name                      = "testacc_vpn-out"
-    match_source_address      = [junos_security_zone.testacc_secIkeIpsec_local.address_book[0].name]
-    match_destination_address = [junos_security_zone.testacc_secIkeIpsec_remote.address_book[0].name]
+    match_source_address      = ["testacc_vpnlocal"]
+    match_destination_address = ["testacc_vpnremote"]
     match_application         = ["any"]
     permit_tunnel_ipsec_vpn   = junos_security_ipsec_vpn.testacc_ipsecvpn2.name
   }
 }
 
 resource junos_security_policy testacc_policyIpsecRemToLoc {
+  depends_on = [
+    junos_security_zone.testacc_secIkeIpsec_local,
+    junos_security_zone.testacc_secIkeIpsec_remote
+  ]
   from_zone = junos_security_zone.testacc_secIkeIpsec_remote.name
   to_zone   = junos_security_zone.testacc_secIkeIpsec_local.name
   policy {
     name                      = "testacc_vpn-in"
-    match_source_address      = [junos_security_zone.testacc_secIkeIpsec_remote.address_book[0].name]
-    match_destination_address = [junos_security_zone.testacc_secIkeIpsec_local.address_book[0].name]
+    match_source_address      = ["testacc_vpnremote"]
+    match_destination_address = ["testacc_vpnlocal"]
     match_application         = ["any"]
     permit_tunnel_ipsec_vpn   = junos_security_ipsec_vpn.testacc_ipsecvpn2.name
   }
@@ -527,24 +535,32 @@ resource junos_security_zone testacc_secIkeIpsec_remote {
   }
 }
 resource junos_security_policy testacc_policyIpsecLocToRem {
+  depends_on = [
+    junos_security_zone.testacc_secIkeIpsec_local,
+    junos_security_zone.testacc_secIkeIpsec_remote
+  ]
   from_zone = junos_security_zone.testacc_secIkeIpsec_local.name
   to_zone   = junos_security_zone.testacc_secIkeIpsec_remote.name
   policy {
     name                      = "testacc_vpn-out"
-    match_source_address      = [junos_security_zone.testacc_secIkeIpsec_local.address_book[0].name]
-    match_destination_address = [junos_security_zone.testacc_secIkeIpsec_remote.address_book[0].name]
+    match_source_address      = ["testacc_vpnlocal"]
+    match_destination_address = ["testacc_vpnremote"]
     match_application         = ["any"]
     permit_tunnel_ipsec_vpn   = junos_security_ipsec_vpn.testacc_ipsecvpn2.name
   }
 }
 
 resource junos_security_policy testacc_policyIpsecRemToLoc {
+  depends_on = [
+    junos_security_zone.testacc_secIkeIpsec_local,
+    junos_security_zone.testacc_secIkeIpsec_remote
+  ]
   from_zone = junos_security_zone.testacc_secIkeIpsec_remote.name
   to_zone   = junos_security_zone.testacc_secIkeIpsec_local.name
   policy {
     name                      = "testacc_vpn-in"
-    match_source_address      = [junos_security_zone.testacc_secIkeIpsec_remote.address_book[0].name]
-    match_destination_address = [junos_security_zone.testacc_secIkeIpsec_local.address_book[0].name]
+    match_source_address      = ["testacc_vpnremote"]
+    match_destination_address = ["testacc_vpnlocal"]
     match_application         = ["any"]
     permit_tunnel_ipsec_vpn   = junos_security_ipsec_vpn.testacc_ipsecvpn2.name
   }

--- a/junos/resource_services_test.go
+++ b/junos/resource_services_test.go
@@ -72,6 +72,9 @@ resource "junos_services_ssl_initiation_profile" "testacc_services" {
   name = "testacc_services"
 }
 resource "junos_services" "testacc" {
+  depends_on = [
+    junos_security_address_book.testacc_services
+  ]
   advanced_anti_malware {
     connection {
       auth_tls_profile = junos_services_ssl_initiation_profile.testacc_services.name
@@ -132,9 +135,9 @@ resource "junos_services" "testacc" {
       batch_query_interval                 = 30
       filter_domain                        = ["test3", "test2"]
       filter_exclude_ip_address_book       = junos_security_address_book.testacc_services.name
-      filter_exclude_ip_address_set        = junos_security_address_book.testacc_services.address_set[0].name
+      filter_exclude_ip_address_set        = "testacc_services_set"
       filter_include_ip_address_book       = junos_security_address_book.testacc_services.name
-      filter_include_ip_address_set        = junos_security_address_book.testacc_services.address_set[0].name
+      filter_include_ip_address_set        = "testacc_services_set"
       invalid_authentication_entry_timeout = 60
       ip_query_disable                     = true
       ip_query_delay_time                  = 30


### PR DESCRIPTION
BUG FIXES:

* resource/`junos_security_policy`: read the config lines with `then allow tunnel pair-policy` to add them when updating the resource and thus avoid modifying the `junos_security_policy_tunnel_pair_policy` resource lines