### PR TITLE
r/system_syslog_file: fix reading start_time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ ENHANCEMENTS:
 
 BUG FIXES:
 
+* resource/`junos_system_syslog_file`: fix reading `start_time` in `archive` block argument to remove timezone in value
+
 ## 1.24.1 (February 11, 2022)
 
 BUG FIXES:

--- a/junos/resource_system_syslog_file.go
+++ b/junos/resource_system_syslog_file.go
@@ -670,7 +670,8 @@ func readSystemSyslogFile(filename string, m interface{}, jnprSess *NetconfObjec
 						return confRead, fmt.Errorf("failed to convert value from '%s' to integer : %w", itemTrim, err)
 					}
 				case strings.HasPrefix(itemTrim, "archive start-time "):
-					confRead.archive[0]["start_time"] = strings.TrimPrefix(itemTrim, "archive start-time ")
+					confRead.archive[0]["start_time"] = strings.Split(strings.Trim(strings.TrimPrefix(
+						itemTrim, "archive start-time "), "\""), " ")[0]
 				case strings.HasPrefix(itemTrim, "archive archive-sites "):
 					itemTrimArchSitesSplit := strings.Split(
 						strings.TrimPrefix(itemTrim, "archive archive-sites "), " ")


### PR DESCRIPTION
BUG FIXES:

* resource/`junos_system_syslog_file`: fix reading `start_time` in `archive` block argument to remove timezone in value