### PR TITLE
Upgrade Golang to v1.18 and linter to v1.45

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,25 +1,6 @@
 name: Go Tests
 on: [push, pull_request]
 jobs:
-  build-1_16:
-    name: Build 1.16
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Go 1.16
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.16
-        id: go
-      - name: Disable cgo
-        run: |
-          echo "CGO_ENABLED=0" >> $GITHUB_ENV
-      - name: Show version
-        run: go version
-      - name: Check out code
-        uses: actions/checkout@v3
-      - name: Build
-        run: go build -v .
-
   build-1_17:
     name: Build 1.17
     runs-on: ubuntu-latest
@@ -39,14 +20,33 @@ jobs:
       - name: Build
         run: go build -v .
 
+  build-1_18:
+    name: Build 1.18
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.18
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+        id: go
+      - name: Disable cgo
+        run: |
+          echo "CGO_ENABLED=0" >> $GITHUB_ENV
+      - name: Show version
+        run: go version
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Build
+        run: go build -v .
+
   test:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.17
+      - name: Set up Go 1.18
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
         id: go
       - name: Disable cgo
         run: |

--- a/.github/workflows/linters-main.yml
+++ b/.github/workflows/linters-main.yml
@@ -8,10 +8,10 @@ jobs:
     name: golangci-lint-latest
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.17
+      - name: Set up Go 1.18
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
         id: go
       - name: Disable cgo
         run: |

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: katbyte/terrafmt
-          ref: v0.3.0
+          ref: v0.4.0
           path: terrafmt
       - name: Build terrafmt bin
         run: cd terrafmt && go install ./... && cd ${GITHUB_WORKSPACE}

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -5,10 +5,10 @@ jobs:
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.17
+      - name: Set up Go 1.18
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
         id: go
       - name: Disable cgo
         run: |
@@ -37,10 +37,10 @@ jobs:
     name: terrafmt
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.17
+      - name: Set up Go 1.18
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
         id: go
       - name: Show version
         run: go version

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -18,7 +18,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.1.0
         with:
-          version: v1.44
+          version: v1.45
           args: -c .golangci.yml -v
 
   markdown-lint:

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -40,10 +40,10 @@ jobs:
           - goos: windows
             goarch: arm64
     steps:
-      - name: Set up Go 1.17
+      - name: Set up Go 1.18
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
         id: go
       - name: Show version
         run: go version

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,6 +33,9 @@ linters-settings:
   gocyclo:
     # minimal code complexity to report, 30 by default
     min-complexity: 90
+  gofumpt:
+    # Choose whether to use the extra rules.
+    extra-rules: true
   govet:
     enable-all: true
     disable:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ENHANCEMENTS:
 
+* release now with golang 1.18
+
 BUG FIXES:
 
 ## 1.25.0 (March 18, 2022)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ for provider and resources documentation.
 
 ### In addition to develop
 
-- [Go](https://golang.org/doc/install) 1.16
+- [Go](https://golang.org/doc/install) 1.17
 
 ## Automatic install (Terraform 0.13 and later)
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jeremmfr/terraform-provider-junos
 
-go 1.16
+go 1.17
 
 require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
@@ -9,6 +9,52 @@ require (
 	github.com/jeremmfr/go-utils v0.4.1
 	github.com/jeremmfr/junosdecode v1.1.0
 	golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd
+)
+
+require (
+	github.com/agext/levenshtein v1.2.2 // indirect
+	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/fatih/color v1.7.0 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/go-cmp v0.5.7 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-hclog v1.2.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/hashicorp/go-plugin v1.4.3 // indirect
+	github.com/hashicorp/go-uuid v1.0.2 // indirect
+	github.com/hashicorp/go-version v1.4.0 // indirect
+	github.com/hashicorp/hc-install v0.3.1 // indirect
+	github.com/hashicorp/hcl/v2 v2.11.1 // indirect
+	github.com/hashicorp/logutils v1.0.0 // indirect
+	github.com/hashicorp/terraform-exec v0.16.0 // indirect
+	github.com/hashicorp/terraform-json v0.13.0 // indirect
+	github.com/hashicorp/terraform-plugin-go v0.8.0 // indirect
+	github.com/hashicorp/terraform-plugin-log v0.3.0 // indirect
+	github.com/hashicorp/terraform-registry-address v0.0.0-20210412075316-9b2996cce896 // indirect
+	github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 // indirect
+	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
+	github.com/mattn/go-colorable v0.1.4 // indirect
+	github.com/mattn/go-isatty v0.0.10 // indirect
+	github.com/mitchellh/copystructure v1.2.0 // indirect
+	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
+	github.com/mitchellh/mapstructure v1.4.3 // indirect
+	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/oklog/run v1.0.0 // indirect
+	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
+	github.com/vmihailenco/msgpack/v4 v4.3.12 // indirect
+	github.com/vmihailenco/tagparser v0.1.1 // indirect
+	github.com/zclconf/go-cty v1.10.0 // indirect
+	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 // indirect
+	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 // indirect
+	golang.org/x/text v0.3.6 // indirect
+	google.golang.org/appengine v1.6.6 // indirect
+	google.golang.org/genproto v0.0.0-20200711021454-869866162049 // indirect
+	google.golang.org/grpc v1.45.0 // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
 )
 
 replace github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/jeremmfr/terraform-plugin-sdk/v2 v2.11.1-0.20220316083425-f711567b3c5d

--- a/junos/data_source_interface.go
+++ b/junos/data_source_interface.go
@@ -385,8 +385,7 @@ func dataSourceInterfaceRead(ctx context.Context, d *schema.ResourceData, m inte
 	return nil
 }
 
-func searchInterfaceID(configInterface string, match string,
-	m interface{}, jnprSess *NetconfObject) (string, error) {
+func searchInterfaceID(configInterface, match string, m interface{}, jnprSess *NetconfObject) (string, error) {
 	sess := m.(*Session)
 	intConfigList := make([]string, 0)
 	showConfig, err := sess.command(cmdShowConfig+"interfaces "+configInterface+pipeDisplaySet, jnprSess)

--- a/junos/data_source_interface_logical.go
+++ b/junos/data_source_interface_logical.go
@@ -549,8 +549,8 @@ func dataSourceInterfaceLogicalRead(ctx context.Context, d *schema.ResourceData,
 	return nil
 }
 
-func searchInterfaceLogicalID(configInterface string, match string,
-	m interface{}, jnprSess *NetconfObject) (string, error) {
+func searchInterfaceLogicalID(configInterface, match string, m interface{}, jnprSess *NetconfObject,
+) (string, error) {
 	sess := m.(*Session)
 	intConfigList := make([]string, 0)
 	showConfig, err := sess.command(cmdShowConfig+"interfaces "+configInterface+pipeDisplaySet, jnprSess)

--- a/junos/data_source_interface_logical_test.go
+++ b/junos/data_source_interface_logical_test.go
@@ -1,6 +1,7 @@
 package junos_test
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -45,9 +46,9 @@ func TestAccDataSourceInterfaceLogical_basic(t *testing.T) {
 }
 
 func testAccDataSourceInterfaceLogicalConfigCreate(interFace string) string {
-	return `
+	return fmt.Sprintf(`
 resource junos_interface_physical testacc_datainterfaceP {
-  name         = "` + interFace + `"
+  name         = "%s"
   description  = "testacc_datainterfaceP"
   vlan_tagging = true
 }
@@ -65,13 +66,13 @@ resource junos_interface_logical testacc_datainterfaceL {
     }
   }
 }
-`
+`, interFace)
 }
 
 func testAccDataSourceInterfaceLogicalConfigData(interFace string) string {
-	return `
+	return fmt.Sprintf(`
 resource junos_interface_physical testacc_datainterfaceP {
-  name         = "` + interFace + `"
+  name         = "%s"
   description  = "testacc_datainterfaceP"
   vlan_tagging = true
 }
@@ -86,12 +87,12 @@ resource junos_interface_logical testacc_datainterfaceL {
 }
 
 data junos_interface_logical testacc_datainterfaceL {
-  config_interface = "` + interFace + `"
+  config_interface = "%s"
   match            = "192.0.2.1/"
 }
 
 data junos_interface_logical testacc_datainterfaceL2 {
   match = "192.0.2.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)"
 }
-`
+`, interFace, interFace)
 }

--- a/junos/data_source_interface_physical.go
+++ b/junos/data_source_interface_physical.go
@@ -370,8 +370,7 @@ func dataSourceInterfacePhysicalRead(ctx context.Context, d *schema.ResourceData
 	return nil
 }
 
-func searchInterfacePhysicalID(configInterface string, match string,
-	m interface{}, jnprSess *NetconfObject) (string, error) {
+func searchInterfacePhysicalID(configInterface, match string, m interface{}, jnprSess *NetconfObject) (string, error) {
 	sess := m.(*Session)
 	intConfigList := make([]string, 0)
 	showConfig, err := sess.command(cmdShowConfig+"interfaces "+configInterface+pipeDisplaySet, jnprSess)

--- a/junos/data_source_interface_physical_test.go
+++ b/junos/data_source_interface_physical_test.go
@@ -1,6 +1,7 @@
 package junos_test
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -37,25 +38,25 @@ func TestAccDataSourceInterfacePhysical_basic(t *testing.T) {
 }
 
 func testAccDataSourceInterfacePhysicalConfigCreate(interFace string) string {
-	return `
+	return fmt.Sprintf(`
 resource junos_interface_physical testacc_datainterfaceP {
-  name         = "` + interFace + `"
+  name         = "%s"
   description  = "testacc_datainterfaceP"
   vlan_tagging = true
 }
-`
+`, interFace)
 }
 
 func testAccDataSourceInterfacePhysicalConfigData(interFace string) string {
-	return `
+	return fmt.Sprintf(`
 resource junos_interface_physical testacc_datainterfaceP {
-  name         = "` + interFace + `"
+  name         = "%s"
   description  = "testacc_datainterfaceP"
   vlan_tagging = true
 }
 
 data junos_interface_physical testacc_datainterfaceP {
-  config_interface = "` + interFace + `"
+  config_interface = "%s"
 }
-`
+`, interFace, interFace)
 }

--- a/junos/data_source_interface_test.go
+++ b/junos/data_source_interface_test.go
@@ -1,6 +1,7 @@
 package junos_test
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -45,9 +46,9 @@ func TestAccDataSourceInterface_basic(t *testing.T) {
 }
 
 func testAccDataSourceInterfaceConfigCreate(interFace string) string {
-	return `
+	return fmt.Sprintf(`
 resource junos_interface testacc_datainterfaceP {
-  name         = "` + interFace + `"
+  name         = "%s"
   description  = "testacc_datainterfaceP"
   vlan_tagging = true
 }
@@ -58,13 +59,13 @@ resource junos_interface testacc_datainterface {
     address = "192.0.2.1/25"
   }
 }
-`
+`, interFace)
 }
 
 func testAccDataSourceInterfaceConfigData(interFace string) string {
-	return `
+	return fmt.Sprintf(`
 resource junos_interface testacc_datainterfaceP {
-  name         = "` + interFace + `"
+  name         = "%s"
   description  = "testacc_datainterfaceP"
   vlan_tagging = true
 }
@@ -77,12 +78,12 @@ resource junos_interface testacc_datainterface {
 }
 
 data junos_interface testacc_datainterface {
-  config_interface = "` + interFace + `"
+  config_interface = "%s"
   match            = "192.0.2.1/"
 }
 
 data junos_interface testacc_datainterface2 {
   match = "192.0.2.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)"
 }
-`
+`, interFace, interFace)
 }

--- a/junos/data_source_interfaces_physical_present.go
+++ b/junos/data_source_interfaces_physical_present.go
@@ -70,8 +70,8 @@ func dataSourceInterfacesPhysicalPresent() *schema.Resource {
 	}
 }
 
-func dataSourceInterfacesPhysicalPresentRead(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func dataSourceInterfacesPhysicalPresentRead(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -102,8 +102,8 @@ func dataSourceInterfacesPhysicalPresentRead(ctx context.Context,
 	return nil
 }
 
-func searchInterfacesPhysicalPresent(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) (interfacesPresentOpts, error) {
+func searchInterfacesPhysicalPresent(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) (interfacesPresentOpts, error) {
 	sess := m.(*Session)
 	var result interfacesPresentOpts
 	replyData, err := sess.commandXML(rpcGetInterfaceInformationTerse, jnprSess)

--- a/junos/data_source_interfaces_physical_present_test.go
+++ b/junos/data_source_interfaces_physical_present_test.go
@@ -1,6 +1,7 @@
 package junos_test
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -135,61 +136,61 @@ func TestAccDataSourceInterfacesPhysicalPresent_basic(t *testing.T) {
 }
 
 func testAccDataSourceInterfacesPhysicalPresentPreSwitch(interFace string) string {
-	return `
+	return fmt.Sprintf(`
 resource junos_interface_physical testacc_dataIfacesPhysPresent {
-  name        = "` + interFace + `"
+  name        = "%s"
   description = "testacc_dataIfacesPhysPresent"
 }
 resource junos_interface_logical testacc_dataIfacesPhysPresent {
   name        = "${junos_interface_physical.testacc_dataIfacesPhysPresent.name}.0"
   description = "testacc_dataIfacesPhysPresent"
 }
-`
+`, interFace)
 }
 
 func testAccDataSourceInterfacesPhysicalPresentConfig(interFace string) string {
-	return `
+	return fmt.Sprintf(`
 resource junos_interface_physical testacc_dataIfacesPhysPresent {
-  name        = "` + interFace + `"
+  name        = "%s"
   description = "testacc_dataIfacesPhysPresent"
 }
 data junos_interfaces_physical_present testacc_dataIfacesPhysPresent {
 }
-`
+`, interFace)
 }
 
 func testAccDataSourceInterfacesPhysicalPresentConfigMatch(interFace string) string {
-	return `
+	return fmt.Sprintf(`
 resource junos_interface_physical testacc_dataIfacesPhysPresent {
-  name        = "` + interFace + `"
+  name        = "%s"
   description = "testacc_dataIfacesPhysPresent"
 }
 data junos_interfaces_physical_present testacc_dataIfacesPhysPresentEth {
-  match_name = "^` + strings.Split(interFace, `-`)[0] + `-.*$"
+  match_name = "^%s-.*$"
 }
 data junos_interfaces_physical_present testacc_dataIfacesPhysPresentEth003 {
-  match_name = "^` + interFace + `$"
+  match_name = "^%s$"
 }
 data junos_interfaces_physical_present testacc_dataIfacesPhysPresentEth003AdmUp {
-  match_name     = "^` + interFace + `$"
+  match_name     = "^%s$"
   match_admin_up = true
 }
 data junos_interfaces_physical_present testacc_dataIfacesPhysPresentEth003OperUp {
-  match_name    = "^` + interFace + `$"
+  match_name    = "^%s$"
   match_oper_up = true
 }
 data junos_interfaces_physical_present testacc_dataIfacesPhysPresentLo0 {
   match_name    = "^lo0$"
   match_oper_up = true
 }
-`
+`, interFace, strings.Split(interFace, `-`)[0], interFace, interFace, interFace)
 }
 
 func testAccDataSourceInterfacesPhysicalPresentConfigMatch2(interFace string) string {
-	return `
+	return fmt.Sprintf(`
 data junos_interfaces_physical_present testacc_dataIfacesPhysPresentEth003AdmUp {
-  match_name     = "^` + interFace + `$"
+  match_name     = "^%s$"
   match_admin_up = true
 }
-`
+`, interFace)
 }

