### PR TITLE
Fix read evpn, ospf protocols empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ ENHANCEMENTS:
 BUG FIXES:
 
 * resource/`junos_evpn`: generate an error when import and delete the state of resource when there isn't evpn config on the device
+* resource/`junos_ospf`: fix read config from the device with an empty resource
 
 ## 1.24.1 (February 11, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ ENHANCEMENTS:
 
 BUG FIXES:
 
+* resource/`junos_evpn`: generate an error when import and delete the state of resource when there isn't evpn config on the device
+
 ## 1.24.1 (February 11, 2022)
 
 BUG FIXES:

--- a/junos/resource_evpn.go
+++ b/junos/resource_evpn.go
@@ -191,7 +191,11 @@ func resourceEvpnReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	fillEvpnData(d, evpnOptions)
+	if evpnOptions.routingInstance == "" {
+		d.SetId("")
+	} else {
+		fillEvpnData(d, evpnOptions)
+	}
 
 	return nil
 }
@@ -286,12 +290,16 @@ func resourceEvpnImport(d *schema.ResourceData, m interface{}) ([]*schema.Resour
 			return nil, err
 		}
 		if !instanceExists {
-			return nil, fmt.Errorf("routing instance %v doesn't exist", d.Get("routing_instance").(string))
+			return nil, fmt.Errorf("routing instance %v doesn't exist", idList[0])
 		}
 	}
 	evpnOptions, err := readEvpn(idList[0], m, jnprSess)
 	if err != nil {
 		return nil, err
+	}
+	if evpnOptions.routingInstance == "" {
+		return nil, fmt.Errorf("don't find protocols evpn with id '%v' "+
+			"(id must be <routing_instance>)", d.Id())
 	}
 	fillEvpnData(d, evpnOptions)
 	if len(idList) > 1 || idList[0] == defaultWord {

--- a/junos/resource_ospf.go
+++ b/junos/resource_ospf.go
@@ -457,7 +457,7 @@ func resourceOspfImport(d *schema.ResourceData, m interface{}) ([]*schema.Resour
 			return nil, err
 		}
 		if !instanceExists {
-			return nil, fmt.Errorf("routing instance %v doesn't exist", d.Get("routing_instance").(string))
+			return nil, fmt.Errorf("routing instance %v doesn't exist", idSplit[1])
 		}
 	}
 	ospfOptions, err := readOspf(idSplit[0], idSplit[1], m, jnprSess)
@@ -652,9 +652,9 @@ func readOspf(version, routingInstance string,
 		}
 	}
 
+	confRead.version = version
+	confRead.routingInstance = routingInstance
 	if showConfig != emptyWord {
-		confRead.version = version
-		confRead.routingInstance = routingInstance
 		for _, item := range strings.Split(showConfig, "\n") {
 			if strings.Contains(item, "<configuration-output>") {
 				continue


### PR DESCRIPTION
BUG FIXES:

* resource/`junos_evpn`: generate an error when import and delete the state of resource when there isn't evpn config on the device
* resource/`junos_ospf`: fix read config from the device with an empty resource

