### PR TITLE
r/system: add `netconf_ssh` block argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ENHANCEMENTS:
 
+* resource/`junos_system`: add `netconf_ssh` block argument inside `services` block argument (Fixes #335)
+
 BUG FIXES:
 
 ## 1.24.0 (January 31, 2022)

--- a/docs/resources/system.md
+++ b/docs/resources/system.md
@@ -144,6 +144,9 @@ The following arguments are supported:
   MSCHAP version 2 for password protocol used in RADIUS packets.
 - **services** (Optional, Block)  
   Declare `services` configuration.
+  - **netconf_ssh** (Optional, Block)  
+    Declare `netconf ssh` configuration.  
+    See [below for nested schema](#netconf_ssh-arguments-for-services).
   - **netconf_traceoptions** (Optional, Block)  
     Declare `netconf traceoptions` configuration.  
     See [below for nested schema](#netconf_traceoptions-arguments-for-services).
@@ -307,6 +310,19 @@ The following arguments are supported:
     Minimum total connection time if all attempts fail (20..60).
   - **tries_before_disconnect** (Optional, Number)  
     Number of times user is allowed to try password (2..10).
+
+---
+
+### netconf_ssh arguments for services
+
+- **client_alive_count_max** (Optional, Number)  
+  Threshold of missing client-alive responses that triggers a disconnect (0..255).
+- **client_alive_interval** (Optional, Number)  
+  Frequency of client-alive requests (0..65535 seconds).
+- **connection_limit** (Optional, Number)  
+  Limit number of simultaneous connections (1..250 connections).
+- **rate_limit** (Optional, Number)  
+  Limit incoming connection rate (1..250 connections per minute).
 
 ---
 

--- a/junos/resource_system_test.go
+++ b/junos/resource_system_test.go
@@ -248,8 +248,14 @@ func TestAccJunosSystem_basic(t *testing.T) {
 	}
 }
 
+// nolint: lll
 func testAccJunosSystemConfigCreate() string {
 	return `
+data junos_system_information "srx" {}
+locals {
+  netconfSSHCltAliveCountMax    = "${tonumber(replace(data.junos_system_information.srx.os_version, "/\\..*$/", "")) >= 21 ? 100 : null}"
+  netconfSSHClientAliveInterval = "${tonumber(replace(data.junos_system_information.srx.os_version, "/\\..*$/", "")) >= 21 ? 1000 : null}"
+}
 resource junos_system "testacc_system" {
   host_name = "testacc-terraform"
   archival_configuration {
@@ -355,6 +361,12 @@ resource junos_system "testacc_system" {
   radius_options_enhanced_accounting        = true
   radius_options_password_protocol_mschapv2 = true
   services {
+    netconf_ssh {
+      client_alive_count_max = local.netconfSSHCltAliveCountMax
+      client_alive_interval  = local.netconfSSHClientAliveInterval
+      connection_limit       = 200
+      rate_limit             = 200
+    }
     netconf_traceoptions {
       file_name           = "testacc_netconf"
       file_match          = "test"


### PR DESCRIPTION
ENHANCEMENTS:

* resource/`junos_system`: add `netconf_ssh` block argument inside `services` block argument (Fixes #335)