--- a/junos/data_source_routing_instance_test.go
+++ b/junos/data_source_routing_instance_test.go
@@ -1,6 +1,7 @@
 package junos_test
 
 import (
+	"fmt"
 	"os"
 	"regexp"
 	"testing"
@@ -44,9 +45,9 @@ func TestAccDataSourceRoutingInstance_basic(t *testing.T) {
 }
 
 func testAccDataSourceRoutingInstanceConfigCreate(interFace string) string {
-	return `
+	return fmt.Sprintf(`
 resource junos_interface_physical testacc_dataRoutingInstance {
-  name         = "` + interFace + `"
+  name         = "%s"
   description  = "testacc_dataRoutingInstance"
   vlan_tagging = true
 }
@@ -58,13 +59,13 @@ resource junos_interface_logical testacc_dataRoutingInstance {
   description      = "testacc_dataRoutingInstance"
   routing_instance = junos_routing_instance.testacc_dataRoutingInstance.name
 }
-`
+`, interFace)
 }
 
 func testAccDataSourceRoutingInstanceConfigData(interFace string) string {
-	return `
+	return fmt.Sprintf(`
 resource junos_interface_physical testacc_dataRoutingInstance {
-  name         = "` + interFace + `"
+  name         = "%s"
   description  = "testacc_dataRoutingInstance"
   vlan_tagging = true
 }
@@ -80,7 +81,7 @@ resource junos_interface_logical testacc_dataRoutingInstance {
 data junos_routing_instance testacc_dataRoutingInstance {
   name = "testacc_dataRoutingInstance"
 }
-`
+`, interFace)
 }
 
 func testAccDataSourceRoutingInstanceConfigDataFailed() string {

--- a/junos/data_source_security_zone_test.go
+++ b/junos/data_source_security_zone_test.go
@@ -1,6 +1,7 @@
 package junos_test
 
 import (
+	"fmt"
 	"os"
 	"regexp"
 	"testing"
@@ -46,9 +47,9 @@ func TestAccDataSourceSecurityZone_basic(t *testing.T) {
 }
 
 func testAccDataSourceSecurityZoneConfigCreate(interFace string) string {
-	return `
+	return fmt.Sprintf(`
 resource junos_interface_physical testacc_dataSecurityZone {
-  name         = "` + interFace + `"
+  name         = "%s"
   description  = "testacc_dataSecurityZone"
   vlan_tagging = true
 }
@@ -67,13 +68,13 @@ resource junos_interface_logical testacc_dataSecurityZone {
   security_zone             = junos_security_zone.testacc_dataSecurityZone.name
   security_inbound_services = ["ssh"]
 }
-`
+`, interFace)
 }
 
 func testAccDataSourceSecurityZoneConfigData(interFace string) string {
-	return `
+	return fmt.Sprintf(`
 resource junos_interface_physical testacc_dataSecurityZone {
-  name         = "` + interFace + `"
+  name         = "%s"
   description  = "testacc_dataSecurityZone"
   vlan_tagging = true
 }
@@ -96,7 +97,7 @@ resource junos_interface_logical testacc_dataSecurityZone {
 data junos_security_zone testacc_dataSecurityZone {
   name = "testacc_dataSecurityZone"
 }
-`
+`, interFace)
 }
 
 func testAccDataSourceSecurityZoneConfigDataFailed() string {

--- a/junos/data_source_system_information_test.go
+++ b/junos/data_source_system_information_test.go
@@ -28,5 +28,5 @@ func TestAccDataSourceSystemInformation_basic(t *testing.T) {
 func testAccSystemInformationConfig() string {
 	return `
 data "junos_system_information" "test" {}
-	`
+`
 }

--- a/junos/func_common.go
+++ b/junos/func_common.go
@@ -258,8 +258,9 @@ func sortSetOfString(list []interface{}) []string {
 	return s
 }
 
-func copyAndRemoveItemMapList(identifier string,
-	m map[string]interface{}, list []map[string]interface{}) []map[string]interface{} {
+func copyAndRemoveItemMapList(
+	identifier string, m map[string]interface{}, list []map[string]interface{},
+) []map[string]interface{} {
 	if m[identifier] == nil {
 		panic(fmt.Errorf("internal error: can't find identifier %s in map", identifier))
 	}
@@ -277,8 +278,9 @@ func copyAndRemoveItemMapList(identifier string,
 	return list
 }
 
-func copyAndRemoveItemMapList2(identifier, identifier2 string,
-	m map[string]interface{}, list []map[string]interface{}) []map[string]interface{} {
+func copyAndRemoveItemMapList2(
+	identifier, identifier2 string, m map[string]interface{}, list []map[string]interface{},
+) []map[string]interface{} {
 	if m[identifier] == nil {
 		panic(fmt.Errorf("internal error: can't find identifier %s in map", identifier))
 	}

--- a/junos/func_resource_bgp.go
+++ b/junos/func_resource_bgp.go
@@ -422,8 +422,8 @@ func readBgpOptsSimple(item string, confRead *bgpOptions) error {
 	return nil
 }
 
-func setBgpOptsBfd(setPrefix string, bfdLivenessDetection []interface{},
-	m interface{}, jnprSess *NetconfObject) error {
+func setBgpOptsBfd(setPrefix string, bfdLivenessDetection []interface{}, m interface{}, jnprSess *NetconfObject,
+) error {
 	sess := m.(*Session)
 	configSet := make([]string, 0)
 
@@ -548,8 +548,9 @@ func readBgpOptsBfd(item string, bfdRead map[string]interface{}) error {
 	return nil
 }
 
-func setBgpOptsFamily(setPrefix, familyType string, familyOptsList []interface{},
-	m interface{}, jnprSess *NetconfObject) error {
+func setBgpOptsFamily(
+	setPrefix, familyType string, familyOptsList []interface{}, m interface{}, jnprSess *NetconfObject,
+) error {
 	sess := m.(*Session)
 	configSet := make([]string, 0)
 	setPrefixFamily := setPrefix + "family "
@@ -725,8 +726,8 @@ func readBgpOptsFamily(item, familyType string, opts []map[string]interface{}) (
 	return append(opts, readOpts), nil
 }
 
-func setBgpOptsGrafefulRestart(setPrefix string, gracefulRestarts []interface{},
-	m interface{}, jnprSess *NetconfObject) error {
+func setBgpOptsGrafefulRestart(setPrefix string, gracefulRestarts []interface{}, m interface{}, jnprSess *NetconfObject,
+) error {
 	sess := m.(*Session)
 	configSet := make([]string, 0)
 

--- a/junos/resource_access_address_assignment_pool.go
+++ b/junos/resource_access_address_assignment_pool.go
@@ -449,8 +449,8 @@ func resourceAccessAddressAssignPool() *schema.Resource {
 	}
 }
 
-func resourceAccessAddressAssignPoolCreate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceAccessAddressAssignPoolCreate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeCreateSetFile != "" {
 		if err := setAccessAddressAssignPool(d, m, nil); err != nil {
@@ -534,8 +534,8 @@ func resourceAccessAddressAssignPoolRead(ctx context.Context, d *schema.Resource
 	return resourceAccessAddressAssignPoolReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceAccessAddressAssignPoolReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceAccessAddressAssignPoolReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	accessAddressAssignPoolOptions, err := readAccessAddressAssignPool(
 		d.Get("name").(string), d.Get("routing_instance").(string), m, jnprSess)
@@ -552,8 +552,8 @@ func resourceAccessAddressAssignPoolReadWJnprSess(
 	return nil
 }
 
-func resourceAccessAddressAssignPoolUpdate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceAccessAddressAssignPoolUpdate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	d.Partial(true)
 	sess := m.(*Session)
 	if sess.junosFakeUpdateAlso {
@@ -598,8 +598,8 @@ func resourceAccessAddressAssignPoolUpdate(ctx context.Context,
 	return append(diagWarns, resourceAccessAddressAssignPoolReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceAccessAddressAssignPoolDelete(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceAccessAddressAssignPoolDelete(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeDeleteAlso {
 		if err := delAccessAddressAssignPool(
@@ -664,8 +664,7 @@ func resourceAccessAddressAssignPoolImport(d *schema.ResourceData, m interface{}
 	return result, nil
 }
 
-func checkAccessAddressAssignPoolExists(name string, instance string, m interface{},
-	jnprSess *NetconfObject) (bool, error) {
+func checkAccessAddressAssignPoolExists(name, instance string, m interface{}, jnprSess *NetconfObject) (bool, error) {
 	sess := m.(*Session)
 	var showConfig string
 	var err error
@@ -870,8 +869,8 @@ func setAccessAddressAssignPoolFamily(family map[string]interface{}, setPrefix s
 	return configSet, nil
 }
 
-func setAccessAddressAssignPoolFamilyDhcpAttributes(
-	dhcpAttr map[string]interface{}, familyType, setPrefix string) ([]string, error) {
+func setAccessAddressAssignPoolFamilyDhcpAttributes(dhcpAttr map[string]interface{}, familyType, setPrefix string,
+) ([]string, error) {
 	configSet := make([]string, 0)
 
 	if v := dhcpAttr["boot_file"].(string); v != "" {
@@ -1044,8 +1043,8 @@ func setAccessAddressAssignPoolFamilyDhcpAttributes(
 	return configSet, nil
 }
 
-func readAccessAddressAssignPool(name string, instance string, m interface{},
-	jnprSess *NetconfObject) (accessAddressAssignPoolOptions, error) {
+func readAccessAddressAssignPool(name, instance string, m interface{}, jnprSess *NetconfObject,
+) (accessAddressAssignPoolOptions, error) {
 	sess := m.(*Session)
 	var confRead accessAddressAssignPoolOptions
 	var showConfig string
@@ -1342,7 +1341,7 @@ func readAccessAddressAssignPoolFamily(itemTrim string, family map[string]interf
 	return nil
 }
 
-func delAccessAddressAssignPool(name string, instance string, m interface{}, jnprSess *NetconfObject) error {
+func delAccessAddressAssignPool(name, instance string, m interface{}, jnprSess *NetconfObject) error {
 	sess := m.(*Session)
 	configSet := make([]string, 0, 1)
 	if instance == defaultW {
@@ -1355,7 +1354,8 @@ func delAccessAddressAssignPool(name string, instance string, m interface{}, jnp
 }
 
 func fillAccessAddressAssignPoolData(
-	d *schema.ResourceData, accessAddressAssignPoolOptions accessAddressAssignPoolOptions) {
+	d *schema.ResourceData, accessAddressAssignPoolOptions accessAddressAssignPoolOptions,
+) {
 	if tfErr := d.Set("name", accessAddressAssignPoolOptions.name); tfErr != nil {
 		panic(tfErr)
 	}

--- a/junos/resource_aggregate_route.go
+++ b/junos/resource_aggregate_route.go
@@ -206,8 +206,8 @@ func resourceAggregateRouteRead(ctx context.Context, d *schema.ResourceData, m i
 	return resourceAggregateRouteReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceAggregateRouteReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceAggregateRouteReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	aggregateRouteOptions, err := readAggregateRoute(d.Get("destination").(string), d.Get("routing_instance").(string),
 		m, jnprSess)
@@ -334,8 +334,7 @@ func resourceAggregateRouteImport(d *schema.ResourceData, m interface{}) ([]*sch
 	return result, nil
 }
 
-func checkAggregateRouteExists(destination string, instance string, m interface{},
-	jnprSess *NetconfObject) (bool, error) {
+func checkAggregateRouteExists(destination, instance string, m interface{}, jnprSess *NetconfObject) (bool, error) {
 	sess := m.(*Session)
 	var showConfig string
 	var err error
@@ -444,8 +443,8 @@ func setAggregateRoute(d *schema.ResourceData, m interface{}, jnprSess *NetconfO
 	return sess.configSet(configSet, jnprSess)
 }
 
-func readAggregateRoute(destination string, instance string, m interface{},
-	jnprSess *NetconfObject) (aggregateRouteOptions, error) {
+func readAggregateRoute(destination, instance string, m interface{}, jnprSess *NetconfObject,
+) (aggregateRouteOptions, error) {
 	sess := m.(*Session)
 	var confRead aggregateRouteOptions
 	var showConfig string
@@ -525,7 +524,7 @@ func readAggregateRoute(destination string, instance string, m interface{},
 	return confRead, nil
 }
 
-func delAggregateRoute(destination string, instance string, m interface{}, jnprSess *NetconfObject) error {
+func delAggregateRoute(destination, instance string, m interface{}, jnprSess *NetconfObject) error {
 	sess := m.(*Session)
 	configSet := make([]string, 0, 1)
 	if instance == defaultW {

--- a/junos/resource_application_set.go
+++ b/junos/resource_application_set.go
@@ -105,8 +105,8 @@ func resourceApplicationSetRead(ctx context.Context, d *schema.ResourceData, m i
 	return resourceApplicationSetReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceApplicationSetReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceApplicationSetReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	applicationSetOptions, err := readApplicationSet(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()

--- a/junos/resource_bridge_domain.go
+++ b/junos/resource_bridge_domain.go
@@ -236,8 +236,8 @@ func resourceBridgeDomainRead(ctx context.Context, d *schema.ResourceData, m int
 	return resourceBridgeDomainReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceBridgeDomainReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceBridgeDomainReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	bridgeDomainOptions, err := readBridgeDomain(d.Get("name").(string), d.Get("routing_instance").(string),
 		m, jnprSess)
@@ -378,8 +378,7 @@ func resourceBridgeDomainImport(d *schema.ResourceData, m interface{}) ([]*schem
 	return result, nil
 }
 
-func checkBridgeDomainExists(name string, instance string, m interface{},
-	jnprSess *NetconfObject) (bool, error) {
+func checkBridgeDomainExists(name, instance string, m interface{}, jnprSess *NetconfObject) (bool, error) {
 	sess := m.(*Session)
 	var showConfig string
 	var err error
@@ -477,8 +476,7 @@ func setBridgeDomain(d *schema.ResourceData, m interface{}, jnprSess *NetconfObj
 	return sess.configSet(configSet, jnprSess)
 }
 
-func readBridgeDomain(name string, instance string, m interface{},
-	jnprSess *NetconfObject) (bridgeDomainOptions, error) {
+func readBridgeDomain(name, instance string, m interface{}, jnprSess *NetconfObject) (bridgeDomainOptions, error) {
 	sess := m.(*Session)
 	var confRead bridgeDomainOptions
 	var showConfig string
@@ -615,8 +613,7 @@ func readBridgeDomain(name string, instance string, m interface{},
 	return confRead, nil
 }
 
-func delBridgeDomainOpts(
-	name string, instance string, vxlan []interface{}, m interface{}, jnprSess *NetconfObject) error {
+func delBridgeDomainOpts(name, instance string, vxlan []interface{}, m interface{}, jnprSess *NetconfObject) error {
 	sess := m.(*Session)
 	configSet := make([]string, 0)
 	delPrefix := deleteLS
@@ -653,7 +650,7 @@ func delBridgeDomainOpts(
 	return sess.configSet(configSet, jnprSess)
 }
 
-func delBridgeDomain(name string, instance string, vxlan []interface{}, m interface{}, jnprSess *NetconfObject) error {
+func delBridgeDomain(name, instance string, vxlan []interface{}, m interface{}, jnprSess *NetconfObject) error {
 	sess := m.(*Session)
 	configSet := make([]string, 0, 1)
 	if instance == defaultW {

--- a/junos/resource_chassis_cluster.go
+++ b/junos/resource_chassis_cluster.go
@@ -246,8 +246,8 @@ func resourceChassisClusterRead(ctx context.Context, d *schema.ResourceData, m i
 	return resourceChassisClusterReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceChassisClusterReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceChassisClusterReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	clusterOptions, err := readChassisCluster(m, jnprSess)
 	mutex.Unlock()

--- a/junos/resource_chassis_cluster_test.go
+++ b/junos/resource_chassis_cluster_test.go
@@ -69,14 +69,14 @@ func TestAccJunosCluster_basic(t *testing.T) {
 func testAccJunosClusterConfigCreate(interFace, interFace2 string) string {
 	return fmt.Sprintf(`
 resource "junos_interface_physical" "testacc_cluster_int2" {
-  name        = "` + interFace2 + `"
+  name        = "%s"
   description = "testacc_cluster_int2"
   gigether_opts {
     redundant_parent = "reth0"
   }
 }
 resource "junos_interface_physical" "testacc_cluster" {
-  name = "` + interFace + `"
+  name = "%s"
 }
 resource "junos_chassis_cluster" "testacc_cluster" {
   fab0 {
@@ -97,20 +97,20 @@ resource "junos_chassis_cluster" "testacc_cluster" {
   }
   reth_count = 2
 }
-`)
+`, interFace2, interFace)
 }
 
 func testAccJunosClusterConfigUpdate(interFace, interFace2 string) string {
 	return fmt.Sprintf(`
 resource "junos_interface_physical" "testacc_cluster_int2" {
-  name        = "` + interFace2 + `"
+  name        = "%s"
   description = "testacc_cluster_int2"
   gigether_opts {
     redundant_parent = "reth0"
   }
 }
 resource "junos_interface_physical" "testacc_cluster" {
-  name = "` + interFace + `"
+  name = "%s"
 }
 resource "junos_chassis_cluster" "testacc_cluster" {
   fab0 {
@@ -138,5 +138,5 @@ resource "junos_chassis_cluster" "testacc_cluster" {
   }
   reth_count = 3
 }
-`)
+`, interFace2, interFace)
 }

--- a/junos/resource_chassis_redundancy.go
+++ b/junos/resource_chassis_redundancy.go
@@ -132,8 +132,8 @@ func resourceChassisRedundancyRead(ctx context.Context, d *schema.ResourceData, 
 	return resourceChassisRedundancyReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceChassisRedundancyReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceChassisRedundancyReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	redundancyOptions, err := readChassisRedundancy(m, jnprSess)
 	mutex.Unlock()

--- a/junos/resource_eventoptions_destination.go
+++ b/junos/resource_eventoptions_destination.go
@@ -62,8 +62,8 @@ func resourceEventoptionsDestination() *schema.Resource {
 	}
 }
 
-func resourceEventoptionsDestinationCreate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceEventoptionsDestinationCreate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeCreateSetFile != "" {
 		if err := setEventoptionsDestination(d, m, nil); err != nil {
@@ -130,8 +130,8 @@ func resourceEventoptionsDestinationRead(ctx context.Context, d *schema.Resource
 	return resourceEventoptionsDestinationReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceEventoptionsDestinationReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceEventoptionsDestinationReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	eventoptionsDestinationOptions, err := readEventoptionsDestination(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
@@ -147,8 +147,8 @@ func resourceEventoptionsDestinationReadWJnprSess(
 	return nil
 }
 
-func resourceEventoptionsDestinationUpdate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceEventoptionsDestinationUpdate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	d.Partial(true)
 	sess := m.(*Session)
 	if sess.junosFakeUpdateAlso {
@@ -191,8 +191,8 @@ func resourceEventoptionsDestinationUpdate(ctx context.Context,
 	return append(diagWarns, resourceEventoptionsDestinationReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceEventoptionsDestinationDelete(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceEventoptionsDestinationDelete(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeDeleteAlso {
 		if err := delEventoptionsDestination(d.Get("name").(string), m, nil); err != nil {
@@ -288,8 +288,8 @@ func setEventoptionsDestination(d *schema.ResourceData, m interface{}, jnprSess 
 	return sess.configSet(configSet, jnprSess)
 }
 
-func readEventoptionsDestination(
-	name string, m interface{}, jnprSess *NetconfObject) (eventoptionsDestinationOptions, error) {
+func readEventoptionsDestination(name string, m interface{}, jnprSess *NetconfObject,
+) (eventoptionsDestinationOptions, error) {
 	sess := m.(*Session)
 	var confRead eventoptionsDestinationOptions
 	confRead.transferDelay = -1 // default value
@@ -349,7 +349,8 @@ func delEventoptionsDestination(destination string, m interface{}, jnprSess *Net
 }
 
 func fillEventoptionsDestinationData(
-	d *schema.ResourceData, eventoptionsDestinationOptions eventoptionsDestinationOptions) {
+	d *schema.ResourceData, eventoptionsDestinationOptions eventoptionsDestinationOptions,
+) {
 	if tfErr := d.Set("name", eventoptionsDestinationOptions.name); tfErr != nil {
 		panic(tfErr)
 	}

--- a/junos/resource_eventoptions_generate_event.go
+++ b/junos/resource_eventoptions_generate_event.go
@@ -55,8 +55,8 @@ func resourceEventoptionsGenerateEvent() *schema.Resource {
 	}
 }
 
-func resourceEventoptionsGenerateEventCreate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceEventoptionsGenerateEventCreate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeCreateSetFile != "" {
 		if err := setEventoptionsGenerateEvent(d, m, nil); err != nil {
@@ -112,8 +112,8 @@ func resourceEventoptionsGenerateEventCreate(ctx context.Context,
 	return append(diagWarns, resourceEventoptionsGenerateEventReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceEventoptionsGenerateEventRead(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceEventoptionsGenerateEventRead(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -124,8 +124,8 @@ func resourceEventoptionsGenerateEventRead(ctx context.Context,
 	return resourceEventoptionsGenerateEventReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceEventoptionsGenerateEventReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceEventoptionsGenerateEventReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	eventoptionsGenerateEventOptions, err := readEventoptionsGenerateEvent(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
@@ -141,8 +141,8 @@ func resourceEventoptionsGenerateEventReadWJnprSess(
 	return nil
 }
 
-func resourceEventoptionsGenerateEventUpdate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceEventoptionsGenerateEventUpdate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	d.Partial(true)
 	sess := m.(*Session)
 	if sess.junosFakeUpdateAlso {
@@ -185,8 +185,8 @@ func resourceEventoptionsGenerateEventUpdate(ctx context.Context,
 	return append(diagWarns, resourceEventoptionsGenerateEventReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceEventoptionsGenerateEventDelete(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceEventoptionsGenerateEventDelete(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeDeleteAlso {
 		if err := delEventoptionsGenerateEvent(d.Get("name").(string), m, nil); err != nil {
@@ -276,8 +276,8 @@ func setEventoptionsGenerateEvent(d *schema.ResourceData, m interface{}, jnprSes
 	return sess.configSet(configSet, jnprSess)
 }
 
-func readEventoptionsGenerateEvent(name string,
-	m interface{}, jnprSess *NetconfObject) (eventoptionsGenerateEventOptions, error) {
+func readEventoptionsGenerateEvent(name string, m interface{}, jnprSess *NetconfObject,
+) (eventoptionsGenerateEventOptions, error) {
 	sess := m.(*Session)
 	var confRead eventoptionsGenerateEventOptions
 
@@ -323,7 +323,8 @@ func delEventoptionsGenerateEvent(event string, m interface{}, jnprSess *Netconf
 }
 
 func fillEventoptionsGenerateEventData(
-	d *schema.ResourceData, eventoptionsGenerateEventOptions eventoptionsGenerateEventOptions) {
+	d *schema.ResourceData, eventoptionsGenerateEventOptions eventoptionsGenerateEventOptions,
+) {
 	if tfErr := d.Set("name", eventoptionsGenerateEventOptions.name); tfErr != nil {
 		panic(tfErr)
 	}

--- a/junos/resource_eventoptions_policy.go
+++ b/junos/resource_eventoptions_policy.go
@@ -533,8 +533,8 @@ func resourceEventoptionsPolicyRead(ctx context.Context, d *schema.ResourceData,
 	return resourceEventoptionsPolicyReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceEventoptionsPolicyReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceEventoptionsPolicyReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	eventoptionsPolicyOptions, err := readEventoptionsPolicy(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()

--- a/junos/resource_evpn.go
+++ b/junos/resource_evpn.go
@@ -375,8 +375,8 @@ func setEvpn(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) err
 	return sess.configSet(configSet, jnprSess)
 }
 
-func readEvpn(routingInstance string,
-	m interface{}, jnprSess *NetconfObject) (evpnOptions, error) {
+func readEvpn(routingInstance string, m interface{}, jnprSess *NetconfObject,
+) (evpnOptions, error) {
 	sess := m.(*Session)
 	var confRead evpnOptions
 	var showConfig string

--- a/junos/resource_firewall_filter.go
+++ b/junos/resource_firewall_filter.go
@@ -339,8 +339,8 @@ func resourceFirewallFilterRead(ctx context.Context, d *schema.ResourceData, m i
 	return resourceFirewallFilterReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceFirewallFilterReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceFirewallFilterReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	filterOptions, err := readFirewallFilter(d.Get("name").(string), d.Get("family").(string), m, jnprSess)
 	mutex.Unlock()
@@ -594,8 +594,8 @@ func fillFirewallFilterData(d *schema.ResourceData, filterOptions filterOptions)
 	}
 }
 
-func setFirewallFilterOptsFrom(setPrefixTermFrom string,
-	configSet []string, fromMap map[string]interface{}) ([]string, error) {
+func setFirewallFilterOptsFrom(setPrefixTermFrom string, configSet []string, fromMap map[string]interface{},
+) ([]string, error) {
 	for _, address := range sortSetOfString(fromMap["address"].(*schema.Set).List()) {
 		err := validateCIDRNetwork(address)
 		if err != nil {

--- a/junos/resource_firewall_policer.go
+++ b/junos/resource_firewall_policer.go
@@ -161,8 +161,8 @@ func resourceFirewallPolicerRead(ctx context.Context, d *schema.ResourceData, m 
 	return resourceFirewallPolicerReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceFirewallPolicerReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceFirewallPolicerReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	policerOptions, err := readFirewallPolicer(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()

--- a/junos/resource_forwardingoptions_sampling_instance.go
+++ b/junos/resource_forwardingoptions_sampling_instance.go
@@ -627,8 +627,8 @@ func resourceForwardingoptionsSamplingInstance() *schema.Resource {
 	}
 }
 
-func resourceForwardingoptionsSamplingInstanceCreate(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceForwardingoptionsSamplingInstanceCreate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeCreateSetFile != "" {
 		if err := setForwardingoptionsSamplingInstance(d, m, nil); err != nil {
@@ -685,8 +685,8 @@ func resourceForwardingoptionsSamplingInstanceCreate(
 	return append(diagWarns, resourceForwardingoptionsSamplingInstanceReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceForwardingoptionsSamplingInstanceRead(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceForwardingoptionsSamplingInstanceRead(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -698,7 +698,8 @@ func resourceForwardingoptionsSamplingInstanceRead(ctx context.Context,
 }
 
 func resourceForwardingoptionsSamplingInstanceReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	samplingInstanceOptions, err := readForwardingoptionsSamplingInstance(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
@@ -714,8 +715,8 @@ func resourceForwardingoptionsSamplingInstanceReadWJnprSess(
 	return nil
 }
 
-func resourceForwardingoptionsSamplingInstanceUpdate(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceForwardingoptionsSamplingInstanceUpdate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	d.Partial(true)
 	sess := m.(*Session)
 	if sess.junosFakeUpdateAlso {
@@ -759,8 +760,8 @@ func resourceForwardingoptionsSamplingInstanceUpdate(
 	return append(diagWarns, resourceForwardingoptionsSamplingInstanceReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceForwardingoptionsSamplingInstanceDelete(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceForwardingoptionsSamplingInstanceDelete(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeDeleteAlso {
 		if err := delForwardingoptionsSamplingInstance(d.Get("name").(string), m, nil); err != nil {
@@ -792,8 +793,8 @@ func resourceForwardingoptionsSamplingInstanceDelete(
 	return diagWarns
 }
 
-func resourceForwardingoptionsSamplingInstanceImport(d *schema.ResourceData,
-	m interface{}) ([]*schema.ResourceData, error) {
+func resourceForwardingoptionsSamplingInstanceImport(d *schema.ResourceData, m interface{},
+) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -820,8 +821,8 @@ func resourceForwardingoptionsSamplingInstanceImport(d *schema.ResourceData,
 	return result, nil
 }
 
-func checkForwardingoptionsSamplingInstanceExists(name string,
-	m interface{}, jnprSess *NetconfObject) (bool, error) {
+func checkForwardingoptionsSamplingInstanceExists(name string, m interface{}, jnprSess *NetconfObject,
+) (bool, error) {
 	sess := m.(*Session)
 	showConfig, err := sess.command(cmdShowConfig+
 		"forwarding-options sampling instance \""+name+"\""+pipeDisplaySet, jnprSess)
@@ -899,7 +900,8 @@ func setForwardingoptionsSamplingInstance(d *schema.ResourceData, m interface{},
 }
 
 func setForwardingoptionsSamplingInstanceInput(
-	setPrefix string, input map[string]interface{}, family string, sess *Session, jnprSess *NetconfObject) error {
+	setPrefix string, input map[string]interface{}, family string, sess *Session, jnprSess *NetconfObject,
+) error {
 	configSet := make([]string, 0)
 	switch family {
 	case inetW:
@@ -940,7 +942,8 @@ func setForwardingoptionsSamplingInstanceInput(
 }
 
 func setForwardingoptionsSamplingInstanceOutput(
-	setPrefix string, output map[string]interface{}, family string, sess *Session, jnprSess *NetconfObject) error {
+	setPrefix string, output map[string]interface{}, family string, sess *Session, jnprSess *NetconfObject,
+) error {
 	configSet := make([]string, 0)
 	switch family {
 	case inetW:
@@ -1058,8 +1061,8 @@ func setForwardingoptionsSamplingInstanceOutput(
 	return sess.configSet(configSet, jnprSess)
 }
 
-func readForwardingoptionsSamplingInstance(name string,
-	m interface{}, jnprSess *NetconfObject) (samplingInstanceOptions, error) {
+func readForwardingoptionsSamplingInstance(name string, m interface{}, jnprSess *NetconfObject,
+) (samplingInstanceOptions, error) {
 	sess := m.(*Session)
 	var confRead samplingInstanceOptions
 
@@ -1221,8 +1224,7 @@ func readForwardingoptionsSamplingInstanceInput(inputRead map[string]interface{}
 	return nil
 }
 
-func readForwardingoptionsSamplingInstanceOutput(
-	outputRead map[string]interface{}, itemTrim string, family string) error {
+func readForwardingoptionsSamplingInstanceOutput(outputRead map[string]interface{}, itemTrim, family string) error {
 	switch {
 	case strings.HasPrefix(itemTrim, "aggregate-export-interval "):
 		var err error
@@ -1374,7 +1376,8 @@ func delForwardingoptionsSamplingInstance(samplingInstance string, m interface{}
 }
 
 func fillForwardingoptionsSamplingInstanceData(
-	d *schema.ResourceData, samplingInstanceOptions samplingInstanceOptions) {
+	d *schema.ResourceData, samplingInstanceOptions samplingInstanceOptions,
+) {
 	if tfErr := d.Set("name", samplingInstanceOptions.name); tfErr != nil {
 		panic(tfErr)
 	}

--- a/junos/resource_generate_route.go
+++ b/junos/resource_generate_route.go
@@ -212,8 +212,8 @@ func resourceGenerateRouteRead(ctx context.Context, d *schema.ResourceData, m in
 	return resourceGenerateRouteReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceGenerateRouteReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceGenerateRouteReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	generateRouteOptions, err := readGenerateRoute(d.Get("destination").(string), d.Get("routing_instance").(string),
 		m, jnprSess)
@@ -452,8 +452,8 @@ func setGenerateRoute(d *schema.ResourceData, m interface{}, jnprSess *NetconfOb
 	return sess.configSet(configSet, jnprSess)
 }
 
-func readGenerateRoute(destination, instance string,
-	m interface{}, jnprSess *NetconfObject) (generateRouteOptions, error) {
+func readGenerateRoute(destination, instance string, m interface{}, jnprSess *NetconfObject,
+) (generateRouteOptions, error) {
 	sess := m.(*Session)
 	var confRead generateRouteOptions
 	var showConfig string
@@ -535,7 +535,7 @@ func readGenerateRoute(destination, instance string,
 	return confRead, nil
 }
 
-func delGenerateRoute(destination string, instance string, m interface{}, jnprSess *NetconfObject) error {
+func delGenerateRoute(destination, instance string, m interface{}, jnprSess *NetconfObject) error {
 	sess := m.(*Session)
 	configSet := make([]string, 0, 1)
 	if instance == defaultW {

--- a/junos/resource_group_dual_system.go
+++ b/junos/resource_group_dual_system.go
@@ -247,8 +247,8 @@ func resourceGroupDualSystemRead(ctx context.Context, d *schema.ResourceData, m 
 	return resourceGroupDualSystemReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceGroupDualSystemReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceGroupDualSystemReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	groupDualSystemOpts, err := readGroupDualSystem(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()

--- a/junos/resource_igmp_snooping_vlan.go
+++ b/junos/resource_igmp_snooping_vlan.go
@@ -246,8 +246,8 @@ func resourceIgmpSnoopingVlanRead(ctx context.Context, d *schema.ResourceData, m
 	return resourceIgmpSnoopingVlanReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceIgmpSnoopingVlanReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceIgmpSnoopingVlanReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	igmpSnoopingVlanOptions, err := readIgmpSnoopingVlan(
 		d.Get("name").(string), d.Get("routing_instance").(string), m, jnprSess)

--- a/junos/resource_igmp_snooping_vlan_test.go
+++ b/junos/resource_igmp_snooping_vlan_test.go
@@ -66,12 +66,12 @@ resource "junos_igmp_snooping_vlan" "vlan10" {
   name            = "vlan10"
   immediate_leave = true
   interface {
-    name                = "` + interFace + `.1"
+    name                = "%s.1"
     host_only_interface = true
   }
   proxy = true
 }
-`)
+`, interFace)
 }
 
 func testAccJunosIgmpSnoopingVlanSWConfigUpdate(interFace string) string {
@@ -83,7 +83,7 @@ resource "junos_igmp_snooping_vlan" "vlan10" {
     name = "ge-0/0/3.1"
   }
   interface {
-    name                       = "` + interFace + `.0"
+    name                       = "%s.0"
     group_limit                = 32
     immediate_leave            = true
     multicast_router_interface = true
@@ -103,7 +103,7 @@ resource "junos_igmp_snooping_vlan" "vlan10" {
   query_response_interval    = "31.0"
   robust_count               = 5
 }
-`)
+`, interFace)
 }
 
 func testAccJunosIgmpSnoopingVlanConfigCreate(interFace string) string {
@@ -120,12 +120,12 @@ resource "junos_igmp_snooping_vlan" "vlan10" {
   routing_instance = junos_routing_instance.testacc_igmp_snooping_vlan.name
   immediate_leave  = true
   interface {
-    name                = "` + interFace + `.1"
+    name                = "%s.1"
     host_only_interface = true
   }
   proxy = true
 }
-`)
+`, interFace)
 }
 
 func testAccJunosIgmpSnoopingVlanConfigUpdate(interFace string) string {
@@ -142,7 +142,7 @@ resource "junos_igmp_snooping_vlan" "vlan10" {
     name = "ge-0/0/3.1"
   }
   interface {
-    name                       = "` + interFace + `.0"
+    name                       = "%s.0"
     group_limit                = 32
     immediate_leave            = true
     multicast_router_interface = true
@@ -161,5 +161,5 @@ resource "junos_igmp_snooping_vlan" "vlan10" {
   query_response_interval    = "31.0"
   robust_count               = 5
 }
-`)
+`, interFace)
 }

--- a/junos/resource_interface.go
+++ b/junos/resource_interface.go
@@ -848,8 +848,7 @@ func resourceInterfaceImport(d *schema.ResourceData, m interface{}) ([]*schema.R
 	return result, nil
 }
 
-func checkInterfaceNC(interFace string, m interface{}, jnprSess *NetconfObject) (
-	ncInt bool, emtyInt bool, errFunc error) {
+func checkInterfaceNC(interFace string, m interface{}, jnprSess *NetconfObject) (ncInt, emtyInt bool, errFunc error) {
 	sess := m.(*Session)
 	showConfig, err := sess.command(cmdShowConfig+"interfaces "+interFace+pipeDisplaySetRelative, jnprSess)
 	if err != nil {
@@ -1464,8 +1463,8 @@ func delZoneInterface(zone string, d *schema.ResourceData, m interface{}, jnprSe
 	return sess.configSet(configSet, jnprSess)
 }
 
-func delRoutingInstanceInterface(instance string, d *schema.ResourceData,
-	m interface{}, jnprSess *NetconfObject) error {
+func delRoutingInstanceInterface(instance string, d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) error {
 	sess := m.(*Session)
 	configSet := make([]string, 0, 1)
 	configSet = append(configSet, delRoutingInstances+instance+" interface "+d.Get("name").(string))
@@ -1548,8 +1547,8 @@ func fillInterfaceData(d *schema.ResourceData, interfaceOpt interfaceOptions) {
 	}
 }
 
-func readFamilyInetAddressOld(item string, inetAddress []map[string]interface{},
-	family string) ([]map[string]interface{}, error) {
+func readFamilyInetAddressOld(item string, inetAddress []map[string]interface{}, family string,
+) ([]map[string]interface{}, error) {
 	var addressConfig []string
 	var itemTrim string
 	switch family {
@@ -1657,8 +1656,8 @@ func readFamilyInetAddressOld(item string, inetAddress []map[string]interface{},
 	return inetAddress, nil
 }
 
-func setFamilyAddressOld(inetAddress interface{}, intCut []string, configSet []string, setName string,
-	family string) ([]string, error) {
+func setFamilyAddressOld(inetAddress interface{}, intCut, configSet []string, setName, family string,
+) ([]string, error) {
 	if family != inetW && family != inet6W {
 		return configSet, fmt.Errorf("setFamilyAddressOld() unknown family %v", family)
 	}

--- a/junos/resource_interface_logical.go
+++ b/junos/resource_interface_logical.go
@@ -730,8 +730,8 @@ func resourceInterfaceLogicalRead(ctx context.Context, d *schema.ResourceData, m
 	return resourceInterfaceLogicalReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceInterfaceLogicalReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceInterfaceLogicalReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	ncInt, emptyInt, setInt, err := checkInterfaceLogicalNCEmpty(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -974,8 +974,8 @@ func resourceInterfaceLogicalImport(d *schema.ResourceData, m interface{}) ([]*s
 	return result, nil
 }
 
-func checkInterfaceLogicalNCEmpty(interFace string, m interface{}, jnprSess *NetconfObject) (
-	ncInt bool, emtyInt bool, justSet bool, _err error) {
+func checkInterfaceLogicalNCEmpty(interFace string, m interface{}, jnprSess *NetconfObject,
+) (ncInt, emtyInt, justSet bool, _err error) {
 	sess := m.(*Session)
 	showConfig, err := sess.command(cmdShowConfig+"interfaces "+interFace+pipeDisplaySetRelative, jnprSess)
 	if err != nil {
@@ -1385,8 +1385,9 @@ func readInterfaceLogical(interFace string, m interface{}, jnprSess *NetconfObje
 	return confRead, nil
 }
 
-func readInterfaceLogicalSecurityInboundTraffic(interFace string, confRead *interfaceLogicalOptions,
-	m interface{}, jnprSess *NetconfObject) error {
+func readInterfaceLogicalSecurityInboundTraffic(
+	interFace string, confRead *interfaceLogicalOptions, m interface{}, jnprSess *NetconfObject,
+) error {
 	sess := m.(*Session)
 
 	showConfig, err := sess.command(cmdShowConfig+
@@ -1468,8 +1469,8 @@ func delZoneInterfaceLogical(zone string, d *schema.ResourceData, m interface{},
 	return sess.configSet(configSet, jnprSess)
 }
 
-func delRoutingInstanceInterfaceLogical(instance string, d *schema.ResourceData,
-	m interface{}, jnprSess *NetconfObject) error {
+func delRoutingInstanceInterfaceLogical(instance string, d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) error {
 	sess := m.(*Session)
 	configSet := make([]string, 0, 1)
 	configSet = append(configSet, delRoutingInstances+instance+" interface "+d.Get("name").(string))
@@ -1504,8 +1505,8 @@ func fillInterfaceLogicalData(d *schema.ResourceData, interfaceLogicalOpt interf
 	}
 }
 
-func readFamilyInetAddress(item string, inetAddress []map[string]interface{},
-	family string) ([]map[string]interface{}, error) {
+func readFamilyInetAddress(item string, inetAddress []map[string]interface{}, family string,
+) ([]map[string]interface{}, error) {
 	var addressConfig []string
 	var itemTrim string
 	switch family {
@@ -1730,7 +1731,7 @@ func readFamilyInet6Dhcpv6Client(item string, dhcp map[string]interface{}) error
 	return nil
 }
 
-func setFamilyAddress(inetAddress map[string]interface{}, setPrefix string, family string) ([]string, error) {
+func setFamilyAddress(inetAddress map[string]interface{}, setPrefix, family string) ([]string, error) {
 	configSet := make([]string, 0)
 	if family != inetW && family != inet6W {
 		panic(fmt.Sprintf("setFamilyAddress() unknown family %v", family))

--- a/junos/resource_interface_logical_test.go
+++ b/junos/resource_interface_logical_test.go
@@ -223,7 +223,7 @@ resource junos_routing_instance "testacc_interface_logical" {
   name = "testacc_interface_logical"
 }
 resource junos_interface_physical testacc_interface_logical_phy {
-  name         = "` + interFace + `"
+  name         = "%s"
   vlan_tagging = true
 }
 resource junos_interface_logical testacc_interface_logical {
@@ -294,7 +294,7 @@ resource junos_interface_logical testacc_interface_logical {
     }
   }
 }
-`)
+`, interFace)
 }
 
 func testAccJunosInterfaceLogicalConfigUpdate(interFace string) string {
@@ -326,7 +326,7 @@ resource junos_routing_instance "testacc_interface_logical" {
   name = "testacc_interface"
 }
 resource junos_interface_physical testacc_interface_logical_phy {
-  name         = "` + interFace + `"
+  name         = "%s"
   vlan_tagging = true
 }
 resource junos_interface_logical testacc_interface_logical {
@@ -387,13 +387,13 @@ resource junos_interface_logical testacc_interface_logical {
     }
   }
 }
-`)
+`, interFace)
 }
 
 func testAccJunosInterfaceLogicalConfigUpdate2(interFace string) string {
 	return fmt.Sprintf(`
 resource junos_interface_physical testacc_interface_logical_phy {
-  name         = "` + interFace + `"
+  name         = "%s"
   vlan_tagging = true
 }
 resource junos_interface_logical testacc_interface_logical {
@@ -410,13 +410,13 @@ resource junos_interface_logical testacc_interface_logical {
     }
   }
 }
