### PR TITLE
Fix #341: firewall_filter: add `packet-mode` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ENHANCEMENTS:
 
+* resource/`junos_firewall_filter`: add `packet_mode` argument inside `then` argumens for `term` (Fixes #341)
+
 BUG FIXES:
 
 ## 1.24.1 (February 11, 2022)

--- a/docs/resources/firewall_filter.md
+++ b/docs/resources/firewall_filter.md
@@ -144,6 +144,8 @@ The following arguments are supported:
   Count the packet in the named counter.
 - **log** (Optional, Boolean)  
   Log the packet.
+- **packet_mode** (Optional, Boolean)  
+  Bypass flow mode for the packet.
 - **policer** (Optional, String)  
   Name of policer to use to rate-limit traffic.
 - **port_mirror** (Optional, Boolean)  

--- a/junos/resource_firewall_filter.go
+++ b/junos/resource_firewall_filter.go
@@ -234,6 +234,10 @@ func resourceFirewallFilter() *schema.Resource {
 										Type:     schema.TypeBool,
 										Optional: true,
 									},
+									"packet_mode": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
 									"policer": {
 										Type:             schema.TypeString,
 										Optional:         true,
@@ -751,6 +755,9 @@ func setFirewallFilterOptsThen(setPrefixTermThen string, configSet []string, the
 	if thenMap["log"].(bool) {
 		configSet = append(configSet, setPrefixTermThen+"log")
 	}
+	if thenMap["packet_mode"].(bool) {
+		configSet = append(configSet, setPrefixTermThen+"packet-mode")
+	}
 	if thenMap["policer"].(string) != "" {
 		configSet = append(configSet, setPrefixTermThen+"policer "+thenMap["policer"].(string))
 	}
@@ -884,6 +891,8 @@ func readFirewallFilterOptsThen(item string, thenMap map[string]interface{}) {
 		thenMap["count"] = strings.TrimPrefix(item, "count ")
 	case item == "log":
 		thenMap["log"] = true
+	case item == "packet-mode":
+		thenMap["packet_mode"] = true
 	case strings.HasPrefix(item, "policer "):
 		thenMap["policer"] = strings.TrimPrefix(item, "policer ")
 	case item == "port-mirror":
@@ -939,6 +948,7 @@ func genMapFirewallFilterOptsThen() map[string]interface{} {
 		"action":             "",
 		"count":              "",
 		"log":                false,
+		"packet_mode":        false,
 		"policer":            "",
 		"port_mirror":        false,
 		"routing_instance":   "",

--- a/junos/resource_firewall_filter_test.go
+++ b/junos/resource_firewall_filter_test.go
@@ -189,6 +189,7 @@ resource junos_firewall_filter "testacc_fwFilter" {
       action             = "next term"
       syslog             = true
       log                = true
+      packet_mode        = true
       port_mirror        = true
       service_accounting = true
     }


### PR DESCRIPTION
ENHANCEMENTS:

* resource/`junos_firewall_filter`: add `packet_mode` argument inside `then` argumens for `term` (Fixes #341)

