### PR TITLE
Fix #338: add plain_text_password argument to system_login_user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ENHANCEMENTS:
 
+* resource/`junos_system_login_user`: add `plain_text_password` argument inside `authentication` block argument to be able to set password in plain text format (Fixes #338)
+
 BUG FIXES:
 
 ## 1.24.1 (February 11, 2022)

--- a/docs/resources/system_login_user.md
+++ b/docs/resources/system_login_user.md
@@ -32,9 +32,20 @@ The following arguments are supported:
 - **authentication** (Optional, Block)  
   Declare `authentication` configuration.
   - **encrypted_password** (Optional, String)  
-    Encrypted password string.
+    Encrypted password string.  
+    Conflict with `plain_text_password`.  
+    If the encrypted password is present on Junos device and `plain_text_password` is used
+    in Terraform config, the value of this argument is left blank to avoid conflict.
   - **no_public_keys** (Optional, Boolean)  
     Disables ssh public key based authentication.
+  - **plain_text_password** (Optional, String, Sensitive)  
+    Plain text password (auto encrypted by Junos device)  
+    Due to encryption, when Terraform refreshes the resource, the plain text password can't be read,
+    so the provider only checks if it exists and can't detect a change of the password itself
+    outside of Terraform.  
+    To be able to detect a change of the password outside of Terraform,
+    preferably use `encrypted_password` argument.  
+    Conflict with `encrypted_password`.
   - **ssh_public_keys** (Optional, Set of String)  
     Secure shell (ssh) public key string.
 - **cli_prompt** (Optional, String)  

--- a/junos/resource_system_login_user.go
+++ b/junos/resource_system_login_user.go
@@ -292,43 +292,42 @@ func setSystemLoginUser(d *schema.ResourceData, m interface{}, jnprSess *Netconf
 
 	configSet = append(configSet, setPrefix+"class "+d.Get("class").(string))
 
-	if d.Get("uid").(int) != 0 {
-		configSet = append(configSet, setPrefix+"uid "+strconv.Itoa(d.Get("uid").(int)))
+	if v := d.Get("uid").(int); v != 0 {
+		configSet = append(configSet, setPrefix+"uid "+strconv.Itoa(v))
 	}
-	for _, v := range d.Get("authentication").([]interface{}) {
-		if v == nil {
+	for _, block := range d.Get("authentication").([]interface{}) {
+		if block == nil {
 			return fmt.Errorf("authentication block is empty")
 		}
-		authentication := v.(map[string]interface{})
-		if authentication["encrypted_password"].(string) != "" {
-			configSet = append(configSet, setPrefix+"authentication encrypted-password \""+
-				authentication["encrypted_password"].(string)+"\"")
+		authentication := block.(map[string]interface{})
+		if pass := authentication["encrypted_password"].(string); pass != "" {
+			configSet = append(configSet, setPrefix+"authentication encrypted-password \""+pass+"\"")
 		}
 		if authentication["no_public_keys"].(bool) {
 			configSet = append(configSet, setPrefix+"authentication no-public-keys")
 		}
-		for _, v2 := range sortSetOfString(authentication["ssh_public_keys"].(*schema.Set).List()) {
+		for _, key := range sortSetOfString(authentication["ssh_public_keys"].(*schema.Set).List()) {
 			switch {
-			case strings.HasPrefix(v2, ssh.KeyAlgoDSA):
-				configSet = append(configSet, setPrefix+"authentication ssh-dsa \""+v2+"\"")
-			case strings.HasPrefix(v2, ssh.KeyAlgoRSA):
-				configSet = append(configSet, setPrefix+"authentication ssh-rsa \""+v2+"\"")
-			case strings.HasPrefix(v2, ssh.KeyAlgoECDSA256),
-				strings.HasPrefix(v2, ssh.KeyAlgoECDSA384),
-				strings.HasPrefix(v2, ssh.KeyAlgoECDSA521):
-				configSet = append(configSet, setPrefix+"authentication ssh-ecdsa \""+v2+"\"")
-			case strings.HasPrefix(v2, ssh.KeyAlgoED25519):
-				configSet = append(configSet, setPrefix+"authentication ssh-ed25519 \""+v2+"\"")
+			case strings.HasPrefix(key, ssh.KeyAlgoDSA):
+				configSet = append(configSet, setPrefix+"authentication ssh-dsa \""+key+"\"")
+			case strings.HasPrefix(key, ssh.KeyAlgoRSA):
+				configSet = append(configSet, setPrefix+"authentication ssh-rsa \""+key+"\"")
+			case strings.HasPrefix(key, ssh.KeyAlgoECDSA256),
+				strings.HasPrefix(key, ssh.KeyAlgoECDSA384),
+				strings.HasPrefix(key, ssh.KeyAlgoECDSA521):
+				configSet = append(configSet, setPrefix+"authentication ssh-ecdsa \""+key+"\"")
+			case strings.HasPrefix(key, ssh.KeyAlgoED25519):
+				configSet = append(configSet, setPrefix+"authentication ssh-ed25519 \""+key+"\"")
 			default:
-				return fmt.Errorf("format in public key '%v' not supported", v2)
+				return fmt.Errorf("format in public key '%v' not supported", key)
 			}
 		}
 	}
-	if d.Get("cli_prompt").(string) != "" {
-		configSet = append(configSet, setPrefix+"cli prompt \""+d.Get("cli_prompt").(string)+"\"")
+	if v := d.Get("cli_prompt").(string); v != "" {
+		configSet = append(configSet, setPrefix+"cli prompt \""+v+"\"")
 	}
-	if d.Get("full_name").(string) != "" {
-		configSet = append(configSet, setPrefix+"full-name \""+d.Get("full_name").(string)+"\"")
+	if v := d.Get("full_name").(string); v != "" {
+		configSet = append(configSet, setPrefix+"full-name \""+v+"\"")
 	}
 
 	return sess.configSet(configSet, jnprSess)

--- a/junos/resource_system_login_user_test.go
+++ b/junos/resource_system_login_user_test.go
@@ -63,6 +63,13 @@ resource "junos_system_login_user" "testacc2" {
   name  = "test.acc2"
   class = "unauthorized"
 }
+resource "junos_system_login_user" "testacc3" {
+  name  = "test.acc3"
+  class = "unauthorized"
+  authentication {
+    plain_text_password = "test1234"
+  }
+}
 `
 }
 


### PR DESCRIPTION
ENHANCEMENTS:

* resource/`junos_system_login_user`: add `plain_text_password` argument inside `authentication` block argument to be able to set password in plain text format (Fixes #338)