-`)
+`, interFace)
 }
 
 func testAccJunosInterfaceLogicalConfigUpdate3(interFace string) string {
 	return fmt.Sprintf(`
 resource junos_interface_physical testacc_interface_logical_phy {
-  name         = "` + interFace + `"
+  name         = "%s"
   vlan_tagging = true
 }
 resource junos_interface_logical testacc_interface_logical {
@@ -463,13 +463,13 @@ resource junos_interface_logical testacc_interface_logical {
 resource junos_interface_logical testacc_interface_logical2 {
   name = "${junos_interface_physical.testacc_interface_logical_phy.name}.101"
 }
-`)
+`, interFace)
 }
 
 func testAccJunosInterfaceLogicalConfigUpdate4(interFace string) string {
 	return fmt.Sprintf(`
 resource junos_interface_physical testacc_interface_logical_phy {
-  name         = "` + interFace + `"
+  name         = "%s"
   vlan_tagging = true
 }
 resource junos_interface_logical testacc_interface_logical {
@@ -498,5 +498,5 @@ resource junos_interface_logical testacc_interface_logical {
 resource junos_interface_logical testacc_interface_logical2 {
   name = "${junos_interface_physical.testacc_interface_logical_phy.name}.101"
 }
-`)
+`, interFace)
 }

--- a/junos/resource_interface_physical.go
+++ b/junos/resource_interface_physical.go
@@ -571,8 +571,8 @@ func resourceInterfacePhysicalRead(ctx context.Context, d *schema.ResourceData, 
 	return resourceInterfacePhysicalReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceInterfacePhysicalReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceInterfacePhysicalReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	ncInt, emptyInt, err := checkInterfacePhysicalNCEmpty(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -750,8 +750,8 @@ func resourceInterfacePhysicalImport(d *schema.ResourceData, m interface{}) ([]*
 	return result, nil
 }
 
-func checkInterfacePhysicalNCEmpty(interFace string, m interface{}, jnprSess *NetconfObject) (
-	ncInt bool, emtyInt bool, errFunc error) {
+func checkInterfacePhysicalNCEmpty(interFace string, m interface{}, jnprSess *NetconfObject,
+) (ncInt, emtyInt bool, errFunc error) {
 	sess := m.(*Session)
 	showConfig, err := sess.command(cmdShowConfig+"interfaces "+interFace+pipeDisplaySetRelative, jnprSess)
 	if err != nil {
@@ -1048,8 +1048,8 @@ func setInterfacePhysical(d *schema.ResourceData, m interface{}, jnprSess *Netco
 	return sess.configSet(configSet, jnprSess)
 }
 
-func setInterfacePhysicalEsi(setPrefix string, esiParams []interface{},
-	m interface{}, jnprSess *NetconfObject) error {
+func setInterfacePhysicalEsi(setPrefix string, esiParams []interface{}, m interface{}, jnprSess *NetconfObject,
+) error {
 	sess := m.(*Session)
 	configSet := make([]string, 0)
 
@@ -1076,7 +1076,8 @@ func setInterfacePhysicalEsi(setPrefix string, esiParams []interface{},
 }
 
 func setInterfacePhysicalParentEtherOpts(
-	ethOpts map[string]interface{}, interfaceName string, m interface{}, jnprSess *NetconfObject) error {
+	ethOpts map[string]interface{}, interfaceName string, m interface{}, jnprSess *NetconfObject,
+) error {
 	sess := m.(*Session)
 	configSet := make([]string, 0)
 	setPrefix := "set interfaces " + interfaceName + " "
@@ -1763,8 +1764,8 @@ func interfaceAggregatedLastChild(ae, interFace string, m interface{}, jnprSess 
 	return lastAE, nil
 }
 
-func interfaceAggregatedCountSearchMax(
-	newAE, oldAE, interFace string, m interface{}, jnprSess *NetconfObject) (string, error) {
+func interfaceAggregatedCountSearchMax(newAE, oldAE, interFace string, m interface{}, jnprSess *NetconfObject,
+) (string, error) {
 	sess := m.(*Session)
 	newAENum := strings.TrimPrefix(newAE, "ae")
 	newAENumInt, err := strconv.Atoi(newAENum)

--- a/junos/resource_interface_physical_disable.go
+++ b/junos/resource_interface_physical_disable.go
@@ -33,8 +33,8 @@ func resourceInterfacePhysicalDisable() *schema.Resource {
 	}
 }
 
-func resourceInterfacePhysicalDisableCreate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceInterfacePhysicalDisableCreate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeCreateSetFile != "" {
 		if err := addInterfacePhysicalNC(d.Get("name").(string), m, nil); err != nil {
@@ -127,7 +127,7 @@ func resourceInterfacePhysicalDisableRead(ctx context.Context, d *schema.Resourc
 	return nil
 }
 
-func resourceInterfacePhysicalDisableDelete(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceInterfacePhysicalDisableDelete(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	return nil
 }

--- a/junos/resource_interface_physical_disable_test.go
+++ b/junos/resource_interface_physical_disable_test.go
@@ -1,6 +1,7 @@
 package junos_test
 
 import (
+	"fmt"
 	"os"
 	"regexp"
 	"testing"
@@ -44,38 +45,38 @@ func TestAccJunosInterfacePhysicalDisable_basic(t *testing.T) {
 }
 
 func testAccJunosInterfacePhysicalDisablePreConfigCreate(interFace string) string {
-	return `
+	return fmt.Sprintf(`
 resource junos_interface_physical testacc_interface_disable {
-  name                  = "` + interFace + `"
+  name                  = "%s"
   no_disable_on_destroy = true
 }
 resource junos_interface_logical testacc_interface_disable {
   name        = "${junos_interface_physical.testacc_interface_disable.name}.0"
   description = "testacc_interface_disable"
 }
-`
+`, interFace)
 }
 
 func testAccJunosInterfacePhysicalDisableConfigCreate(interFace string) string {
-	return `
+	return fmt.Sprintf(`
 resource junos_interface_physical_disable testacc_interface_disable {
-  name = "` + interFace + `"
+  name = "%s"
 }
 resource junos_interface_physical_disable testacc_interface_disable2 {
-  name = "` + interFace + `"
+  name = "%s"
 }
-`
+`, interFace, interFace)
 }
 
 func testAccJunosInterfacePhysicalDisableConfigConflict(interFace string) string {
-	return `
+	return fmt.Sprintf(`
 resource junos_interface_physical testacc_interface_disable {
-  name                  = "` + interFace + `"
+  name                  = "%s"
   description           = "testacc_interface_disable"
   no_disable_on_destroy = true
 }
 resource junos_interface_physical_disable testacc_interface_disable {
-  name = "` + interFace + `"
+  name = "%s"
 }
-`
+`, interFace, interFace)
 }

--- a/junos/resource_interface_physical_test.go
+++ b/junos/resource_interface_physical_test.go
@@ -1,6 +1,7 @@
 package junos_test
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -186,38 +187,38 @@ func TestAccJunosInterfacePhysical_basic(t *testing.T) {
 }
 
 func testAccJunosInterfacePhysicalSWConfigCreate(interFace string) string {
-	return `
+	return fmt.Sprintf(`
 resource junos_interface_physical testacc_interface {
-  name         = "` + interFace + `"
+  name         = "%s"
   description  = "testacc_interface"
   trunk        = true
   vlan_native  = 100
   vlan_members = ["100-110"]
 }
-`
+`, interFace)
 }
 
 func testAccJunosInterfacePhysicalSWConfigUpdate(interFace string) string {
-	return `
+	return fmt.Sprintf(`
 resource junos_interface_physical testacc_interface {
-  name         = "` + interFace + `"
+  name         = "%s"
   description  = "testacc_interfaceU"
   vlan_members = ["100"]
 }
-`
+`, interFace)
 }
 
 func testAccJunosInterfacePhysicalConfigCreate(interFace, interfaceAE, interFace2 string) string {
-	return `
+	return fmt.Sprintf(`
 resource junos_interface_physical testacc_interface {
-  name        = "` + interFace + `"
+  name        = "%s"
   description = "testacc_interface"
   gigether_opts {
-    ae_8023ad = "` + interfaceAE + `"
+    ae_8023ad = "%s"
   }
 }
 resource junos_interface_physical testacc_interface2 {
-  name        = "` + interFace2 + `"
+  name        = "%s"
   description = "testacc_interface2"
   gigether_opts {
     flow_control     = true
@@ -229,7 +230,7 @@ resource "junos_interface_physical" "testacc_interfaceAE" {
   depends_on = [
     junos_interface_physical.testacc_interface,
   ]
-  name        = "` + interfaceAE + `"
+  name        = "%s"
   description = "testacc_interfaceAE"
   parent_ether_opts {
     flow_control = true
@@ -247,20 +248,20 @@ resource "junos_interface_physical" "testacc_interfaceAE" {
   }
   vlan_tagging = true
 }
-`
+`, interFace, interfaceAE, interFace2, interfaceAE)
 }
 
 func testAccJunosInterfacePhysicalConfigUpdate(interFace, interfaceAE, interFace2 string) string {
-	return `
+	return fmt.Sprintf(`
 resource junos_interface_physical testacc_interface {
-  name        = "` + interFace + `"
+  name        = "%s"
   description = "testacc_interfaceU"
   gigether_opts {
-    ae_8023ad = "` + interfaceAE + `"
+    ae_8023ad = "%s"
   }
 }
 resource junos_interface_physical testacc_interface2 {
-  name        = "` + interFace2 + `"
+  name        = "%s"
   description = "testacc_interface2"
   ether_opts {
     flow_control     = true
@@ -281,7 +282,7 @@ resource "junos_interface_physical" "testacc_interfaceAE" {
     junos_interface_physical.testacc_interface,
     junos_interface_logical.testacc_interfaceLO,
   ]
-  name        = "` + interfaceAE + `"
+  name        = "%s"
   description = "testacc_interfaceAE"
   parent_ether_opts {
     bfd_liveness_detection {
@@ -304,32 +305,32 @@ resource "junos_interface_physical" "testacc_interfaceAE" {
   }
   vlan_tagging = true
 }
-`
+`, interFace, interfaceAE, interFace2, interfaceAE)
 }
 
 func testAccJunosInterfacePhysicalConfigUpdate2(interFace, interfaceAE string) string {
-	return `
+	return fmt.Sprintf(`
 resource junos_interface_physical testacc_interface {
-  name        = "` + interFace + `"
+  name        = "%s"
   description = "testacc_interfaceU"
   ether_opts {
-    ae_8023ad = "` + interfaceAE + `"
+    ae_8023ad = "%s"
   }
 }
-`
+`, interFace, interfaceAE)
 }
 
 func testAccJunosInterfacePhysicalRouterConfigCreate(interFace, interfaceAE string) string {
-	return `
+	return fmt.Sprintf(`
 resource "junos_interface_physical" "testacc_interface" {
-  name        = "` + interFace + `"
+  name        = "%s"
   description = "testacc_interface"
   gigether_opts {
-    ae_8023ad = "` + interfaceAE + `"
+    ae_8023ad = "%s"
   }
 }
 resource "junos_interface_physical" "testacc_interfaceAE" {
-  name        = "` + interfaceAE + `"
+  name        = "%s"
   description = "testacc_interfaceAE"
   esi {
     identifier = "00:01:11:11:11:11:11:11:11:11"
@@ -341,20 +342,20 @@ resource "junos_interface_physical" "testacc_interfaceAE" {
   }
   vlan_tagging = true
 }
-`
+`, interFace, interfaceAE, interfaceAE)
 }
 
 func testAccJunosInterfacePhysicalRouterConfigUpdate(interFace, interfaceAE string) string {
-	return `
+	return fmt.Sprintf(`
 resource "junos_interface_physical" "testacc_interface" {
-  name        = "` + interFace + `"
+  name        = "%s"
   description = "testacc_interface"
   gigether_opts {
-    ae_8023ad = "` + interfaceAE + `"
+    ae_8023ad = "%s"
   }
 }
 resource "junos_interface_physical" "testacc_interfaceAE" {
-  name        = "` + interfaceAE + `"
+  name        = "%s"
   description = "testacc_interfaceAE"
   esi {
     identifier = "00:11:11:11:11:11:11:11:11:11"
@@ -362,23 +363,23 @@ resource "junos_interface_physical" "testacc_interfaceAE" {
   }
   vlan_tagging = true
 }
-`
+`, interFace, interfaceAE, interfaceAE)
 }
 
 func testAccJunosInterfacePhysicalSRXConfigCreate(interFace, interFace2 string) string {
-	return `
+	return fmt.Sprintf(`
 resource "junos_interface_physical" "testacc_interface" {
   depends_on = [
     junos_chassis_cluster.testacc_interface
   ]
-  name        = "` + interFace + `"
+  name        = "%s"
   description = "testacc_interface"
   gigether_opts {
     redundant_parent = "reth0"
   }
 }
 resource "junos_interface_physical" "testacc_interface2" {
-  name = "` + interFace2 + `"
+  name = "%s"
 }
 resource "junos_chassis_cluster" "testacc_interface" {
   fab0 {
@@ -405,5 +406,5 @@ resource "junos_interface_physical" "testacc_interface_reth" {
     minimum_links    = 1
   }
 }
-`
+`, interFace, interFace2)
 }

--- a/junos/resource_interface_test.go
+++ b/junos/resource_interface_test.go
@@ -262,23 +262,23 @@ func TestAccJunosInterface_basic(t *testing.T) {
 func testAccJunosInterfaceConfigCreate(interFace string) string {
 	return fmt.Sprintf(`
 resource junos_interface testacc_interface {
-  name         = "` + interFace + `"
+  name         = "%s"
   description  = "testacc_interface"
   trunk        = true
   vlan_native  = 100
   vlan_members = ["100-110"]
 }
-`)
+`, interFace)
 }
 
 func testAccJunosInterfaceConfigUpdate(interFace string) string {
 	return fmt.Sprintf(`
 resource junos_interface testacc_interface {
-  name         = "` + interFace + `"
+  name         = "%s"
   description  = "testacc_interfaceU"
   vlan_members = ["100"]
 }
-`)
+`, interFace)
 }
 
 func testAccJunosInterfacePlusConfigCreate(interFace, interfaceAE string) string {
@@ -310,9 +310,9 @@ resource junos_routing_instance "testacc_interface" {
   name = "testacc_interface"
 }
 resource junos_interface testacc_interface {
-  name         = "` + interFace + `"
+  name         = "%s"
   description  = "testacc_interface"
-  ether802_3ad = "` + interfaceAE + `"
+  ether802_3ad = "%s"
 }
 resource junos_interface testacc_interfaceAE {
   name             = junos_interface.testacc_interface.ether802_3ad
@@ -382,7 +382,7 @@ resource junos_interface testacc_interfaceAEunit {
     address = "fe80::1/64"
   }
 }
-`)
+`, interFace, interfaceAE)
 }
 
 func testAccJunosInterfacePlusConfigUpdate(interFace, interfaceAE string) string {
@@ -414,9 +414,9 @@ resource junos_routing_instance "testacc_interface" {
   name = "testacc_interface"
 }
 resource junos_interface testacc_interface {
-  name         = "` + interFace + `"
+  name         = "%s"
   description  = "testacc_interfaceU"
-  ether802_3ad = "` + interfaceAE + `"
+  ether802_3ad = "%s"
 }
 resource junos_interface testacc_interfaceAE {
   name         = junos_interface.testacc_interface.ether802_3ad
@@ -468,5 +468,5 @@ resource junos_interface testacc_interfaceAEunit {
     address = "fe80::1/64"
   }
 }
-`)
+`, interFace, interfaceAE)
 }

--- a/junos/resource_layer2_control_test.go
+++ b/junos/resource_layer2_control_test.go
@@ -1,6 +1,7 @@
 package junos_test
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -53,7 +54,7 @@ resource "junos_layer2_control" "l2c" {
 }
 
 func testAccJunosLayer2ControlConfigUpdate(interFace string) string {
-	return `
+	return fmt.Sprintf(`
 resource "junos_chassis_redundancy" "l2c" {
   graceful_switchover = true
 }
@@ -67,42 +68,42 @@ resource "junos_layer2_control" "l2c" {
   bpdu_block {
     disable_timeout = 300
     interface {
-      name    = "` + interFace + `"
+      name    = "%s"
       disable = true
       drop    = true
     }
   }
   mac_rewrite_interface {
-    name           = "` + interFace + `"
+    name           = "%s"
     enable_all_ifl = true
     protocol       = ["cdp", "stp"]
   }
   nonstop_bridging = true
 }
-`
+`, interFace, interFace)
 }
 
 func testAccJunosLayer2ControlConfigUpdate2(interFace, interFace2 string) string {
-	return `
+	return fmt.Sprintf(`
 resource "junos_layer2_control" "l2c" {
   bpdu_block {
     interface {
-      name = "` + interFace2 + `"
+      name = "%s"
     }
     interface {
-      name    = "` + interFace + `"
+      name    = "%s"
       disable = true
       drop    = true
     }
   }
   mac_rewrite_interface {
-    name           = "` + interFace2 + `"
+    name           = "%s"
     enable_all_ifl = true
     protocol       = ["cdp", "stp"]
   }
   mac_rewrite_interface {
-    name = "` + interFace + `"
+    name = "%s"
   }
 }
-`
+`, interFace2, interFace, interFace2, interFace)
 }

--- a/junos/resource_lldp_interface.go
+++ b/junos/resource_lldp_interface.go
@@ -152,8 +152,8 @@ func resourceLldpInterfaceRead(ctx context.Context, d *schema.ResourceData, m in
 	return resourceLldpInterfaceReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceLldpInterfaceReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceLldpInterfaceReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	lldpInterfaceOptions, err := readLldpInterface(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()

--- a/junos/resource_lldp_interface_test.go
+++ b/junos/resource_lldp_interface_test.go
@@ -63,10 +63,10 @@ resource "junos_lldp_interface" "testacc_all" {
   name = "all"
 }
 resource "junos_lldp_interface" "testacc_interface" {
-  name = "` + interFace + `"
+  name = "%s"
   power_negotiation {}
 }
-`)
+`, interFace)
 }
 
 func testAccJunosLldpInterfaceSWConfigUpdate(interFace string) string {
@@ -80,13 +80,13 @@ resource "junos_lldp_interface" "testacc_all" {
 
 }
 resource "junos_lldp_interface" "testacc_interface" {
-  name    = "` + interFace + `"
+  name    = "%s"
   disable = true
   power_negotiation {
     disable = true
   }
 }
-`)
+`, interFace)
 }
 
 func testAccJunosLldpInterfaceConfigCreate(interFace string) string {
@@ -95,9 +95,9 @@ resource "junos_lldp_interface" "testacc_all" {
   name = "all"
 }
 resource "junos_lldp_interface" "testacc_interface" {
-  name = "` + interFace + `"
+  name = "%s"
 }
-`)
+`, interFace)
 }
 
 func testAccJunosLldpInterfaceConfigUpdate(interFace string) string {
@@ -109,9 +109,9 @@ resource "junos_lldp_interface" "testacc_all" {
 
 }
 resource "junos_lldp_interface" "testacc_interface" {
-  name                      = "` + interFace + `"
+  name                      = "%s"
   disable                   = true
   trap_notification_disable = true
 }
-`)
+`, interFace)
 }

--- a/junos/resource_lldpmed_interface.go
+++ b/junos/resource_lldpmed_interface.go
@@ -197,8 +197,8 @@ func resourceLldpMedInterfaceRead(ctx context.Context, d *schema.ResourceData, m
 	return resourceLldpMedInterfaceReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceLldpMedInterfaceReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceLldpMedInterfaceReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	lldpMedInterfaceOptions, err := readLldpMedInterface(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()

--- a/junos/resource_lldpmed_interface_test.go
+++ b/junos/resource_lldpmed_interface_test.go
@@ -66,10 +66,10 @@ resource "junos_lldpmed_interface" "testacc_all" {
   name = "all"
 }
 resource "junos_lldpmed_interface" "testacc_interface" {
-  name = "` + interFace + `"
+  name = "%s"
   location {}
 }
-`)
+`, interFace)
 }
 
 func testAccJunosLldpMedInterfaceSWConfigUpdate(interFace string) string {
@@ -82,7 +82,7 @@ resource "junos_lldpmed_interface" "testacc_all" {
   }
 }
 resource "junos_lldpmed_interface" "testacc_interface" {
-  name = "` + interFace + `"
+  name = "%s"
   location {
     civic_based_country_code = "FR"
     civic_based_ca_type {
@@ -94,7 +94,7 @@ resource "junos_lldpmed_interface" "testacc_interface" {
     }
   }
 }
-`)
+`, interFace)
 }
 
 func testAccJunosLldpMedInterfaceConfigCreate(interFace string) string {
@@ -104,11 +104,11 @@ resource "junos_lldpmed_interface" "testacc_all" {
   disable = true
 }
 resource "junos_lldpmed_interface" "testacc_interface" {
-  name   = "` + interFace + `"
+  name   = "%s"
   enable = true
   location {}
 }
-`)
+`, interFace)
 }
 
 func testAccJunosLldpMedInterfaceConfigUpdate(interFace string) string {
@@ -121,7 +121,7 @@ resource "junos_lldpmed_interface" "testacc_all" {
   }
 }
 resource "junos_lldpmed_interface" "testacc_interface" {
-  name = "` + interFace + `"
+  name = "%s"
   location {
     civic_based_country_code = "UK"
     civic_based_ca_type {
@@ -133,7 +133,7 @@ resource "junos_lldpmed_interface" "testacc_interface" {
     }
   }
 }
-`)
+`, interFace)
 }
 
 func testAccJunosLldpMedInterfaceConfigUpdate2(interFace string) string {
@@ -145,11 +145,11 @@ resource "junos_lldpmed_interface" "testacc_all" {
   }
 }
 resource "junos_lldpmed_interface" "testacc_interface" {
-  name = "` + interFace + `"
+  name = "%s"
   location {
     co_ordinate_latitude  = 180
     co_ordinate_longitude = 180
   }
 }
-`)
+`, interFace)
 }

