### PR TITLE
Fix #350: Attach interfaces to the security zone

### DIFF
--- a/docs/resources/security_zone.md
+++ b/docs/resources/security_zone.md
@@ -26,6 +26,8 @@ The following arguments are supported:
 
 - **name** (Required, String, Forces new resource)  
   The name of security zone.
+- **interfaces** (Optional, Set of String)  
+  List of interfaces in the zone.
 - **address_book** (Optional, Block Set)  
   For each name of address to declare.
   - **name** (Required, String)  

--- a/junos/resource_security_zone.go
+++ b/junos/resource_security_zone.go
@@ -46,6 +46,11 @@ func resourceSecurityZone() *schema.Resource {
 				Required:         true,
 				ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatDefault),
 			},
+			"interfaces": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 			"address_book": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -549,6 +554,9 @@ func setSecurityZone(d *schema.ResourceData, m interface{}, jnprSess *NetconfObj
 					addressBookSet["name"].(string)+" description \""+v2+"\"")
 			}
 		}
+	}
+	for _, v := range d.Get("interfaces").([]interface{}) {
+		configSet = append(configSet, setPrefix+" interfaces "+v.(string))
 	}
 	if d.Get("advance_policy_based_routing_profile").(string) != "" {
 		configSet = append(configSet, setPrefix+" advance-policy-based-routing-profile \""+

--- a/junos/resource_security_zone_test.go
+++ b/junos/resource_security_zone_test.go
@@ -36,6 +36,8 @@ func TestAccJunosSecurityZone_basic(t *testing.T) {
 							"address_book_set.0.address.*", "testacc_zone1"),
 						resource.TestCheckResourceAttr("junos_security_zone.testacc_securityZone",
 							"application_tracking", "true"),
+						resource.TestCheckResourceAttr("junos_security_zone.testacc_securityZone",
+							"interfaces.*", "ge-0/0/0.0"),
 						resource.TestCheckTypeSetElemAttr("junos_security_zone.testacc_securityZone",
 							"inbound_protocols.*", "bgp"),
 						resource.TestCheckResourceAttr("junos_security_zone.testacc_securityZone",
@@ -139,6 +141,7 @@ resource junos_security_zone "testacc_securityZone" {
     description = "testacc_zone 4"
     network     = "192.0.2.0/255.0.255.255"
   }
+	interfaces           = ["ge-0/0/0.0"]
   application_tracking = true
   inbound_protocols    = ["bgp"]
   description          = "testacc securityZone"


### PR DESCRIPTION
ENHANCEMENTS:
* resource/`junos_security_zone`: add `interfaces` argument to be able to assign interfaces to a security zone (Fixes https://github.com/jeremmfr/terraform-provider-junos/issues/350)