--- a/junos/resource_null_commit_file_test.go
+++ b/junos/resource_null_commit_file_test.go
@@ -1,6 +1,7 @@
 package junos_test
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -45,42 +46,42 @@ func TestAccJunosNullCommitFile_basic(t *testing.T) {
 }
 
 func testAccJunosNullCommitFilePreCreate(interFace string) string {
-	return `
+	return fmt.Sprintf(`
 resource junos_interface_physical testacc_nullcommitfile {
-  name         = "` + interFace + `"
+  name         = "%s"
   description  = "testacc_null"
   vlan_tagging = true
 }
-`
+`, interFace)
 }
 
 func testAccJunosNullCommitFileCreate(interFace string) string {
-	return `
+	return fmt.Sprintf(`
 resource junos_interface_physical testacc_nullcommitfile {
-  name         = "` + interFace + `"
+  name         = "%s"
   description  = "testacc_null"
   vlan_tagging = true
 }
 resource "local_file" "hostname" {
-  content  = "set interfaces ` + interFace + ` description testacc_nullfile"
-  filename = "` + testaccNullCommitFile + `"
+  content  = "set interfaces %s description testacc_nullfile"
+  filename = "%s"
 }
 resource junos_null_commit_file "testacc_nullcommitfile" {
   filename                = local_file.hostname.filename
   clear_file_after_commit = true
 }
-`
+`, interFace, interFace, testaccNullCommitFile)
 }
 
 func testAccJunosNullCommitFileRead(interFace string) string {
-	return `
+	return fmt.Sprintf(`
 resource junos_interface_physical testacc_nullcommitfile {
-  name         = "` + interFace + `"
+  name         = "%s"
   description  = "testacc_null"
   vlan_tagging = true
 }
 data junos_interface_physical testacc_nullcommitfile {
-  config_interface = "` + interFace + `"
+  config_interface = "%s"
 }
-`
+`, interFace, interFace)
 }

--- a/junos/resource_ospf.go
+++ b/junos/resource_ospf.go
@@ -621,8 +621,8 @@ func setOspf(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) err
 	return sess.configSet(configSet, jnprSess)
 }
 
-func readOspf(version, routingInstance string,
-	m interface{}, jnprSess *NetconfObject) (ospfOptions, error) {
+func readOspf(version, routingInstance string, m interface{}, jnprSess *NetconfObject,
+) (ospfOptions, error) {
 	sess := m.(*Session)
 	var confRead ospfOptions
 	confRead.externalPreference = -1

--- a/junos/resource_ospf_area.go
+++ b/junos/resource_ospf_area.go
@@ -532,8 +532,8 @@ func resourceOspfAreaImport(d *schema.ResourceData, m interface{}) ([]*schema.Re
 	return result, nil
 }
 
-func checkOspfAreaExists(idArea, version, routingInstance string,
-	m interface{}, jnprSess *NetconfObject) (bool, error) {
+func checkOspfAreaExists(idArea, version, routingInstance string, m interface{}, jnprSess *NetconfObject,
+) (bool, error) {
 	sess := m.(*Session)
 	var showConfig string
 	var err error
@@ -790,8 +790,8 @@ func setOspfArea(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject)
 	return sess.configSet(configSet, jnprSess)
 }
 
-func readOspfArea(idArea, version, routingInstance string,
-	m interface{}, jnprSess *NetconfObject) (ospfAreaOptions, error) {
+func readOspfArea(idArea, version, routingInstance string, m interface{}, jnprSess *NetconfObject,
+) (ospfAreaOptions, error) {
 	sess := m.(*Session)
 	var confRead ospfAreaOptions
 	var showConfig string

--- a/junos/resource_ospf_area_test.go
+++ b/junos/resource_ospf_area_test.go
@@ -1,6 +1,7 @@
 package junos_test
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -78,7 +79,7 @@ func TestAccJunosOspfArea_basic(t *testing.T) {
 }
 
 func testAccJunosOspfAreaConfigCreate(interFace string) string {
-	return `
+	return fmt.Sprintf(`
 resource junos_ospf_area "testacc_ospfarea" {
   area_id = "0.0.0.0"
   interface {
@@ -96,14 +97,14 @@ resource junos_ospf_area "testacc_ospfarea" {
   }
 }
 resource junos_interface_logical "testacc_ospfarea" {
-  name        = "` + interFace + `.0"
+  name        = "%s.0"
   description = "testacc_ospfarea"
 }
-`
+`, interFace)
 }
 
 func testAccJunosOspfAreaConfigUpdate(interFace, interFace2 string) string {
-	return `
+	return fmt.Sprintf(`
 resource junos_ospf_area "testacc_ospfarea" {
   area_id = "0.0.0.0"
   interface {
@@ -146,11 +147,11 @@ resource junos_ospf_area "testacc_ospfarea" {
   }
 }
 resource junos_interface_logical "testacc_ospfarea" {
-  name        = "` + interFace + `.0"
+  name        = "%s.0"
   description = "testacc_ospfarea"
 }
 resource junos_interface_logical "testacc_ospfarea2" {
-  name             = "` + interFace2 + `.0"
+  name             = "%s.0"
   description      = "testacc_ospfarea2"
   routing_instance = junos_routing_instance.testacc_ospfarea.name
 }
@@ -206,5 +207,5 @@ resource junos_ospf_area "testacc_ospfarea2" {
     }
   }
 }
-`
+`, interFace, interFace2)
 }

--- a/junos/resource_policyoptions_as_path.go
+++ b/junos/resource_policyoptions_as_path.go
@@ -110,8 +110,8 @@ func resourcePolicyoptionsAsPathRead(ctx context.Context, d *schema.ResourceData
 	return resourcePolicyoptionsAsPathReadWJnprSess(d, m, jnprSess)
 }
 
-func resourcePolicyoptionsAsPathReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourcePolicyoptionsAsPathReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	asPathOptions, err := readPolicyoptionsAsPath(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()

--- a/junos/resource_policyoptions_as_path_group.go
+++ b/junos/resource_policyoptions_as_path_group.go
@@ -57,8 +57,8 @@ func resourcePolicyoptionsAsPathGroup() *schema.Resource {
 	}
 }
 
-func resourcePolicyoptionsAsPathGroupCreate(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourcePolicyoptionsAsPathGroupCreate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeCreateSetFile != "" {
 		if err := setPolicyoptionsAsPathGroup(d, m, nil); err != nil {
@@ -125,8 +125,8 @@ func resourcePolicyoptionsAsPathGroupRead(ctx context.Context, d *schema.Resourc
 	return resourcePolicyoptionsAsPathGroupReadWJnprSess(d, m, jnprSess)
 }
 
-func resourcePolicyoptionsAsPathGroupReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourcePolicyoptionsAsPathGroupReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	asPathGroupOptions, err := readPolicyoptionsAsPathGroup(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
@@ -142,8 +142,8 @@ func resourcePolicyoptionsAsPathGroupReadWJnprSess(
 	return nil
 }
 
-func resourcePolicyoptionsAsPathGroupUpdate(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourcePolicyoptionsAsPathGroupUpdate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	d.Partial(true)
 	sess := m.(*Session)
 	if sess.junosFakeUpdateAlso {
@@ -186,8 +186,8 @@ func resourcePolicyoptionsAsPathGroupUpdate(
 	return append(diagWarns, resourcePolicyoptionsAsPathGroupReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourcePolicyoptionsAsPathGroupDelete(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourcePolicyoptionsAsPathGroupDelete(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeDeleteAlso {
 		if err := delPolicyoptionsAsPathGroup(d.Get("name").(string), m, nil); err != nil {

--- a/junos/resource_policyoptions_community.go
+++ b/junos/resource_policyoptions_community.go
@@ -112,8 +112,8 @@ func resourcePolicyoptionsCommunityRead(ctx context.Context, d *schema.ResourceD
 	return resourcePolicyoptionsCommunityReadWJnprSess(d, m, jnprSess)
 }
 
-func resourcePolicyoptionsCommunityReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourcePolicyoptionsCommunityReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	communityOptions, err := readPolicyoptionsCommunity(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()

--- a/junos/resource_policyoptions_policy_statement.go
+++ b/junos/resource_policyoptions_policy_statement.go
@@ -406,8 +406,8 @@ func schemaPolicyoptionsPolicyStatementTo() map[string]*schema.Schema {
 	}
 }
 
-func resourcePolicyoptionsPolicyStatementCreate(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourcePolicyoptionsPolicyStatementCreate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeCreateSetFile != "" {
 		if err := setPolicyStatement(d, m, nil); err != nil {
@@ -475,8 +475,8 @@ func resourcePolicyoptionsPolicyStatementCreate(
 	return append(diagWarns, resourcePolicyoptionsPolicyStatementReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourcePolicyoptionsPolicyStatementRead(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourcePolicyoptionsPolicyStatementRead(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -487,8 +487,8 @@ func resourcePolicyoptionsPolicyStatementRead(
 	return resourcePolicyoptionsPolicyStatementReadWJnprSess(d, m, jnprSess)
 }
 
-func resourcePolicyoptionsPolicyStatementReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourcePolicyoptionsPolicyStatementReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	policyStatementOptions, err := readPolicyStatement(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -520,8 +520,8 @@ func resourcePolicyoptionsPolicyStatementReadWJnprSess(
 	return nil
 }
 
-func resourcePolicyoptionsPolicyStatementUpdate(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourcePolicyoptionsPolicyStatementUpdate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	d.Partial(true)
 	sess := m.(*Session)
 	if sess.junosFakeUpdateAlso {
@@ -592,8 +592,8 @@ func resourcePolicyoptionsPolicyStatementUpdate(
 	return append(diagWarns, resourcePolicyoptionsPolicyStatementReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourcePolicyoptionsPolicyStatementDelete(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourcePolicyoptionsPolicyStatementDelete(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeDeleteAlso {
 		if err := delPolicyStatement(d.Get("name").(string), m, nil); err != nil {
@@ -833,8 +833,8 @@ func readPolicyStatement(name string, m interface{}, jnprSess *NetconfObject) (p
 	return confRead, nil
 }
 
-func readPolicyStatementFwTableExport(policyName string,
-	m interface{}, jnprSess *NetconfObject) (bool, error) {
+func readPolicyStatementFwTableExport(policyName string, m interface{}, jnprSess *NetconfObject,
+) (bool, error) {
 	sess := m.(*Session)
 	showConfig, err := sess.command(cmdShowConfig+
 		"routing-options forwarding-table export"+pipeDisplaySetRelative, jnprSess)

--- a/junos/resource_policyoptions_prefix_list.go
+++ b/junos/resource_policyoptions_prefix_list.go
@@ -49,8 +49,8 @@ func resourcePolicyoptionsPrefixList() *schema.Resource {
 	}
 }
 
-func resourcePolicyoptionsPrefixListCreate(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourcePolicyoptionsPrefixListCreate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeCreateSetFile != "" {
 		if err := setPolicyoptionsPrefixList(d, m, nil); err != nil {
@@ -117,8 +117,8 @@ func resourcePolicyoptionsPrefixListRead(ctx context.Context, d *schema.Resource
 	return resourcePolicyoptionsPrefixListReadWJnprSess(d, m, jnprSess)
 }
 
-func resourcePolicyoptionsPrefixListReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourcePolicyoptionsPrefixListReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	prefixListOptions, err := readPolicyoptionsPrefixList(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
@@ -134,8 +134,8 @@ func resourcePolicyoptionsPrefixListReadWJnprSess(
 	return nil
 }
 
-func resourcePolicyoptionsPrefixListUpdate(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourcePolicyoptionsPrefixListUpdate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	d.Partial(true)
 	sess := m.(*Session)
 	if sess.junosFakeUpdateAlso {
@@ -178,8 +178,8 @@ func resourcePolicyoptionsPrefixListUpdate(
 	return append(diagWarns, resourcePolicyoptionsPrefixListReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourcePolicyoptionsPrefixListDelete(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourcePolicyoptionsPrefixListDelete(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeDeleteAlso {
 		if err := delPolicyoptionsPrefixList(d.Get("name").(string), m, nil); err != nil {

--- a/junos/resource_rib_group.go
+++ b/junos/resource_rib_group.go
@@ -332,7 +332,7 @@ func readRibGroup(group string, m interface{}, jnprSess *NetconfObject) (ribGrou
 	return confRead, nil
 }
 
-func delRibGroupElement(element string, group string, m interface{}, jnprSess *NetconfObject) error {
+func delRibGroupElement(element, group string, m interface{}, jnprSess *NetconfObject) error {
 	sess := m.(*Session)
 	configSet := make([]string, 0, 1)
 	configSet = append(configSet, "delete routing-options rib-groups "+group+" "+element)

--- a/junos/resource_routing_instance.go
+++ b/junos/resource_routing_instance.go
@@ -207,8 +207,8 @@ func resourceRoutingInstanceRead(ctx context.Context, d *schema.ResourceData, m 
 	return resourceRoutingInstanceReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceRoutingInstanceReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceRoutingInstanceReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	instanceOptions, err := readRoutingInstance(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()

--- a/junos/resource_routing_options.go
+++ b/junos/resource_routing_options.go
@@ -223,8 +223,8 @@ func resourceRoutingOptionsRead(ctx context.Context, d *schema.ResourceData, m i
 	return resourceRoutingOptionsReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceRoutingOptionsReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceRoutingOptionsReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	routingOptionsOptions, err := readRoutingOptions(m, jnprSess)
 	mutex.Unlock()

--- a/junos/resource_rstp_interface.go
+++ b/junos/resource_rstp_interface.go
@@ -189,8 +189,8 @@ func resourceRstpInterfaceRead(ctx context.Context, d *schema.ResourceData, m in
 	return resourceRstpInterfaceReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceRstpInterfaceReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceRstpInterfaceReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	rstpInterfaceOptions, err := readRstpInterface(
 		d.Get("name").(string), d.Get("routing_instance").(string), m, jnprSess)

--- a/junos/resource_rstp_interface_test.go
+++ b/junos/resource_rstp_interface_test.go
@@ -95,7 +95,7 @@ resource "junos_rstp_interface" "all" {
 }
 
 resource "junos_interface_physical" "testacc_rstp_interface" {
-  name         = "` + interFace + `"
+  name         = "%s"
   vlan_members = ["default"]
 }
 
@@ -120,7 +120,7 @@ resource "junos_rstp_interface" "all2" {
   mode                      = "shared"
   priority                  = 240
 }
-`)
+`, interFace)
 }
 
 func testAccJunosRstpInterfaceConfigCreate() string {

--- a/junos/resource_security_address_book.go
+++ b/junos/resource_security_address_book.go
@@ -245,8 +245,8 @@ func resourceSecurityAddressBookRead(ctx context.Context, d *schema.ResourceData
 	return resourceSecurityAddressBookReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceSecurityAddressBookReadWJnprSess(d *schema.ResourceData, m interface{},
-	jnprSess *NetconfObject) diag.Diagnostics {
+func resourceSecurityAddressBookReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	addressOptions, err := readSecurityAddressBook(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
@@ -594,8 +594,8 @@ func fillSecurityAddressBookData(d *schema.ResourceData, addressOptions addressB
 	}
 }
 
-func copySecurityAddressBookAddressDescriptions(descMap map[string]string,
-	addrList []map[string]interface{}) (newList []map[string]interface{}) {
+func copySecurityAddressBookAddressDescriptions(descMap map[string]string, addrList []map[string]interface{},
+) (newList []map[string]interface{}) {
 	for _, ele := range addrList {
 		ele["description"] = descMap[ele["name"].(string)]
 		newList = append(newList, ele)

--- a/junos/resource_security_dynamic_address_feed_server.go
+++ b/junos/resource_security_dynamic_address_feed_server.go
@@ -92,8 +92,8 @@ func resourceSecurityDynamicAddressFeedServer() *schema.Resource {
 	}
 }
 
-func resourceSecurityDynamicAddressFeedServerCreate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityDynamicAddressFeedServerCreate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeCreateSetFile != "" {
 		if err := setSecurityDynamicAddressFeedServer(d, m, nil); err != nil {
@@ -155,8 +155,8 @@ func resourceSecurityDynamicAddressFeedServerCreate(ctx context.Context,
 	return append(diagWarns, resourceSecurityDynamicAddressFeedServerReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceSecurityDynamicAddressFeedServerRead(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityDynamicAddressFeedServerRead(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -168,7 +168,8 @@ func resourceSecurityDynamicAddressFeedServerRead(ctx context.Context,
 }
 
 func resourceSecurityDynamicAddressFeedServerReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	dynamicAddressFeedServerOptions, err := readSecurityDynamicAddressFeedServer(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
@@ -184,8 +185,8 @@ func resourceSecurityDynamicAddressFeedServerReadWJnprSess(
 	return nil
 }
 
-func resourceSecurityDynamicAddressFeedServerUpdate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityDynamicAddressFeedServerUpdate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	d.Partial(true)
 	sess := m.(*Session)
 	if sess.junosFakeUpdateAlso {
@@ -228,8 +229,8 @@ func resourceSecurityDynamicAddressFeedServerUpdate(ctx context.Context,
 	return append(diagWarns, resourceSecurityDynamicAddressFeedServerReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceSecurityDynamicAddressFeedServerDelete(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityDynamicAddressFeedServerDelete(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeDeleteAlso {
 		if err := delSecurityDynamicAddressFeedServer(d.Get("name").(string), m, nil); err != nil {
@@ -261,8 +262,8 @@ func resourceSecurityDynamicAddressFeedServerDelete(ctx context.Context,
 	return diagWarns
 }
 
-func resourceSecurityDynamicAddressFeedServerImport(
-	d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+func resourceSecurityDynamicAddressFeedServerImport(d *schema.ResourceData, m interface{},
+) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -342,8 +343,8 @@ func setSecurityDynamicAddressFeedServer(d *schema.ResourceData, m interface{}, 
 	return sess.configSet(configSet, jnprSess)
 }
 
-func readSecurityDynamicAddressFeedServer(
-	name string, m interface{}, jnprSess *NetconfObject) (dynamicAddressFeedServerOptions, error) {
+func readSecurityDynamicAddressFeedServer(name string, m interface{}, jnprSess *NetconfObject,
+) (dynamicAddressFeedServerOptions, error) {
 	sess := m.(*Session)
 	var confRead dynamicAddressFeedServerOptions
 	// default -1
@@ -426,7 +427,8 @@ func delSecurityDynamicAddressFeedServer(name string, m interface{}, jnprSess *N
 }
 
 func fillSecurityDynamicAddressFeedServerData(
-	d *schema.ResourceData, dynamicAddressFeedServerOptions dynamicAddressFeedServerOptions) {
+	d *schema.ResourceData, dynamicAddressFeedServerOptions dynamicAddressFeedServerOptions,
+) {
 	if tfErr := d.Set("name", dynamicAddressFeedServerOptions.name); tfErr != nil {
 		panic(tfErr)
 	}

--- a/junos/resource_security_dynamic_address_name.go
+++ b/junos/resource_security_dynamic_address_name.go
@@ -88,8 +88,8 @@ func resourceSecurityDynamicAddressName() *schema.Resource {
 	}
 }
 
-func resourceSecurityDynamicAddressNameCreate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityDynamicAddressNameCreate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeCreateSetFile != "" {
 		if err := setSecurityDynamicAddressName(d, m, nil); err != nil {
@@ -149,8 +149,8 @@ func resourceSecurityDynamicAddressNameCreate(ctx context.Context,
 	return append(diagWarns, resourceSecurityDynamicAddressNameReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceSecurityDynamicAddressNameRead(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityDynamicAddressNameRead(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -161,8 +161,8 @@ func resourceSecurityDynamicAddressNameRead(ctx context.Context,
 	return resourceSecurityDynamicAddressNameReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceSecurityDynamicAddressNameReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceSecurityDynamicAddressNameReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	dynamicAddressNameOptions, err := readSecurityDynamicAddressName(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
@@ -178,8 +178,8 @@ func resourceSecurityDynamicAddressNameReadWJnprSess(
 	return nil
 }
 
-func resourceSecurityDynamicAddressNameUpdate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityDynamicAddressNameUpdate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	d.Partial(true)
 	sess := m.(*Session)
 	if sess.junosFakeUpdateAlso {
@@ -222,8 +222,8 @@ func resourceSecurityDynamicAddressNameUpdate(ctx context.Context,
 	return append(diagWarns, resourceSecurityDynamicAddressNameReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceSecurityDynamicAddressNameDelete(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityDynamicAddressNameDelete(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeDeleteAlso {
 		if err := delSecurityDynamicAddressName(d.Get("name").(string), m, nil); err != nil {
@@ -255,8 +255,8 @@ func resourceSecurityDynamicAddressNameDelete(ctx context.Context,
 	return diagWarns
 }
 
-func resourceSecurityDynamicAddressNameImport(
-	d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+func resourceSecurityDynamicAddressNameImport(d *schema.ResourceData, m interface{},
+) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -332,8 +332,8 @@ func setSecurityDynamicAddressName(d *schema.ResourceData, m interface{}, jnprSe
 	return sess.configSet(configSet, jnprSess)
 }
 
-func readSecurityDynamicAddressName(
-	name string, m interface{}, jnprSess *NetconfObject) (dynamicAddressNameOptions, error) {
+func readSecurityDynamicAddressName(name string, m interface{}, jnprSess *NetconfObject,
+) (dynamicAddressNameOptions, error) {
 	sess := m.(*Session)
 	var confRead dynamicAddressNameOptions
 
@@ -404,8 +404,8 @@ func delSecurityDynamicAddressName(name string, m interface{}, jnprSess *Netconf
 	return sess.configSet(configSet, jnprSess)
 }
 
-func fillSecurityDynamicAddressNameData(
-	d *schema.ResourceData, dynamicAddressNameOptions dynamicAddressNameOptions) {
+func fillSecurityDynamicAddressNameData(d *schema.ResourceData, dynamicAddressNameOptions dynamicAddressNameOptions,
+) {
 	if tfErr := d.Set("name", dynamicAddressNameOptions.name); tfErr != nil {
 		panic(tfErr)
 	}

--- a/junos/resource_security_global_policy.go
+++ b/junos/resource_security_global_policy.go
@@ -247,8 +247,8 @@ func resourceSecurityGlobalPolicyRead(ctx context.Context, d *schema.ResourceDat
 	return resourceSecurityGlobalPolicyReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceSecurityGlobalPolicyReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceSecurityGlobalPolicyReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	globalPolicyOptions, err := readSecurityGlobalPolicy(m, jnprSess)
 	mutex.Unlock()
@@ -616,8 +616,9 @@ func readGlobalPolicyPermitApplicationServices(itemTrimPolicy string, applicatio
 	}
 }
 
-func setGlobalPolicyPermitApplicationServices(setPrefixPolicy string,
-	policyPermitApplicationServices map[string]interface{}) ([]string, error) {
+func setGlobalPolicyPermitApplicationServices(
+	setPrefixPolicy string, policyPermitApplicationServices map[string]interface{},
+) ([]string, error) {
 	configSet := make([]string, 0)
 	setPrefixPolicyPermitAppSvc := setPrefixPolicy + " then permit application-services "
 	if v := policyPermitApplicationServices["advanced_anti_malware_policy"].(string); v != "" {

--- a/junos/resource_security_idp_custom_attack.go
+++ b/junos/resource_security_idp_custom_attack.go
@@ -815,8 +815,8 @@ func schemaSecurityIdpCustomAttackTypeSignature(chain bool) map[string]*schema.S
 	return r
 }
 
-func resourceSecurityIdpCustomAttackCreate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityIdpCustomAttackCreate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeCreateSetFile != "" {
 		if err := setSecurityIdpCustomAttack(d, m, nil); err != nil {
@@ -886,8 +886,8 @@ func resourceSecurityIdpCustomAttackRead(ctx context.Context, d *schema.Resource
 	return resourceSecurityIdpCustomAttackReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceSecurityIdpCustomAttackReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceSecurityIdpCustomAttackReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	idpCustomAttackOptions, err := readSecurityIdpCustomAttack(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
@@ -903,8 +903,8 @@ func resourceSecurityIdpCustomAttackReadWJnprSess(
 	return nil
 }
 
-func resourceSecurityIdpCustomAttackUpdate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityIdpCustomAttackUpdate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	d.Partial(true)
 	sess := m.(*Session)
 	if sess.junosFakeUpdateAlso {
@@ -947,8 +947,8 @@ func resourceSecurityIdpCustomAttackUpdate(ctx context.Context,
 	return append(diagWarns, resourceSecurityIdpCustomAttackReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceSecurityIdpCustomAttackDelete(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityIdpCustomAttackDelete(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeDeleteAlso {
 		if err := delSecurityIdpCustomAttack(d.Get("name").(string), m, nil); err != nil {
@@ -1097,8 +1097,8 @@ func setSecurityIdpCustomAttack(d *schema.ResourceData, m interface{}, jnprSess 
 	return sess.configSet(configSet, jnprSess)
 }
 
-func setSecurityIdpCustomAttackTypeAnomaly(
-	setPrefixOrigin string, attackAnomaly map[string]interface{}) []string {
+func setSecurityIdpCustomAttackTypeAnomaly(setPrefixOrigin string, attackAnomaly map[string]interface{},
+) []string {
 	configSet := make([]string, 0)
 
 	setPrefix := setPrefixOrigin + "attack-type anomaly "
@@ -1114,8 +1114,8 @@ func setSecurityIdpCustomAttackTypeAnomaly(
 	return configSet
 }
 
-func setSecurityIdpCustomAttackTypeSignature(
-	setPrefixOrigin string, attackSignature map[string]interface{}) ([]string, error) {
+func setSecurityIdpCustomAttackTypeSignature(setPrefixOrigin string, attackSignature map[string]interface{},
+) ([]string, error) {
 	configSet := make([]string, 0)
 	setPrefix := setPrefixOrigin + "attack-type signature "
 
@@ -1214,8 +1214,8 @@ func setSecurityIdpCustomAttackTypeSignature(
 	return configSet, nil
 }
 
-func setSecurityIdpCustomAttackTypeSignatureProtoICMP(
-	v6 bool, setPrefixOrigin string, protoICMP map[string]interface{}) []string {
+func setSecurityIdpCustomAttackTypeSignatureProtoICMP(v6 bool, setPrefixOrigin string, protoICMP map[string]interface{},
+) []string {
 	configSet := make([]string, 0)
 	setPrefix := setPrefixOrigin + "protocol icmp "
 	if v6 {
@@ -1261,8 +1261,8 @@ func setSecurityIdpCustomAttackTypeSignatureProtoICMP(
 	return configSet
 }
 
-func setSecurityIdpCustomAttackTypeSignatureProtoIPv4(
-	setPrefixOrigin string, protoIPv4 map[string]interface{}) []string {
+func setSecurityIdpCustomAttackTypeSignatureProtoIPv4(setPrefixOrigin string, protoIPv4 map[string]interface{},
+) []string {
 	configSet := make([]string, 0)
 	setPrefix := setPrefixOrigin + "protocol ipv4 "
 	if match := protoIPv4["checksum_validate_match"].(string); match != "" {
@@ -1326,8 +1326,8 @@ func setSecurityIdpCustomAttackTypeSignatureProtoIPv4(
 	return configSet
 }
 
-func setSecurityIdpCustomAttackTypeSignatureProtoIPv6(
-	setPrefixOrigin string, protoIPv6 map[string]interface{}) []string {
+func setSecurityIdpCustomAttackTypeSignatureProtoIPv6(setPrefixOrigin string, protoIPv6 map[string]interface{},
+) []string {
 	configSet := make([]string, 0)
 	setPrefix := setPrefixOrigin + "protocol ipv6 "
 	if match := protoIPv6["destination_match"].(string); match != "" {
@@ -1398,8 +1398,8 @@ func setSecurityIdpCustomAttackTypeSignatureProtoIPv6(
 	return configSet
 }
 
-func setSecurityIdpCustomAttackTypeSignatureProtoTCP(
-	setPrefixOrigin string, protoTCP map[string]interface{}) []string {
+func setSecurityIdpCustomAttackTypeSignatureProtoTCP(setPrefixOrigin string, protoTCP map[string]interface{},
+) []string {
 	configSet := make([]string, 0)
 	setPrefix := setPrefixOrigin + "protocol tcp "
 	if match := protoTCP["ack_number_match"].(string); match != "" {
@@ -1487,8 +1487,8 @@ func setSecurityIdpCustomAttackTypeSignatureProtoTCP(
 	return configSet
 }
 
-func setSecurityIdpCustomAttackTypeSignatureProtoUDP(
-	setPrefixOrigin string, protoUDP map[string]interface{}) []string {
+func setSecurityIdpCustomAttackTypeSignatureProtoUDP(setPrefixOrigin string, protoUDP map[string]interface{},
+) []string {
 	configSet := make([]string, 0)
 	setPrefix := setPrefixOrigin + "protocol udp "
 	if match := protoUDP["checksum_validate_match"].(string); match != "" {
@@ -1519,8 +1519,8 @@ func setSecurityIdpCustomAttackTypeSignatureProtoUDP(
 	return configSet
 }
 
-func readSecurityIdpCustomAttack(customAttack string, m interface{}, jnprSess *NetconfObject) (
-	idpCustomAttackOptions, error) {
+func readSecurityIdpCustomAttack(customAttack string, m interface{}, jnprSess *NetconfObject,
+) (idpCustomAttackOptions, error) {
 	sess := m.(*Session)
 	var confRead idpCustomAttackOptions
 	confRead.timeBindingCount = -1 // default to -1

--- a/junos/resource_security_idp_custom_attack_group.go
+++ b/junos/resource_security_idp_custom_attack_group.go
@@ -39,8 +39,8 @@ func resourceSecurityIdpCustomAttackGroup() *schema.Resource {
 	}
 }
 
-func resourceSecurityIdpCustomAttackGroupCreate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityIdpCustomAttackGroupCreate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeCreateSetFile != "" {
 		if err := setSecurityIdpCustomAttackGroup(d, m, nil); err != nil {
@@ -99,8 +99,8 @@ func resourceSecurityIdpCustomAttackGroupCreate(ctx context.Context,
 	return append(diagWarns, resourceSecurityIdpCustomAttackGroupReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceSecurityIdpCustomAttackGroupRead(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityIdpCustomAttackGroupRead(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -111,8 +111,8 @@ func resourceSecurityIdpCustomAttackGroupRead(ctx context.Context,
 	return resourceSecurityIdpCustomAttackGroupReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceSecurityIdpCustomAttackGroupReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceSecurityIdpCustomAttackGroupReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	idpCustomAttackGroupOptions, err := readSecurityIdpCustomAttackGroup(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
@@ -128,8 +128,8 @@ func resourceSecurityIdpCustomAttackGroupReadWJnprSess(
 	return nil
 }
 
-func resourceSecurityIdpCustomAttackGroupUpdate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityIdpCustomAttackGroupUpdate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	d.Partial(true)
 	sess := m.(*Session)
 	if sess.junosFakeUpdateAlso {
@@ -173,8 +173,8 @@ func resourceSecurityIdpCustomAttackGroupUpdate(ctx context.Context,
 	return append(diagWarns, resourceSecurityIdpCustomAttackGroupReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceSecurityIdpCustomAttackGroupDelete(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityIdpCustomAttackGroupDelete(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeDeleteAlso {
 		if err := delSecurityIdpCustomAttackGroup(d.Get("name").(string), m, nil); err != nil {
@@ -232,8 +232,8 @@ func resourceSecurityIdpCustomAttackGroupImport(d *schema.ResourceData, m interf
 	return result, nil
 }
 
-func checkSecurityIdpCustomAttackGroupExists(
-	customAttackGroup string, m interface{}, jnprSess *NetconfObject) (bool, error) {
+func checkSecurityIdpCustomAttackGroupExists(customAttackGroup string, m interface{}, jnprSess *NetconfObject,
+) (bool, error) {
 	sess := m.(*Session)
 	showConfig, err := sess.command(cmdShowConfig+
 		"security idp custom-attack-group \""+customAttackGroup+"\""+pipeDisplaySet, jnprSess)
@@ -260,8 +260,8 @@ func setSecurityIdpCustomAttackGroup(d *schema.ResourceData, m interface{}, jnpr
 	return sess.configSet(configSet, jnprSess)
 }
 
-func readSecurityIdpCustomAttackGroup(customAttackGroup string, m interface{}, jnprSess *NetconfObject) (
-	idpCustomAttackGroupOptions, error) {
+func readSecurityIdpCustomAttackGroup(customAttackGroup string, m interface{}, jnprSess *NetconfObject,
+) (idpCustomAttackGroupOptions, error) {
 	sess := m.(*Session)
 	var confRead idpCustomAttackGroupOptions
 
@@ -297,7 +297,8 @@ func delSecurityIdpCustomAttackGroup(customAttack string, m interface{}, jnprSes
 }
 
 func fillSecurityIdpCustomAttackGroupData(
-	d *schema.ResourceData, idpCustomAttackGroupOptions idpCustomAttackGroupOptions) {
+	d *schema.ResourceData, idpCustomAttackGroupOptions idpCustomAttackGroupOptions,
+) {
 	if tfErr := d.Set("name", idpCustomAttackGroupOptions.name); tfErr != nil {
 		panic(tfErr)
 	}

--- a/junos/resource_security_idp_policy.go
+++ b/junos/resource_security_idp_policy.go
@@ -348,8 +348,8 @@ func resourceSecurityIdpPolicyRead(ctx context.Context, d *schema.ResourceData, 
 	return resourceSecurityIdpPolicyReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceSecurityIdpPolicyReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceSecurityIdpPolicyReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	idpPolicyOptions, err := readSecurityIdpPolicy(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
@@ -732,8 +732,8 @@ func setSecurityIdpPolicyIpsRule(setPrefix string, rule map[string]interface{}) 
 	return configSet, nil
 }
 
-func readSecurityIdpPolicy(policy string, m interface{}, jnprSess *NetconfObject) (
-	idpPolicyOptions, error) {
+func readSecurityIdpPolicy(policy string, m interface{}, jnprSess *NetconfObject,
+) (idpPolicyOptions, error) {
 	sess := m.(*Session)
 	var confRead idpPolicyOptions
 

--- a/junos/resource_security_ike_ipsec_test.go
+++ b/junos/resource_security_ike_ipsec_test.go
@@ -1,6 +1,7 @@
 package junos_test
 
 import (
+	"fmt"
 	"os"
 	"regexp"
 	"testing"
@@ -252,9 +253,9 @@ func TestAccJunosSecurityIkeIpsec_basic(t *testing.T) {
 }
 
 func testAccJunosSecurityIkeIpsecConfigCreate(interFace string) string {
-	return `
+	return fmt.Sprintf(`
 resource junos_interface_logical "testacc_ikegateway" {
-  name = "` + interFace + `.0"
+  name = "%s.0"
   family_inet {
     address {
       cidr_ip = "192.0.2.4/25"
@@ -324,13 +325,13 @@ resource junos_security_ipsec_vpn "testacc_ipsecvpn" {
   establish_tunnels = "on-traffic"
   df_bit            = "clear"
 }
-`
+`, interFace)
 }
 
 func testAccJunosSecurityIkeIpsecConfigUpdate(interFace string) string {
-	return `
+	return fmt.Sprintf(`
 resource junos_interface_logical "testacc_ikegateway" {
-  name = "` + interFace + `.0"
+  name = "%s.0"
   family_inet {
     address {
       cidr_ip = "192.0.2.4/25"
@@ -447,13 +448,13 @@ resource junos_security_policy_tunnel_pair_policy testacc_vpn-in-out {
   policy_a_to_b = junos_security_policy.testacc_policyIpsecLocToRem.policy[0].name
   policy_b_to_a = junos_security_policy.testacc_policyIpsecRemToLoc.policy[0].name
 }
-`
+`, interFace)
 }
 
 func testAccJunosSecurityIkeIpsecConfigUpdate2(interFace string) string {
-	return `
+	return fmt.Sprintf(`
 resource junos_interface_logical "testacc_ikegateway" {
-  name = "` + interFace + `.0"
+  name = "%s.0"
   family_inet {
     address {
       cidr_ip = "192.0.2.4/25"
@@ -571,13 +572,13 @@ resource junos_security_policy_tunnel_pair_policy testacc_vpn-in-out {
   policy_a_to_b = junos_security_policy.testacc_policyIpsecLocToRem.policy[0].name
   policy_b_to_a = junos_security_policy.testacc_policyIpsecRemToLoc.policy[0].name
 }
-`
+`, interFace)
 }
 
 func testAccJunosSecurityIkeIpsecConfigUpdate3(interFace string) string {
-	return `
+	return fmt.Sprintf(`
 resource junos_interface_logical "testacc_ikegateway" {
-  name = "` + interFace + `.0"
+  name = "%s.0"
   family_inet {
     address {
       cidr_ip = "192.0.2.4/25"
@@ -640,13 +641,13 @@ resource junos_interface_logical "testacc_ipsecvpn_bind" {
   family_inet {}
 }
 resource junos_interface_st0_unit testacc_ipsec_vpn {}
-`
+`, interFace)
 }
 
 func testAccJunosSecurityIkeIpsecConfigUpdate4(interFace string) string {
-	return `
+	return fmt.Sprintf(`
 resource junos_interface_logical "testacc_ikegateway" {
-  name = "` + interFace + `.0"
+  name = "%s.0"
   family_inet {
     address {
       cidr_ip = "192.0.2.4/25"
@@ -674,13 +675,13 @@ resource junos_security_ike_gateway "testacc_ikegateway" {
   policy             = junos_security_ike_policy.testacc_ikepol.name
   external_interface = junos_interface_logical.testacc_ikegateway.name
 }
-`
+`, interFace)
 }
 
 func testAccJunosSecurityIkeIpsecConfigUpdate5(interFace string) string {
-	return `
+	return fmt.Sprintf(`
 resource junos_interface_logical "testacc_ikegateway" {
-  name = "` + interFace + `.0"
+  name = "%s.0"
   family_inet {
     address {
       cidr_ip = "192.0.2.4/25"
@@ -708,13 +709,13 @@ resource junos_security_ike_gateway "testacc_ikegateway" {
   policy             = junos_security_ike_policy.testacc_ikepol.name
   external_interface = junos_interface_logical.testacc_ikegateway.name
 }
-`
+`, interFace)
 }
 
 func testAccJunosSecurityIkeIpsecConfigUpdate6(interFace string) string {
-	return `
+	return fmt.Sprintf(`
 resource junos_interface_logical "testacc_ikegateway" {
-  name = "` + interFace + `.0"
+  name = "%s.0"
   family_inet {
     address {
       cidr_ip = "192.0.2.4/25"
@@ -744,13 +745,13 @@ resource junos_security_ike_gateway "testacc_ikegateway" {
   policy             = junos_security_ike_policy.testacc_ikepol.name
   external_interface = junos_interface_logical.testacc_ikegateway.name
 }
-`
+`, interFace)
 }
 
 func testAccJunosSecurityIkeIpsecConfigUpdate7(interFace string) string {
-	return `
+	return fmt.Sprintf(`
 resource junos_interface_logical "testacc_ikegateway" {
-  name = "` + interFace + `.0"
+  name = "%s.0"
   family_inet {
     address {
       cidr_ip = "192.0.2.4/25"
@@ -780,5 +781,5 @@ resource junos_security_ike_gateway "testacc_ikegateway" {
   policy             = junos_security_ike_policy.testacc_ikepol.name
   external_interface = junos_interface_logical.testacc_ikegateway.name
 }
-`
+`, interFace)
 }

--- a/junos/resource_security_ipsec_proposal.go
+++ b/junos/resource_security_ipsec_proposal.go
@@ -133,8 +133,8 @@ func resourceIpsecProposalRead(ctx context.Context, d *schema.ResourceData, m in
 	return resourceIpsecProposalReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceIpsecProposalReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceIpsecProposalReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	ipsecProposalOptions, err := readIpsecProposal(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()

--- a/junos/resource_security_log_stream.go
+++ b/junos/resource_security_log_stream.go
@@ -192,8 +192,8 @@ func resourceSecurityLogStreamRead(ctx context.Context, d *schema.ResourceData, 
 	return resourceSecurityLogStreamReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceSecurityLogStreamReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceSecurityLogStreamReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	securityLogStreamOptions, err := readSecurityLogStream(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
@@ -375,8 +375,8 @@ func setSecurityLogStream(d *schema.ResourceData, m interface{}, jnprSess *Netco
 	return sess.configSet(configSet, jnprSess)
 }
 
-func readSecurityLogStream(securityLogStream string, m interface{}, jnprSess *NetconfObject) (
-	securityLogStreamOptions, error) {
+func readSecurityLogStream(securityLogStream string, m interface{}, jnprSess *NetconfObject,
+) (securityLogStreamOptions, error) {
 	sess := m.(*Session)
 	var confRead securityLogStreamOptions
 

--- a/junos/resource_security_nat_destination.go
+++ b/junos/resource_security_nat_destination.go
@@ -200,8 +200,8 @@ func resourceSecurityNatDestinationRead(ctx context.Context, d *schema.ResourceD
 	return resourceSecurityNatDestinationReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceSecurityNatDestinationReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceSecurityNatDestinationReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	natDestinationOptions, err := readSecurityNatDestination(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()

--- a/junos/resource_security_nat_destination_pool.go
+++ b/junos/resource_security_nat_destination_pool.go
@@ -66,8 +66,8 @@ func resourceSecurityNatDestinationPool() *schema.Resource {
 	}
 }
 
-func resourceSecurityNatDestinationPoolCreate(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityNatDestinationPoolCreate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeCreateSetFile != "" {
 		if err := setSecurityNatDestinationPool(d, m, nil); err != nil {
@@ -127,8 +127,8 @@ func resourceSecurityNatDestinationPoolCreate(
 	return append(diagWarns, resourceSecurityNatDestinationPoolReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceSecurityNatDestinationPoolRead(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityNatDestinationPoolRead(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -139,8 +139,8 @@ func resourceSecurityNatDestinationPoolRead(
 	return resourceSecurityNatDestinationPoolReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceSecurityNatDestinationPoolReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceSecurityNatDestinationPoolReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	natDestinationPoolOptions, err := readSecurityNatDestinationPool(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
@@ -156,8 +156,8 @@ func resourceSecurityNatDestinationPoolReadWJnprSess(
 	return nil
 }
 
-func resourceSecurityNatDestinationPoolUpdate(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityNatDestinationPoolUpdate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	d.Partial(true)
 	sess := m.(*Session)
 	if sess.junosFakeUpdateAlso {
@@ -200,8 +200,8 @@ func resourceSecurityNatDestinationPoolUpdate(
 	return append(diagWarns, resourceSecurityNatDestinationPoolReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceSecurityNatDestinationPoolDelete(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityNatDestinationPoolDelete(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeDeleteAlso {
 		if err := delSecurityNatDestinationPool(d.Get("name").(string), m, nil); err != nil {
@@ -296,8 +296,8 @@ func setSecurityNatDestinationPool(d *schema.ResourceData, m interface{}, jnprSe
 	return sess.configSet(configSet, jnprSess)
 }
 
-func readSecurityNatDestinationPool(name string,
-	m interface{}, jnprSess *NetconfObject) (natDestinationPoolOptions, error) {
+func readSecurityNatDestinationPool(name string, m interface{}, jnprSess *NetconfObject,
+) (natDestinationPoolOptions, error) {
 	sess := m.(*Session)
 	var confRead natDestinationPoolOptions
 

--- a/junos/resource_security_nat_source.go
+++ b/junos/resource_security_nat_source.go
@@ -235,8 +235,8 @@ func resourceSecurityNatSourceRead(ctx context.Context, d *schema.ResourceData, 
 	return resourceSecurityNatSourceReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceSecurityNatSourceReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceSecurityNatSourceReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	natSourceOptions, err := readSecurityNatSource(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()

--- a/junos/resource_security_nat_source_pool.go
+++ b/junos/resource_security_nat_source_pool.go
@@ -164,8 +164,8 @@ func resourceSecurityNatSourcePoolRead(ctx context.Context, d *schema.ResourceDa
 	return resourceSecurityNatSourcePoolReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceSecurityNatSourcePoolReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceSecurityNatSourcePoolReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	natSourcePoolOptions, err := readSecurityNatSourcePool(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()

--- a/junos/resource_security_nat_static.go
+++ b/junos/resource_security_nat_static.go
@@ -221,8 +221,8 @@ func resourceSecurityNatStaticRead(ctx context.Context, d *schema.ResourceData, 
 	return resourceSecurityNatStaticReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceSecurityNatStaticReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceSecurityNatStaticReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	natStaticOptions, err := readSecurityNatStatic(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()

--- a/junos/resource_security_nat_static_rule.go
+++ b/junos/resource_security_nat_static_rule.go
@@ -122,8 +122,8 @@ func resourceSecurityNatStaticRule() *schema.Resource {
 	}
 }
 
-func resourceSecurityNatStaticRuleCreate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityNatStaticRuleCreate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeCreateSetFile != "" {
 		if err := setSecurityNatStaticRule(d, m, nil); err != nil {
@@ -210,8 +210,8 @@ func resourceSecurityNatStaticRuleRead(ctx context.Context, d *schema.ResourceDa
 	return resourceSecurityNatStaticRuleReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceSecurityNatStaticRuleReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceSecurityNatStaticRuleReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	natStaticRuleOptions, err := readSecurityNatStaticRule(d.Get("rule_set").(string), d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
@@ -227,8 +227,8 @@ func resourceSecurityNatStaticRuleReadWJnprSess(
 	return nil
 }
 
-func resourceSecurityNatStaticRuleUpdate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityNatStaticRuleUpdate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	d.Partial(true)
 	sess := m.(*Session)
 	if sess.junosFakeUpdateAlso {
@@ -271,8 +271,8 @@ func resourceSecurityNatStaticRuleUpdate(ctx context.Context,
 	return append(diagWarns, resourceSecurityNatStaticRuleReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceSecurityNatStaticRuleDelete(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityNatStaticRuleDelete(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeDeleteAlso {
 		if err := delSecurityNatStaticRule(d.Get("rule_set").(string), d.Get("name").(string), m, nil); err != nil {
@@ -435,8 +435,8 @@ func setSecurityNatStaticRule(d *schema.ResourceData, m interface{}, jnprSess *N
 	return sess.configSet(configSet, jnprSess)
 }
 
-func readSecurityNatStaticRule(ruleSet, name string,
-	m interface{}, jnprSess *NetconfObject) (natStaticRuleOptions, error) {
+func readSecurityNatStaticRule(ruleSet, name string, m interface{}, jnprSess *NetconfObject,
+) (natStaticRuleOptions, error) {
 	sess := m.(*Session)
 	var confRead natStaticRuleOptions
 

--- a/junos/resource_security_policy.go
+++ b/junos/resource_security_policy.go
@@ -265,8 +265,8 @@ func resourceSecurityPolicyRead(ctx context.Context, d *schema.ResourceData, m i
 	return resourceSecurityPolicyReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceSecurityPolicyReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceSecurityPolicyReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	policyOptions, err := readSecurityPolicy(d.Get("from_zone").(string)+idSeparator+d.Get("to_zone").(string),
 		m, jnprSess)
@@ -595,7 +595,8 @@ func readSecurityPolicy(idPolicy string, m interface{}, jnprSess *NetconfObject)
 }
 
 func readSecurityPolicyTunnelPairPolicyLines(
-	listLines *[]string, fromZone string, toZone string, m interface{}, jnprSess *NetconfObject) error {
+	listLines *[]string, fromZone, toZone string, m interface{}, jnprSess *NetconfObject,
+) error {
 	sess := m.(*Session)
 	showConfig, err := sess.command(cmdShowConfig+
 		"security policies from-zone "+fromZone+" to-zone "+toZone+pipeDisplaySet, jnprSess)
@@ -619,7 +620,7 @@ func readSecurityPolicyTunnelPairPolicyLines(
 	return nil
 }
 
-func delSecurityPolicy(fromZone string, toZone string, m interface{}, jnprSess *NetconfObject) error {
+func delSecurityPolicy(fromZone, toZone string, m interface{}, jnprSess *NetconfObject) error {
 	sess := m.(*Session)
 	configSet := make([]string, 0, 1)
 	configSet = append(configSet, "delete security policies from-zone "+fromZone+" to-zone "+toZone)
@@ -716,8 +717,8 @@ func readPolicyPermitApplicationServices(itemTrimPolicy string, applicationServi
 	}
 }
 
-func setPolicyPermitApplicationServices(setPrefixPolicy string,
-	policyPermitApplicationServices map[string]interface{}) ([]string, error) {
+func setPolicyPermitApplicationServices(setPrefixPolicy string, policyPermitApplicationServices map[string]interface{},
+) ([]string, error) {
 	configSet := make([]string, 0)
 	setPrefixPolicyPermitAppSvc := setPrefixPolicy + " then permit application-services"
 	if v := policyPermitApplicationServices["advanced_anti_malware_policy"].(string); v != "" {

--- a/junos/resource_security_policy_tunnel_pair_policy.go
+++ b/junos/resource_security_policy_tunnel_pair_policy.go
@@ -53,8 +53,8 @@ func resourceSecurityPolicyTunnelPairPolicy() *schema.Resource {
 	}
 }
 
-func resourceSecurityPolicyTunnelPairPolicyCreate(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityPolicyTunnelPairPolicyCreate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeCreateSetFile != "" {
 		if err := setSecurityPolicyTunnelPairPolicy(d, m, nil); err != nil {
@@ -142,8 +142,8 @@ func resourceSecurityPolicyTunnelPairPolicyCreate(
 	return append(diagWarns, resourceSecurityPolicyTunnelPairPolicyReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceSecurityPolicyTunnelPairPolicyRead(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityPolicyTunnelPairPolicyRead(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -154,8 +154,8 @@ func resourceSecurityPolicyTunnelPairPolicyRead(
 	return resourceSecurityPolicyTunnelPairPolicyReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceSecurityPolicyTunnelPairPolicyReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceSecurityPolicyTunnelPairPolicyReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	policyPairPolicyOptions, err := readSecurityPolicyTunnelPairPolicy(d.Get("zone_a").(string)+idSeparator+
 		d.Get("policy_a_to_b").(string)+idSeparator+
@@ -174,8 +174,8 @@ func resourceSecurityPolicyTunnelPairPolicyReadWJnprSess(
 	return nil
 }
 
-func resourceSecurityPolicyTunnelPairPolicyDelete(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityPolicyTunnelPairPolicyDelete(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeDeleteAlso {
 		if err := delSecurityPolicyTunnelPairPolicy(d, m, nil); err != nil {
@@ -207,8 +207,8 @@ func resourceSecurityPolicyTunnelPairPolicyDelete(
 	return diagWarns
 }
 
-func resourceSecurityPolicyTunnelPairPolicyImport(d *schema.ResourceData,
-	m interface{}) ([]*schema.ResourceData, error) {
+func resourceSecurityPolicyTunnelPairPolicyImport(d *schema.ResourceData, m interface{},
+) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -241,8 +241,8 @@ func resourceSecurityPolicyTunnelPairPolicyImport(d *schema.ResourceData,
 	return result, nil
 }
 
-func checkSecurityPolicyPairExists(zoneA, policyAtoB, zoneB, policyBtoA string,
-	m interface{}, jnprSess *NetconfObject) (bool, error) {
+func checkSecurityPolicyPairExists(zoneA, policyAtoB, zoneB, policyBtoA string, m interface{}, jnprSess *NetconfObject,
+) (bool, error) {
 	sess := m.(*Session)
 
 	showConfigPairAtoB, err := sess.command(cmdShowConfig+
@@ -280,8 +280,8 @@ func setSecurityPolicyTunnelPairPolicy(d *schema.ResourceData, m interface{}, jn
 	return sess.configSet(configSet, jnprSess)
 }
 
-func readSecurityPolicyTunnelPairPolicy(idRessource string,
-	m interface{}, jnprSess *NetconfObject) (policyPairPolicyOptions, error) {
+func readSecurityPolicyTunnelPairPolicy(idRessource string, m interface{}, jnprSess *NetconfObject,
+) (policyPairPolicyOptions, error) {
 	zone := strings.Split(idRessource, idSeparator)
 	zoneA := zone[0]
 	policyAtoB := zone[1]

--- a/junos/resource_security_screen.go
+++ b/junos/resource_security_screen.go
@@ -650,8 +650,8 @@ func resourceSecurityScreenRead(ctx context.Context, d *schema.ResourceData, m i
 	return resourceSecurityScreenReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceSecurityScreenReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceSecurityScreenReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	screenOptions, err := readSecurityScreen(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()

--- a/junos/resource_security_screen_whitelist.go
+++ b/junos/resource_security_screen_whitelist.go
@@ -40,8 +40,8 @@ func resourceSecurityScreenWhiteList() *schema.Resource {
 	}
 }
 
-func resourceSecurityScreenWhiteListCreate(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityScreenWhiteListCreate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeCreateSetFile != "" {
 		if err := setSecurityScreenWhiteList(d, m, nil); err != nil {
@@ -101,8 +101,8 @@ func resourceSecurityScreenWhiteListCreate(
 	return append(diagWarns, resourceSecurityScreenWhiteListReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceSecurityScreenWhiteListRead(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityScreenWhiteListRead(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -113,8 +113,8 @@ func resourceSecurityScreenWhiteListRead(
 	return resourceSecurityScreenWhiteListReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceSecurityScreenWhiteListReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceSecurityScreenWhiteListReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	whiteListOptions, err := readSecurityScreenWhiteList(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
@@ -130,8 +130,8 @@ func resourceSecurityScreenWhiteListReadWJnprSess(
 	return nil
 }
 
-func resourceSecurityScreenWhiteListUpdate(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityScreenWhiteListUpdate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	d.Partial(true)
 	sess := m.(*Session)
 	if sess.junosFakeUpdateAlso {
@@ -174,8 +174,8 @@ func resourceSecurityScreenWhiteListUpdate(
 	return append(diagWarns, resourceSecurityScreenWhiteListReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceSecurityScreenWhiteListDelete(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityScreenWhiteListDelete(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeDeleteAlso {
 		if err := delSecurityScreenWhiteList(d.Get("name").(string), m, nil); err != nil {

--- a/junos/resource_security_test.go
+++ b/junos/resource_security_test.go
@@ -1,6 +1,7 @@
 package junos_test
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -277,12 +278,12 @@ resource junos_system "system" {
 }
 
 func testAccJunosSecurityConfigCreate(interFace string) string {
-	return `
+	return fmt.Sprintf(`
 resource junos_interface_logical "testacc_security" {
   lifecycle {
     create_before_destroy = true
   }
-  name        = "` + interFace + `.0"
+  name        = "%s.0"
   description = "testacc_security"
 }
 resource "junos_services_proxy_profile" "testacc_security" {
@@ -448,7 +449,7 @@ resource junos_security "testacc_security" {
     }
   }
 }
-`
+`, interFace)
 }
 
 func testAccJunosSecurityConfigUpdate(interFace string) string {

--- a/junos/resource_security_utm_custom_url_category.go
+++ b/junos/resource_security_utm_custom_url_category.go
@@ -40,8 +40,8 @@ func resourceSecurityUtmCustomURLCategory() *schema.Resource {
 	}
 }
 
-func resourceSecurityUtmCustomURLCategoryCreate(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityUtmCustomURLCategoryCreate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeCreateSetFile != "" {
 		if err := setUtmCustomURLCategory(d, m, nil); err != nil {
@@ -101,8 +101,8 @@ func resourceSecurityUtmCustomURLCategoryCreate(
 	return append(diagWarns, resourceSecurityUtmCustomURLCategoryReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceSecurityUtmCustomURLCategoryRead(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityUtmCustomURLCategoryRead(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -113,8 +113,8 @@ func resourceSecurityUtmCustomURLCategoryRead(
 	return resourceSecurityUtmCustomURLCategoryReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceSecurityUtmCustomURLCategoryReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceSecurityUtmCustomURLCategoryReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	utmCustomURLCategoryOptions, err := readUtmCustomURLCategory(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
@@ -130,8 +130,8 @@ func resourceSecurityUtmCustomURLCategoryReadWJnprSess(
 	return nil
 }
 
-func resourceSecurityUtmCustomURLCategoryUpdate(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityUtmCustomURLCategoryUpdate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	d.Partial(true)
 	sess := m.(*Session)
 	if sess.junosFakeUpdateAlso {
@@ -174,8 +174,8 @@ func resourceSecurityUtmCustomURLCategoryUpdate(
 	return append(diagWarns, resourceSecurityUtmCustomURLCategoryReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceSecurityUtmCustomURLCategoryDelete(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityUtmCustomURLCategoryDelete(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeDeleteAlso {
 		if err := delUtmCustomURLCategory(d.Get("name").(string), m, nil); err != nil {
@@ -260,8 +260,8 @@ func setUtmCustomURLCategory(d *schema.ResourceData, m interface{}, jnprSess *Ne
 	return sess.configSet(configSet, jnprSess)
 }
 
-func readUtmCustomURLCategory(urlCategory string, m interface{}, jnprSess *NetconfObject) (
-	utmCustomURLCategoryOptions, error) {
+func readUtmCustomURLCategory(urlCategory string, m interface{}, jnprSess *NetconfObject,
+) (utmCustomURLCategoryOptions, error) {
 	sess := m.(*Session)
 	var confRead utmCustomURLCategoryOptions
 

--- a/junos/resource_security_utm_custom_url_pattern.go
+++ b/junos/resource_security_utm_custom_url_pattern.go
@@ -40,8 +40,8 @@ func resourceSecurityUtmCustomURLPattern() *schema.Resource {
 	}
 }
 
-func resourceSecurityUtmCustomURLPatternCreate(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityUtmCustomURLPatternCreate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeCreateSetFile != "" {
 		if err := setUtmCustomURLPattern(d, m, nil); err != nil {
@@ -100,8 +100,8 @@ func resourceSecurityUtmCustomURLPatternCreate(
 	return append(diagWarns, resourceSecurityUtmCustomURLPatternReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceSecurityUtmCustomURLPatternRead(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityUtmCustomURLPatternRead(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -112,8 +112,8 @@ func resourceSecurityUtmCustomURLPatternRead(
 	return resourceSecurityUtmCustomURLPatternReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceSecurityUtmCustomURLPatternReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceSecurityUtmCustomURLPatternReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	utmCustomURLPatternOptions, err := readUtmCustomURLPattern(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
@@ -129,8 +129,8 @@ func resourceSecurityUtmCustomURLPatternReadWJnprSess(
 	return nil
 }
 
-func resourceSecurityUtmCustomURLPatternUpdate(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityUtmCustomURLPatternUpdate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	d.Partial(true)
 	sess := m.(*Session)
 	if sess.junosFakeUpdateAlso {
@@ -173,8 +173,8 @@ func resourceSecurityUtmCustomURLPatternUpdate(
 	return append(diagWarns, resourceSecurityUtmCustomURLPatternReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceSecurityUtmCustomURLPatternDelete(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityUtmCustomURLPatternDelete(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeDeleteAlso {
 		if err := delUtmCustomURLPattern(d.Get("name").(string), m, nil); err != nil {
@@ -258,8 +258,8 @@ func setUtmCustomURLPattern(d *schema.ResourceData, m interface{}, jnprSess *Net
 	return sess.configSet(configSet, jnprSess)
 }
 
-func readUtmCustomURLPattern(urlPattern string, m interface{}, jnprSess *NetconfObject) (
-	utmCustomURLPatternOptions, error) {
+func readUtmCustomURLPattern(urlPattern string, m interface{}, jnprSess *NetconfObject,
+) (utmCustomURLPatternOptions, error) {
 	sess := m.(*Session)
 	var confRead utmCustomURLPatternOptions
 

--- a/junos/resource_security_utm_policy.go
+++ b/junos/resource_security_utm_policy.go
@@ -204,8 +204,8 @@ func resourceSecurityUtmPolicyRead(ctx context.Context, d *schema.ResourceData, 
 	return resourceSecurityUtmPolicyReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceSecurityUtmPolicyReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceSecurityUtmPolicyReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	utmPolicyOptions, err := readUtmPolicy(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
@@ -430,8 +430,8 @@ func setUtmPolicy(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject
 	return sess.configSet(configSet, jnprSess)
 }
 
-func readUtmPolicy(policy string, m interface{}, jnprSess *NetconfObject) (
-	utmPolicyOptions, error) {
+func readUtmPolicy(policy string, m interface{}, jnprSess *NetconfObject,
+) (utmPolicyOptions, error) {
 	sess := m.(*Session)
 	var confRead utmPolicyOptions
 

--- a/junos/resource_security_utm_profile_web_filtering_juniper_enhanced.go
+++ b/junos/resource_security_utm_profile_web_filtering_juniper_enhanced.go
@@ -188,8 +188,8 @@ func resourceSecurityUtmProfileWebFilteringEnhanced() *schema.Resource {
 	}
 }
 
-func resourceSecurityUtmProfileWebFilteringEnhancedCreate(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityUtmProfileWebFilteringEnhancedCreate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeCreateSetFile != "" {
 		if err := setUtmProfileWebFEnhanced(d, m, nil); err != nil {
@@ -249,8 +249,8 @@ func resourceSecurityUtmProfileWebFilteringEnhancedCreate(
 	return append(diagWarns, resourceSecurityUtmProfileWebFilteringEnhancedReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceSecurityUtmProfileWebFilteringEnhancedRead(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityUtmProfileWebFilteringEnhancedRead(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -262,7 +262,8 @@ func resourceSecurityUtmProfileWebFilteringEnhancedRead(
 }
 
 func resourceSecurityUtmProfileWebFilteringEnhancedReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	utmProfileWebFEnhancedOptions, err := readUtmProfileWebFEnhanced(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
@@ -278,8 +279,8 @@ func resourceSecurityUtmProfileWebFilteringEnhancedReadWJnprSess(
 	return nil
 }
 
-func resourceSecurityUtmProfileWebFilteringEnhancedUpdate(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityUtmProfileWebFilteringEnhancedUpdate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	d.Partial(true)
 	sess := m.(*Session)
 	if sess.junosFakeUpdateAlso {
@@ -322,8 +323,8 @@ func resourceSecurityUtmProfileWebFilteringEnhancedUpdate(
 	return append(diagWarns, resourceSecurityUtmProfileWebFilteringEnhancedReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceSecurityUtmProfileWebFilteringEnhancedDelete(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityUtmProfileWebFilteringEnhancedDelete(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeDeleteAlso {
 		if err := delUtmProfileWebFEnhanced(d.Get("name").(string), m, nil); err != nil {
@@ -355,8 +356,8 @@ func resourceSecurityUtmProfileWebFilteringEnhancedDelete(
 	return diagWarns
 }
 
-func resourceSecurityUtmProfileWebFilteringEnhancedImport(
-	d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+func resourceSecurityUtmProfileWebFilteringEnhancedImport(d *schema.ResourceData, m interface{},
+) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -504,8 +505,8 @@ func setUtmProfileWebFEnhanced(d *schema.ResourceData, m interface{}, jnprSess *
 	return sess.configSet(configSet, jnprSess)
 }
 
-func readUtmProfileWebFEnhanced(profile string, m interface{}, jnprSess *NetconfObject) (
-	utmProfileWebFilteringEnhancedOptions, error) {
+func readUtmProfileWebFEnhanced(profile string, m interface{}, jnprSess *NetconfObject,
+) (utmProfileWebFilteringEnhancedOptions, error) {
 	sess := m.(*Session)
 	var confRead utmProfileWebFilteringEnhancedOptions
 
@@ -630,8 +631,9 @@ func delUtmProfileWebFEnhanced(profile string, m interface{}, jnprSess *NetconfO
 	return sess.configSet(configSet, jnprSess)
 }
 
-func fillUtmProfileWebFEnhancedData(d *schema.ResourceData,
-	utmProfileWebFEnhancedOptions utmProfileWebFilteringEnhancedOptions) {
+func fillUtmProfileWebFEnhancedData(
+	d *schema.ResourceData, utmProfileWebFEnhancedOptions utmProfileWebFilteringEnhancedOptions,
+) {
 	if tfErr := d.Set("name", utmProfileWebFEnhancedOptions.name); tfErr != nil {
 		panic(tfErr)
 	}

--- a/junos/resource_security_utm_profile_web_filtering_juniper_local.go
+++ b/junos/resource_security_utm_profile_web_filtering_juniper_local.go
@@ -81,8 +81,8 @@ func resourceSecurityUtmProfileWebFilteringLocal() *schema.Resource {
 	}
 }
 
-func resourceSecurityUtmProfileWebFilteringLocalCreate(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityUtmProfileWebFilteringLocalCreate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeCreateSetFile != "" {
 		if err := setUtmProfileWebFLocal(d, m, nil); err != nil {
@@ -142,8 +142,8 @@ func resourceSecurityUtmProfileWebFilteringLocalCreate(
 	return append(diagWarns, resourceSecurityUtmProfileWebFilteringLocalReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceSecurityUtmProfileWebFilteringLocalRead(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityUtmProfileWebFilteringLocalRead(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -155,7 +155,8 @@ func resourceSecurityUtmProfileWebFilteringLocalRead(
 }
 
 func resourceSecurityUtmProfileWebFilteringLocalReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	utmProfileWebFLocalOptions, err := readUtmProfileWebFLocal(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
@@ -171,8 +172,8 @@ func resourceSecurityUtmProfileWebFilteringLocalReadWJnprSess(
 	return nil
 }
 
-func resourceSecurityUtmProfileWebFilteringLocalUpdate(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityUtmProfileWebFilteringLocalUpdate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	d.Partial(true)
 	sess := m.(*Session)
 	if sess.junosFakeUpdateAlso {
@@ -215,8 +216,8 @@ func resourceSecurityUtmProfileWebFilteringLocalUpdate(
 	return append(diagWarns, resourceSecurityUtmProfileWebFilteringLocalReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceSecurityUtmProfileWebFilteringLocalDelete(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityUtmProfileWebFilteringLocalDelete(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeDeleteAlso {
 		if err := delUtmProfileWebFLocal(d.Get("name").(string), m, nil); err != nil {
@@ -248,8 +249,8 @@ func resourceSecurityUtmProfileWebFilteringLocalDelete(
 	return diagWarns
 }
 
-func resourceSecurityUtmProfileWebFilteringLocalImport(
-	d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+func resourceSecurityUtmProfileWebFilteringLocalImport(d *schema.ResourceData, m interface{},
+) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -332,8 +333,8 @@ func setUtmProfileWebFLocal(d *schema.ResourceData, m interface{}, jnprSess *Net
 	return sess.configSet(configSet, jnprSess)
 }
 
-func readUtmProfileWebFLocal(profile string, m interface{}, jnprSess *NetconfObject) (
-	utmProfileWebFilteringLocalOptions, error) {
+func readUtmProfileWebFLocal(profile string, m interface{}, jnprSess *NetconfObject,
+) (utmProfileWebFilteringLocalOptions, error) {
 	sess := m.(*Session)
 	var confRead utmProfileWebFilteringLocalOptions
 
@@ -399,8 +400,9 @@ func delUtmProfileWebFLocal(profile string, m interface{}, jnprSess *NetconfObje
 	return sess.configSet(configSet, jnprSess)
 }
 
-func fillUtmProfileWebFLocalData(d *schema.ResourceData,
-	utmProfileWebFLocalOptions utmProfileWebFilteringLocalOptions) {
+func fillUtmProfileWebFLocalData(
+	d *schema.ResourceData, utmProfileWebFLocalOptions utmProfileWebFilteringLocalOptions,
+) {
 	if tfErr := d.Set("name", utmProfileWebFLocalOptions.name); tfErr != nil {
 		panic(tfErr)
 	}

--- a/junos/resource_security_utm_profile_web_filtering_websense_redirect.go
+++ b/junos/resource_security_utm_profile_web_filtering_websense_redirect.go
@@ -105,8 +105,8 @@ func resourceSecurityUtmProfileWebFilteringWebsense() *schema.Resource {
 	}
 }
 
-func resourceSecurityUtmProfileWebFilteringWebsenseCreate(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityUtmProfileWebFilteringWebsenseCreate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeCreateSetFile != "" {
 		if err := setUtmProfileWebFWebsense(d, m, nil); err != nil {
@@ -166,8 +166,8 @@ func resourceSecurityUtmProfileWebFilteringWebsenseCreate(
 	return append(diagWarns, resourceSecurityUtmProfileWebFilteringWebsenseReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceSecurityUtmProfileWebFilteringWebsenseRead(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityUtmProfileWebFilteringWebsenseRead(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -179,7 +179,8 @@ func resourceSecurityUtmProfileWebFilteringWebsenseRead(
 }
 
 func resourceSecurityUtmProfileWebFilteringWebsenseReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	utmProfileWebFWebsenseOptions, err := readUtmProfileWebFWebsense(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
@@ -195,8 +196,8 @@ func resourceSecurityUtmProfileWebFilteringWebsenseReadWJnprSess(
 	return nil
 }
 
-func resourceSecurityUtmProfileWebFilteringWebsenseUpdate(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityUtmProfileWebFilteringWebsenseUpdate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	d.Partial(true)
 	sess := m.(*Session)
 	if sess.junosFakeUpdateAlso {
@@ -239,8 +240,8 @@ func resourceSecurityUtmProfileWebFilteringWebsenseUpdate(
 	return append(diagWarns, resourceSecurityUtmProfileWebFilteringWebsenseReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceSecurityUtmProfileWebFilteringWebsenseDelete(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityUtmProfileWebFilteringWebsenseDelete(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeDeleteAlso {
 		if err := delUtmProfileWebFWebsense(d.Get("name").(string), m, nil); err != nil {
@@ -272,8 +273,8 @@ func resourceSecurityUtmProfileWebFilteringWebsenseDelete(
 	return diagWarns
 }
 
-func resourceSecurityUtmProfileWebFilteringWebsenseImport(
-	d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+func resourceSecurityUtmProfileWebFilteringWebsenseImport(d *schema.ResourceData, m interface{},
+) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -373,8 +374,8 @@ func setUtmProfileWebFWebsense(d *schema.ResourceData, m interface{}, jnprSess *
 	return sess.configSet(configSet, jnprSess)
 }
 
-func readUtmProfileWebFWebsense(profile string, m interface{}, jnprSess *NetconfObject) (
-	utmProfileWebFilteringWebsenseOptions, error) {
+func readUtmProfileWebFWebsense(profile string, m interface{}, jnprSess *NetconfObject,
+) (utmProfileWebFilteringWebsenseOptions, error) {
 	sess := m.(*Session)
 	var confRead utmProfileWebFilteringWebsenseOptions
 
@@ -464,8 +465,9 @@ func delUtmProfileWebFWebsense(profile string, m interface{}, jnprSess *NetconfO
 	return sess.configSet(configSet, jnprSess)
 }
 
-func fillUtmProfileWebFWebsenseData(d *schema.ResourceData,
-	utmProfileWebFWebsenseOptions utmProfileWebFilteringWebsenseOptions) {
+func fillUtmProfileWebFWebsenseData(
+	d *schema.ResourceData, utmProfileWebFWebsenseOptions utmProfileWebFilteringWebsenseOptions,
+) {
 	if tfErr := d.Set("name", utmProfileWebFWebsenseOptions.name); tfErr != nil {
 		panic(tfErr)
 	}

--- a/junos/resource_security_zone.go
+++ b/junos/resource_security_zone.go
@@ -304,8 +304,8 @@ func resourceSecurityZoneRead(ctx context.Context, d *schema.ResourceData, m int
 	return resourceSecurityZoneReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceSecurityZoneReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceSecurityZoneReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	zoneOptions, err := readSecurityZone(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()

--- a/junos/resource_security_zone_book_address.go
+++ b/junos/resource_security_zone_book_address.go
@@ -95,8 +95,8 @@ func resourceSecurityZoneBookAddress() *schema.Resource {
 	}
 }
 
-func resourceSecurityZoneBookAddressCreate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityZoneBookAddressCreate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeCreateSetFile != "" {
 		if err := setSecurityZoneBookAddress(d, m, nil); err != nil {
@@ -183,8 +183,8 @@ func resourceSecurityZoneBookAddressRead(ctx context.Context, d *schema.Resource
 	return resourceSecurityZoneBookAddressReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceSecurityZoneBookAddressReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceSecurityZoneBookAddressReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	zoneBookAddressOptions, err := readSecurityZoneBookAddress(d.Get("zone").(string), d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
@@ -200,8 +200,8 @@ func resourceSecurityZoneBookAddressReadWJnprSess(
 	return nil
 }
 
-func resourceSecurityZoneBookAddressUpdate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityZoneBookAddressUpdate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	d.Partial(true)
 	sess := m.(*Session)
 	if sess.junosFakeUpdateAlso {
@@ -244,8 +244,8 @@ func resourceSecurityZoneBookAddressUpdate(ctx context.Context,
 	return append(diagWarns, resourceSecurityZoneBookAddressReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceSecurityZoneBookAddressDelete(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityZoneBookAddressDelete(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeDeleteAlso {
 		if err := delSecurityZoneBookAddress(d.Get("zone").(string), d.Get("name").(string), m, nil); err != nil {
@@ -354,8 +354,8 @@ func setSecurityZoneBookAddress(d *schema.ResourceData, m interface{}, jnprSess 
 	return sess.configSet(configSet, jnprSess)
 }
 
-func readSecurityZoneBookAddress(
-	zone, address string, m interface{}, jnprSess *NetconfObject) (zoneBookAddressOptions, error) {
+func readSecurityZoneBookAddress(zone, address string, m interface{}, jnprSess *NetconfObject,
+) (zoneBookAddressOptions, error) {
 	sess := m.(*Session)
 	var confRead zoneBookAddressOptions
 

--- a/junos/resource_security_zone_book_address_set.go
+++ b/junos/resource_security_zone_book_address_set.go
@@ -59,8 +59,8 @@ func resourceSecurityZoneBookAddressSet() *schema.Resource {
 	}
 }
 
-func resourceSecurityZoneBookAddressSetCreate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityZoneBookAddressSetCreate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeCreateSetFile != "" {
 		if err := setSecurityZoneBookAddressSet(d, m, nil); err != nil {
@@ -136,8 +136,8 @@ func resourceSecurityZoneBookAddressSetCreate(ctx context.Context,
 	return append(diagWarns, resourceSecurityZoneBookAddressSetReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceSecurityZoneBookAddressSetRead(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityZoneBookAddressSetRead(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -148,8 +148,8 @@ func resourceSecurityZoneBookAddressSetRead(ctx context.Context,
 	return resourceSecurityZoneBookAddressSetReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceSecurityZoneBookAddressSetReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceSecurityZoneBookAddressSetReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	zoneBookAddressSetOptions, err := readSecurityZoneBookAddressSet(
 		d.Get("zone").(string), d.Get("name").(string), m, jnprSess)
@@ -166,8 +166,8 @@ func resourceSecurityZoneBookAddressSetReadWJnprSess(
 	return nil
 }
 
-func resourceSecurityZoneBookAddressSetUpdate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityZoneBookAddressSetUpdate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	d.Partial(true)
 	sess := m.(*Session)
 	if sess.junosFakeUpdateAlso {
@@ -210,8 +210,8 @@ func resourceSecurityZoneBookAddressSetUpdate(ctx context.Context,
 	return append(diagWarns, resourceSecurityZoneBookAddressSetReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceSecurityZoneBookAddressSetDelete(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSecurityZoneBookAddressSetDelete(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeDeleteAlso {
 		if err := delSecurityZoneBookAddressSet(d.Get("zone").(string), d.Get("name").(string), m, nil); err != nil {
@@ -274,8 +274,8 @@ func resourceSecurityZoneBookAddressSetImport(d *schema.ResourceData, m interfac
 	return result, nil
 }
 
-func checkSecurityZoneBookAddressSetsExists(
-	zone, addressSet string, m interface{}, jnprSess *NetconfObject) (bool, error) {
+func checkSecurityZoneBookAddressSetsExists(zone, addressSet string, m interface{}, jnprSess *NetconfObject,
+) (bool, error) {
 	sess := m.(*Session)
 	showConfig, err := sess.command(cmdShowConfig+
 		"security zones security-zone "+zone+" address-book address-set "+addressSet+pipeDisplaySet, jnprSess)
@@ -312,8 +312,8 @@ func setSecurityZoneBookAddressSet(d *schema.ResourceData, m interface{}, jnprSe
 	return sess.configSet(configSet, jnprSess)
 }
 
-func readSecurityZoneBookAddressSet(
-	zone, addressSet string, m interface{}, jnprSess *NetconfObject) (zoneBookAddressSetOptions, error) {
+func readSecurityZoneBookAddressSet(zone, addressSet string, m interface{}, jnprSess *NetconfObject,
+) (zoneBookAddressSetOptions, error) {
 	sess := m.(*Session)
 	var confRead zoneBookAddressSetOptions
 

--- a/junos/resource_security_zone_test.go
+++ b/junos/resource_security_zone_test.go
@@ -1,6 +1,7 @@
 package junos_test
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -150,7 +151,7 @@ resource junos_security_zone "testacc_securityZone" {
 }
 
 func testAccJunosSecurityZoneConfigUpdate(interFace string) string {
-	return `
+	return fmt.Sprintf(`
 resource junos_security_zone "testacc_securityZone" {
   name = "testacc_securityZone"
   address_book {
@@ -169,20 +170,20 @@ resource junos_security_zone "testacc_securityZone" {
   inbound_services  = ["ssh"]
 }
 resource junos_interface_logical "testacc_securityZone" {
-  name          = "` + interFace + `.0"
+  name          = "%s.0"
   security_zone = junos_security_zone.testacc_securityZone.name
 }
-`
+`, interFace)
 }
 
 func testAccJunosSecurityZoneConfigUpdate2(interFace string) string {
-	return `
+	return fmt.Sprintf(`
 resource junos_security_zone "testacc_securityZone" {
   name = "testacc_securityZone"
 }
 resource junos_interface_logical "testacc_securityZone" {
-  name          = "` + interFace + `.0"
+  name          = "%s.0"
   security_zone = junos_security_zone.testacc_securityZone.name
 }
-`
+`, interFace)
 }

--- a/junos/resource_services_advanced_anti_malware_policy.go
+++ b/junos/resource_services_advanced_anti_malware_policy.go
@@ -136,8 +136,8 @@ func resourceServicesAdvancedAntiMalwarePolicy() *schema.Resource {
 	}
 }
 
-func resourceServicesAdvancedAntiMalwarePolicyCreate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServicesAdvancedAntiMalwarePolicyCreate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeCreateSetFile != "" {
 		if err := setServicesAdvancedAntiMalwarePolicy(d, m, nil); err != nil {
@@ -197,8 +197,8 @@ func resourceServicesAdvancedAntiMalwarePolicyCreate(ctx context.Context,
 	return append(diagWarns, resourceServicesAdvancedAntiMalwarePolicyReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceServicesAdvancedAntiMalwarePolicyRead(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServicesAdvancedAntiMalwarePolicyRead(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -210,7 +210,8 @@ func resourceServicesAdvancedAntiMalwarePolicyRead(ctx context.Context,
 }
 
 func resourceServicesAdvancedAntiMalwarePolicyReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	svcAdvancedAntiMalwarePolicyOptions, err := readServicesAdvancedAntiMalwarePolicy(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
@@ -226,8 +227,8 @@ func resourceServicesAdvancedAntiMalwarePolicyReadWJnprSess(
 	return nil
 }
 
-func resourceServicesAdvancedAntiMalwarePolicyUpdate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServicesAdvancedAntiMalwarePolicyUpdate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	d.Partial(true)
 	sess := m.(*Session)
 	if sess.junosFakeUpdateAlso {
@@ -270,8 +271,8 @@ func resourceServicesAdvancedAntiMalwarePolicyUpdate(ctx context.Context,
 	return append(diagWarns, resourceServicesAdvancedAntiMalwarePolicyReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceServicesAdvancedAntiMalwarePolicyDelete(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServicesAdvancedAntiMalwarePolicyDelete(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeDeleteAlso {
 		if err := delServicesAdvancedAntiMalwarePolicy(d.Get("name").(string), m, nil); err != nil {
@@ -303,8 +304,8 @@ func resourceServicesAdvancedAntiMalwarePolicyDelete(ctx context.Context,
 	return diagWarns
 }
 
-func resourceServicesAdvancedAntiMalwarePolicyImport(
-	d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+func resourceServicesAdvancedAntiMalwarePolicyImport(d *schema.ResourceData, m interface{},
+) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -330,8 +331,8 @@ func resourceServicesAdvancedAntiMalwarePolicyImport(
 	return result, nil
 }
 
-func checkServicesAdvancedAntiMalwarePolicyExists(
-	policy string, m interface{}, jnprSess *NetconfObject) (bool, error) {
+func checkServicesAdvancedAntiMalwarePolicyExists(policy string, m interface{}, jnprSess *NetconfObject,
+) (bool, error) {
 	sess := m.(*Session)
 	showConfig, err := sess.command(cmdShowConfig+
 		"services advanced-anti-malware policy \""+policy+"\""+pipeDisplaySet, jnprSess)
@@ -405,8 +406,8 @@ func setServicesAdvancedAntiMalwarePolicy(d *schema.ResourceData, m interface{},
 	return sess.configSet(configSet, jnprSess)
 }
 
-func readServicesAdvancedAntiMalwarePolicy(policy string, m interface{}, jnprSess *NetconfObject) (
-	svcAdvancedAntiMalwarePolicyOptions, error) {
+func readServicesAdvancedAntiMalwarePolicy(policy string, m interface{}, jnprSess *NetconfObject,
+) (svcAdvancedAntiMalwarePolicyOptions, error) {
 	sess := m.(*Session)
 	var confRead svcAdvancedAntiMalwarePolicyOptions
 
@@ -478,7 +479,8 @@ func delServicesAdvancedAntiMalwarePolicy(policy string, m interface{}, jnprSess
 }
 
 func fillServicesAdvancedAntiMalwarePolicyData(
-	d *schema.ResourceData, svcAdvancedAntiMalwarePolicyOptions svcAdvancedAntiMalwarePolicyOptions) {
+	d *schema.ResourceData, svcAdvancedAntiMalwarePolicyOptions svcAdvancedAntiMalwarePolicyOptions,
+) {
 	if tfErr := d.Set("name",
 		svcAdvancedAntiMalwarePolicyOptions.name); tfErr != nil {
 		panic(tfErr)

--- a/junos/resource_services_flowmonitoring_vipfix_template.go
+++ b/junos/resource_services_flowmonitoring_vipfix_template.go
@@ -130,8 +130,8 @@ func resourceServicesFlowMonitoringVIPFixTemplate() *schema.Resource {
 	}
 }
 
-func resourceServicesFlowMonitoringVIPFixTemplateCreate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServicesFlowMonitoringVIPFixTemplateCreate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeCreateSetFile != "" {
 		if err := setServicesFlowMonitoringVIPFixTemplate(d, m, nil); err != nil {
@@ -190,8 +190,8 @@ func resourceServicesFlowMonitoringVIPFixTemplateCreate(ctx context.Context,
 	return append(diagWarns, resourceServicesFlowMonitoringVIPFixTemplateReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceServicesFlowMonitoringVIPFixTemplateRead(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServicesFlowMonitoringVIPFixTemplateRead(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -203,7 +203,8 @@ func resourceServicesFlowMonitoringVIPFixTemplateRead(ctx context.Context,
 }
 
 func resourceServicesFlowMonitoringVIPFixTemplateReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	flowMonitoringVIPFixTemplateOptions, err := readServicesFlowMonitoringVIPFixTemplate(
 		d.Get("name").(string), m, jnprSess)
@@ -220,8 +221,8 @@ func resourceServicesFlowMonitoringVIPFixTemplateReadWJnprSess(
 	return nil
 }
 
-func resourceServicesFlowMonitoringVIPFixTemplateUpdate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServicesFlowMonitoringVIPFixTemplateUpdate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	d.Partial(true)
 	sess := m.(*Session)
 	if sess.junosFakeUpdateAlso {
@@ -264,8 +265,8 @@ func resourceServicesFlowMonitoringVIPFixTemplateUpdate(ctx context.Context,
 	return append(diagWarns, resourceServicesFlowMonitoringVIPFixTemplateReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceServicesFlowMonitoringVIPFixTemplateDelete(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServicesFlowMonitoringVIPFixTemplateDelete(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeDeleteAlso {
 		if err := delServicesFlowMonitoringVIPFixTemplate(d.Get("name").(string), m, nil); err != nil {
@@ -297,8 +298,8 @@ func resourceServicesFlowMonitoringVIPFixTemplateDelete(ctx context.Context,
 	return diagWarns
 }
 
-func resourceServicesFlowMonitoringVIPFixTemplateImport(
-	d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+func resourceServicesFlowMonitoringVIPFixTemplateImport(d *schema.ResourceData, m interface{},
+) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -325,8 +326,8 @@ func resourceServicesFlowMonitoringVIPFixTemplateImport(
 	return result, nil
 }
 
-func checkServicesFlowMonitoringVIPFixTemplateExists(
-	template string, m interface{}, jnprSess *NetconfObject) (bool, error) {
+func checkServicesFlowMonitoringVIPFixTemplateExists(template string, m interface{}, jnprSess *NetconfObject,
+) (bool, error) {
 	sess := m.(*Session)
 	showConfig, err := sess.command(cmdShowConfig+
 		"services flow-monitoring version-ipfix template \""+template+"\""+pipeDisplaySet, jnprSess)
@@ -401,8 +402,8 @@ func setServicesFlowMonitoringVIPFixTemplate(d *schema.ResourceData, m interface
 	return sess.configSet(configSet, jnprSess)
 }
 
-func readServicesFlowMonitoringVIPFixTemplate(template string, m interface{}, jnprSess *NetconfObject) (
-	flowMonitoringVIPFixTemplateOptions, error) {
+func readServicesFlowMonitoringVIPFixTemplate(template string, m interface{}, jnprSess *NetconfObject,
+) (flowMonitoringVIPFixTemplateOptions, error) {
 	sess := m.(*Session)
 	var confRead flowMonitoringVIPFixTemplateOptions
 	// setup default value
@@ -512,7 +513,8 @@ func delServicesFlowMonitoringVIPFixTemplate(template string, m interface{}, jnp
 }
 
 func fillServicesFlowMonitoringVIPFixTemplateData(
-	d *schema.ResourceData, flowMonitoringVIPFixTemplateOptions flowMonitoringVIPFixTemplateOptions) {
+	d *schema.ResourceData, flowMonitoringVIPFixTemplateOptions flowMonitoringVIPFixTemplateOptions,
+) {
 	if tfErr := d.Set("name", flowMonitoringVIPFixTemplateOptions.name); tfErr != nil {
 		panic(tfErr)
 	}

--- a/junos/resource_services_proxy_profile.go
+++ b/junos/resource_services_proxy_profile.go
@@ -45,8 +45,8 @@ func resourceServicesProxyProfile() *schema.Resource {
 	}
 }
 
-func resourceServicesProxyProfileCreate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServicesProxyProfileCreate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeCreateSetFile != "" {
 		if err := setServicesProxyProfile(d, m, nil); err != nil {
@@ -102,8 +102,8 @@ func resourceServicesProxyProfileCreate(ctx context.Context,
 	return append(diagWarns, resourceServicesProxyProfileReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceServicesProxyProfileRead(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServicesProxyProfileRead(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -114,8 +114,8 @@ func resourceServicesProxyProfileRead(ctx context.Context,
 	return resourceServicesProxyProfileReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceServicesProxyProfileReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceServicesProxyProfileReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	proxyProfileOptions, err := readServicesProxyProfile(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
@@ -131,8 +131,8 @@ func resourceServicesProxyProfileReadWJnprSess(
 	return nil
 }
 
-func resourceServicesProxyProfileUpdate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServicesProxyProfileUpdate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	d.Partial(true)
 	sess := m.(*Session)
 	if sess.junosFakeUpdateAlso {
@@ -175,8 +175,8 @@ func resourceServicesProxyProfileUpdate(ctx context.Context,
 	return append(diagWarns, resourceServicesProxyProfileReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceServicesProxyProfileDelete(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServicesProxyProfileDelete(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeDeleteAlso {
 		if err := delServicesProxyProfile(d.Get("name").(string), m, nil); err != nil {
@@ -208,8 +208,8 @@ func resourceServicesProxyProfileDelete(ctx context.Context,
 	return diagWarns
 }
 
-func resourceServicesProxyProfileImport(
-	d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+func resourceServicesProxyProfileImport(d *schema.ResourceData, m interface{},
+) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -262,8 +262,7 @@ func setServicesProxyProfile(d *schema.ResourceData, m interface{}, jnprSess *Ne
 	return sess.configSet(configSet, jnprSess)
 }
 
-func readServicesProxyProfile(profile string, m interface{}, jnprSess *NetconfObject) (
-	proxyProfileOptions, error) {
+func readServicesProxyProfile(profile string, m interface{}, jnprSess *NetconfObject) (proxyProfileOptions, error) {
 	sess := m.(*Session)
 	var confRead proxyProfileOptions
 
@@ -305,8 +304,8 @@ func delServicesProxyProfile(profile string, m interface{}, jnprSess *NetconfObj
 	return sess.configSet(configSet, jnprSess)
 }
 
-func fillServicesProxyProfileData(
-	d *schema.ResourceData, proxyProfileOptions proxyProfileOptions) {
+func fillServicesProxyProfileData(d *schema.ResourceData, proxyProfileOptions proxyProfileOptions,
+) {
 	if tfErr := d.Set("name", proxyProfileOptions.name); tfErr != nil {
 		panic(tfErr)
 	}

--- a/junos/resource_services_rpm_probe.go
+++ b/junos/resource_services_rpm_probe.go
@@ -318,8 +318,8 @@ func resourceServicesRpmProbe() *schema.Resource {
 	}
 }
 
-func resourceServicesRpmProbeCreate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServicesRpmProbeCreate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeCreateSetFile != "" {
 		if err := setServicesRpmProbe(d, m, nil); err != nil {
@@ -375,8 +375,8 @@ func resourceServicesRpmProbeCreate(ctx context.Context,
 	return append(diagWarns, resourceServicesRpmProbeReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceServicesRpmProbeRead(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServicesRpmProbeRead(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -387,8 +387,8 @@ func resourceServicesRpmProbeRead(ctx context.Context,
 	return resourceServicesRpmProbeReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceServicesRpmProbeReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceServicesRpmProbeReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	rpmProbeOptions, err := readServicesRpmProbe(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
@@ -404,8 +404,8 @@ func resourceServicesRpmProbeReadWJnprSess(
 	return nil
 }
 
-func resourceServicesRpmProbeUpdate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServicesRpmProbeUpdate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	d.Partial(true)
 	sess := m.(*Session)
 	if sess.junosFakeUpdateAlso {
@@ -448,8 +448,8 @@ func resourceServicesRpmProbeUpdate(ctx context.Context,
 	return append(diagWarns, resourceServicesRpmProbeReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceServicesRpmProbeDelete(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServicesRpmProbeDelete(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeDeleteAlso {
 		if err := delServicesRpmProbe(d.Get("name").(string), m, nil); err != nil {
@@ -481,8 +481,8 @@ func resourceServicesRpmProbeDelete(ctx context.Context,
 	return diagWarns
 }
 
-func resourceServicesRpmProbeImport(
-	d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+func resourceServicesRpmProbeImport(d *schema.ResourceData, m interface{},
+) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -690,8 +690,8 @@ func setServicesRpmProbe(d *schema.ResourceData, m interface{}, jnprSess *Netcon
 	return sess.configSet(configSet, jnprSess)
 }
 
-func readServicesRpmProbe(probe string, m interface{}, jnprSess *NetconfObject) (
-	rpmProbeOptions, error) {
+func readServicesRpmProbe(probe string, m interface{}, jnprSess *NetconfObject,
+) (rpmProbeOptions, error) {
 	sess := m.(*Session)
 	var confRead rpmProbeOptions
 
@@ -981,8 +981,8 @@ func delServicesRpmProbe(probe string, m interface{}, jnprSess *NetconfObject) e
 	return sess.configSet(configSet, jnprSess)
 }
 
-func fillServicesRpmProbeData(
-	d *schema.ResourceData, rpmProbeOptions rpmProbeOptions) {
+func fillServicesRpmProbeData(d *schema.ResourceData, rpmProbeOptions rpmProbeOptions,
+) {
 	if tfErr := d.Set("name", rpmProbeOptions.name); tfErr != nil {
 		panic(tfErr)
 	}

--- a/junos/resource_services_security_intelligence_policy.go
+++ b/junos/resource_services_security_intelligence_policy.go
@@ -57,8 +57,8 @@ func resourceServicesSecurityIntellPolicy() *schema.Resource {
 	}
 }
 
-func resourceServicesSecurityIntellPolicyCreate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServicesSecurityIntellPolicyCreate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeCreateSetFile != "" {
 		if err := setServicesSecurityIntellPolicy(d, m, nil); err != nil {
@@ -114,8 +114,8 @@ func resourceServicesSecurityIntellPolicyCreate(ctx context.Context,
 	return append(diagWarns, resourceServicesSecurityIntellPolicyReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceServicesSecurityIntellPolicyRead(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServicesSecurityIntellPolicyRead(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -126,8 +126,8 @@ func resourceServicesSecurityIntellPolicyRead(ctx context.Context,
 	return resourceServicesSecurityIntellPolicyReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceServicesSecurityIntellPolicyReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceServicesSecurityIntellPolicyReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	securityIntellPolicyOptions, err := readServicesSecurityIntellPolicy(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
@@ -143,8 +143,8 @@ func resourceServicesSecurityIntellPolicyReadWJnprSess(
 	return nil
 }
 
-func resourceServicesSecurityIntellPolicyUpdate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServicesSecurityIntellPolicyUpdate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	d.Partial(true)
 	sess := m.(*Session)
 	if sess.junosFakeUpdateAlso {
@@ -187,8 +187,8 @@ func resourceServicesSecurityIntellPolicyUpdate(ctx context.Context,
 	return append(diagWarns, resourceServicesSecurityIntellPolicyReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceServicesSecurityIntellPolicyDelete(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServicesSecurityIntellPolicyDelete(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeDeleteAlso {
 		if err := delServicesSecurityIntellPolicy(d.Get("name").(string), m, nil); err != nil {
@@ -220,8 +220,8 @@ func resourceServicesSecurityIntellPolicyDelete(ctx context.Context,
 	return diagWarns
 }
 
-func resourceServicesSecurityIntellPolicyImport(
-	d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+func resourceServicesSecurityIntellPolicyImport(d *schema.ResourceData, m interface{},
+) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -283,8 +283,8 @@ func setServicesSecurityIntellPolicy(d *schema.ResourceData, m interface{}, jnpr
 	return sess.configSet(configSet, jnprSess)
 }
 
-func readServicesSecurityIntellPolicy(policy string, m interface{}, jnprSess *NetconfObject) (
-	securityIntellPolicyOptions, error) {
+func readServicesSecurityIntellPolicy(policy string, m interface{}, jnprSess *NetconfObject,
+) (securityIntellPolicyOptions, error) {
 	sess := m.(*Session)
 	var confRead securityIntellPolicyOptions
 
@@ -327,7 +327,8 @@ func delServicesSecurityIntellPolicy(policy string, m interface{}, jnprSess *Net
 }
 
 func fillServicesSecurityIntellPolicyData(
-	d *schema.ResourceData, securityIntellPolicyOptions securityIntellPolicyOptions) {
+	d *schema.ResourceData, securityIntellPolicyOptions securityIntellPolicyOptions,
+) {
 	if tfErr := d.Set("name", securityIntellPolicyOptions.name); tfErr != nil {
 		panic(tfErr)
 	}

--- a/junos/resource_services_security_intelligence_profile.go
+++ b/junos/resource_services_security_intelligence_profile.go
@@ -118,8 +118,8 @@ func resourceServicesSecurityIntellProfile() *schema.Resource {
 	}
 }
 
-func resourceServicesSecurityIntellProfileCreate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServicesSecurityIntellProfileCreate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeCreateSetFile != "" {
 		if err := setServicesSecurityIntellProfile(d, m, nil); err != nil {
@@ -175,8 +175,8 @@ func resourceServicesSecurityIntellProfileCreate(ctx context.Context,
 	return append(diagWarns, resourceServicesSecurityIntellProfileReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceServicesSecurityIntellProfileRead(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServicesSecurityIntellProfileRead(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -187,8 +187,8 @@ func resourceServicesSecurityIntellProfileRead(ctx context.Context,
 	return resourceServicesSecurityIntellProfileReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceServicesSecurityIntellProfileReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceServicesSecurityIntellProfileReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	securityIntellProfileOptions, err := readServicesSecurityIntellProfile(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
@@ -204,8 +204,8 @@ func resourceServicesSecurityIntellProfileReadWJnprSess(
 	return nil
 }
 
-func resourceServicesSecurityIntellProfileUpdate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServicesSecurityIntellProfileUpdate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	d.Partial(true)
 	sess := m.(*Session)
 	if sess.junosFakeUpdateAlso {
@@ -248,8 +248,8 @@ func resourceServicesSecurityIntellProfileUpdate(ctx context.Context,
 	return append(diagWarns, resourceServicesSecurityIntellProfileReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceServicesSecurityIntellProfileDelete(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServicesSecurityIntellProfileDelete(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeDeleteAlso {
 		if err := delServicesSecurityIntellProfile(d.Get("name").(string), m, nil); err != nil {
@@ -281,8 +281,8 @@ func resourceServicesSecurityIntellProfileDelete(ctx context.Context,
 	return diagWarns
 }
 
-func resourceServicesSecurityIntellProfileImport(
-	d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+func resourceServicesSecurityIntellProfileImport(d *schema.ResourceData, m interface{},
+) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -367,8 +367,8 @@ func setServicesSecurityIntellProfile(d *schema.ResourceData, m interface{}, jnp
 	return sess.configSet(configSet, jnprSess)
 }
 
-func readServicesSecurityIntellProfile(profile string, m interface{}, jnprSess *NetconfObject) (
-	securityIntellProfileOptions, error) {
+func readServicesSecurityIntellProfile(profile string, m interface{}, jnprSess *NetconfObject,
+) (securityIntellProfileOptions, error) {
 	sess := m.(*Session)
 	var confRead securityIntellProfileOptions
 
@@ -468,7 +468,8 @@ func delServicesSecurityIntellProfile(profile string, m interface{}, jnprSess *N
 }
 
 func fillServicesSecurityIntellProfileData(
-	d *schema.ResourceData, securityIntellProfileOptions securityIntellProfileOptions) {
+	d *schema.ResourceData, securityIntellProfileOptions securityIntellProfileOptions,
+) {
 	if tfErr := d.Set("name", securityIntellProfileOptions.name); tfErr != nil {
 		panic(tfErr)
 	}

--- a/junos/resource_services_ssl_initiation_profile.go
+++ b/junos/resource_services_ssl_initiation_profile.go
@@ -100,8 +100,8 @@ func resourceServicesSSLInitiationProfile() *schema.Resource {
 	}
 }
 
-func resourceServicesSSLInitiationProfileCreate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServicesSSLInitiationProfileCreate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeCreateSetFile != "" {
 		if err := setServicesSSLInitiationProfile(d, m, nil); err != nil {
@@ -159,8 +159,8 @@ func resourceServicesSSLInitiationProfileCreate(ctx context.Context,
 	return append(diagWarns, resourceServicesSSLInitiationProfileReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceServicesSSLInitiationProfileRead(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServicesSSLInitiationProfileRead(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -171,8 +171,8 @@ func resourceServicesSSLInitiationProfileRead(ctx context.Context,
 	return resourceServicesSSLInitiationProfileReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceServicesSSLInitiationProfileReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceServicesSSLInitiationProfileReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	svcSSLInitiationProfileOptions, err := readServicesSSLInitiationProfile(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
@@ -188,8 +188,8 @@ func resourceServicesSSLInitiationProfileReadWJnprSess(
 	return nil
 }
 
-func resourceServicesSSLInitiationProfileUpdate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServicesSSLInitiationProfileUpdate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	d.Partial(true)
 	sess := m.(*Session)
 	if sess.junosFakeUpdateAlso {
@@ -232,8 +232,8 @@ func resourceServicesSSLInitiationProfileUpdate(ctx context.Context,
 	return append(diagWarns, resourceServicesSSLInitiationProfileReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceServicesSSLInitiationProfileDelete(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServicesSSLInitiationProfileDelete(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeDeleteAlso {
 		if err := delServicesSSLInitiationProfile(d.Get("name").(string), m, nil); err != nil {
@@ -265,8 +265,8 @@ func resourceServicesSSLInitiationProfileDelete(ctx context.Context,
 	return diagWarns
 }
 
-func resourceServicesSSLInitiationProfileImport(
-	d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+func resourceServicesSSLInitiationProfileImport(d *schema.ResourceData, m interface{},
+) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -292,8 +292,8 @@ func resourceServicesSSLInitiationProfileImport(
 	return result, nil
 }
 
-func checkServicesSSLInitiationProfileExists(
-	profile string, m interface{}, jnprSess *NetconfObject) (bool, error) {
+func checkServicesSSLInitiationProfileExists(profile string, m interface{}, jnprSess *NetconfObject,
+) (bool, error) {
 	sess := m.(*Session)
 	showConfig, err := sess.command(cmdShowConfig+
 		"services ssl initiation profile \""+profile+"\""+pipeDisplaySet, jnprSess)
@@ -356,8 +356,8 @@ func setServicesSSLInitiationProfile(d *schema.ResourceData, m interface{}, jnpr
 	return sess.configSet(configSet, jnprSess)
 }
 
-func readServicesSSLInitiationProfile(profile string, m interface{}, jnprSess *NetconfObject) (
-	svcSSLInitiationProfileOptions, error) {
+func readServicesSSLInitiationProfile(profile string, m interface{}, jnprSess *NetconfObject,
+) (svcSSLInitiationProfileOptions, error) {
 	sess := m.(*Session)
 	var confRead svcSSLInitiationProfileOptions
 
@@ -428,7 +428,8 @@ func delServicesSSLInitiationProfile(profile string, m interface{}, jnprSess *Ne
 }
 
 func fillServicesSSLInitiationProfileData(
-	d *schema.ResourceData, svcSSLInitiationProfileOptions svcSSLInitiationProfileOptions) {
+	d *schema.ResourceData, svcSSLInitiationProfileOptions svcSSLInitiationProfileOptions,
+) {
 	if tfErr := d.Set("name", svcSSLInitiationProfileOptions.name); tfErr != nil {
 		panic(tfErr)
 	}

--- a/junos/resource_services_test.go
+++ b/junos/resource_services_test.go
@@ -254,5 +254,5 @@ resource "junos_services" "testacc" {
     }
   }
 }
-  `
+`
 }

--- a/junos/resource_services_user_identification_ad_access_domain.go
+++ b/junos/resource_services_user_identification_ad_access_domain.go
@@ -125,8 +125,8 @@ func resourceServicesUserIdentAdAccessDomain() *schema.Resource {
 	}
 }
 
-func resourceServicesUserIdentAdAccessDomainCreate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServicesUserIdentAdAccessDomainCreate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeCreateSetFile != "" {
 		if err := setServicesUserIdentAdAccessDomain(d, m, nil); err != nil {
@@ -185,8 +185,8 @@ func resourceServicesUserIdentAdAccessDomainCreate(ctx context.Context,
 	return append(diagWarns, resourceServicesUserIdentAdAccessDomainReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceServicesUserIdentAdAccessDomainRead(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServicesUserIdentAdAccessDomainRead(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -198,7 +198,8 @@ func resourceServicesUserIdentAdAccessDomainRead(ctx context.Context,
 }
 
 func resourceServicesUserIdentAdAccessDomainReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	svcUserIdentAdAccessDomainOptions, err := readServicesUserIdentAdAccessDomain(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()
@@ -214,8 +215,8 @@ func resourceServicesUserIdentAdAccessDomainReadWJnprSess(
 	return nil
 }
 
-func resourceServicesUserIdentAdAccessDomainUpdate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServicesUserIdentAdAccessDomainUpdate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	d.Partial(true)
 	sess := m.(*Session)
 	if sess.junosFakeUpdateAlso {
@@ -258,8 +259,8 @@ func resourceServicesUserIdentAdAccessDomainUpdate(ctx context.Context,
 	return append(diagWarns, resourceServicesUserIdentAdAccessDomainReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceServicesUserIdentAdAccessDomainDelete(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServicesUserIdentAdAccessDomainDelete(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeDeleteAlso {
 		if err := delServicesUserIdentAdAccessDomain(d.Get("name").(string), m, nil); err != nil {
@@ -291,8 +292,8 @@ func resourceServicesUserIdentAdAccessDomainDelete(ctx context.Context,
 	return diagWarns
 }
 
-func resourceServicesUserIdentAdAccessDomainImport(
-	d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+func resourceServicesUserIdentAdAccessDomainImport(d *schema.ResourceData, m interface{},
+) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -319,8 +320,8 @@ func resourceServicesUserIdentAdAccessDomainImport(
 	return result, nil
 }
 
-func checkServicesUserIdentAdAccessDomainExists(domain string,
-	m interface{}, jnprSess *NetconfObject) (bool, error) {
+func checkServicesUserIdentAdAccessDomainExists(domain string, m interface{}, jnprSess *NetconfObject,
+) (bool, error) {
 	sess := m.(*Session)
 	showConfig, err := sess.command(cmdShowConfig+
 		"services user-identification active-directory-access domain "+domain+pipeDisplaySet, jnprSess)
@@ -388,8 +389,8 @@ func setServicesUserIdentAdAccessDomain(d *schema.ResourceData, m interface{}, j
 	return sess.configSet(configSet, jnprSess)
 }
 
-func readServicesUserIdentAdAccessDomain(domain string,
-	m interface{}, jnprSess *NetconfObject) (svcUserIdentAdAccessDomainOptions, error) {
+func readServicesUserIdentAdAccessDomain(domain string, m interface{}, jnprSess *NetconfObject,
+) (svcUserIdentAdAccessDomainOptions, error) {
 	sess := m.(*Session)
 	var confRead svcUserIdentAdAccessDomainOptions
 
@@ -496,7 +497,8 @@ func delServicesUserIdentAdAccessDomain(domain string, m interface{}, jnprSess *
 }
 
 func fillServicesUserIdentAdAccessDomainData(
-	d *schema.ResourceData, svcUserIdentAdAccessDomainOptions svcUserIdentAdAccessDomainOptions) {
+	d *schema.ResourceData, svcUserIdentAdAccessDomainOptions svcUserIdentAdAccessDomainOptions,
+) {
 	if tfErr := d.Set("name", svcUserIdentAdAccessDomainOptions.name); tfErr != nil {
 		panic(tfErr)
 	}

--- a/junos/resource_services_user_identification_device_identity_profile.go
+++ b/junos/resource_services_user_identification_device_identity_profile.go
@@ -61,8 +61,8 @@ func resourceServicesUserIdentDeviceIdentityProfile() *schema.Resource {
 	}
 }
 
-func resourceServicesUserIdentDeviceIdentityProfileCreate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServicesUserIdentDeviceIdentityProfileCreate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeCreateSetFile != "" {
 		if err := setServicesUserIdentDeviceIdentityProfile(d, m, nil); err != nil {
@@ -122,8 +122,8 @@ func resourceServicesUserIdentDeviceIdentityProfileCreate(ctx context.Context,
 	return append(diagWarns, resourceServicesUserIdentDeviceIdentityProfileReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceServicesUserIdentDeviceIdentityProfileRead(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServicesUserIdentDeviceIdentityProfileRead(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -135,7 +135,8 @@ func resourceServicesUserIdentDeviceIdentityProfileRead(ctx context.Context,
 }
 
 func resourceServicesUserIdentDeviceIdentityProfileReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	svcUserIdentDevIdentProfileOptions, err := readServicesUserIdentDeviceIdentityProfile(
 		d.Get("name").(string), m, jnprSess)
@@ -152,8 +153,8 @@ func resourceServicesUserIdentDeviceIdentityProfileReadWJnprSess(
 	return nil
 }
 
-func resourceServicesUserIdentDeviceIdentityProfileUpdate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServicesUserIdentDeviceIdentityProfileUpdate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	d.Partial(true)
 	sess := m.(*Session)
 	if sess.junosFakeUpdateAlso {
@@ -196,8 +197,8 @@ func resourceServicesUserIdentDeviceIdentityProfileUpdate(ctx context.Context,
 	return append(diagWarns, resourceServicesUserIdentDeviceIdentityProfileReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceServicesUserIdentDeviceIdentityProfileDelete(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceServicesUserIdentDeviceIdentityProfileDelete(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeDeleteAlso {
 		if err := delServicesUserIdentDeviceIdentityProfile(d.Get("name").(string), m, nil); err != nil {
@@ -230,8 +231,8 @@ func resourceServicesUserIdentDeviceIdentityProfileDelete(ctx context.Context,
 	return diagWarns
 }
 
-func resourceServicesUserIdentDeviceIdentityProfileImport(
-	d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+func resourceServicesUserIdentDeviceIdentityProfileImport(d *schema.ResourceData, m interface{},
+) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -258,8 +259,8 @@ func resourceServicesUserIdentDeviceIdentityProfileImport(
 	return result, nil
 }
 
-func checkServicesUserIdentDeviceIdentityProfileExists(
-	profile string, m interface{}, jnprSess *NetconfObject) (bool, error) {
+func checkServicesUserIdentDeviceIdentityProfileExists(profile string, m interface{}, jnprSess *NetconfObject,
+) (bool, error) {
 	sess := m.(*Session)
 	showConfig, err := sess.command(cmdShowConfig+
 		"services user-identification device-information end-user-profile profile-name "+profile+pipeDisplaySet, jnprSess)
@@ -296,8 +297,8 @@ func setServicesUserIdentDeviceIdentityProfile(d *schema.ResourceData, m interfa
 	return sess.configSet(configSet, jnprSess)
 }
 
-func readServicesUserIdentDeviceIdentityProfile(profile string, m interface{}, jnprSess *NetconfObject) (
-	svcUserIdentDevIdentProfileOptions, error) {
+func readServicesUserIdentDeviceIdentityProfile(profile string, m interface{}, jnprSess *NetconfObject,
+) (svcUserIdentDevIdentProfileOptions, error) {
 	sess := m.(*Session)
 	var confRead svcUserIdentDevIdentProfileOptions
 
@@ -347,7 +348,8 @@ func delServicesUserIdentDeviceIdentityProfile(profile string, m interface{}, jn
 }
 
 func fillServicesUserIdentDeviceIdentityProfileData(
-	d *schema.ResourceData, svcUserIdentDevIdentProfileOptions svcUserIdentDevIdentProfileOptions) {
+	d *schema.ResourceData, svcUserIdentDevIdentProfileOptions svcUserIdentDevIdentProfileOptions,
+) {
 	if tfErr := d.Set("name", svcUserIdentDevIdentProfileOptions.name); tfErr != nil {
 		panic(tfErr)
 	}

--- a/junos/resource_snmp_clientlist.go
+++ b/junos/resource_snmp_clientlist.go
@@ -104,8 +104,8 @@ func resourceSnmpClientlistRead(ctx context.Context, d *schema.ResourceData, m i
 	return resourceSnmpClientlistReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceSnmpClientlistReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceSnmpClientlistReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	snmpClientlistOptions, err := readSnmpClientlist(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()

--- a/junos/resource_snmp_community.go
+++ b/junos/resource_snmp_community.go
@@ -152,8 +152,8 @@ func resourceSnmpCommunityRead(ctx context.Context, d *schema.ResourceData, m in
 	return resourceSnmpCommunityReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceSnmpCommunityReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceSnmpCommunityReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	snmpCommunityOptions, err := readSnmpCommunity(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()

--- a/junos/resource_snmp_v3_community.go
+++ b/junos/resource_snmp_v3_community.go
@@ -120,8 +120,8 @@ func resourceSnmpV3CommunityRead(ctx context.Context, d *schema.ResourceData, m 
 	return resourceSnmpV3CommunityReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceSnmpV3CommunityReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceSnmpV3CommunityReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	snmpV3CommunityOptions, err := readSnmpV3Community(d.Get("community_index").(string), m, jnprSess)
 	mutex.Unlock()

--- a/junos/resource_snmp_v3_usm_user.go
+++ b/junos/resource_snmp_v3_usm_user.go
@@ -188,8 +188,8 @@ func resourceSnmpV3UsmUserRead(ctx context.Context, d *schema.ResourceData, m in
 	return resourceSnmpV3UsmUserReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceSnmpV3UsmUserReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceSnmpV3UsmUserReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	configSrc := snmpV3UsmUserOptions{
 		name:                   d.Get("name").(string),
 		engineType:             d.Get("engine_type").(string),

--- a/junos/resource_snmp_v3_vacm_accessgroup.go
+++ b/junos/resource_snmp_v3_vacm_accessgroup.go
@@ -195,8 +195,8 @@ func resourceSnmpV3VacmAccessGroupRead(ctx context.Context, d *schema.ResourceDa
 	return resourceSnmpV3VacmAccessGroupReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceSnmpV3VacmAccessGroupReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceSnmpV3VacmAccessGroupReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	snmpV3VacmAccessGroupOptions, err := readSnmpV3VacmAccessGroup(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()

--- a/junos/resource_snmp_v3_vacm_securitytogroup.go
+++ b/junos/resource_snmp_v3_vacm_securitytogroup.go
@@ -46,8 +46,8 @@ func resourceSnmpV3VacmSecurityToGroup() *schema.Resource {
 	}
 }
 
-func resourceSnmpV3VacmSecurityToGroupCreate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSnmpV3VacmSecurityToGroupCreate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeCreateSetFile != "" {
 		if err := setSnmpV3VacmSecurityToGroup(d, m, nil); err != nil {
@@ -107,8 +107,8 @@ func resourceSnmpV3VacmSecurityToGroupCreate(ctx context.Context,
 	return append(diagWarns, resourceSnmpV3VacmSecurityToGroupReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceSnmpV3VacmSecurityToGroupRead(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSnmpV3VacmSecurityToGroupRead(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -119,8 +119,8 @@ func resourceSnmpV3VacmSecurityToGroupRead(ctx context.Context,
 	return resourceSnmpV3VacmSecurityToGroupReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceSnmpV3VacmSecurityToGroupReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceSnmpV3VacmSecurityToGroupReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	snmpV3VacmSecurityToGroupOptions, err := readSnmpV3VacmSecurityToGroup(
 		d.Get("model").(string), d.Get("name").(string), m, jnprSess)
@@ -137,8 +137,8 @@ func resourceSnmpV3VacmSecurityToGroupReadWJnprSess(
 	return nil
 }
 
-func resourceSnmpV3VacmSecurityToGroupUpdate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSnmpV3VacmSecurityToGroupUpdate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	d.Partial(true)
 	sess := m.(*Session)
 	if sess.junosFakeUpdateAlso {
@@ -181,8 +181,8 @@ func resourceSnmpV3VacmSecurityToGroupUpdate(ctx context.Context,
 	return append(diagWarns, resourceSnmpV3VacmSecurityToGroupReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceSnmpV3VacmSecurityToGroupDelete(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSnmpV3VacmSecurityToGroupDelete(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeDeleteAlso {
 		if err := delSnmpV3VacmSecurityToGroup(d.Get("model").(string), d.Get("name").(string), m, nil); err != nil {
@@ -318,7 +318,8 @@ func delSnmpV3VacmSecurityToGroup(model, name string, m interface{}, jnprSess *N
 }
 
 func fillSnmpV3VacmSecurityToGroupData(
-	d *schema.ResourceData, snmpV3VacmSecurityToGroupOptions snmpV3VacmSecurityToGroupOptions) {
+	d *schema.ResourceData, snmpV3VacmSecurityToGroupOptions snmpV3VacmSecurityToGroupOptions,
+) {
 	if tfErr := d.Set("model", snmpV3VacmSecurityToGroupOptions.model); tfErr != nil {
 		panic(tfErr)
 	}

--- a/junos/resource_snmp_view.go
+++ b/junos/resource_snmp_view.go
@@ -112,8 +112,8 @@ func resourceSnmpViewRead(ctx context.Context, d *schema.ResourceData, m interfa
 	return resourceSnmpViewReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceSnmpViewReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceSnmpViewReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	snmpViewOptions, err := readSnmpView(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()

--- a/junos/resource_static_route.go
+++ b/junos/resource_static_route.go
@@ -412,7 +412,7 @@ func resourceStaticRouteImport(d *schema.ResourceData, m interface{}) ([]*schema
 	return result, nil
 }
 
-func checkStaticRouteExists(destination string, instance string, m interface{}, jnprSess *NetconfObject) (bool, error) {
+func checkStaticRouteExists(destination, instance string, m interface{}, jnprSess *NetconfObject) (bool, error) {
 	sess := m.(*Session)
 	var showConfig string
 	var err error
@@ -572,8 +572,7 @@ func setStaticRoute(d *schema.ResourceData, m interface{}, jnprSess *NetconfObje
 	return sess.configSet(configSet, jnprSess)
 }
 
-func readStaticRoute(destination string, instance string, m interface{},
-	jnprSess *NetconfObject) (staticRouteOptions, error) {
+func readStaticRoute(destination, instance string, m interface{}, jnprSess *NetconfObject) (staticRouteOptions, error) {
 	sess := m.(*Session)
 	var confRead staticRouteOptions
 	var showConfig string
@@ -699,7 +698,7 @@ func readStaticRoute(destination string, instance string, m interface{},
 	return confRead, nil
 }
 
-func delStaticRoute(destination string, instance string, m interface{}, jnprSess *NetconfObject) error {
+func delStaticRoute(destination, instance string, m interface{}, jnprSess *NetconfObject) error {
 	sess := m.(*Session)
 	configSet := make([]string, 0, 1)
 	switch {

--- a/junos/resource_switch_options.go
+++ b/junos/resource_switch_options.go
@@ -89,8 +89,8 @@ func resourceSwitchOptionsRead(ctx context.Context, d *schema.ResourceData, m in
 	return resourceSwitchOptionsReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceSwitchOptionsReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceSwitchOptionsReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	switchOptionsOptions, err := readSwitchOptions(m, jnprSess)
 	mutex.Unlock()

--- a/junos/resource_system_login_class.go
+++ b/junos/resource_system_login_class.go
@@ -250,8 +250,8 @@ func resourceSystemLoginClassRead(ctx context.Context, d *schema.ResourceData, m
 	return resourceSystemLoginClassReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceSystemLoginClassReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceSystemLoginClassReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	systemLoginClassOptions, err := readSystemLoginClass(d.Get("name").(string), m, jnprSess)
 	mutex.Unlock()

--- a/junos/resource_system_login_user.go
+++ b/junos/resource_system_login_user.go
@@ -159,8 +159,8 @@ func resourceSystemLoginUserRead(ctx context.Context, d *schema.ResourceData, m 
 	return resourceSystemLoginUserReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceSystemLoginUserReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceSystemLoginUserReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	plainTextPassword := readSystemLoginUserReadDataPlainTextPassword(d)
 	mutex.Lock()
 	systemLoginUserOptions, err := readSystemLoginUser(d.Get("name").(string), plainTextPassword, m, jnprSess)

--- a/junos/resource_system_ntp_server.go
+++ b/junos/resource_system_ntp_server.go
@@ -125,8 +125,8 @@ func resourceSystemNtpServerRead(ctx context.Context, d *schema.ResourceData, m 
 	return resourceSystemNtpServerReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceSystemNtpServerReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceSystemNtpServerReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	ntpServerOptions, err := readSystemNtpServer(d.Get("address").(string), m, jnprSess)
 	mutex.Unlock()

--- a/junos/resource_system_radius_server.go
+++ b/junos/resource_system_radius_server.go
@@ -189,8 +189,8 @@ func resourceSystemRadiusServerRead(ctx context.Context, d *schema.ResourceData,
 	return resourceSystemRadiusServerReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceSystemRadiusServerReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceSystemRadiusServerReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	radiusServerOptions, err := readSystemRadiusServer(d.Get("address").(string), m, jnprSess)
 	mutex.Unlock()

--- a/junos/resource_system_root_authentication.go
+++ b/junos/resource_system_root_authentication.go
@@ -47,8 +47,8 @@ func resourceSystemRootAuthentication() *schema.Resource {
 	}
 }
 
-func resourceSystemRootAuthenticationCreate(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSystemRootAuthenticationCreate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeCreateSetFile != "" {
 		if err := setSystemRootAuthentication(d, m, nil); err != nil {
@@ -93,8 +93,8 @@ func resourceSystemRootAuthenticationRead(ctx context.Context, d *schema.Resourc
 	return resourceSystemRootAuthenticationReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceSystemRootAuthenticationReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceSystemRootAuthenticationReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	systemRootAuthOptions, err := readSystemRootAuthentication(m, jnprSess)
 	mutex.Unlock()
@@ -106,8 +106,8 @@ func resourceSystemRootAuthenticationReadWJnprSess(
 	return nil
 }
 
-func resourceSystemRootAuthenticationUpdate(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSystemRootAuthenticationUpdate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	d.Partial(true)
 	sess := m.(*Session)
 	if sess.junosFakeUpdateAlso {
@@ -150,8 +150,8 @@ func resourceSystemRootAuthenticationUpdate(
 	return append(diagWarns, resourceSystemRootAuthenticationReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceSystemRootAuthenticationDelete(
-	ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSystemRootAuthenticationDelete(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	return nil
 }
 

--- a/junos/resource_system_services_dhcp_localserver_group.go
+++ b/junos/resource_system_services_dhcp_localserver_group.go
@@ -730,8 +730,8 @@ func schemaSystemServicesDhcpLocalServerGroupOverridesV6() map[string]*schema.Sc
 	}
 }
 
-func resourceSystemServicesDhcpLocalServerGroupCreate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSystemServicesDhcpLocalServerGroupCreate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeCreateSetFile != "" {
 		if err := setSystemServicesDhcpLocalServerGroup(d, m, nil); err != nil {
@@ -821,8 +821,8 @@ func resourceSystemServicesDhcpLocalServerGroupCreate(ctx context.Context,
 	return append(diagWarns, resourceSystemServicesDhcpLocalServerGroupReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceSystemServicesDhcpLocalServerGroupRead(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSystemServicesDhcpLocalServerGroupRead(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -834,7 +834,8 @@ func resourceSystemServicesDhcpLocalServerGroupRead(ctx context.Context,
 }
 
 func resourceSystemServicesDhcpLocalServerGroupReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	systemServicesDhcpLocalServerGroupOptions, err := readSystemServicesDhcpLocalServerGroup(
 		d.Get("name").(string), d.Get("routing_instance").(string), d.Get("version").(string), m, jnprSess)
@@ -851,8 +852,8 @@ func resourceSystemServicesDhcpLocalServerGroupReadWJnprSess(
 	return nil
 }
 
-func resourceSystemServicesDhcpLocalServerGroupUpdate(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSystemServicesDhcpLocalServerGroupUpdate(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	d.Partial(true)
 	sess := m.(*Session)
 	if sess.junosFakeUpdateAlso {
@@ -897,8 +898,8 @@ func resourceSystemServicesDhcpLocalServerGroupUpdate(ctx context.Context,
 	return append(diagWarns, resourceSystemServicesDhcpLocalServerGroupReadWJnprSess(d, m, jnprSess)...)
 }
 
-func resourceSystemServicesDhcpLocalServerGroupDelete(ctx context.Context,
-	d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourceSystemServicesDhcpLocalServerGroupDelete(ctx context.Context, d *schema.ResourceData, m interface{},
+) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeDeleteAlso {
 		if err := delSystemServicesDhcpLocalServerGroup(
@@ -932,8 +933,8 @@ func resourceSystemServicesDhcpLocalServerGroupDelete(ctx context.Context,
 	return diagWarns
 }
 
-func resourceSystemServicesDhcpLocalServerGroupImport(
-	d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+func resourceSystemServicesDhcpLocalServerGroupImport(d *schema.ResourceData, m interface{},
+) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
 	jnprSess, err := sess.startNewSession()
 	if err != nil {
@@ -975,8 +976,9 @@ func resourceSystemServicesDhcpLocalServerGroupImport(
 	return result, nil
 }
 
-func checkSystemServicesDhcpLocalServerGroupExists(name, instance, version string, m interface{},
-	jnprSess *NetconfObject) (bool, error) {
+func checkSystemServicesDhcpLocalServerGroupExists(
+	name, instance, version string, m interface{}, jnprSess *NetconfObject,
+) (bool, error) {
 	sess := m.(*Session)
 	var showConfig string
 	var err error
@@ -1279,7 +1281,8 @@ func setSystemServicesDhcpLocalServerGroup(d *schema.ResourceData, m interface{}
 }
 
 func setSystemServicesDhcpLocalServerGroupInterface(
-	interFace map[string]interface{}, setPrefixInterface, version string) ([]string, error) {
+	interFace map[string]interface{}, setPrefixInterface, version string,
+) ([]string, error) {
 	configSet := make([]string, 0)
 
 	setPrefix := setPrefixInterface + "interface " + interFace["name"].(string) + " "
@@ -1358,8 +1361,8 @@ func setSystemServicesDhcpLocalServerGroupInterface(
 	return configSet, nil
 }
 
-func setSystemServicesDhcpLocalServerGroupFamilyDhcpOverridesV4(
-	overrides map[string]interface{}, setPrefix string) ([]string, error) {
+func setSystemServicesDhcpLocalServerGroupFamilyDhcpOverridesV4(overrides map[string]interface{}, setPrefix string,
+) ([]string, error) {
 	configSet := make([]string, 0)
 	setPrefix += "overrides "
 
@@ -1422,8 +1425,8 @@ func setSystemServicesDhcpLocalServerGroupFamilyDhcpOverridesV4(
 	return configSet, nil
 }
 
-func setSystemServicesDhcpLocalServerGroupFamilyDhcpOverridesV6(
-	overrides map[string]interface{}, setPrefix string) ([]string, error) {
+func setSystemServicesDhcpLocalServerGroupFamilyDhcpOverridesV6(overrides map[string]interface{}, setPrefix string,
+) ([]string, error) {
 	configSet := make([]string, 0)
 	setPrefix += "overrides "
 
@@ -1495,8 +1498,8 @@ func setSystemServicesDhcpLocalServerGroupFamilyDhcpOverridesV6(
 	return configSet, nil
 }
 
-func readSystemServicesDhcpLocalServerGroup(name, instance, version string, m interface{},
-	jnprSess *NetconfObject) (systemServicesDhcpLocalServerGroupOptions, error) {
+func readSystemServicesDhcpLocalServerGroup(name, instance, version string, m interface{}, jnprSess *NetconfObject,
+) (systemServicesDhcpLocalServerGroupOptions, error) {
 	sess := m.(*Session)
 	var confRead systemServicesDhcpLocalServerGroupOptions
 	var showConfig string
@@ -2040,8 +2043,8 @@ func readSystemServicesDhcpLocalServerGroupOverridesV6(itemTrim string, override
 	return nil
 }
 
-func delSystemServicesDhcpLocalServerGroup(
-	name, instance, version string, m interface{}, jnprSess *NetconfObject) error {
+func delSystemServicesDhcpLocalServerGroup(name, instance, version string, m interface{}, jnprSess *NetconfObject,
+) error {
 	sess := m.(*Session)
 	configSet := make([]string, 0, 1)
 	switch {
@@ -2061,7 +2064,8 @@ func delSystemServicesDhcpLocalServerGroup(
 }
 
 func fillSystemServicesDhcpLocalServerGroupData(
-	d *schema.ResourceData, systemServicesDhcpLocalServerGroupOptions systemServicesDhcpLocalServerGroupOptions) {
+	d *schema.ResourceData, systemServicesDhcpLocalServerGroupOptions systemServicesDhcpLocalServerGroupOptions,
+) {
 	if tfErr := d.Set("name",
 		systemServicesDhcpLocalServerGroupOptions.name); tfErr != nil {
 		panic(tfErr)

--- a/junos/resource_system_syslog_file.go
+++ b/junos/resource_system_syslog_file.go
@@ -299,8 +299,8 @@ func resourceSystemSyslogFileRead(ctx context.Context, d *schema.ResourceData, m
 	return resourceSystemSyslogFileReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceSystemSyslogFileReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceSystemSyslogFileReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	syslogFileOptions, err := readSystemSyslogFile(d.Get("filename").(string), m, jnprSess)
 	mutex.Unlock()

--- a/junos/resource_system_syslog_host.go
+++ b/junos/resource_system_syslog_host.go
@@ -255,8 +255,8 @@ func resourceSystemSyslogHostRead(ctx context.Context, d *schema.ResourceData, m
 	return resourceSystemSyslogHostReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceSystemSyslogHostReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceSystemSyslogHostReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	syslogHostOptions, err := readSystemSyslogHost(d.Get("host").(string), m, jnprSess)
 	mutex.Unlock()

--- a/junos/resource_vstp_interface.go
+++ b/junos/resource_vstp_interface.go
@@ -358,8 +358,8 @@ func resourceVstpInterfaceRead(ctx context.Context, d *schema.ResourceData, m in
 	return resourceVstpInterfaceReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceVstpInterfaceReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceVstpInterfaceReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	vstpInterfaceOptions, err := readVstpInterface(
 		d.Get("name").(string), d.Get("routing_instance").(string),

--- a/junos/resource_vstp_interface_test.go
+++ b/junos/resource_vstp_interface_test.go
@@ -61,7 +61,7 @@ func TestAccJunosVstpInterface_basic(t *testing.T) {
 }
 
 func testAccJunosVstpInterfaceSWConfigCreate(interFace string) string {
-	return `
+	return fmt.Sprintf(`
 resource "junos_vstp_interface" "testacc_vstp_interface" {
   name = "all"
 }
@@ -69,7 +69,7 @@ resource "junos_vstp_vlan" "testacc_vstp_interface2" {
   vlan_id = "10"
 }
 resource junos_interface_physical testacc_vstp_interface2 {
-  name         = "` + interFace + `"
+  name         = "%s"
   description  = "testacc_vstp_interface2"
   vlan_members = ["15"]
 }
@@ -108,11 +108,11 @@ resource "junos_vstp_vlan_group" "testacc_vstp_interface6" {
   vlan             = ["13"]
 }
 resource "junos_vstp_interface" "testacc_vstp_interface6" {
-  name             = "` + interFace + `"
+  name             = "%s"
   routing_instance = junos_routing_instance.testacc_vstp_interface.name
   vlan_group       = junos_vstp_vlan_group.testacc_vstp_interface6.name
 }
-`
+`, interFace, interFace)
 }
 
 func testAccJunosVstpInterfaceSWConfigUpdate(interFace string) string {
@@ -129,7 +129,7 @@ resource "junos_vstp_vlan" "testacc_vstp_interface2" {
   vlan_id = "10"
 }
 resource junos_interface_physical testacc_vstp_interface2 {
-  name         = "` + interFace + `"
+  name         = "%s"
   description  = "testacc_vstp_interface2"
   vlan_members = ["15"]
 }
@@ -174,11 +174,11 @@ resource "junos_vstp_vlan_group" "testacc_vstp_interface6" {
   vlan             = ["13"]
 }
 resource "junos_vstp_interface" "testacc_vstp_interface6" {
-  name             = "` + interFace + `"
+  name             = "%s"
   no_root_port     = true
   priority         = 64
   routing_instance = junos_routing_instance.testacc_vstp_interface.name
   vlan_group       = junos_vstp_vlan_group.testacc_vstp_interface6.name
 }
-`)
+`, interFace, interFace)
 }

--- a/junos/resource_vstp_vlan.go
+++ b/junos/resource_vstp_vlan.go
@@ -174,8 +174,8 @@ func resourceVstpVlanRead(ctx context.Context, d *schema.ResourceData, m interfa
 	return resourceVstpVlanReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceVstpVlanReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceVstpVlanReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	vstpVlanOptions, err := readVstpVlan(d.Get("vlan_id").(string), d.Get("routing_instance").(string), m, jnprSess)
 	mutex.Unlock()

--- a/junos/resource_vstp_vlan_group.go
+++ b/junos/resource_vstp_vlan_group.go
@@ -181,8 +181,8 @@ func resourceVstpVlanGroupRead(ctx context.Context, d *schema.ResourceData, m in
 	return resourceVstpVlanGroupReadWJnprSess(d, m, jnprSess)
 }
 
-func resourceVstpVlanGroupReadWJnprSess(
-	d *schema.ResourceData, m interface{}, jnprSess *NetconfObject) diag.Diagnostics {
+func resourceVstpVlanGroupReadWJnprSess(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject,
+) diag.Diagnostics {
 	mutex.Lock()
 	vstpVlanGroupOptions, err := readVstpVlanGroup(d.Get("name").(string), d.Get("routing_instance").(string), m, jnprSess)
 	mutex.Unlock()


### PR DESCRIPTION
- bump golang version to v1.18
- bump linter golangci-lint to v1.45
- fix new gofumpt errors (and active extra on gofumpt)
- bump katbyte/terrafmt linter to v0.4.0
- refactor generation of strings in testacc with interface arguments