### PR TITLE
Fix terrafmt missing blocks

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -54,6 +54,9 @@ jobs:
           path: terrafmt
       - name: Build terrafmt bin
         run: cd terrafmt && go install ./... && cd ${GITHUB_WORKSPACE}
+      - name: Detect resource/data-source blocks without double quote on type and name (blocks not detected by terrafmt)
+        run: |
+          ! egrep -i '((resource|data)\s+[-a-z0-9_"]+)\s+[-a-z0-9_"]+\s+\{' junos/*_test.go docs/*.md docs/*/*.md | egrep -i -v '((resource|data)\s+"[-a-z0-9_]+")\s+"[-a-z0-9_]+"\s+\{'
       - name: Terrafmt diff on docs markdown
         run: find docs | egrep "md$" | sort | while read f; do terrafmt diff $f; done >> /tmp/results.md
       - name: Terrafmt diff on _test.go

--- a/docs/data-sources/interface.md
+++ b/docs/data-sources/interface.md
@@ -15,11 +15,11 @@ For more consistency, functionalities of this data source have been splitted in 
 
 ```hcl
 # Search interface with IP
-data junos_interface "demo_ip" {
+data "junos_interface" "demo_ip" {
   match = "192.0.2.2/"
 }
 # Search interface with name
-data junos_interface "interface_fw_demo" {
+data "junos_interface" "interface_fw_demo" {
   config_interface = "ge-0/0/3.0"
 }
 ```

--- a/docs/data-sources/interface_logical.md
+++ b/docs/data-sources/interface_logical.md
@@ -11,11 +11,11 @@ Get information on a logical interface
 
 ```hcl
 # Search interface with IP
-data junos_interface_logical "demo_ip" {
+data "junos_interface_logical" "demo_ip" {
   match = "192.0.2.2/"
 }
 # Search interface with name
-data junos_interface_logical "interface_fw_demo" {
+data "junos_interface_logical" "interface_fw_demo" {
   config_interface = "ge-0/0/3.0"
 }
 ```

--- a/docs/data-sources/interface_physical.md
+++ b/docs/data-sources/interface_physical.md
@@ -11,7 +11,7 @@ Get information on a physical interface
 
 ```hcl
 # Search interface with name
-data junos_interface_physical "interface_physical_demo" {
+data "junos_interface_physical" "interface_physical_demo" {
   config_interface = "ge-0/0/3"
 }
 ```

--- a/docs/data-sources/interfaces_physical_present.md
+++ b/docs/data-sources/interfaces_physical_present.md
@@ -11,7 +11,7 @@ admin/operational status.
 
 ```hcl
 # All interfaces that begin with 'ge-'
-data junos_interfaces_physical_present "interfaces_ge" {
+data "junos_interfaces_physical_present" "interfaces_ge" {
   match_name = "^ge-.*$"
 }
 ```

--- a/docs/data-sources/routing_instance.md
+++ b/docs/data-sources/routing_instance.md
@@ -10,7 +10,7 @@ Get information on a routing instance.
 
 ```hcl
 # Read routing instance
-data junos_routing_instance "demo_ri" {
+data "junos_routing_instance" "demo_ri" {
   name = "prod-vr"
 }
 ```

--- a/docs/data-sources/security_zone.md
+++ b/docs/data-sources/security_zone.md
@@ -10,7 +10,7 @@ Get information from a security zone.
 
 ```hcl
 # Read security zone
-resource junos_security_zone "demo_zone" {
+data "junos_security_zone" "demo_zone" {
   name = "DemoZone"
 }
 ```

--- a/docs/data-sources/system_information.md
+++ b/docs/data-sources/system_information.md
@@ -9,7 +9,7 @@ Get information of the Junos device system information.
 ## Example Usage
 
 ```hcl
-data junos_system_information "example" {}
+data "junos_system_information" "example" {}
 ```
 
 ## Attributes Reference

--- a/docs/guides/interface-deprecated.md
+++ b/docs/guides/interface-deprecated.md
@@ -19,7 +19,7 @@ For example :
 
 ```hcl
 # deprecated junos_interface
-resource junos_interface "interface_physical_demo" {
+resource "junos_interface" "interface_physical_demo" {
   name         = "ge-0/0/0"
   description  = "interfacePhysicalDemo"
   trunk        = true
@@ -27,7 +27,7 @@ resource junos_interface "interface_physical_demo" {
 }
 
 # new junos_interface_physical
-resource junos_interface_physical "interface_physical_demo" {
+resource "junos_interface_physical" "interface_physical_demo" {
   name         = "ge-0/0/0"
   description  = "interfacePhysicalDemo"
   trunk        = true
@@ -51,7 +51,7 @@ For example :
 
 ```hcl
 # deprecated junos_interface 
-resource junos_interface "interface_logical_demo_100" {
+resource "junos_interface" "interface_logical_demo_100" {
   name        = "ge-0/0/2.100"
   description = "interfaceLogicalDemo100"
   inet_address {
@@ -59,14 +59,14 @@ resource junos_interface "interface_logical_demo_100" {
   }
   inet_filter_input = "filter_demo"
 }
-resource junos_interface "st0_100" {
+resource "junos_interface" "st0_100" {
   name        = "st0.100"
   description = "st0_100"
   inet        = true
 }
 
 # new junos_interface_logical
-resource junos_interface_logical "interface_logical_demo_100" {
+resource "junos_interface_logical" "interface_logical_demo_100" {
   name        = "ge-0/0/2.100"
   description = "interfaceLogicalDemo100"
   family_inet {
@@ -76,7 +76,7 @@ resource junos_interface_logical "interface_logical_demo_100" {
     filter_input = "filter_demo"
   }
 }
-resource junos_interface_logical "st0_100" {
+resource "junos_interface_logical" "st0_100" {
   name        = "st0.100"
   description = "st0_100"
   family_inet {}

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,7 +62,7 @@ provider "junos" {
 }
 
 # Configure an interface
-resource junos_interface_physical "server1" {
+resource "junos_interface_physical" "server1" {
   name = "ge-0/0/3"
   # ...
 }

--- a/docs/resources/access_address_assignment_pool.md
+++ b/docs/resources/access_address_assignment_pool.md
@@ -10,7 +10,7 @@ Provides an access address-assignment pool.
 
 ```hcl
 # Add an access address-assignment pool
-resource junos_access_address_assignment_pool "demo_dhcp_pool" {
+resource "junos_access_address_assignment_pool" "demo_dhcp_pool" {
   name = "demo_dhcp_pool"
   family {
     type    = "inet"

--- a/docs/resources/aggregate_route.md
+++ b/docs/resources/aggregate_route.md
@@ -10,7 +10,7 @@ Provides an aggregate route resource for destination.
 
 ```hcl
 # Add an aggregate route
-resource junos_aggregate_route "demo_aggregate_route" {
+resource "junos_aggregate_route" "demo_aggregate_route" {
   destination      = "192.0.2.0/25"
   routing_instance = "prod-vr"
   brief            = true

--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -10,7 +10,7 @@ Provides an application resource.
 
 ```hcl
 # Add an application
-resource junos_application "mysql" {
+resource "junos_application" "mysql" {
   name             = "mysql"
   protocol         = "tcp"
   destination_port = "3306"

--- a/docs/resources/application_set.md
+++ b/docs/resources/application_set.md
@@ -10,7 +10,7 @@ Provides a set of applications resource.
 
 ```hcl
 # Add a set of applications
-resource junos_application_set "ssh_telnet" {
+resource "junos_application_set" "ssh_telnet" {
   name         = "ssh_telnet"
   applications = ["junos-ssh", "junos-telnet"]
 }

--- a/docs/resources/bgp_group.md
+++ b/docs/resources/bgp_group.md
@@ -10,7 +10,7 @@ Provides a bgp group resource.
 
 ```hcl
 # Configure a bgp group
-resource junos_bgp_group "groupbgpdemo" {
+resource "junos_bgp_group" "groupbgpdemo" {
   name             = "GroupBgpDemo"
   routing_instance = "default"
   peer_as          = "65002"

--- a/docs/resources/bgp_neighbor.md
+++ b/docs/resources/bgp_neighbor.md
@@ -10,7 +10,7 @@ Provides a bgp neighbor resource.
 
 ```hcl
 # Configure a bgp neighbor
-resource junos_bgp_neighbor "bgpneighbordemo" {
+resource "junos_bgp_neighbor" "bgpneighbordemo" {
   ip               = "192.0.2.4"
   routing_instance = "default"
   group            = "GroupBgpDemo"

--- a/docs/resources/chassis_redundancy.md
+++ b/docs/resources/chassis_redundancy.md
@@ -13,7 +13,7 @@ Configure `chassis redundancy` block
 
 ```hcl
 # Configure chassis redundancy
-resource junos_chassis_redundancy "chassis_redundancy" {
+resource "junos_chassis_redundancy" "chassis_redundancy" {
   graceful_switchover = true
 }
 ```

--- a/docs/resources/evpn.md
+++ b/docs/resources/evpn.md
@@ -15,7 +15,7 @@ various options potentially required in `switch-options` or on the `routing-inst
 
 ```hcl
 # Configure evpn
-resource junos_evpn "default" {
+resource "junos_evpn" "default" {
   encapsulation = "vxlan"
   switch_or_ri_options {
     route_distinguisher = "20:1"

--- a/docs/resources/firewall_filter.md
+++ b/docs/resources/firewall_filter.md
@@ -10,7 +10,7 @@ Provides a firewall filter resource.
 
 ```hcl
 # Configure a firewall filter
-resource junos_firewall_filter "filterdemo" {
+resource "junos_firewall_filter" "filterdemo" {
   name   = "filterDemo"
   family = "inet"
   term {

--- a/docs/resources/firewall_policer.md
+++ b/docs/resources/firewall_policer.md
@@ -10,7 +10,7 @@ Provides a firewall policer resource.
 
 ```hcl
 # Configure a firewall policer
-resource junos_firewall_policer "policer_demo" {
+resource "junos_firewall_policer" "policer_demo" {
   name            = "policerDemo"
   filter_specific = true
   if_exceeding {

--- a/docs/resources/generate_route.md
+++ b/docs/resources/generate_route.md
@@ -10,7 +10,7 @@ Provides a generate route resource for destination.
 
 ```hcl
 # Add a generate route
-resource junos_generate_route "demo_generate_route" {
+resource "junos_generate_route" "demo_generate_route" {
   destination      = "192.0.2.0/25"
   routing_instance = "prod-vr"
   brief            = true

--- a/docs/resources/igmp_snooping_vlan.md
+++ b/docs/resources/igmp_snooping_vlan.md
@@ -9,7 +9,7 @@ Provides a IGMP snooping vlan resource.
 ## Example Usage
 
 ```hcl
-resource junos_igmp_snooping_vlan "all" {
+resource "junos_igmp_snooping_vlan" "all" {
   name = "all"
 }
 ```

--- a/docs/resources/interface.md
+++ b/docs/resources/interface.md
@@ -14,19 +14,19 @@ There is a guide for help migrating to the new resources.
 
 ```hcl
 # Configure interface of switch
-resource junos_interface "interface_switch_demo" {
+resource "junos_interface" "interface_switch_demo" {
   name         = "ge-0/0/0"
   description  = "interfaceSwitchDemo"
   trunk        = true
   vlan_members = ["100"]
 }
 # Configure a L3 interface on Junos Router or firewall
-resource junos_interface "interface_fw_demo" {
+resource "junos_interface" "interface_fw_demo" {
   name         = "ge-0/0/0"
   description  = "interfaceFwDemo"
   vlan_tagging = true
 }
-resource junos_interface "interface_fw_demo_100" {
+resource "junos_interface" "interface_fw_demo_100" {
   name        = "${junos_interface.interface_fw_demo.name}.100"
   description = "interfaceFwDemo100"
   inet_address {

--- a/docs/resources/interface_logical.md
+++ b/docs/resources/interface_logical.md
@@ -9,7 +9,7 @@ Provides a logical interface resource.
 ## Example Usage
 
 ```hcl
-resource junos_interface_logical "interface_fw_demo_100" {
+resource "junos_interface_logical" "interface_fw_demo_100" {
   name        = "ae0.100"
   description = "interfaceFwDemo100"
   family_inet {

--- a/docs/resources/interface_physical.md
+++ b/docs/resources/interface_physical.md
@@ -10,14 +10,14 @@ Provides a physical interface resource.
 
 ```hcl
 # Configure interface of switch
-resource junos_interface_physical "interface_switch_demo" {
+resource "junos_interface_physical" "interface_switch_demo" {
   name         = "ge-0/0/0"
   description  = "interfaceSwitchDemo"
   trunk        = true
   vlan_members = ["100"]
 }
 # Prepare physical interface for L3 logical interfaces on Junos Router or firewall
-resource junos_interface_physical "interface_fw_demo" {
+resource "junos_interface_physical" "interface_fw_demo" {
   name         = "ge-0/0/1"
   description  = "interfaceFwDemo"
   vlan_tagging = true

--- a/docs/resources/interface_physical_disable.md
+++ b/docs/resources/interface_physical_disable.md
@@ -17,7 +17,7 @@ Destroy this resource has no effect on the Junos configuration.
 
 ```hcl
 # Disable an interface
-resource junos_interface_physical_disable "interface_demo" {
+resource "junos_interface_physical_disable" "interface_demo" {
   name = "ge-0/0/0"
 }
 ```

--- a/docs/resources/interface_st0_unit.md
+++ b/docs/resources/interface_st0_unit.md
@@ -12,7 +12,7 @@ New st0 unit interface can be configured with `junos_interface_logical` resource
 ## Example Usage
 
 ```hcl
-resource junos_interface_st0_unit "demo" {}
+resource "junos_interface_st0_unit" "demo" {}
 ```
 
 ## Attributes Reference

--- a/docs/resources/layer2_control.md
+++ b/docs/resources/layer2_control.md
@@ -13,7 +13,7 @@ Configure `protocols layer2-control` block
 
 ```hcl
 # Configure layer2 control
-resource junos_layer2_control "l2control" {
+resource "junos_layer2_control" "l2control" {
   bpdu_block {}
 }
 ```

--- a/docs/resources/lldp_interface.md
+++ b/docs/resources/lldp_interface.md
@@ -9,7 +9,7 @@ Provides a LLDP interface resource.
 ## Example Usage
 
 ```hcl
-resource junos_lldp_interface "all" {
+resource "junos_lldp_interface" "all" {
   name = "all"
 }
 ```

--- a/docs/resources/lldpmed_interface.md
+++ b/docs/resources/lldpmed_interface.md
@@ -9,7 +9,7 @@ Provides a LLDP MED interface resource.
 ## Example Usage
 
 ```hcl
-resource junos_lldpmed_interface "all" {
+resource "junos_lldpmed_interface" "all" {
   name = "all"
 }
 ```

--- a/docs/resources/null_commit_file.md
+++ b/docs/resources/null_commit_file.md
@@ -14,7 +14,7 @@ candidate configuration on device, and commit
 ```hcl
 # Load file and commit
 variable "setfile" { default = "~/junos/setfile" }
-resource junos_null_commit_file "setfile" {
+resource "junos_null_commit_file" "setfile" {
   filename = var.setfile
   triggers = {
     md5 = filemd5(var.setfile)

--- a/docs/resources/ospf.md
+++ b/docs/resources/ospf.md
@@ -15,7 +15,7 @@ routing-instance level.
 
 ```hcl
 # Configure ospf
-resource junos_ospf "ospf" {
+resource "junos_ospf" "ospf" {
   export = ["redistribe"]
 }
 ```

--- a/docs/resources/ospf_area.md
+++ b/docs/resources/ospf_area.md
@@ -10,7 +10,7 @@ Provides an ospf area resource.
 
 ```hcl
 # Add an ospf area
-resource junos_ospf_area "demo_area" {
+resource "junos_ospf_area" "demo_area" {
   area_id = "0.0.0.0"
   interface {
     name = "all"

--- a/docs/resources/policyoptions_as_path.md
+++ b/docs/resources/policyoptions_as_path.md
@@ -10,7 +10,7 @@ Provides an as-path resource.
 
 ```hcl
 # Add an as-path
-resource junos_policyoptions_as_path "github" {
+resource "junos_policyoptions_as_path" "github" {
   name = "github"
   path = ".* 36459"
 }

--- a/docs/resources/policyoptions_as_path_group.md
+++ b/docs/resources/policyoptions_as_path_group.md
@@ -10,7 +10,7 @@ Provides an as-path group resource.
 
 ```hcl
 # Add an as-path group
-resource junos_policyoptions_as_path_group "via_century_link" {
+resource "junos_policyoptions_as_path_group" "via_century_link" {
   name = "viaCenturyLink"
   as_path {
     name = "qwest"

--- a/docs/resources/policyoptions_community.md
+++ b/docs/resources/policyoptions_community.md
@@ -10,7 +10,7 @@ Provides a community BGP resource.
 
 ```hcl
 # Add a community
-resource junos_policyoptions_community "community_demo" {
+resource "junos_policyoptions_community" "community_demo" {
   name    = "communityDemo"
   members = ["65000:100"]
 }

--- a/docs/resources/policyoptions_policy_statement.md
+++ b/docs/resources/policyoptions_policy_statement.md
@@ -10,7 +10,7 @@ Provides a routing policy resource.
 
 ```hcl
 # Add a policy
-resource junos_policyoptions_policy_statement "demo_policy" {
+resource "junos_policyoptions_policy_statement" "demo_policy" {
   name = "DemoPolicy"
   from {
     protocol = ["bgp"]

--- a/docs/resources/policyoptions_prefix_list.md
+++ b/docs/resources/policyoptions_prefix_list.md
@@ -10,7 +10,7 @@ Provides a prefix list resource.
 
 ```hcl
 # Add a prefix list
-resource junos_policyoptions_prefix_list "demo_plist" {
+resource "junos_policyoptions_prefix_list" "demo_plist" {
   name   = "DemoPList"
   prefix = ["192.0.2.0/25"]
 }

--- a/docs/resources/rib_group.md
+++ b/docs/resources/rib_group.md
@@ -10,7 +10,7 @@ Provides a rib group resource.
 
 ```hcl
 # Add a rib group
-resource junos_rib_group "demo_rib" {
+resource "junos_rib_group" "demo_rib" {
   name          = "prod"
   import_policy = ["policy-import-rib"]
   import_rib    = ["prod-vr.inet.0", "externe-vr.inet.0"]

--- a/docs/resources/routing_instance.md
+++ b/docs/resources/routing_instance.md
@@ -10,7 +10,7 @@ Provides a routing instance resource.
 
 ```hcl
 # Add a routing instance
-resource junos_routing_instance "demo_ri" {
+resource "junos_routing_instance" "demo_ri" {
   name = "prod-vr"
 }
 ```

--- a/docs/resources/routing_options.md
+++ b/docs/resources/routing_options.md
@@ -14,7 +14,7 @@ Configure static configuration in `routing-options` block
 
 ```hcl
 # Configure routing-options
-resource junos_routing_options "routing_options" {
+resource "junos_routing_options" "routing_options" {
   autonomous_system {
     number = "65000"
   }

--- a/docs/resources/rstp.md
+++ b/docs/resources/rstp.md
@@ -14,7 +14,7 @@ Configure static configuration in `protocols rstp` block for root or routing-ins
 
 ```hcl
 # Configure rstp
-resource junos_rstp "rstp" {
+resource "junos_rstp" "rstp" {
   bpdu_block_on_edge = true
 }
 ```

--- a/docs/resources/rstp_interface.md
+++ b/docs/resources/rstp_interface.md
@@ -9,7 +9,7 @@ Provides a RSTP interface resource.
 ## Example Usage
 
 ```hcl
-resource junos_rstp_interface "all" {
+resource "junos_rstp_interface" "all" {
   name = "all"
 }
 ```

--- a/docs/resources/security.md
+++ b/docs/resources/security.md
@@ -14,7 +14,7 @@ Configure static configuration in `security` block
 
 ```hcl
 # Configure security
-resource junos_security "security" {
+resource "junos_security" "security" {
   ike_traceoptions {
     file {
       name  = "ike.log"

--- a/docs/resources/security_address_book.md
+++ b/docs/resources/security_address_book.md
@@ -10,7 +10,7 @@ Provides a security address book resource.
 
 ```hcl
 # Add an address book with entries
-resource junos_security_address_book "testAddressBook" {
+resource "junos_security_address_book" "testAddressBook" {
   name        = "testAddressBook"
   attach_zone = ["SecurityZone"]
   network_address {

--- a/docs/resources/security_global_policy.md
+++ b/docs/resources/security_global_policy.md
@@ -13,7 +13,7 @@ Configure static configuration in `security policies global` block
 
 ```hcl
 # Configure security policies global
-resource junos_security_global_policy "global" {
+resource "junos_security_global_policy" "global" {
   policy {
     name                      = "test"
     match_source_address      = ["blue"]

--- a/docs/resources/security_idp_custom_attack.md
+++ b/docs/resources/security_idp_custom_attack.md
@@ -10,7 +10,7 @@ Provides a security idp custom-attack resource.
 
 ```hcl
 # Add an idp custom-attack
-resource junos_security_idp_custom_attack "demo_idp_custom_attack" {
+resource "junos_security_idp_custom_attack" "demo_idp_custom_attack" {
   name               = "SSH:BRUTE-FORCE-CUSTOM"
   recommended_action = "drop"
   severity           = "minor"

--- a/docs/resources/security_idp_custom_attack_group.md
+++ b/docs/resources/security_idp_custom_attack_group.md
@@ -10,7 +10,7 @@ Provides a security idp custom-attack-group resource.
 
 ```hcl
 # Add an idp custom-attack_group
-resource junos_security_idp_custom_attack_group "demo_idp_custom_attack_group" {
+resource "junos_security_idp_custom_attack_group" "demo_idp_custom_attack_group" {
   name   = "group_of_Attacks"
   member = ["custom_attack_1", "custom_attack_2"]
 }

--- a/docs/resources/security_idp_policy.md
+++ b/docs/resources/security_idp_policy.md
@@ -10,7 +10,7 @@ Provides a security idp policy resource.
 
 ```hcl
 # Add an idp policy
-resource junos_security_idp_policy "demo_idp_policy" {
+resource "junos_security_idp_policy" "demo_idp_policy" {
   name = "Idp-Policy"
   ips_rule {
     name        = "rules_1"

--- a/docs/resources/security_ike_gateway.md
+++ b/docs/resources/security_ike_gateway.md
@@ -10,7 +10,7 @@ Provides a security ike gateway resource.
 
 ```hcl
 # Add an ike gateway
-resource junos_security_ike_gateway "demo_vpn_p1" {
+resource "junos_security_ike_gateway" "demo_vpn_p1" {
   name               = "first-vpn"
   address            = ["192.0.2.1"]
   policy             = "ike-policy"

--- a/docs/resources/security_ike_policy.md
+++ b/docs/resources/security_ike_policy.md
@@ -10,7 +10,7 @@ Provides a security ike policy resource.
 
 ```hcl
 # Add an ike policy
-resource junos_security_ike_policy "demo_vpn_policy" {
+resource "junos_security_ike_policy" "demo_vpn_policy" {
   name                = "ike-policy"
   proposals           = ["ike-proposal"]
   pre_shared_key_text = "theKey"

--- a/docs/resources/security_ike_proposal.md
+++ b/docs/resources/security_ike_proposal.md
@@ -10,7 +10,7 @@ Provides a security ike proposal resource.
 
 ```hcl
 # Add an ike proposal
-resource junos_security_ike_proposal "demo_vpn_proposal" {
+resource "junos_security_ike_proposal" "demo_vpn_proposal" {
   name                     = "ike-proposal"
   authentication_algorithm = "sha1"
   encryption_algorithm     = "aes-128-cbc"

--- a/docs/resources/security_ipsec_policy.md
+++ b/docs/resources/security_ipsec_policy.md
@@ -10,7 +10,7 @@ Provides a security ipsec policy resource.
 
 ```hcl
 # Add an ipsec policy
-resource junos_security_ipsec_policy "demo_vpn_policy" {
+resource "junos_security_ipsec_policy" "demo_vpn_policy" {
   name      = "ipsec-policy"
   proposals = ["ipsec-proposal"]
   pfs_keys  = "group2"

--- a/docs/resources/security_ipsec_proposal.md
+++ b/docs/resources/security_ipsec_proposal.md
@@ -10,7 +10,7 @@ Provides a security ipsec proposal resource.
 
 ```hcl
 # Add an ipsec proposal
-resource junos_security_ipsec_proposal "demo_vpn_proposal" {
+resource "junos_security_ipsec_proposal" "demo_vpn_proposal" {
   name                     = "ipsec-proposal"
   authentication_algorithm = "hmac-sha1-96"
   encryption_algorithm     = "aes-128-cbc"

--- a/docs/resources/security_ipsec_vpn.md
+++ b/docs/resources/security_ipsec_vpn.md
@@ -10,7 +10,7 @@ Provides a security ipsec vpn resource.
 
 ```hcl
 # Add a route-based ipsec vpn
-resource junos_security_ipsec_vpn "demo_vpn" {
+resource "junos_security_ipsec_vpn" "demo_vpn" {
   name              = "first-vpn"
   establish_tunnels = "immediately"
   bind_interface    = junos_interface_st0_unit.demo.id
@@ -19,7 +19,7 @@ resource junos_security_ipsec_vpn "demo_vpn" {
     policy  = "ipsec-policy"
   }
 }
-resource junos_interface_st0_unit demo {}
+resource "junos_interface_st0_unit" "demo" {}
 ```
 
 ## Argument Reference

--- a/docs/resources/security_log_stream.md
+++ b/docs/resources/security_log_stream.md
@@ -10,7 +10,7 @@ Provides a security log stream resource.
 
 ```hcl
 # Add a security log stream
-resource junos_security_log_stream "demo_logstream" {
+resource "junos_security_log_stream" "demo_logstream" {
   name     = "demo_logstream"
   category = ["idp", "screen"]
   format   = "sd-syslog"

--- a/docs/resources/security_nat_destination.md
+++ b/docs/resources/security_nat_destination.md
@@ -10,7 +10,7 @@ Provides a security destination nat resource.
 
 ```hcl
 # Add a destination nat
-resource junos_security_nat_destination "demo_dnat" {
+resource "junos_security_nat_destination" "demo_dnat" {
   name = "dnat_from_untrust"
   from {
     type  = "zone"

--- a/docs/resources/security_nat_destination_pool.md
+++ b/docs/resources/security_nat_destination_pool.md
@@ -10,7 +10,7 @@ Provides a security pool resource for destination nat.
 
 ```hcl
 # Add a destination nat pool
-resource junos_security_nat_destination_pool "demo_dnat_pool" {
+resource "junos_security_nat_destination_pool" "demo_dnat_pool" {
   name    = "ip_internal"
   address = "192.0.2.2/32"
 }

--- a/docs/resources/security_nat_source.md
+++ b/docs/resources/security_nat_source.md
@@ -10,7 +10,7 @@ Provides a security source nat resource.
 
 ```hcl
 # Add a source nat
-resource junos_security_nat_source "demo_snat" {
+resource "junos_security_nat_source" "demo_snat" {
   name = "nat_from_trust_to_untrust"
   from {
     type  = "zone"

--- a/docs/resources/security_nat_source_pool.md
+++ b/docs/resources/security_nat_source_pool.md
@@ -10,7 +10,7 @@ Provides a security pool resource for source nat.
 
 ```hcl
 # Add a source nat pool
-resource junos_security_nat_source_pool "demo_snat_pool" {
+resource "junos_security_nat_source_pool" "demo_snat_pool" {
   name    = "ip_external"
   address = ["192.0.2.129/32"]
 }

--- a/docs/resources/security_nat_static.md
+++ b/docs/resources/security_nat_static.md
@@ -10,7 +10,7 @@ Provides a security static nat resource.
 
 ```hcl
 # Add a static nat
-resource junos_security_nat_static "demo_nat" {
+resource "junos_security_nat_static" "demo_nat" {
   name = "nat_from_trust"
   from {
     type  = "zone"

--- a/docs/resources/security_nat_static_rule.md
+++ b/docs/resources/security_nat_static_rule.md
@@ -14,7 +14,7 @@ between resources.
 
 ```hcl
 # Add a static nat rule
-resource junos_security_nat_static_rule "demo_nat_rule" {
+resource "junos_security_nat_static_rule" "demo_nat_rule" {
   name                = "nat_192_0_2_0_25"
   rule_set            = "nat_from_trust"
   destination_address = "192.0.2.0/25"

--- a/docs/resources/security_policy.md
+++ b/docs/resources/security_policy.md
@@ -10,7 +10,7 @@ Provides a security policy resource.
 
 ```hcl
 # Add a security policy
-resource junos_security_policy "demo_policy" {
+resource "junos_security_policy" "demo_policy" {
   from_zone = "trust"
   to_zone   = "untrust"
   policy {

--- a/docs/resources/security_policy_tunnel_pair_policy.md
+++ b/docs/resources/security_policy_tunnel_pair_policy.md
@@ -10,7 +10,7 @@ Provides a tunnel pair policy resource options in each policy.
 
 ```hcl
 # Add a tunnel pair policy
-resource junos_security_policy_tunnel_pair_policy "demo_pair" {
+resource "junos_security_policy_tunnel_pair_policy" "demo_pair" {
   zone_a        = "trust"
   zone_b        = "untrust"
   policy_a_to_b = "trust_to_untrust"

--- a/docs/resources/security_screen.md
+++ b/docs/resources/security_screen.md
@@ -10,7 +10,7 @@ Provides a security screen resource.
 
 ```hcl
 # Add a security screen
-resource junos_security_screen "demo_screen" {
+resource "junos_security_screen" "demo_screen" {
   name               = "demo_screen"
   alarm_without_drop = true
   description        = "desc screen"

--- a/docs/resources/security_screen_whitelist.md
+++ b/docs/resources/security_screen_whitelist.md
@@ -10,7 +10,7 @@ Provides a security screen white-list resource.
 
 ```hcl
 # Add a security screen white-list
-resource junos_security_screen_whitelist "demo_screen_whitelist" {
+resource "junos_security_screen_whitelist" "demo_screen_whitelist" {
   name = "demo_screen_whitelist"
   address = [
     "192.0.2.128/26",

--- a/docs/resources/security_utm_custom_url_category.md
+++ b/docs/resources/security_utm_custom_url_category.md
@@ -10,7 +10,7 @@ Provides a security utm custom-object custom-url-category resource.
 
 ```hcl
 # Add a security utm custom-object custom-url-category
-resource junos_security_utm_custom_url_category "demo_url_category" {
+resource "junos_security_utm_custom_url_category" "demo_url_category" {
   name = "custom-category"
   value = [
     "custompattern1",

--- a/docs/resources/security_utm_custom_url_pattern.md
+++ b/docs/resources/security_utm_custom_url_pattern.md
@@ -10,7 +10,7 @@ Provides a security utm custom-object url-pattern resource.
 
 ```hcl
 # Add a security utm custom-object url-pattern
-resource junos_security_utm_custom_url_pattern "demo_url_pattern" {
+resource "junos_security_utm_custom_url_pattern" "demo_url_pattern" {
   name = "Global_Whitelisted"
   value = [
     "http://*.google.com",

--- a/docs/resources/security_utm_policy.md
+++ b/docs/resources/security_utm_policy.md
@@ -10,7 +10,7 @@ Provides a security utm utm-policy resource.
 
 ```hcl
 # Add a security utm utm-policy
-resource junos_security_utm_policy "demo_policy" {
+resource "junos_security_utm_policy" "demo_policy" {
   name = "Demo Policy"
   anti_virus {
     http_profile = "junos-av-defaults"

--- a/docs/resources/security_utm_profile_web_filtering_juniper_enhanced.md
+++ b/docs/resources/security_utm_profile_web_filtering_juniper_enhanced.md
@@ -10,7 +10,7 @@ Provides a security utm feature-profile web-filtering juniper-enhanced profile r
 
 ```hcl
 # Add a security utm feature-profile web-filtering juniper-enhanced profile
-resource junos_security_utm_profile_web_filtering_juniper_enhanced "demo_profile" {
+resource "junos_security_utm_profile_web_filtering_juniper_enhanced" "demo_profile" {
   name = "Default Webfilter"
   category {
     name   = "Enhanced_Network_Errors"

--- a/docs/resources/security_utm_profile_web_filtering_juniper_local.md
+++ b/docs/resources/security_utm_profile_web_filtering_juniper_local.md
@@ -10,7 +10,7 @@ Provides a security utm feature-profile web-filtering juniper-local profile reso
 
 ```hcl
 # Add a security utm feature-profile web-filtering juniper-local profile
-resource junos_security_utm_profile_web_filtering_juniper_local "demo_profile" {
+resource "junos_security_utm_profile_web_filtering_juniper_local" "demo_profile" {
   name                 = "Default Webfilter2"
   default_action       = "log-and-permit"
   custom_block_message = "Blocked by Juniper"

--- a/docs/resources/security_utm_profile_web_filtering_websense_redirect.md
+++ b/docs/resources/security_utm_profile_web_filtering_websense_redirect.md
@@ -10,7 +10,7 @@ Provides a security utm feature-profile web-filtering websense-redirect profile 
 
 ```hcl
 # Add a security utm feature-profile web-filtering websense-redirect profile
-resource junos_security_utm_profile_web_filtering_websense_redirect "demo_profile" {
+resource "junos_security_utm_profile_web_filtering_websense_redirect" "demo_profile" {
   name                 = "Default Webfilter3"
   custom_block_message = "Blocked by Juniper"
   server {

--- a/docs/resources/security_zone.md
+++ b/docs/resources/security_zone.md
@@ -10,7 +10,7 @@ Provides a security zone resource.
 
 ```hcl
 # Add a security zone
-resource junos_security_zone "demo_zone" {
+resource "junos_security_zone" "demo_zone" {
   name              = "DemoZone"
   inbound_protocols = ["bgp"]
   address_book {

--- a/docs/resources/security_zone_book_address.md
+++ b/docs/resources/security_zone_book_address.md
@@ -13,7 +13,7 @@ true otherwise there will be a conflict between resources.
 
 ```hcl
 # Add an address
-resource junos_security_zone_book_address "demo" {
+resource "junos_security_zone_book_address" "demo" {
   name = "address1"
   zone = "theZone"
   cidr = "192.0.2.0/25"

--- a/docs/resources/security_zone_book_address_set.md
+++ b/docs/resources/security_zone_book_address_set.md
@@ -13,7 +13,7 @@ true otherwise there will be a conflict between resources.
 
 ```hcl
 # Add an address-set
-resource junos_security_zone_book_address_set "demo" {
+resource "junos_security_zone_book_address_set" "demo" {
   name    = "addressSet1"
   zone    = "theZone"
   address = ["address1"]

--- a/docs/resources/services.md
+++ b/docs/resources/services.md
@@ -14,7 +14,7 @@ Configure static configuration in `services` block
 
 ```hcl
 # Configure services
-resource junos_services "services" {
+resource "junos_services" "services" {
   security_intelligence {
     authentication_token = "abcdefghijklmnopqrstuvwxyz123400"
     url                  = "https://example.com/api/manifest.xml"

--- a/docs/resources/snmp.md
+++ b/docs/resources/snmp.md
@@ -14,7 +14,7 @@ Configure static configuration in `snmp` block
 
 ```hcl
 # Configure snmp
-resource junos_snmp "snmp" {
+resource "junos_snmp" "snmp" {
   filter_duplicates          = true
   filter_internal_interfaces = true
   health_monitor {}

--- a/docs/resources/snmp_clientlist.md
+++ b/docs/resources/snmp_clientlist.md
@@ -10,7 +10,7 @@ Provides a snmp client-list resource.
 
 ```hcl
 # Add a snmp clientlist
-resource junos_snmp_clientlist "list1" {
+resource "junos_snmp_clientlist" "list1" {
   name   = "list1"
   prefix = ["192.0.2.0/24"]
 }

--- a/docs/resources/snmp_community.md
+++ b/docs/resources/snmp_community.md
@@ -10,7 +10,7 @@ Provides a snmp community resource.
 
 ```hcl
 # Add a snmp community
-resource junos_snmp_community "public" {
+resource "junos_snmp_community" "public" {
   name                    = "public"
   authorization_read_only = true
 }

--- a/docs/resources/snmp_v3_community.md
+++ b/docs/resources/snmp_v3_community.md
@@ -10,7 +10,7 @@ Provides a snmp v3 community resource.
 
 ```hcl
 # Add a snmp v3 community
-resource junos_snmp_v3_community "index1" {
+resource "junos_snmp_v3_community" "index1" {
   community_index = "index1"
   security_name   = "john"
 }

--- a/docs/resources/snmp_v3_usm_user.md
+++ b/docs/resources/snmp_v3_usm_user.md
@@ -10,11 +10,11 @@ Provides a snmp v3 USM user resource.
 
 ```hcl
 # Add a snmp v3 usm local-engine user
-resource junos_snmp_v3_usm_user "user1" {
+resource "junos_snmp_v3_usm_user" "user1" {
   name = "user1"
 }
 # Add a snmp v3 usm remote-engine user
-resource junos_snmp_v3_usm_user "user2" {
+resource "junos_snmp_v3_usm_user" "user2" {
   name        = "user2"
   engine_type = "remote"
   engine_id   = "800007E5804089071BC6D10A41"

--- a/docs/resources/snmp_v3_vacm_accessgroup.md
+++ b/docs/resources/snmp_v3_vacm_accessgroup.md
@@ -10,7 +10,7 @@ Provides a snmp v3 VACM access group resource.
 
 ```hcl
 # Add a snmpv3 VACM access group
-resource junos_snmp_v3_vacm_accessgroup "group1" {
+resource "junos_snmp_v3_vacm_accessgroup" "group1" {
   name = "group1"
   default_context_prefix {
     model     = "any"

--- a/docs/resources/snmp_v3_vacm_securitytogroup.md
+++ b/docs/resources/snmp_v3_vacm_securitytogroup.md
@@ -10,7 +10,7 @@ Provides a snmp v3 VACM security name assignment to group resource.
 
 ```hcl
 # Assigns security names to group
-resource junos_snmp_v3_vacm_securitytogroup "read" {
+resource "junos_snmp_v3_vacm_securitytogroup" "read" {
   model = "usm"
   name  = "read"
   group = "group1"

--- a/docs/resources/snmp_view.md
+++ b/docs/resources/snmp_view.md
@@ -10,7 +10,7 @@ Provides a snmp view resource.
 
 ```hcl
 # Add a snmp view
-resource junos_snmp_view "view1" {
+resource "junos_snmp_view" "view1" {
   name        = "view1"
   oid_include = [".1"]
 }

--- a/docs/resources/static_route.md
+++ b/docs/resources/static_route.md
@@ -10,7 +10,7 @@ Provides a static route resource for destination.
 
 ```hcl
 # Add a static route
-resource junos_static_route "demo_static_route" {
+resource "junos_static_route" "demo_static_route" {
   destination      = "192.0.2.0/25"
   routing_instance = "prod-vr"
   next_hop         = ["st0.0"]

--- a/docs/resources/switch_options.md
+++ b/docs/resources/switch_options.md
@@ -14,7 +14,7 @@ Configure static configuration in `switch-options` block
 
 ```hcl
 # Configure switch-options
-resource junos_switch_options "switch_options" {
+resource "junos_switch_options" "switch_options" {
   vtep_source_interface = "lo0.0"
 }
 ```

--- a/docs/resources/system.md
+++ b/docs/resources/system.md
@@ -16,7 +16,7 @@ Configure static configuration in `system` block (except `system root-authentica
 
 ```hcl
 # Configure system
-resource junos_system "system" {
+resource "junos_system" "system" {
   host_name   = "MyJunOS-device"
   name_server = ["192.0.2.10", "192.0.2.11"]
   services {

--- a/docs/resources/system_login_class.md
+++ b/docs/resources/system_login_class.md
@@ -10,7 +10,7 @@ Provides a system login class resource.
 
 ```hcl
 # Add a system login class
-resource junos_system_login_class "engineering" {
+resource "junos_system_login_class" "engineering" {
   name         = "engineering"
   idle_timeout = 30
   login_alarms = true

--- a/docs/resources/system_login_user.md
+++ b/docs/resources/system_login_user.md
@@ -10,7 +10,7 @@ Provides a system login user resource.
 
 ```hcl
 # Add a system login user
-resource junos_system_login_user "user1" {
+resource "junos_system_login_user" "user1" {
   name  = "user1"
   class = "operator"
   authentication {

--- a/docs/resources/system_ntp_server.md
+++ b/docs/resources/system_ntp_server.md
@@ -10,7 +10,7 @@ Configure a system ntp server.
 
 ```hcl
 # Add a system ntp server
-resource junos_system_ntp_server "demo_ntp_server" {
+resource "junos_system_ntp_server" "demo_ntp_server" {
   address = "192.0.2.1"
   prefer  = true
 }

--- a/docs/resources/system_radius_server.md
+++ b/docs/resources/system_radius_server.md
@@ -10,7 +10,7 @@ Configure a system radius-server.
 
 ```hcl
 # Add a system radius-server
-resource junos_system_radius_server "demo_radius_server" {
+resource "junos_system_radius_server" "demo_radius_server" {
   address = "192.0.2.1"
   secret  = "password"
 }

--- a/docs/resources/system_root_authentication.md
+++ b/docs/resources/system_root_authentication.md
@@ -14,7 +14,7 @@ Configure `system root-authentication` block
 
 ```hcl
 # Configure system root-authentication
-resource junos_system_root_authentication "root_auth" {
+resource "junos_system_root_authentication" "root_auth" {
   encrypted_password = "$6$XXX"
   ssh_public_keys = [
     "ssh-rsa XXXX",

--- a/docs/resources/system_services_dhcp_localserver_group.md
+++ b/docs/resources/system_services_dhcp_localserver_group.md
@@ -10,14 +10,14 @@ Provides a DHCP (or DHCPv6) local server group.
 
 ```hcl
 # Add a DHCP local server group
-resource junos_system_services_dhcp_localserver_group "demo_dhcp_group" {
+resource "junos_system_services_dhcp_localserver_group" "demo_dhcp_group" {
   name = "demo_dhcp_group"
   interface {
     name = "ge-0/0/3.1"
   }
 }
 # Add a DHCPv6 local server group
-resource junos_system_services_dhcp_localserver_group "demo_dhcp_group_v6" {
+resource "junos_system_services_dhcp_localserver_group" "demo_dhcp_group_v6" {
   name    = "demo_dhcp_group"
   version = "v6"
   interface {

--- a/docs/resources/system_syslog_file.md
+++ b/docs/resources/system_syslog_file.md
@@ -10,7 +10,7 @@ Configure a system syslog file.
 
 ```hcl
 # Add a system syslog file
-resource junos_system_syslog_file "demo_syslog_file" {
+resource "junos_system_syslog_file" "demo_syslog_file" {
   filename     = "demo"
   any_severity = "emergency"
 }

--- a/docs/resources/system_syslog_host.md
+++ b/docs/resources/system_syslog_host.md
@@ -10,7 +10,7 @@ Configure a system syslog host.
 
 ```hcl
 # Add a system syslog host
-resource junos_system_syslog_host "demo_syslog_host" {
+resource "junos_system_syslog_host" "demo_syslog_host" {
   host = "192.0.2.1"
   port = 514
 }

--- a/docs/resources/vlan.md
+++ b/docs/resources/vlan.md
@@ -10,7 +10,7 @@ Provides a vlan resource.
 
 ```hcl
 # Add a vlan
-resource junos_vlan "blue" {
+resource "junos_vlan" "blue" {
   name        = "blue"
   description = "blue-10"
   vlan_id     = 10

--- a/docs/resources/vstp.md
+++ b/docs/resources/vstp.md
@@ -14,7 +14,7 @@ Configure static configuration in `protocols vstp` block for root or routing-ins
 
 ```hcl
 # Configure vstp
-resource junos_vstp "vstp" {
+resource "junos_vstp" "vstp" {
   bpdu_block_on_edge = true
 }
 ```

--- a/docs/resources/vstp_interface.md
+++ b/docs/resources/vstp_interface.md
@@ -9,7 +9,7 @@ Provides a VSTP interface resource.
 ## Example Usage
 
 ```hcl
-resource junos_vstp_interface "all" {
+resource "junos_vstp_interface" "all" {
   name = "all"
 }
 ```

--- a/docs/resources/vstp_vlan.md
+++ b/docs/resources/vstp_vlan.md
@@ -9,7 +9,7 @@ Provides a VSTP vlan resource.
 ## Example Usage
 
 ```hcl
-resource junos_vstp_vlan "all" {
+resource "junos_vstp_vlan" "all" {
   vlan_id = "all"
 }
 ```

--- a/docs/resources/vstp_vlan_group.md
+++ b/docs/resources/vstp_vlan_group.md
@@ -9,7 +9,7 @@ Provides a VSTP vlan-group group resource.
 ## Example Usage
 
 ```hcl
-resource junos_vstp_vlan_group "grp" {
+resource "junos_vstp_vlan_group" "grp" {
   name = "grp"
   vlan = ["10", "11"]
 }

--- a/junos/data_source_interface_logical_test.go
+++ b/junos/data_source_interface_logical_test.go
@@ -47,12 +47,12 @@ func TestAccDataSourceInterfaceLogical_basic(t *testing.T) {
 
 func testAccDataSourceInterfaceLogicalConfigCreate(interFace string) string {
 	return fmt.Sprintf(`
-resource junos_interface_physical testacc_datainterfaceP {
+resource "junos_interface_physical" "testacc_datainterfaceP" {
   name         = "%s"
   description  = "testacc_datainterfaceP"
   vlan_tagging = true
 }
-resource junos_interface_logical testacc_datainterfaceL {
+resource "junos_interface_logical" "testacc_datainterfaceL" {
   name        = "${junos_interface_physical.testacc_datainterfaceP.name}.100"
   description = "testacc_datainterfaceL"
   family_inet {
@@ -71,12 +71,12 @@ resource junos_interface_logical testacc_datainterfaceL {
 
 func testAccDataSourceInterfaceLogicalConfigData(interFace string) string {
 	return fmt.Sprintf(`
-resource junos_interface_physical testacc_datainterfaceP {
+resource "junos_interface_physical" "testacc_datainterfaceP" {
   name         = "%s"
   description  = "testacc_datainterfaceP"
   vlan_tagging = true
 }
-resource junos_interface_logical testacc_datainterfaceL {
+resource "junos_interface_logical" "testacc_datainterfaceL" {
   name        = "${junos_interface_physical.testacc_datainterfaceP.name}.100"
   description = "testacc_datainterfaceL"
   family_inet {
@@ -86,12 +86,12 @@ resource junos_interface_logical testacc_datainterfaceL {
   }
 }
 
-data junos_interface_logical testacc_datainterfaceL {
+data "junos_interface_logical" "testacc_datainterfaceL" {
   config_interface = "%s"
   match            = "192.0.2.1/"
 }
 
-data junos_interface_logical testacc_datainterfaceL2 {
+data "junos_interface_logical" "testacc_datainterfaceL2" {
   match = "192.0.2.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)"
 }
 `, interFace, interFace)

--- a/junos/data_source_interface_physical_test.go
+++ b/junos/data_source_interface_physical_test.go
@@ -39,7 +39,7 @@ func TestAccDataSourceInterfacePhysical_basic(t *testing.T) {
 
 func testAccDataSourceInterfacePhysicalConfigCreate(interFace string) string {
 	return fmt.Sprintf(`
-resource junos_interface_physical testacc_datainterfaceP {
+resource "junos_interface_physical" "testacc_datainterfaceP" {
   name         = "%s"
   description  = "testacc_datainterfaceP"
   vlan_tagging = true
@@ -49,13 +49,13 @@ resource junos_interface_physical testacc_datainterfaceP {
 
 func testAccDataSourceInterfacePhysicalConfigData(interFace string) string {
 	return fmt.Sprintf(`
-resource junos_interface_physical testacc_datainterfaceP {
+resource "junos_interface_physical" "testacc_datainterfaceP" {
   name         = "%s"
   description  = "testacc_datainterfaceP"
   vlan_tagging = true
 }
 
-data junos_interface_physical testacc_datainterfaceP {
+data "junos_interface_physical" "testacc_datainterfaceP" {
   config_interface = "%s"
 }
 `, interFace, interFace)

--- a/junos/data_source_interface_test.go
+++ b/junos/data_source_interface_test.go
@@ -47,12 +47,12 @@ func TestAccDataSourceInterface_basic(t *testing.T) {
 
 func testAccDataSourceInterfaceConfigCreate(interFace string) string {
 	return fmt.Sprintf(`
-resource junos_interface testacc_datainterfaceP {
+resource "junos_interface" "testacc_datainterfaceP" {
   name         = "%s"
   description  = "testacc_datainterfaceP"
   vlan_tagging = true
 }
-resource junos_interface testacc_datainterface {
+resource "junos_interface" "testacc_datainterface" {
   name        = "${junos_interface.testacc_datainterfaceP.name}.100"
   description = "testacc_datainterface"
   inet_address {
@@ -64,12 +64,12 @@ resource junos_interface testacc_datainterface {
 
 func testAccDataSourceInterfaceConfigData(interFace string) string {
 	return fmt.Sprintf(`
-resource junos_interface testacc_datainterfaceP {
+resource "junos_interface" "testacc_datainterfaceP" {
   name         = "%s"
   description  = "testacc_datainterfaceP"
   vlan_tagging = true
 }
-resource junos_interface testacc_datainterface {
+resource "junos_interface" "testacc_datainterface" {
   name        = "${junos_interface.testacc_datainterfaceP.name}.100"
   description = "testacc_datainterface"
   inet_address {
@@ -77,12 +77,12 @@ resource junos_interface testacc_datainterface {
   }
 }
 
-data junos_interface testacc_datainterface {
+data "junos_interface" "testacc_datainterface" {
   config_interface = "%s"
   match            = "192.0.2.1/"
 }
 
-data junos_interface testacc_datainterface2 {
+data "junos_interface" "testacc_datainterface2" {
   match = "192.0.2.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)"
 }
 `, interFace, interFace)

--- a/junos/data_source_interfaces_physical_present_test.go
+++ b/junos/data_source_interfaces_physical_present_test.go
@@ -137,11 +137,11 @@ func TestAccDataSourceInterfacesPhysicalPresent_basic(t *testing.T) {
 
 func testAccDataSourceInterfacesPhysicalPresentPreSwitch(interFace string) string {
 	return fmt.Sprintf(`
-resource junos_interface_physical testacc_dataIfacesPhysPresent {
+resource "junos_interface_physical" "testacc_dataIfacesPhysPresent" {
   name        = "%s"
   description = "testacc_dataIfacesPhysPresent"
 }
-resource junos_interface_logical testacc_dataIfacesPhysPresent {
+resource "junos_interface_logical" "testacc_dataIfacesPhysPresent" {
   name        = "${junos_interface_physical.testacc_dataIfacesPhysPresent.name}.0"
   description = "testacc_dataIfacesPhysPresent"
 }
@@ -150,36 +150,36 @@ resource junos_interface_logical testacc_dataIfacesPhysPresent {
 
 func testAccDataSourceInterfacesPhysicalPresentConfig(interFace string) string {
 	return fmt.Sprintf(`
-resource junos_interface_physical testacc_dataIfacesPhysPresent {
+resource "junos_interface_physical" "testacc_dataIfacesPhysPresent" {
   name        = "%s"
   description = "testacc_dataIfacesPhysPresent"
 }
-data junos_interfaces_physical_present testacc_dataIfacesPhysPresent {
+data "junos_interfaces_physical_present" "testacc_dataIfacesPhysPresent" {
 }
 `, interFace)
 }
 
 func testAccDataSourceInterfacesPhysicalPresentConfigMatch(interFace string) string {
 	return fmt.Sprintf(`
-resource junos_interface_physical testacc_dataIfacesPhysPresent {
+resource "junos_interface_physical" "testacc_dataIfacesPhysPresent" {
   name        = "%s"
   description = "testacc_dataIfacesPhysPresent"
 }
-data junos_interfaces_physical_present testacc_dataIfacesPhysPresentEth {
+data "junos_interfaces_physical_present" "testacc_dataIfacesPhysPresentEth" {
   match_name = "^%s-.*$"
 }
-data junos_interfaces_physical_present testacc_dataIfacesPhysPresentEth003 {
+data "junos_interfaces_physical_present" "testacc_dataIfacesPhysPresentEth003" {
   match_name = "^%s$"
 }
-data junos_interfaces_physical_present testacc_dataIfacesPhysPresentEth003AdmUp {
+data "junos_interfaces_physical_present" "testacc_dataIfacesPhysPresentEth003AdmUp" {
   match_name     = "^%s$"
   match_admin_up = true
 }
-data junos_interfaces_physical_present testacc_dataIfacesPhysPresentEth003OperUp {
+data "junos_interfaces_physical_present" "testacc_dataIfacesPhysPresentEth003OperUp" {
   match_name    = "^%s$"
   match_oper_up = true
 }
-data junos_interfaces_physical_present testacc_dataIfacesPhysPresentLo0 {
+data "junos_interfaces_physical_present" "testacc_dataIfacesPhysPresentLo0" {
   match_name    = "^lo0$"
   match_oper_up = true
 }
@@ -188,7 +188,7 @@ data junos_interfaces_physical_present testacc_dataIfacesPhysPresentLo0 {
 
 func testAccDataSourceInterfacesPhysicalPresentConfigMatch2(interFace string) string {
 	return fmt.Sprintf(`
-data junos_interfaces_physical_present testacc_dataIfacesPhysPresentEth003AdmUp {
+data "junos_interfaces_physical_present" "testacc_dataIfacesPhysPresentEth003AdmUp" {
   match_name     = "^%s$"
   match_admin_up = true
 }

--- a/junos/data_source_routing_instance_test.go
+++ b/junos/data_source_routing_instance_test.go
@@ -46,15 +46,15 @@ func TestAccDataSourceRoutingInstance_basic(t *testing.T) {
 
 func testAccDataSourceRoutingInstanceConfigCreate(interFace string) string {
 	return fmt.Sprintf(`
-resource junos_interface_physical testacc_dataRoutingInstance {
+resource "junos_interface_physical" "testacc_dataRoutingInstance" {
   name         = "%s"
   description  = "testacc_dataRoutingInstance"
   vlan_tagging = true
 }
-resource junos_routing_instance testacc_dataRoutingInstance {
+resource "junos_routing_instance" "testacc_dataRoutingInstance" {
   name = "testacc_dataRoutingInstance"
 }
-resource junos_interface_logical testacc_dataRoutingInstance {
+resource "junos_interface_logical" "testacc_dataRoutingInstance" {
   name             = "${junos_interface_physical.testacc_dataRoutingInstance.name}.100"
   description      = "testacc_dataRoutingInstance"
   routing_instance = junos_routing_instance.testacc_dataRoutingInstance.name
@@ -64,21 +64,21 @@ resource junos_interface_logical testacc_dataRoutingInstance {
 
 func testAccDataSourceRoutingInstanceConfigData(interFace string) string {
 	return fmt.Sprintf(`
-resource junos_interface_physical testacc_dataRoutingInstance {
+resource "junos_interface_physical" "testacc_dataRoutingInstance" {
   name         = "%s"
   description  = "testacc_dataRoutingInstance"
   vlan_tagging = true
 }
-resource junos_routing_instance testacc_dataRoutingInstance {
+resource "junos_routing_instance" "testacc_dataRoutingInstance" {
   name = "testacc_dataRoutingInstance"
 }
-resource junos_interface_logical testacc_dataRoutingInstance {
+resource "junos_interface_logical" "testacc_dataRoutingInstance" {
   name             = "${junos_interface_physical.testacc_dataRoutingInstance.name}.100"
   description      = "testacc_dataRoutingInstance"
   routing_instance = junos_routing_instance.testacc_dataRoutingInstance.name
 }
 
-data junos_routing_instance testacc_dataRoutingInstance {
+data "junos_routing_instance" "testacc_dataRoutingInstance" {
   name = "testacc_dataRoutingInstance"
 }
 `, interFace)
@@ -86,7 +86,7 @@ data junos_routing_instance testacc_dataRoutingInstance {
 
 func testAccDataSourceRoutingInstanceConfigDataFailed() string {
 	return `
-data junos_routing_instance testacc_dataRoutingInstance {
+data "junos_routing_instance" "testacc_dataRoutingInstance" {
   name = "testacc"
 }
 `

--- a/junos/data_source_security_zone_test.go
+++ b/junos/data_source_security_zone_test.go
@@ -48,21 +48,21 @@ func TestAccDataSourceSecurityZone_basic(t *testing.T) {
 
 func testAccDataSourceSecurityZoneConfigCreate(interFace string) string {
 	return fmt.Sprintf(`
-resource junos_interface_physical testacc_dataSecurityZone {
+resource "junos_interface_physical" "testacc_dataSecurityZone" {
   name         = "%s"
   description  = "testacc_dataSecurityZone"
   vlan_tagging = true
 }
-resource junos_security_zone testacc_dataSecurityZone {
+resource "junos_security_zone" "testacc_dataSecurityZone" {
   name                          = "testacc_dataSecurityZone"
   address_book_configure_singly = true
 }
-resource junos_security_zone_book_address "testacc_dataSecurityZone" {
+resource "junos_security_zone_book_address" "testacc_dataSecurityZone" {
   name = "testacc_dataSecurityZone"
   zone = junos_security_zone.testacc_dataSecurityZone.name
   cidr = "192.0.2.0/25"
 }
-resource junos_interface_logical testacc_dataSecurityZone {
+resource "junos_interface_logical" "testacc_dataSecurityZone" {
   name                      = "${junos_interface_physical.testacc_dataSecurityZone.name}.100"
   description               = "testacc_dataSecurityZone"
   security_zone             = junos_security_zone.testacc_dataSecurityZone.name
@@ -73,28 +73,28 @@ resource junos_interface_logical testacc_dataSecurityZone {
 
 func testAccDataSourceSecurityZoneConfigData(interFace string) string {
 	return fmt.Sprintf(`
-resource junos_interface_physical testacc_dataSecurityZone {
+resource "junos_interface_physical" "testacc_dataSecurityZone" {
   name         = "%s"
   description  = "testacc_dataSecurityZone"
   vlan_tagging = true
 }
-resource junos_security_zone testacc_dataSecurityZone {
+resource "junos_security_zone" "testacc_dataSecurityZone" {
   name                          = "testacc_dataSecurityZone"
   address_book_configure_singly = true
 }
-resource junos_security_zone_book_address "testacc_dataSecurityZone" {
+resource "junos_security_zone_book_address" "testacc_dataSecurityZone" {
   name = "testacc_dataSecurityZone"
   zone = junos_security_zone.testacc_dataSecurityZone.name
   cidr = "192.0.2.0/25"
 }
-resource junos_interface_logical testacc_dataSecurityZone {
+resource "junos_interface_logical" "testacc_dataSecurityZone" {
   name                      = "${junos_interface_physical.testacc_dataSecurityZone.name}.100"
   description               = "testacc_dataSecurityZone"
   security_zone             = junos_security_zone.testacc_dataSecurityZone.name
   security_inbound_services = ["ssh"]
 }
 
-data junos_security_zone testacc_dataSecurityZone {
+data "junos_security_zone" "testacc_dataSecurityZone" {
   name = "testacc_dataSecurityZone"
 }
 `, interFace)
@@ -102,7 +102,7 @@ data junos_security_zone testacc_dataSecurityZone {
 
 func testAccDataSourceSecurityZoneConfigDataFailed() string {
 	return `
-data junos_routing_instance testacc_dataSecurityZone {
+data "junos_routing_instance" "testacc_dataSecurityZone" {
   name = "testacc"
 }
 `

--- a/junos/resource_access_address_assignment_pool_test.go
+++ b/junos/resource_access_address_assignment_pool_test.go
@@ -65,7 +65,7 @@ resource "junos_access_address_assignment_pool" "testacc_accessAddAssP6_1" {
 
 func testAccJunosAccessAddressAssignmentPoolUpdate() string {
 	return `
-resource junos_interface_logical "testacc_accessAddAssP4" {
+resource "junos_interface_logical" "testacc_accessAddAssP4" {
   name = "lo0.1"
 }
 resource "junos_access_address_assignment_pool" "testacc_accessAddAssP4" {

--- a/junos/resource_aggregate_route_test.go
+++ b/junos/resource_aggregate_route_test.go
@@ -68,10 +68,10 @@ func TestAccJunosAggregateRoute_basic(t *testing.T) {
 
 func testAccJunosAggregateRouteConfigCreate() string {
 	return `
-resource junos_routing_instance testacc_aggregateRoute {
+resource "junos_routing_instance" "testacc_aggregateRoute" {
   name = "testacc_aggregateRoute"
 }
-resource junos_policyoptions_policy_statement "testacc_aggregateRoute" {
+resource "junos_policyoptions_policy_statement" "testacc_aggregateRoute" {
   lifecycle {
     create_before_destroy = true
   }
@@ -81,7 +81,7 @@ resource junos_policyoptions_policy_statement "testacc_aggregateRoute" {
   }
 }
 
-resource junos_aggregate_route testacc_aggregateRoute {
+resource "junos_aggregate_route" "testacc_aggregateRoute" {
   destination                  = "192.0.2.0/24"
   routing_instance             = junos_routing_instance.testacc_aggregateRoute.name
   preference                   = 100
@@ -97,7 +97,7 @@ resource junos_aggregate_route testacc_aggregateRoute {
   as_path_origin               = "igp"
   as_path_path                 = "65000 65000"
 }
-resource junos_aggregate_route testacc_aggregateRoute6 {
+resource "junos_aggregate_route" "testacc_aggregateRoute6" {
   destination                  = "2001:db8:85a3::/48"
   routing_instance             = junos_routing_instance.testacc_aggregateRoute.name
   preference                   = 100
@@ -118,17 +118,17 @@ resource junos_aggregate_route testacc_aggregateRoute6 {
 
 func testAccJunosAggregateRouteConfigUpdate() string {
 	return `
-resource junos_routing_instance testacc_aggregateRoute {
+resource "junos_routing_instance" "testacc_aggregateRoute" {
   name = "testacc_aggregateRoute"
 }
 
-resource junos_aggregate_route testacc_aggregateRoute {
+resource "junos_aggregate_route" "testacc_aggregateRoute" {
   destination      = "192.0.2.0/24"
   routing_instance = junos_routing_instance.testacc_aggregateRoute.name
   passive          = true
   brief            = true
 }
-resource junos_aggregate_route testacc_aggregateRoute6 {
+resource "junos_aggregate_route" "testacc_aggregateRoute6" {
   destination      = "2001:db8:85a3::/48"
   routing_instance = junos_routing_instance.testacc_aggregateRoute.name
   passive          = true

--- a/junos/resource_bgp_group_test.go
+++ b/junos/resource_bgp_group_test.go
@@ -199,18 +199,18 @@ func TestAccJunosBgpGroup_basic(t *testing.T) {
 
 func testAccJunosBgpGroupConfigCreate() string {
 	return `
-resource junos_routing_options "testacc_bgpgroup" {
+resource "junos_routing_options" "testacc_bgpgroup" {
   clean_on_destroy = true
   autonomous_system {
     number = "65001"
   }
   graceful_restart {}
 }
-resource junos_routing_instance "testacc_bgpgroup" {
+resource "junos_routing_instance" "testacc_bgpgroup" {
   name = "testacc_bgpgroup"
   as   = "65000"
 }
-resource junos_policyoptions_policy_statement "testacc_bgpgroup" {
+resource "junos_policyoptions_policy_statement" "testacc_bgpgroup" {
   lifecycle {
     create_before_destroy = true
   }
@@ -219,7 +219,7 @@ resource junos_policyoptions_policy_statement "testacc_bgpgroup" {
     action = "accept"
   }
 }
-resource junos_bgp_group "testacc_bgpgroup" {
+resource "junos_bgp_group" "testacc_bgpgroup" {
   depends_on = [
     junos_routing_options.testacc_bgpgroup
   ]
@@ -308,18 +308,18 @@ resource junos_bgp_group "testacc_bgpgroup" {
 
 func testAccJunosBgpGroupConfigUpdate() string {
 	return `
-resource junos_routing_options "testacc_bgpgroup" {
+resource "junos_routing_options" "testacc_bgpgroup" {
   clean_on_destroy = true
   autonomous_system {
     number = "65001"
   }
   graceful_restart {}
 }
-resource junos_routing_instance "testacc_bgpgroup" {
+resource "junos_routing_instance" "testacc_bgpgroup" {
   name = "testacc_bgpgroup"
   as   = "65000"
 }
-resource junos_bgp_group "testacc_bgpgroup" {
+resource "junos_bgp_group" "testacc_bgpgroup" {
   depends_on = [
     junos_routing_options.testacc_bgpgroup
   ]
@@ -344,14 +344,14 @@ resource junos_bgp_group "testacc_bgpgroup" {
 
 func testAccJunosBgpGroupConfigUpdate2() string {
 	return `
-resource junos_routing_options "testacc_bgpgroup" {
+resource "junos_routing_options" "testacc_bgpgroup" {
   clean_on_destroy = true
   autonomous_system {
     number = "65001"
   }
   graceful_restart {}
 }
-resource junos_bgp_group "testacc_bgpgroup" {
+resource "junos_bgp_group" "testacc_bgpgroup" {
   depends_on = [
     junos_routing_options.testacc_bgpgroup
   ]
@@ -381,14 +381,14 @@ resource junos_bgp_group "testacc_bgpgroup" {
 
 func testAccJunosBgpGroupConfigUpdate3() string {
 	return `
-resource junos_routing_options "testacc_bgpgroup" {
+resource "junos_routing_options" "testacc_bgpgroup" {
   clean_on_destroy = true
   autonomous_system {
     number = "65001"
   }
   graceful_restart {}
 }
-resource junos_bgp_group "testacc_bgpgroup" {
+resource "junos_bgp_group" "testacc_bgpgroup" {
   depends_on = [
     junos_routing_options.testacc_bgpgroup
   ]

--- a/junos/resource_bgp_neighbor_test.go
+++ b/junos/resource_bgp_neighbor_test.go
@@ -195,18 +195,18 @@ func TestAccJunosBgpNeighbor_basic(t *testing.T) {
 
 func testAccJunosBgpNeighborConfigCreate() string {
 	return `
-resource junos_routing_options "testacc_bgpneighbor" {
+resource "junos_routing_options" "testacc_bgpneighbor" {
   clean_on_destroy = true
   autonomous_system {
     number = "65001"
   }
   graceful_restart {}
 }
-resource junos_routing_instance "testacc_bgpneighbor" {
+resource "junos_routing_instance" "testacc_bgpneighbor" {
   name = "testacc_bgpneighbor"
   as   = "65000"
 }
-resource junos_policyoptions_policy_statement "testacc_bgpneighbor" {
+resource "junos_policyoptions_policy_statement" "testacc_bgpneighbor" {
   lifecycle {
     create_before_destroy = true
   }
@@ -215,11 +215,11 @@ resource junos_policyoptions_policy_statement "testacc_bgpneighbor" {
     action = "accept"
   }
 }
-resource junos_bgp_group "testacc_bgpneighbor" {
+resource "junos_bgp_group" "testacc_bgpneighbor" {
   name             = "testacc_bgpneighbor"
   routing_instance = junos_routing_instance.testacc_bgpneighbor.name
 }
-resource junos_bgp_neighbor "testacc_bgpneighbor" {
+resource "junos_bgp_neighbor" "testacc_bgpneighbor" {
   depends_on = [
     junos_routing_options.testacc_bgpneighbor
   ]
@@ -309,23 +309,23 @@ resource junos_bgp_neighbor "testacc_bgpneighbor" {
 
 func testAccJunosBgpNeighborConfigUpdate() string {
 	return `
-resource junos_routing_options "testacc_bgpneighbor" {
+resource "junos_routing_options" "testacc_bgpneighbor" {
   clean_on_destroy = true
   autonomous_system {
     number = "65001"
   }
   graceful_restart {}
 }
-resource junos_routing_instance "testacc_bgpneighbor" {
+resource "junos_routing_instance" "testacc_bgpneighbor" {
   name = "testacc_bgpneighbor"
   as   = "65000"
 }
-resource junos_bgp_group "testacc_bgpneighbor" {
+resource "junos_bgp_group" "testacc_bgpneighbor" {
   name             = "testacc_bgpneighbor"
   routing_instance = junos_routing_instance.testacc_bgpneighbor.name
   type             = "internal"
 }
-resource junos_bgp_neighbor "testacc_bgpneighbor" {
+resource "junos_bgp_neighbor" "testacc_bgpneighbor" {
   depends_on = [
     junos_routing_options.testacc_bgpneighbor
   ]
@@ -352,23 +352,23 @@ resource junos_bgp_neighbor "testacc_bgpneighbor" {
 
 func testAccJunosBgpNeighborConfigUpdate2() string {
 	return `
-resource junos_routing_options "testacc_bgpneighbor" {
+resource "junos_routing_options" "testacc_bgpneighbor" {
   clean_on_destroy = true
   autonomous_system {
     number = "65001"
   }
   graceful_restart {}
 }
-resource junos_routing_instance "testacc_bgpneighbor2" {
+resource "junos_routing_instance" "testacc_bgpneighbor2" {
   name = "testacc_bgpneighbor2"
   as   = "65000"
 }
-resource junos_bgp_group "testacc_bgpneighbor2" {
+resource "junos_bgp_group" "testacc_bgpneighbor2" {
   name             = "testacc_bgpneighbor2"
   routing_instance = junos_routing_instance.testacc_bgpneighbor2.name
   type             = "internal"
 }
-resource junos_bgp_neighbor "testacc_bgpneighbor2" {
+resource "junos_bgp_neighbor" "testacc_bgpneighbor2" {
   depends_on = [
     junos_routing_options.testacc_bgpneighbor
   ]
@@ -382,14 +382,14 @@ resource junos_bgp_neighbor "testacc_bgpneighbor2" {
   local_as_no_prepend_global_as = true
   metric_out_minimum_igp_offset = -10
 }
-resource junos_bgp_group "testacc_bgpneighbor2b" {
+resource "junos_bgp_group" "testacc_bgpneighbor2b" {
   depends_on = [
     junos_routing_options.testacc_bgpneighbor
   ]
   name = "testacc_bgpneighbor2b"
   type = "internal"
 }
-resource junos_bgp_neighbor "testacc_bgpneighbor2b" {
+resource "junos_bgp_neighbor" "testacc_bgpneighbor2b" {
   ip    = "192.0.2.5"
   group = junos_bgp_group.testacc_bgpneighbor2b.name
   family_evpn {
@@ -410,23 +410,23 @@ resource junos_bgp_neighbor "testacc_bgpneighbor2b" {
 
 func testAccJunosBgpNeighborConfigUpdate3() string {
 	return `
-resource junos_routing_options "testacc_bgpneighbor" {
+resource "junos_routing_options" "testacc_bgpneighbor" {
   clean_on_destroy = true
   autonomous_system {
     number = "65001"
   }
   graceful_restart {}
 }
-resource junos_routing_instance "testacc_bgpneighbor2" {
+resource "junos_routing_instance" "testacc_bgpneighbor2" {
   name = "testacc_bgpneighbor2"
   as   = "65000"
 }
-resource junos_bgp_group "testacc_bgpneighbor2" {
+resource "junos_bgp_group" "testacc_bgpneighbor2" {
   name             = "testacc_bgpneighbor2"
   routing_instance = junos_routing_instance.testacc_bgpneighbor2.name
   type             = "internal"
 }
-resource junos_bgp_neighbor "testacc_bgpneighbor2" {
+resource "junos_bgp_neighbor" "testacc_bgpneighbor2" {
   depends_on = [
     junos_routing_options.testacc_bgpneighbor
   ]
@@ -437,14 +437,14 @@ resource junos_bgp_neighbor "testacc_bgpneighbor2" {
   local_as_alias         = true
   metric_out_minimum_igp = true
 }
-resource junos_bgp_group "testacc_bgpneighbor2b" {
+resource "junos_bgp_group" "testacc_bgpneighbor2b" {
   depends_on = [
     junos_routing_options.testacc_bgpneighbor
   ]
   name = "testacc_bgpneighbor2b"
   type = "internal"
 }
-resource junos_bgp_neighbor "testacc_bgpneighbor2b" {
+resource "junos_bgp_neighbor" "testacc_bgpneighbor2b" {
   ip    = "192.0.2.5"
   group = junos_bgp_group.testacc_bgpneighbor2b.name
   family_evpn {}

--- a/junos/resource_firewall_filter_test.go
+++ b/junos/resource_firewall_filter_test.go
@@ -169,7 +169,7 @@ func TestAccJunosFirewallFilter_basic(t *testing.T) {
 
 func testAccJunosFirewallFilterConfigCreate() string {
 	return `
-resource junos_firewall_filter "testacc_fwFilter" {
+resource "junos_firewall_filter" "testacc_fwFilter" {
   name               = "testacc_fwFilter"
   family             = "inet"
   interface_specific = true
@@ -205,11 +205,11 @@ resource junos_firewall_filter "testacc_fwFilter" {
     }
   }
 }
-resource junos_policyoptions_prefix_list "testacc_fwFilter" {
+resource "junos_policyoptions_prefix_list" "testacc_fwFilter" {
   name   = "testacc_fwFilter"
   prefix = ["192.0.2.0/25"]
 }
-resource junos_policyoptions_prefix_list "testacc_fwFilter2" {
+resource "junos_policyoptions_prefix_list" "testacc_fwFilter2" {
   name   = "testacc_fwFilter2"
   prefix = ["192.0.2.128/25"]
 }
@@ -218,7 +218,7 @@ resource junos_policyoptions_prefix_list "testacc_fwFilter2" {
 
 func testAccJunosFirewallFilterConfigUpdate() string {
 	return `
-resource junos_firewall_filter "testacc_fwFilter" {
+resource "junos_firewall_filter" "testacc_fwFilter" {
   name               = "testacc_fwFilter"
   family             = "inet"
   interface_specific = true
@@ -293,7 +293,7 @@ resource junos_firewall_filter "testacc_fwFilter" {
     }
   }
 }
-resource junos_firewall_filter "testacc_fwFilter6" {
+resource "junos_firewall_filter" "testacc_fwFilter6" {
   name   = "testacc_fwFilter6"
   family = "inet6"
   term {
@@ -306,15 +306,15 @@ resource junos_firewall_filter "testacc_fwFilter6" {
     }
   }
 }
-resource junos_policyoptions_prefix_list "testacc_fwFilter" {
+resource "junos_policyoptions_prefix_list" "testacc_fwFilter" {
   name   = "testacc_fwFilter"
   prefix = ["192.0.2.0/25"]
 }
-resource junos_policyoptions_prefix_list "testacc_fwFilter2" {
+resource "junos_policyoptions_prefix_list" "testacc_fwFilter2" {
   name   = "testacc_fwFilter2"
   prefix = ["192.0.2.128/25"]
 }
-resource junos_firewall_policer testacc_fwfilter {
+resource "junos_firewall_policer" "testacc_fwfilter" {
   name = "testacc_fwfilter"
   if_exceeding {
     bandwidth_percent = 80

--- a/junos/resource_firewall_policer_test.go
+++ b/junos/resource_firewall_policer_test.go
@@ -59,7 +59,7 @@ func TestAccJunosFirewallPolicer_basic(t *testing.T) {
 
 func testAccJunosFirewallPolicerConfigCreate() string {
 	return `
-resource junos_firewall_policer testacc_fwPolic {
+resource "junos_firewall_policer" "testacc_fwPolic" {
   name            = "testacc_fwPolic"
   filter_specific = true
   if_exceeding {
@@ -75,7 +75,7 @@ resource junos_firewall_policer testacc_fwPolic {
 
 func testAccJunosFirewallPolicerConfigUpdate() string {
 	return `
-resource junos_firewall_policer testacc_fwPolic {
+resource "junos_firewall_policer" "testacc_fwPolic" {
   name = "testacc_fwPolic"
   if_exceeding {
     bandwidth_limit  = "32k"

--- a/junos/resource_generate_route_test.go
+++ b/junos/resource_generate_route_test.go
@@ -71,10 +71,10 @@ func TestAccJunosGenerateRoute_basic(t *testing.T) {
 
 func testAccJunosGenerateRouteConfigCreate() string {
 	return `
-resource junos_routing_instance testacc_generateRoute {
+resource "junos_routing_instance" "testacc_generateRoute" {
   name = "testacc_generateRoute"
 }
-resource junos_policyoptions_policy_statement "testacc_generateRoute" {
+resource "junos_policyoptions_policy_statement" "testacc_generateRoute" {
   lifecycle {
     create_before_destroy = true
   }
@@ -84,7 +84,7 @@ resource junos_policyoptions_policy_statement "testacc_generateRoute" {
   }
 }
 
-resource junos_generate_route testacc_generateRoute {
+resource "junos_generate_route" "testacc_generateRoute" {
   destination                  = "192.0.2.0/24"
   routing_instance             = junos_routing_instance.testacc_generateRoute.name
   preference                   = 100
@@ -100,7 +100,7 @@ resource junos_generate_route testacc_generateRoute {
   as_path_origin               = "igp"
   as_path_path                 = "65000 65000"
 }
-resource junos_generate_route testacc_generateRoute6 {
+resource "junos_generate_route" "testacc_generateRoute6" {
   destination                  = "2001:db8:85a3::/48"
   routing_instance             = junos_routing_instance.testacc_generateRoute.name
   preference                   = 100
@@ -121,17 +121,17 @@ resource junos_generate_route testacc_generateRoute6 {
 
 func testAccJunosGenerateRouteConfigUpdate() string {
 	return `
-resource junos_routing_instance testacc_generateRoute {
+resource "junos_routing_instance" "testacc_generateRoute" {
   name = "testacc_generateRoute"
 }
 
-resource junos_generate_route testacc_generateRoute {
+resource "junos_generate_route" "testacc_generateRoute" {
   destination      = "192.0.2.0/24"
   routing_instance = junos_routing_instance.testacc_generateRoute.name
   passive          = true
   brief            = true
 }
-resource junos_generate_route testacc_generateRoute6 {
+resource "junos_generate_route" "testacc_generateRoute6" {
   destination      = "2001:db8:85a3::/48"
   routing_instance = junos_routing_instance.testacc_generateRoute.name
   passive          = true
@@ -142,14 +142,14 @@ resource junos_generate_route testacc_generateRoute6 {
 
 func testAccJunosGenerateRouteConfigUpdate2() string {
 	return `
-resource junos_routing_instance testacc_generateRoute {
+resource "junos_routing_instance" "testacc_generateRoute" {
   name = "testacc_generateRoute"
 }
-resource junos_routing_instance testacc_generateRoute2 {
+resource "junos_routing_instance" "testacc_generateRoute2" {
   name = "testacc_generateRoute2"
 }
 
-resource junos_generate_route testacc_generateRoute {
+resource "junos_generate_route" "testacc_generateRoute" {
   destination      = "192.0.2.0/24"
   routing_instance = junos_routing_instance.testacc_generateRoute.name
   next_table       = "${junos_routing_instance.testacc_generateRoute2.name}.inet.0"

--- a/junos/resource_interface_logical_test.go
+++ b/junos/resource_interface_logical_test.go
@@ -196,7 +196,7 @@ func TestAccJunosInterfaceLogical_basic(t *testing.T) {
 
 func testAccJunosInterfaceLogicalConfigCreate(interFace string) string {
 	return fmt.Sprintf(`
-resource junos_firewall_filter "testacc_intlogicalInet" {
+resource "junos_firewall_filter" "testacc_intlogicalInet" {
   name   = "testacc_intlogicalInet"
   family = "inet"
   term {
@@ -206,7 +206,7 @@ resource junos_firewall_filter "testacc_intlogicalInet" {
     }
   }
 }
-resource junos_firewall_filter "testacc_intlogicalInet6" {
+resource "junos_firewall_filter" "testacc_intlogicalInet6" {
   name   = "testacc_intlogicalInet6"
   family = "inet6"
   term {
@@ -216,17 +216,17 @@ resource junos_firewall_filter "testacc_intlogicalInet6" {
     }
   }
 }
-resource junos_security_zone "testacc_interface_logical" {
+resource "junos_security_zone" "testacc_interface_logical" {
   name = "testacc_interface_logical"
 }
-resource junos_routing_instance "testacc_interface_logical" {
+resource "junos_routing_instance" "testacc_interface_logical" {
   name = "testacc_interface_logical"
 }
-resource junos_interface_physical testacc_interface_logical_phy {
+resource "junos_interface_physical" "testacc_interface_logical_phy" {
   name         = "%s"
   vlan_tagging = true
 }
-resource junos_interface_logical testacc_interface_logical {
+resource "junos_interface_logical" "testacc_interface_logical" {
   name                       = "${junos_interface_physical.testacc_interface_logical_phy.name}.100"
   description                = "testacc_interface_${junos_interface_physical.testacc_interface_logical_phy.name}.100"
   security_zone              = junos_security_zone.testacc_interface_logical.name
@@ -299,7 +299,7 @@ resource junos_interface_logical testacc_interface_logical {
 
 func testAccJunosInterfaceLogicalConfigUpdate(interFace string) string {
 	return fmt.Sprintf(`
-resource junos_firewall_filter "testacc_intlogicalInet" {
+resource "junos_firewall_filter" "testacc_intlogicalInet" {
   name   = "testacc_intlogicalInet"
   family = "inet"
   term {
@@ -309,7 +309,7 @@ resource junos_firewall_filter "testacc_intlogicalInet" {
     }
   }
 }
-resource junos_firewall_filter "testacc_intlogicalInet6" {
+resource "junos_firewall_filter" "testacc_intlogicalInet6" {
   name   = "testacc_intlogicalInet6"
   family = "inet6"
   term {
@@ -319,17 +319,17 @@ resource junos_firewall_filter "testacc_intlogicalInet6" {
     }
   }
 }
-resource junos_security_zone "testacc_interface_logical" {
+resource "junos_security_zone" "testacc_interface_logical" {
   name = "testacc_interface"
 }
-resource junos_routing_instance "testacc_interface_logical" {
+resource "junos_routing_instance" "testacc_interface_logical" {
   name = "testacc_interface"
 }
-resource junos_interface_physical testacc_interface_logical_phy {
+resource "junos_interface_physical" "testacc_interface_logical_phy" {
   name         = "%s"
   vlan_tagging = true
 }
-resource junos_interface_logical testacc_interface_logical {
+resource "junos_interface_logical" "testacc_interface_logical" {
   lifecycle {
     create_before_destroy = true
   }
@@ -392,11 +392,11 @@ resource junos_interface_logical testacc_interface_logical {
 
 func testAccJunosInterfaceLogicalConfigUpdate2(interFace string) string {
 	return fmt.Sprintf(`
-resource junos_interface_physical testacc_interface_logical_phy {
+resource "junos_interface_physical" "testacc_interface_logical_phy" {
   name         = "%s"
   vlan_tagging = true
 }
-resource junos_interface_logical testacc_interface_logical {
+resource "junos_interface_logical" "testacc_interface_logical" {
   name    = "${junos_interface_physical.testacc_interface_logical_phy.name}.100"
   vlan_id = 100
   family_inet {
@@ -415,11 +415,11 @@ resource junos_interface_logical testacc_interface_logical {
 
 func testAccJunosInterfaceLogicalConfigUpdate3(interFace string) string {
 	return fmt.Sprintf(`
-resource junos_interface_physical testacc_interface_logical_phy {
+resource "junos_interface_physical" "testacc_interface_logical_phy" {
   name         = "%s"
   vlan_tagging = true
 }
-resource junos_interface_logical testacc_interface_logical {
+resource "junos_interface_logical" "testacc_interface_logical" {
   name    = "${junos_interface_physical.testacc_interface_logical_phy.name}.100"
   vlan_id = 100
   family_inet {
@@ -460,7 +460,7 @@ resource junos_interface_logical testacc_interface_logical {
     }
   }
 }
-resource junos_interface_logical testacc_interface_logical2 {
+resource "junos_interface_logical" "testacc_interface_logical2" {
   name = "${junos_interface_physical.testacc_interface_logical_phy.name}.101"
 }
 `, interFace)
@@ -468,11 +468,11 @@ resource junos_interface_logical testacc_interface_logical2 {
 
 func testAccJunosInterfaceLogicalConfigUpdate4(interFace string) string {
 	return fmt.Sprintf(`
-resource junos_interface_physical testacc_interface_logical_phy {
+resource "junos_interface_physical" "testacc_interface_logical_phy" {
   name         = "%s"
   vlan_tagging = true
 }
-resource junos_interface_logical testacc_interface_logical {
+resource "junos_interface_logical" "testacc_interface_logical" {
   name    = "${junos_interface_physical.testacc_interface_logical_phy.name}.100"
   vlan_id = 100
   family_inet {
@@ -495,7 +495,7 @@ resource junos_interface_logical testacc_interface_logical {
     }
   }
 }
-resource junos_interface_logical testacc_interface_logical2 {
+resource "junos_interface_logical" "testacc_interface_logical2" {
   name = "${junos_interface_physical.testacc_interface_logical_phy.name}.101"
 }
 `, interFace)

--- a/junos/resource_interface_physical_disable_test.go
+++ b/junos/resource_interface_physical_disable_test.go
@@ -46,11 +46,11 @@ func TestAccJunosInterfacePhysicalDisable_basic(t *testing.T) {
 
 func testAccJunosInterfacePhysicalDisablePreConfigCreate(interFace string) string {
 	return fmt.Sprintf(`
-resource junos_interface_physical testacc_interface_disable {
+resource "junos_interface_physical" "testacc_interface_disable" {
   name                  = "%s"
   no_disable_on_destroy = true
 }
-resource junos_interface_logical testacc_interface_disable {
+resource "junos_interface_logical" "testacc_interface_disable" {
   name        = "${junos_interface_physical.testacc_interface_disable.name}.0"
   description = "testacc_interface_disable"
 }
@@ -59,10 +59,10 @@ resource junos_interface_logical testacc_interface_disable {
 
 func testAccJunosInterfacePhysicalDisableConfigCreate(interFace string) string {
 	return fmt.Sprintf(`
-resource junos_interface_physical_disable testacc_interface_disable {
+resource "junos_interface_physical_disable" "testacc_interface_disable" {
   name = "%s"
 }
-resource junos_interface_physical_disable testacc_interface_disable2 {
+resource "junos_interface_physical_disable" "testacc_interface_disable2" {
   name = "%s"
 }
 `, interFace, interFace)
@@ -70,12 +70,12 @@ resource junos_interface_physical_disable testacc_interface_disable2 {
 
 func testAccJunosInterfacePhysicalDisableConfigConflict(interFace string) string {
 	return fmt.Sprintf(`
-resource junos_interface_physical testacc_interface_disable {
+resource "junos_interface_physical" "testacc_interface_disable" {
   name                  = "%s"
   description           = "testacc_interface_disable"
   no_disable_on_destroy = true
 }
-resource junos_interface_physical_disable testacc_interface_disable {
+resource "junos_interface_physical_disable" "testacc_interface_disable" {
   name = "%s"
 }
 `, interFace, interFace)

--- a/junos/resource_interface_physical_test.go
+++ b/junos/resource_interface_physical_test.go
@@ -188,7 +188,7 @@ func TestAccJunosInterfacePhysical_basic(t *testing.T) {
 
 func testAccJunosInterfacePhysicalSWConfigCreate(interFace string) string {
 	return fmt.Sprintf(`
-resource junos_interface_physical testacc_interface {
+resource "junos_interface_physical" "testacc_interface" {
   name         = "%s"
   description  = "testacc_interface"
   trunk        = true
@@ -200,7 +200,7 @@ resource junos_interface_physical testacc_interface {
 
 func testAccJunosInterfacePhysicalSWConfigUpdate(interFace string) string {
 	return fmt.Sprintf(`
-resource junos_interface_physical testacc_interface {
+resource "junos_interface_physical" "testacc_interface" {
   name         = "%s"
   description  = "testacc_interfaceU"
   vlan_members = ["100"]
@@ -210,14 +210,14 @@ resource junos_interface_physical testacc_interface {
 
 func testAccJunosInterfacePhysicalConfigCreate(interFace, interfaceAE, interFace2 string) string {
 	return fmt.Sprintf(`
-resource junos_interface_physical testacc_interface {
+resource "junos_interface_physical" "testacc_interface" {
   name        = "%s"
   description = "testacc_interface"
   gigether_opts {
     ae_8023ad = "%s"
   }
 }
-resource junos_interface_physical testacc_interface2 {
+resource "junos_interface_physical" "testacc_interface2" {
   name        = "%s"
   description = "testacc_interface2"
   gigether_opts {
@@ -253,14 +253,14 @@ resource "junos_interface_physical" "testacc_interfaceAE" {
 
 func testAccJunosInterfacePhysicalConfigUpdate(interFace, interfaceAE, interFace2 string) string {
 	return fmt.Sprintf(`
-resource junos_interface_physical testacc_interface {
+resource "junos_interface_physical" "testacc_interface" {
   name        = "%s"
   description = "testacc_interfaceU"
   gigether_opts {
     ae_8023ad = "%s"
   }
 }
-resource junos_interface_physical testacc_interface2 {
+resource "junos_interface_physical" "testacc_interface2" {
   name        = "%s"
   description = "testacc_interface2"
   ether_opts {
@@ -310,7 +310,7 @@ resource "junos_interface_physical" "testacc_interfaceAE" {
 
 func testAccJunosInterfacePhysicalConfigUpdate2(interFace, interfaceAE string) string {
 	return fmt.Sprintf(`
-resource junos_interface_physical testacc_interface {
+resource "junos_interface_physical" "testacc_interface" {
   name        = "%s"
   description = "testacc_interfaceU"
   ether_opts {

--- a/junos/resource_interface_st0_unit_test.go
+++ b/junos/resource_interface_st0_unit_test.go
@@ -28,6 +28,6 @@ func TestAccJunosInterfaceSt0Unit_basic(t *testing.T) {
 
 func testAccJunosInterfaceSt0UnitConfig() string {
 	return `
-resource junos_interface_st0_unit testacc {}
+resource "junos_interface_st0_unit" "testacc" {}
 `
 }

--- a/junos/resource_interface_test.go
+++ b/junos/resource_interface_test.go
@@ -261,7 +261,7 @@ func TestAccJunosInterface_basic(t *testing.T) {
 
 func testAccJunosInterfaceConfigCreate(interFace string) string {
 	return fmt.Sprintf(`
-resource junos_interface testacc_interface {
+resource "junos_interface" "testacc_interface" {
   name         = "%s"
   description  = "testacc_interface"
   trunk        = true
@@ -273,7 +273,7 @@ resource junos_interface testacc_interface {
 
 func testAccJunosInterfaceConfigUpdate(interFace string) string {
 	return fmt.Sprintf(`
-resource junos_interface testacc_interface {
+resource "junos_interface" "testacc_interface" {
   name         = "%s"
   description  = "testacc_interfaceU"
   vlan_members = ["100"]
@@ -283,7 +283,7 @@ resource junos_interface testacc_interface {
 
 func testAccJunosInterfacePlusConfigCreate(interFace, interfaceAE string) string {
 	return fmt.Sprintf(`
-resource junos_firewall_filter "testacc_interfaceInet" {
+resource "junos_firewall_filter" "testacc_interfaceInet" {
   name   = "testacc_interfaceInet"
   family = "inet"
   term {
@@ -293,7 +293,7 @@ resource junos_firewall_filter "testacc_interfaceInet" {
     }
   }
 }
-resource junos_firewall_filter "testacc_interfaceInet6" {
+resource "junos_firewall_filter" "testacc_interfaceInet6" {
   name   = "testacc_interfaceInet6"
   family = "inet6"
   term {
@@ -303,25 +303,25 @@ resource junos_firewall_filter "testacc_interfaceInet6" {
     }
   }
 }
-resource junos_security_zone "testacc_interface" {
+resource "junos_security_zone" "testacc_interface" {
   name = "testacc_interface"
 }
-resource junos_routing_instance "testacc_interface" {
+resource "junos_routing_instance" "testacc_interface" {
   name = "testacc_interface"
 }
-resource junos_interface testacc_interface {
+resource "junos_interface" "testacc_interface" {
   name         = "%s"
   description  = "testacc_interface"
   ether802_3ad = "%s"
 }
-resource junos_interface testacc_interfaceAE {
+resource "junos_interface" "testacc_interfaceAE" {
   name             = junos_interface.testacc_interface.ether802_3ad
   description      = "testacc_interfaceAE"
   ae_lacp          = "active"
   ae_minimum_links = 1
   vlan_tagging     = true
 }
-resource junos_interface testacc_interfaceAEunit {
+resource "junos_interface" "testacc_interfaceAEunit" {
   name               = "${junos_interface.testacc_interfaceAE.name}.100"
   description        = "testacc_interface_${junos_interface.testacc_interfaceAE.name}.100"
   security_zone      = junos_security_zone.testacc_interface.name
@@ -387,7 +387,7 @@ resource junos_interface testacc_interfaceAEunit {
 
 func testAccJunosInterfacePlusConfigUpdate(interFace, interfaceAE string) string {
 	return fmt.Sprintf(`
-resource junos_firewall_filter "testacc_interfaceInet" {
+resource "junos_firewall_filter" "testacc_interfaceInet" {
   name   = "testacc_interfaceInet"
   family = "inet"
   term {
@@ -397,7 +397,7 @@ resource junos_firewall_filter "testacc_interfaceInet" {
     }
   }
 }
-resource junos_firewall_filter "testacc_interfaceInet6" {
+resource "junos_firewall_filter" "testacc_interfaceInet6" {
   name   = "testacc_interfaceInet6"
   family = "inet6"
   term {
@@ -407,23 +407,23 @@ resource junos_firewall_filter "testacc_interfaceInet6" {
     }
   }
 }
-resource junos_security_zone "testacc_interface" {
+resource "junos_security_zone" "testacc_interface" {
   name = "testacc_interface"
 }
-resource junos_routing_instance "testacc_interface" {
+resource "junos_routing_instance" "testacc_interface" {
   name = "testacc_interface"
 }
-resource junos_interface testacc_interface {
+resource "junos_interface" "testacc_interface" {
   name         = "%s"
   description  = "testacc_interfaceU"
   ether802_3ad = "%s"
 }
-resource junos_interface testacc_interfaceAE {
+resource "junos_interface" "testacc_interfaceAE" {
   name         = junos_interface.testacc_interface.ether802_3ad
   description  = "testacc_interfaceAE"
   vlan_tagging = true
 }
-resource junos_interface testacc_interfaceAEunit {
+resource "junos_interface" "testacc_interfaceAEunit" {
   name               = "${junos_interface.testacc_interfaceAE.name}.100"
   vlan_tagging_id    = 101
   description        = "testacc_interface_${junos_interface.testacc_interfaceAE.name}.100"

--- a/junos/resource_null_commit_file_test.go
+++ b/junos/resource_null_commit_file_test.go
@@ -47,7 +47,7 @@ func TestAccJunosNullCommitFile_basic(t *testing.T) {
 
 func testAccJunosNullCommitFilePreCreate(interFace string) string {
 	return fmt.Sprintf(`
-resource junos_interface_physical testacc_nullcommitfile {
+resource "junos_interface_physical" "testacc_nullcommitfile" {
   name         = "%s"
   description  = "testacc_null"
   vlan_tagging = true
@@ -57,7 +57,7 @@ resource junos_interface_physical testacc_nullcommitfile {
 
 func testAccJunosNullCommitFileCreate(interFace string) string {
 	return fmt.Sprintf(`
-resource junos_interface_physical testacc_nullcommitfile {
+resource "junos_interface_physical" "testacc_nullcommitfile" {
   name         = "%s"
   description  = "testacc_null"
   vlan_tagging = true
@@ -66,7 +66,7 @@ resource "local_file" "hostname" {
   content  = "set interfaces %s description testacc_nullfile"
   filename = "%s"
 }
-resource junos_null_commit_file "testacc_nullcommitfile" {
+resource "junos_null_commit_file" "testacc_nullcommitfile" {
   filename                = local_file.hostname.filename
   clear_file_after_commit = true
 }
@@ -75,12 +75,12 @@ resource junos_null_commit_file "testacc_nullcommitfile" {
 
 func testAccJunosNullCommitFileRead(interFace string) string {
 	return fmt.Sprintf(`
-resource junos_interface_physical testacc_nullcommitfile {
+resource "junos_interface_physical" "testacc_nullcommitfile" {
   name         = "%s"
   description  = "testacc_null"
   vlan_tagging = true
 }
-data junos_interface_physical testacc_nullcommitfile {
+data "junos_interface_physical" "testacc_nullcommitfile" {
   config_interface = "%s"
 }
 `, interFace, interFace)

--- a/junos/resource_ospf_area_test.go
+++ b/junos/resource_ospf_area_test.go
@@ -80,7 +80,7 @@ func TestAccJunosOspfArea_basic(t *testing.T) {
 
 func testAccJunosOspfAreaConfigCreate(interFace string) string {
 	return fmt.Sprintf(`
-resource junos_ospf_area "testacc_ospfarea" {
+resource "junos_ospf_area" "testacc_ospfarea" {
   area_id = "0.0.0.0"
   interface {
     name                = "all"
@@ -96,7 +96,7 @@ resource junos_ospf_area "testacc_ospfarea" {
     secondary = true
   }
 }
-resource junos_interface_logical "testacc_ospfarea" {
+resource "junos_interface_logical" "testacc_ospfarea" {
   name        = "%s.0"
   description = "testacc_ospfarea"
 }
@@ -105,7 +105,7 @@ resource junos_interface_logical "testacc_ospfarea" {
 
 func testAccJunosOspfAreaConfigUpdate(interFace, interFace2 string) string {
 	return fmt.Sprintf(`
-resource junos_ospf_area "testacc_ospfarea" {
+resource "junos_ospf_area" "testacc_ospfarea" {
   area_id = "0.0.0.0"
   interface {
     name                           = "all"
@@ -146,19 +146,19 @@ resource junos_ospf_area "testacc_ospfarea" {
     }
   }
 }
-resource junos_interface_logical "testacc_ospfarea" {
+resource "junos_interface_logical" "testacc_ospfarea" {
   name        = "%s.0"
   description = "testacc_ospfarea"
 }
-resource junos_interface_logical "testacc_ospfarea2" {
+resource "junos_interface_logical" "testacc_ospfarea2" {
   name             = "%s.0"
   description      = "testacc_ospfarea2"
   routing_instance = junos_routing_instance.testacc_ospfarea.name
 }
-resource junos_routing_instance "testacc_ospfarea" {
+resource "junos_routing_instance" "testacc_ospfarea" {
   name = "testacc_ospfarea"
 }
-resource junos_ospf_area "testacc_ospfarea2" {
+resource "junos_ospf_area" "testacc_ospfarea2" {
   area_id          = "0.0.0.0"
   version          = "v3"
   routing_instance = junos_routing_instance.testacc_ospfarea.name

--- a/junos/resource_ospf_test.go
+++ b/junos/resource_ospf_test.go
@@ -37,13 +37,13 @@ func TestAccJunosOspf_basic(t *testing.T) {
 
 func testAccJunosOspfConfigCreate() string {
 	return `
-resource junos_policyoptions_policy_statement "testacc_ospf" {
+resource "junos_policyoptions_policy_statement" "testacc_ospf" {
   name = "testacc_ospf"
   then {
     action = "accept"
   }
 }
-resource junos_ospf "testacc_ospf" {
+resource "junos_ospf" "testacc_ospf" {
   database_protection {
     ignore_count      = 10
     ignore_time       = 600
@@ -86,21 +86,21 @@ resource junos_ospf "testacc_ospf" {
     rapid_runs              = 5
   }
 }
-resource junos_routing_instance "testacc_ospf" {
+resource "junos_routing_instance" "testacc_ospf" {
   name = "testacc_ospf"
 }
 resource "junos_rib_group" "testacc_ospf_ri" {
   name       = "testacc_ospf_ri"
   import_rib = ["${junos_routing_instance.testacc_ospf.name}.inet.0"]
 }
-resource junos_ospf "testacc_ospf_ri" {
+resource "junos_ospf" "testacc_ospf_ri" {
   routing_instance = junos_routing_instance.testacc_ospf.name
   export           = [junos_policyoptions_policy_statement.testacc_ospf.name]
   import           = [junos_policyoptions_policy_statement.testacc_ospf.name]
   domain_id        = "192.0.2.1:100"
   rib_group        = junos_rib_group.testacc_ospf_ri.name
 }
-resource junos_ospf "testacc_ospf_v3" {
+resource "junos_ospf" "testacc_ospf_v3" {
   version = "v3"
   export  = [junos_policyoptions_policy_statement.testacc_ospf.name]
   import  = [junos_policyoptions_policy_statement.testacc_ospf.name]
@@ -110,13 +110,13 @@ resource junos_ospf "testacc_ospf_v3" {
 
 func testAccJunosOspfConfigUpdate() string {
 	return `
-resource junos_policyoptions_policy_statement "testacc_ospf" {
+resource "junos_policyoptions_policy_statement" "testacc_ospf" {
   name = "testacc_ospf"
   then {
     action = "accept"
   }
 }
-resource junos_ospf "testacc_ospf" {
+resource "junos_ospf" "testacc_ospf" {
   database_protection {
     maximum_lsa = 10
   }

--- a/junos/resource_policyoptions_test.go
+++ b/junos/resource_policyoptions_test.go
@@ -479,29 +479,29 @@ func TestAccJunosPolicyOptions_basic(t *testing.T) {
 
 func testAccJunosPolicyOptionsConfigCreate() string {
 	return `
-resource junos_routing_instance "testacc_policyOptions" {
+resource "junos_routing_instance" "testacc_policyOptions" {
   name = "testacc_policyOptions"
 }
-resource junos_policyoptions_as_path "testacc_policyOptions" {
+resource "junos_policyoptions_as_path" "testacc_policyOptions" {
   name = "testacc_policyOptions"
   path = "5|12|18"
 }
-resource junos_policyoptions_as_path_group "testacc_policyOptions" {
+resource "junos_policyoptions_as_path_group" "testacc_policyOptions" {
   name = "testacc_policyOptions"
   as_path {
     name = "testacc_policyOptions"
     path = "5|12|18"
   }
 }
-resource junos_policyoptions_community "testacc_policyOptions" {
+resource "junos_policyoptions_community" "testacc_policyOptions" {
   name    = "testacc_policyOptions"
   members = ["65000:100"]
 }
-resource junos_policyoptions_prefix_list "testacc_policyOptions" {
+resource "junos_policyoptions_prefix_list" "testacc_policyOptions" {
   name   = "testacc_policyOptions"
   prefix = ["192.0.2.0/25"]
 }
-resource junos_policyoptions_policy_statement "testacc_policyOptions" {
+resource "junos_policyoptions_policy_statement" "testacc_policyOptions" {
   name = "testacc_policyOptions"
   from {
     aggregate_contributor = true
@@ -660,7 +660,7 @@ resource junos_policyoptions_policy_statement "testacc_policyOptions" {
     }
   }
 }
-resource junos_policyoptions_policy_statement "testacc_policyOptions2" {
+resource "junos_policyoptions_policy_statement" "testacc_policyOptions2" {
   name = "testacc_policyOptions2"
   from {
     bgp_as_path_group = [junos_policyoptions_as_path_group.testacc_policyOptions.name]
@@ -701,7 +701,7 @@ resource junos_policyoptions_policy_statement "testacc_policyOptions2" {
     }
   }
 }
-resource junos_policyoptions_policy_statement "testacc_policyOptions3" {
+resource "junos_policyoptions_policy_statement" "testacc_policyOptions3" {
   name                              = "testacc_policyOptions3"
   add_it_to_forwarding_table_export = true
   from {
@@ -719,33 +719,33 @@ resource junos_policyoptions_policy_statement "testacc_policyOptions3" {
 
 func testAccJunosPolicyOptionsConfigUpdate() string {
 	return `
-resource junos_routing_instance "testacc_policyOptions" {
+resource "junos_routing_instance" "testacc_policyOptions" {
   name = "testacc_policyOptions"
 }
-resource junos_policyoptions_as_path "testacc_policyOptions" {
+resource "junos_policyoptions_as_path" "testacc_policyOptions" {
   name = "testacc_policyOptions"
   path = "5|15"
 }
-resource junos_policyoptions_as_path_group "testacc_policyOptions" {
+resource "junos_policyoptions_as_path_group" "testacc_policyOptions" {
   name = "testacc_policyOptions"
   as_path {
     name = "testacc_policyOptions"
     path = "5|15"
   }
 }
-resource junos_policyoptions_community "testacc_policyOptions" {
+resource "junos_policyoptions_community" "testacc_policyOptions" {
   name    = "testacc_policyOptions"
   members = ["65000:200"]
 }
-resource junos_policyoptions_prefix_list "testacc_policyOptions" {
+resource "junos_policyoptions_prefix_list" "testacc_policyOptions" {
   name   = "testacc_policyOptions"
   prefix = ["192.0.2.0/26", "192.0.2.64/26"]
 }
-resource junos_policyoptions_prefix_list "testacc_policyOptions2" {
+resource "junos_policyoptions_prefix_list" "testacc_policyOptions2" {
   name       = "testacc_policyOptions2"
   apply_path = "system radius-server <*>"
 }
-resource junos_policyoptions_policy_statement "testacc_policyOptions" {
+resource "junos_policyoptions_policy_statement" "testacc_policyOptions" {
   name = "testacc_policyOptions"
   from {
     aggregate_contributor = true
@@ -852,7 +852,7 @@ resource junos_policyoptions_policy_statement "testacc_policyOptions" {
     }
   }
 }
-resource junos_policyoptions_policy_statement "testacc_policyOptions2" {
+resource "junos_policyoptions_policy_statement" "testacc_policyOptions2" {
   name = "testacc_policyOptions2"
   from {
     bgp_as_path_group = [junos_policyoptions_as_path_group.testacc_policyOptions.name]

--- a/junos/resource_rib_group_test.go
+++ b/junos/resource_rib_group_test.go
@@ -51,16 +51,16 @@ func TestAccJunosRibGroup_basic(t *testing.T) {
 
 func testAccJunosRibGroupConfigCreate() string {
 	return `
-resource junos_routing_instance "testacc_ribGroup1" {
+resource "junos_routing_instance" "testacc_ribGroup1" {
   name = "testacc_ribGroup1"
 }
-resource junos_policyoptions_policy_statement "testacc_ribGroup" {
+resource "junos_policyoptions_policy_statement" "testacc_ribGroup" {
   name = "testacc_ribGroup"
   then {
     action = "accept"
   }
 }
-resource junos_rib_group testacc_ribGroup {
+resource "junos_rib_group" "testacc_ribGroup" {
   name          = "testacc_ribGroup-test"
   import_policy = [junos_policyoptions_policy_statement.testacc_ribGroup.name, ]
   import_rib = [
@@ -73,19 +73,19 @@ resource junos_rib_group testacc_ribGroup {
 
 func testAccJunosRibGroupConfigUpdate() string {
 	return `
-resource junos_routing_instance "testacc_ribGroup1" {
+resource "junos_routing_instance" "testacc_ribGroup1" {
   name = "testacc_ribGroup1"
 }
-resource junos_routing_instance "testacc_ribGroup2" {
+resource "junos_routing_instance" "testacc_ribGroup2" {
   name = "testacc_ribGroup2"
 }
-resource junos_policyoptions_policy_statement "testacc_ribGroup" {
+resource "junos_policyoptions_policy_statement" "testacc_ribGroup" {
   name = "testacc_ribGroup"
   then {
     action = "accept"
   }
 }
-resource junos_rib_group testacc_ribGroup {
+resource "junos_rib_group" "testacc_ribGroup" {
   name          = "testacc_ribGroup-test"
   import_policy = [junos_policyoptions_policy_statement.testacc_ribGroup.name, ]
   import_rib = [

--- a/junos/resource_routing_instance_test.go
+++ b/junos/resource_routing_instance_test.go
@@ -74,18 +74,18 @@ func TestAccJunosRoutingInstance_basic(t *testing.T) {
 
 func testAccJunosRoutingInstanceConfigSRXCreate() string {
 	return `
-resource junos_routing_instance "testacc_routingInst" {
+resource "junos_routing_instance" "testacc_routingInst" {
   name            = "testacc_routingInst"
   as              = "65000"
   description     = "testacc routingInst"
   instance_export = [junos_policyoptions_policy_statement.testacc_routingInst2.name]
   instance_import = [junos_policyoptions_policy_statement.testacc_routingInst2.name]
 }
-resource junos_policyoptions_community "testacc_routingInst2" {
+resource "junos_policyoptions_community" "testacc_routingInst2" {
   name    = "testacc_routingInst2"
   members = ["target:65000:100"]
 }
-resource junos_policyoptions_policy_statement "testacc_routingInst2" {
+resource "junos_policyoptions_policy_statement" "testacc_routingInst2" {
   name = "testacc_routingInst2"
   from {
     bgp_community = [junos_policyoptions_community.testacc_routingInst2.name]
@@ -99,7 +99,7 @@ resource junos_policyoptions_policy_statement "testacc_routingInst2" {
 
 func testAccJunosRoutingInstanceConfigSRXUpdate() string {
 	return `
-resource junos_routing_instance "testacc_routingInst" {
+resource "junos_routing_instance" "testacc_routingInst" {
   name = "testacc_routingInst"
   as   = "65001"
   instance_export = [
@@ -111,15 +111,15 @@ resource junos_routing_instance "testacc_routingInst" {
     junos_policyoptions_policy_statement.testacc_routingInst2.name,
   ]
 }
-resource junos_policyoptions_community "testacc_routingInst2" {
+resource "junos_policyoptions_community" "testacc_routingInst2" {
   name    = "testacc_routingInst2"
   members = ["target:65000:100"]
 }
-resource junos_policyoptions_community "testacc_routingInst3" {
+resource "junos_policyoptions_community" "testacc_routingInst3" {
   name    = "testacc_routingInst3"
   members = ["target:65000:200"]
 }
-resource junos_policyoptions_policy_statement "testacc_routingInst2" {
+resource "junos_policyoptions_policy_statement" "testacc_routingInst2" {
   name = "testacc_routingInst2"
   from {
     bgp_community = [junos_policyoptions_community.testacc_routingInst2.name]
@@ -128,7 +128,7 @@ resource junos_policyoptions_policy_statement "testacc_routingInst2" {
     action = "accept"
   }
 }
-resource junos_policyoptions_policy_statement "testacc_routingInst3" {
+resource "junos_policyoptions_policy_statement" "testacc_routingInst3" {
   name = "testacc_routingInst3"
   from {
     bgp_community = [junos_policyoptions_community.testacc_routingInst3.name]
@@ -142,18 +142,18 @@ resource junos_policyoptions_policy_statement "testacc_routingInst3" {
 
 func testAccJunosRoutingInstanceConfigCreate() string {
 	return `
-resource junos_routing_instance "testacc_routingInst" {
+resource "junos_routing_instance" "testacc_routingInst" {
   name            = "testacc_routingInst"
   as              = "65000"
   description     = "testacc routingInst"
   instance_export = [junos_policyoptions_policy_statement.testacc_routingInst2.name]
   instance_import = [junos_policyoptions_policy_statement.testacc_routingInst2.name]
 }
-resource junos_policyoptions_community "testacc_routingInst2" {
+resource "junos_policyoptions_community" "testacc_routingInst2" {
   name    = "testacc_routingInst2"
   members = ["target:65000:100"]
 }
-resource junos_policyoptions_policy_statement "testacc_routingInst2" {
+resource "junos_policyoptions_policy_statement" "testacc_routingInst2" {
   name = "testacc_routingInst2"
   from {
     bgp_community = [junos_policyoptions_community.testacc_routingInst2.name]
@@ -162,7 +162,7 @@ resource junos_policyoptions_policy_statement "testacc_routingInst2" {
     action = "accept"
   }
 }
-resource junos_interface_logical "testacc_routingInst2" {
+resource "junos_interface_logical" "testacc_routingInst2" {
   name = "lo0.1"
   family_inet {
     address {
@@ -170,7 +170,7 @@ resource junos_interface_logical "testacc_routingInst2" {
     }
   }
 }
-resource junos_routing_instance "testacc_routingInst2" {
+resource "junos_routing_instance" "testacc_routingInst2" {
   name                  = "testacc_routingInst2"
   type                  = "l2vpn"
   route_distinguisher   = "1:2"
@@ -182,13 +182,13 @@ resource junos_routing_instance "testacc_routingInst2" {
   vtep_source_interface = junos_interface_logical.testacc_routingInst2.name
 }
 
-resource junos_routing_instance "testacc_routingInst3" {
+resource "junos_routing_instance" "testacc_routingInst3" {
   name                  = "testacc_routingInst3"
   configure_type_singly = true
   type                  = ""
   vtep_source_interface = junos_interface_logical.testacc_routingInst2.name
 }
-resource junos_routing_instance "testacc_routingInst4" {
+resource "junos_routing_instance" "testacc_routingInst4" {
   name                = "testacc_routingInst4"
   type                = "virtual-switch"
   route_distinguisher = "8:9"
@@ -200,7 +200,7 @@ resource junos_routing_instance "testacc_routingInst4" {
 
 func testAccJunosRoutingInstanceConfigUpdate() string {
 	return `
-resource junos_routing_instance "testacc_routingInst" {
+resource "junos_routing_instance" "testacc_routingInst" {
   name = "testacc_routingInst"
   as   = "65001"
   instance_export = [
@@ -212,15 +212,15 @@ resource junos_routing_instance "testacc_routingInst" {
     junos_policyoptions_policy_statement.testacc_routingInst2.name,
   ]
 }
-resource junos_policyoptions_community "testacc_routingInst2" {
+resource "junos_policyoptions_community" "testacc_routingInst2" {
   name    = "testacc_routingInst2"
   members = ["target:65000:100"]
 }
-resource junos_policyoptions_community "testacc_routingInst3" {
+resource "junos_policyoptions_community" "testacc_routingInst3" {
   name    = "testacc_routingInst3"
   members = ["target:65000:200"]
 }
-resource junos_policyoptions_policy_statement "testacc_routingInst2" {
+resource "junos_policyoptions_policy_statement" "testacc_routingInst2" {
   name = "testacc_routingInst2"
   from {
     bgp_community = [junos_policyoptions_community.testacc_routingInst2.name]
@@ -229,7 +229,7 @@ resource junos_policyoptions_policy_statement "testacc_routingInst2" {
     action = "accept"
   }
 }
-resource junos_policyoptions_policy_statement "testacc_routingInst3" {
+resource "junos_policyoptions_policy_statement" "testacc_routingInst3" {
   name = "testacc_routingInst3"
   from {
     bgp_community = [junos_policyoptions_community.testacc_routingInst3.name]
@@ -238,7 +238,7 @@ resource junos_policyoptions_policy_statement "testacc_routingInst3" {
     action = "accept"
   }
 }
-resource junos_interface_logical "testacc_routingInst2" {
+resource "junos_interface_logical" "testacc_routingInst2" {
   name = "lo0.1"
   family_inet {
     address {
@@ -246,7 +246,7 @@ resource junos_interface_logical "testacc_routingInst2" {
     }
   }
 }
-resource junos_routing_instance "testacc_routingInst2" {
+resource "junos_routing_instance" "testacc_routingInst2" {
   name                = "testacc_routingInst2"
   type                = "l2vpn"
   route_distinguisher = "1:2"
@@ -264,13 +264,13 @@ resource junos_routing_instance "testacc_routingInst2" {
   vtep_source_interface = junos_interface_logical.testacc_routingInst2.name
 }
 
-resource junos_routing_instance "testacc_routingInst3" {
+resource "junos_routing_instance" "testacc_routingInst3" {
   name                  = "testacc_routingInst3"
   configure_type_singly = true
   type                  = ""
   vtep_source_interface = junos_interface_logical.testacc_routingInst2.name
 }
-resource junos_routing_instance "testacc_routingInst4" {
+resource "junos_routing_instance" "testacc_routingInst4" {
   name                = "testacc_routingInst4"
   type                = "virtual-switch"
   route_distinguisher = "10:11"

--- a/junos/resource_routing_options_test.go
+++ b/junos/resource_routing_options_test.go
@@ -92,7 +92,7 @@ resource "junos_policyoptions_policy_statement" "testacc_routing_options3" {
   }
 }
 
-resource junos_routing_options "testacc_routing_options" {
+resource "junos_routing_options" "testacc_routing_options" {
   autonomous_system {
     number         = "65000"
     asdot_notation = true
@@ -146,7 +146,7 @@ resource "junos_policyoptions_policy_statement" "testacc_routing_options3" {
   }
 }
 
-resource junos_routing_options "testacc_routing_options" {
+resource "junos_routing_options" "testacc_routing_options" {
   clean_on_destroy                         = true
   forwarding_table_export_configure_singly = true
   forwarding_table {
@@ -165,7 +165,7 @@ resource junos_routing_options "testacc_routing_options" {
     junos_policyoptions_policy_statement.testacc_routing_options3.name,
   ]
 }
-resource junos_policyoptions_policy_statement "testacc_routing_options" {
+resource "junos_policyoptions_policy_statement" "testacc_routing_options" {
   name                              = "testacc_routing_options"
   add_it_to_forwarding_table_export = true
   from {

--- a/junos/resource_security_address_book_test.go
+++ b/junos/resource_security_address_book_test.go
@@ -156,7 +156,7 @@ resource "junos_security_address_book" "testacc_securityNamedAddressBook" {
 
 func testAccJunosSecurityAddressBookConfigUpdate() string {
 	return `
-resource junos_security_address_book "testacc_securityGlobalAddressBook" {
+resource "junos_security_address_book" "testacc_securityGlobalAddressBook" {
   description = "testacc global description"
   network_address {
     name        = "testacc_network"
@@ -178,7 +178,7 @@ resource junos_security_address_book "testacc_securityGlobalAddressBook" {
   }
 }
 
-resource junos_security_address_book "testacc_securityNamedAddressBook" {
+resource "junos_security_address_book" "testacc_securityNamedAddressBook" {
   name = "testacc_secAddrBook"
   network_address {
     name  = "testacc_network"

--- a/junos/resource_security_global_policy_test.go
+++ b/junos/resource_security_global_policy_test.go
@@ -50,10 +50,10 @@ func TestAccJunosSecurityGlobalPolicy_basic(t *testing.T) {
 
 func testAccJunosSecurityGlobalPolicyConfigCreate() string {
 	return `
-resource junos_security_zone "testacc_secglobpolicy1" {
+resource "junos_security_zone" "testacc_secglobpolicy1" {
   name = "testacc_secglobpolicy1"
 }
-resource junos_security_zone "testacc_secglobpolicy2" {
+resource "junos_security_zone" "testacc_secglobpolicy2" {
   lifecycle {
     create_before_destroy = true
   }
@@ -80,7 +80,7 @@ resource "junos_services_user_identification_device_identity_profile" "profile" 
     value = ["testacc_secglobpolicy"]
   }
 }
-resource junos_security_global_policy "testacc_secglobpolicy" {
+resource "junos_security_global_policy" "testacc_secglobpolicy" {
   depends_on = [
     junos_security_address_book.testacc_secglobpolicy
   ]
@@ -101,7 +101,7 @@ resource junos_security_global_policy "testacc_secglobpolicy" {
 
 func testAccJunosSecurityGlobalPolicyConfigUpdate() string {
 	return `
-resource junos_security_zone "testacc_secglobpolicy1" {
+resource "junos_security_zone" "testacc_secglobpolicy1" {
   lifecycle {
     create_before_destroy = true
   }
@@ -120,7 +120,7 @@ resource "junos_security_address_book" "testacc_secglobpolicy" {
     value = "192.0.2.2/32"
   }
 }
-resource junos_services_advanced_anti_malware_policy "testacc_secglobpolicy" {
+resource "junos_services_advanced_anti_malware_policy" "testacc_secglobpolicy" {
   lifecycle {
     create_before_destroy = true
   }
@@ -128,7 +128,7 @@ resource junos_services_advanced_anti_malware_policy "testacc_secglobpolicy" {
   verdict_threshold        = "recommended"
   default_notification_log = true
 }
-resource junos_security_global_policy "testacc_secglobpolicy" {
+resource "junos_security_global_policy" "testacc_secglobpolicy" {
   depends_on = [
     junos_security_address_book.testacc_secglobpolicy
   ]
@@ -166,13 +166,13 @@ resource junos_security_global_policy "testacc_secglobpolicy" {
 
 func testAccJunosSecurityGlobalPolicyConfigUpdate2() string {
 	return `
-resource junos_security_zone "testacc_secglobpolicy1" {
+resource "junos_security_zone" "testacc_secglobpolicy1" {
   lifecycle {
     create_before_destroy = true
   }
   name = "testacc_secglobpolicy1"
 }
-resource junos_security_idp_policy "testacc_secglobpolicy" {
+resource "junos_security_idp_policy" "testacc_secglobpolicy" {
   lifecycle {
     create_before_destroy = true
   }
@@ -191,7 +191,7 @@ resource "junos_security_address_book" "testacc_secglobpolicy" {
     value = "192.0.2.2/32"
   }
 }
-resource junos_security_global_policy "testacc_secglobpolicy" {
+resource "junos_security_global_policy" "testacc_secglobpolicy" {
   depends_on = [
     junos_security_address_book.testacc_secglobpolicy
   ]

--- a/junos/resource_security_idp_policy_test.go
+++ b/junos/resource_security_idp_policy_test.go
@@ -34,7 +34,7 @@ func TestAccJunosSecurityIdpPolicy_basic(t *testing.T) {
 
 func testAccJunosSecurityIdpPolicyConfigCreate() string {
 	return `
-resource junos_security "testacc_secIdpPolicy" {
+resource "junos_security" "testacc_secIdpPolicy" {
   lifecycle {
     ignore_changes = [
       log
@@ -131,7 +131,7 @@ resource "junos_security_idp_policy" "testacc_idp_pol" {
 
 func testAccJunosSecurityIdpPolicyConfigUpdate() string {
 	return `
-resource junos_security "testacc_secIdpPolicy" {
+resource "junos_security" "testacc_secIdpPolicy" {
   idp_sensor_configuration {
     packet_log {
       source_address = "192.0.2.4"
@@ -182,7 +182,7 @@ resource "junos_security_idp_policy" "testacc_idp_pol" {
 
 func testAccJunosSecurityIdpPolicyConfigPostCheck() string {
 	return `
-resource junos_security "testacc_secIdpPolicy" {
+resource "junos_security" "testacc_secIdpPolicy" {
   alg {
     dns_disable    = true
     ftp_disable    = true

--- a/junos/resource_security_ike_ipsec_test.go
+++ b/junos/resource_security_ike_ipsec_test.go
@@ -254,7 +254,7 @@ func TestAccJunosSecurityIkeIpsec_basic(t *testing.T) {
 
 func testAccJunosSecurityIkeIpsecConfigCreate(interFace string) string {
 	return fmt.Sprintf(`
-resource junos_interface_logical "testacc_ikegateway" {
+resource "junos_interface_logical" "testacc_ikegateway" {
   name = "%s.0"
   family_inet {
     address {
@@ -262,20 +262,20 @@ resource junos_interface_logical "testacc_ikegateway" {
     }
   }
 }
-resource junos_security_ike_proposal "testacc_ikeprop" {
+resource "junos_security_ike_proposal" "testacc_ikeprop" {
   name                     = "testacc_ikeprop"
   authentication_algorithm = "sha1"
   encryption_algorithm     = "aes-256-cbc"
   dh_group                 = "group2"
   lifetime_seconds         = 3600
 }
-resource junos_security_ike_policy "testacc_ikepol" {
+resource "junos_security_ike_policy" "testacc_ikepol" {
   name                = "testacc_ikepol"
   proposals           = [junos_security_ike_proposal.testacc_ikeprop.name]
   mode                = "main"
   pre_shared_key_text = "thePassWord"
 }
-resource junos_security_ike_gateway "testacc_ikegateway" {
+resource "junos_security_ike_gateway" "testacc_ikegateway" {
   name               = "testacc_ikegateway"
   address            = ["192.0.2.3"]
   policy             = junos_security_ike_policy.testacc_ikepol.name
@@ -295,19 +295,19 @@ resource junos_security_ike_gateway "testacc_ikegateway" {
   version = "v2-only"
 }
 
-resource junos_security_ipsec_proposal "testacc_ipsecprop" {
+resource "junos_security_ipsec_proposal" "testacc_ipsecprop" {
   name                     = "testacc_ipsecprop"
   authentication_algorithm = "hmac-sha1-96"
   protocol                 = "esp"
   encryption_algorithm     = "aes-128-cbc"
 }
-resource junos_security_ipsec_policy "testacc_ipsecpol" {
+resource "junos_security_ipsec_policy" "testacc_ipsecpol" {
   name      = "testacc_ipsecpol"
   proposals = [junos_security_ipsec_proposal.testacc_ipsecprop.name]
   pfs_keys  = "group2"
 }
-resource junos_interface_st0_unit testacc_ipsecvpn {}
-resource junos_security_ipsec_vpn "testacc_ipsecvpn" {
+resource "junos_interface_st0_unit" "testacc_ipsecvpn" {}
+resource "junos_security_ipsec_vpn" "testacc_ipsecvpn" {
   name           = "testacc_ipsecvpn"
   bind_interface = junos_interface_st0_unit.testacc_ipsecvpn.id
   ike {
@@ -330,7 +330,7 @@ resource junos_security_ipsec_vpn "testacc_ipsecvpn" {
 
 func testAccJunosSecurityIkeIpsecConfigUpdate(interFace string) string {
 	return fmt.Sprintf(`
-resource junos_interface_logical "testacc_ikegateway" {
+resource "junos_interface_logical" "testacc_ikegateway" {
   name = "%s.0"
   family_inet {
     address {
@@ -338,20 +338,20 @@ resource junos_interface_logical "testacc_ikegateway" {
     }
   }
 }
-resource junos_security_ike_proposal "testacc_ikeprop" {
+resource "junos_security_ike_proposal" "testacc_ikeprop" {
   name                     = "testacc_ikeprop"
   authentication_algorithm = "sha1"
   encryption_algorithm     = "aes-256-cbc"
   dh_group                 = "group1"
   lifetime_seconds         = 3600
 }
-resource junos_security_ike_policy "testacc_ikepol" {
+resource "junos_security_ike_policy" "testacc_ikepol" {
   name                = "testacc_ikepol"
   proposal_set        = "standard"
   mode                = "main"
   pre_shared_key_text = "mysecret"
 }
-resource junos_security_ike_gateway "testacc_ikegateway" {
+resource "junos_security_ike_gateway" "testacc_ikegateway" {
   name               = "testacc_ikegateway"
   address            = ["192.0.2.4"]
   policy             = junos_security_ike_policy.testacc_ikepol.name
@@ -373,18 +373,18 @@ resource junos_security_ike_gateway "testacc_ikegateway" {
   }
 }
 
-resource junos_security_ipsec_proposal "testacc_ipsecprop" {
+resource "junos_security_ipsec_proposal" "testacc_ipsecprop" {
   name                     = "testacc_ipsecprop"
   authentication_algorithm = "hmac-sha1-96"
   protocol                 = "esp"
   encryption_algorithm     = "aes-256-cbc"
 }
-resource junos_security_ipsec_policy "testacc_ipsecpol" {
+resource "junos_security_ipsec_policy" "testacc_ipsecpol" {
   name         = "testacc_ipsecpol"
   proposal_set = "standard"
   pfs_keys     = "group1"
 }
-resource junos_security_ipsec_vpn "testacc_ipsecvpn2" {
+resource "junos_security_ipsec_vpn" "testacc_ipsecvpn2" {
   name = "testacc_ipsecvpn2"
   ike {
     gateway          = junos_security_ike_gateway.testacc_ikegateway.name
@@ -396,21 +396,21 @@ resource junos_security_ipsec_vpn "testacc_ipsecvpn2" {
   establish_tunnels = "immediately"
   df_bit            = "clear"
 }
-resource junos_security_zone testacc_secIkeIpsec_local {
+resource "junos_security_zone" "testacc_secIkeIpsec_local" {
   name = "testacc_secIkeIPsec_local"
   address_book {
     name    = "testacc_vpnlocal"
     network = "192.0.2.64/26"
   }
 }
-resource junos_security_zone testacc_secIkeIpsec_remote {
+resource "junos_security_zone" "testacc_secIkeIpsec_remote" {
   name = "testacc_secIkeIPsec_remote"
   address_book {
     name    = "testacc_vpnremote"
     network = "192.0.2.128/26"
   }
 }
-resource junos_security_policy testacc_policyIpsecLocToRem {
+resource "junos_security_policy" "testacc_policyIpsecLocToRem" {
   depends_on = [
     junos_security_zone.testacc_secIkeIpsec_local,
     junos_security_zone.testacc_secIkeIpsec_remote
@@ -426,7 +426,7 @@ resource junos_security_policy testacc_policyIpsecLocToRem {
   }
 }
 
-resource junos_security_policy testacc_policyIpsecRemToLoc {
+resource "junos_security_policy" "testacc_policyIpsecRemToLoc" {
   depends_on = [
     junos_security_zone.testacc_secIkeIpsec_local,
     junos_security_zone.testacc_secIkeIpsec_remote
@@ -442,7 +442,7 @@ resource junos_security_policy testacc_policyIpsecRemToLoc {
   }
 }
 
-resource junos_security_policy_tunnel_pair_policy testacc_vpn-in-out {
+resource "junos_security_policy_tunnel_pair_policy" "testacc_vpn-in-out" {
   zone_a        = junos_security_zone.testacc_secIkeIpsec_local.name
   zone_b        = junos_security_zone.testacc_secIkeIpsec_remote.name
   policy_a_to_b = junos_security_policy.testacc_policyIpsecLocToRem.policy[0].name
@@ -453,7 +453,7 @@ resource junos_security_policy_tunnel_pair_policy testacc_vpn-in-out {
 
 func testAccJunosSecurityIkeIpsecConfigUpdate2(interFace string) string {
 	return fmt.Sprintf(`
-resource junos_interface_logical "testacc_ikegateway" {
+resource "junos_interface_logical" "testacc_ikegateway" {
   name = "%s.0"
   family_inet {
     address {
@@ -461,20 +461,20 @@ resource junos_interface_logical "testacc_ikegateway" {
     }
   }
 }
-resource junos_security_ike_proposal "testacc_ikeprop" {
+resource "junos_security_ike_proposal" "testacc_ikeprop" {
   name                     = "testacc_ikeprop"
   authentication_algorithm = "sha1"
   encryption_algorithm     = "aes-256-cbc"
   dh_group                 = "group1"
   lifetime_seconds         = 3600
 }
-resource junos_security_ike_policy "testacc_ikepol" {
+resource "junos_security_ike_policy" "testacc_ikepol" {
   name                = "testacc_ikepol"
   proposals           = [junos_security_ike_proposal.testacc_ikeprop.name]
   mode                = "aggressive"
   pre_shared_key_text = "mysecret"
 }
-resource junos_security_ike_gateway "testacc_ikegateway" {
+resource "junos_security_ike_gateway" "testacc_ikegateway" {
   name = "testacc_ikegateway"
   dynamic_remote {
     distinguished_name {
@@ -497,18 +497,18 @@ resource junos_security_ike_gateway "testacc_ikegateway" {
   local_address = "192.0.2.4"
 }
 
-resource junos_security_ipsec_proposal "testacc_ipsecprop" {
+resource "junos_security_ipsec_proposal" "testacc_ipsecprop" {
   name                     = "testacc_ipsecprop"
   authentication_algorithm = "hmac-sha1-96"
   protocol                 = "esp"
   encryption_algorithm     = "aes-256-cbc"
 }
-resource junos_security_ipsec_policy "testacc_ipsecpol" {
+resource "junos_security_ipsec_policy" "testacc_ipsecpol" {
   name      = "testacc_ipsecpol"
   proposals = [junos_security_ipsec_proposal.testacc_ipsecprop.name]
   pfs_keys  = "group1"
 }
-resource junos_security_ipsec_vpn "testacc_ipsecvpn2" {
+resource "junos_security_ipsec_vpn" "testacc_ipsecvpn2" {
   name = "testacc_ipsecvpn2"
   ike {
     gateway          = junos_security_ike_gateway.testacc_ikegateway.name
@@ -520,21 +520,21 @@ resource junos_security_ipsec_vpn "testacc_ipsecvpn2" {
   establish_tunnels = "immediately"
   df_bit            = "clear"
 }
-resource junos_security_zone testacc_secIkeIpsec_local {
+resource "junos_security_zone" "testacc_secIkeIpsec_local" {
   name = "testacc_secIkeIPsec_local"
   address_book {
     name    = "testacc_vpnlocal"
     network = "192.0.2.64/26"
   }
 }
-resource junos_security_zone testacc_secIkeIpsec_remote {
+resource "junos_security_zone" "testacc_secIkeIpsec_remote" {
   name = "testacc_secIkeIPsec_remote"
   address_book {
     name    = "testacc_vpnremote"
     network = "192.0.2.128/26"
   }
 }
-resource junos_security_policy testacc_policyIpsecLocToRem {
+resource "junos_security_policy" "testacc_policyIpsecLocToRem" {
   depends_on = [
     junos_security_zone.testacc_secIkeIpsec_local,
     junos_security_zone.testacc_secIkeIpsec_remote
@@ -550,7 +550,7 @@ resource junos_security_policy testacc_policyIpsecLocToRem {
   }
 }
 
-resource junos_security_policy testacc_policyIpsecRemToLoc {
+resource "junos_security_policy" "testacc_policyIpsecRemToLoc" {
   depends_on = [
     junos_security_zone.testacc_secIkeIpsec_local,
     junos_security_zone.testacc_secIkeIpsec_remote
@@ -566,7 +566,7 @@ resource junos_security_policy testacc_policyIpsecRemToLoc {
   }
 }
 
-resource junos_security_policy_tunnel_pair_policy testacc_vpn-in-out {
+resource "junos_security_policy_tunnel_pair_policy" "testacc_vpn-in-out" {
   zone_a        = junos_security_zone.testacc_secIkeIpsec_local.name
   zone_b        = junos_security_zone.testacc_secIkeIpsec_remote.name
   policy_a_to_b = junos_security_policy.testacc_policyIpsecLocToRem.policy[0].name
@@ -577,7 +577,7 @@ resource junos_security_policy_tunnel_pair_policy testacc_vpn-in-out {
 
 func testAccJunosSecurityIkeIpsecConfigUpdate3(interFace string) string {
 	return fmt.Sprintf(`
-resource junos_interface_logical "testacc_ikegateway" {
+resource "junos_interface_logical" "testacc_ikegateway" {
   name = "%s.0"
   family_inet {
     address {
@@ -585,20 +585,20 @@ resource junos_interface_logical "testacc_ikegateway" {
     }
   }
 }
-resource junos_security_ike_proposal "testacc_ikeprop" {
+resource "junos_security_ike_proposal" "testacc_ikeprop" {
   name                     = "testacc_ikeprop"
   authentication_algorithm = "sha1"
   encryption_algorithm     = "aes-256-cbc"
   dh_group                 = "group1"
   lifetime_seconds         = 3600
 }
-resource junos_security_ike_policy "testacc_ikepol" {
+resource "junos_security_ike_policy" "testacc_ikepol" {
   name                = "testacc_ikepol"
   proposals           = [junos_security_ike_proposal.testacc_ikeprop.name]
   mode                = "aggressive"
   pre_shared_key_text = "mysecret"
 }
-resource junos_security_ike_gateway "testacc_ikegateway" {
+resource "junos_security_ike_gateway" "testacc_ikegateway" {
   name = "testacc_ikegateway"
   dynamic_remote {
     hostname = "host1.example.com"
@@ -606,18 +606,18 @@ resource junos_security_ike_gateway "testacc_ikegateway" {
   policy             = junos_security_ike_policy.testacc_ikepol.name
   external_interface = junos_interface_logical.testacc_ikegateway.name
 }
-resource junos_security_ipsec_proposal "testacc_ipsecprop" {
+resource "junos_security_ipsec_proposal" "testacc_ipsecprop" {
   name                     = "testacc_ipsecprop"
   authentication_algorithm = "hmac-sha1-96"
   protocol                 = "esp"
   encryption_algorithm     = "aes-128-cbc"
 }
-resource junos_security_ipsec_policy "testacc_ipsecpol" {
+resource "junos_security_ipsec_policy" "testacc_ipsecpol" {
   name      = "testacc_ipsecpol"
   proposals = [junos_security_ipsec_proposal.testacc_ipsecprop.name]
   pfs_keys  = "group2"
 }
-resource junos_security_ipsec_vpn "testacc_ipsecvpn" {
+resource "junos_security_ipsec_vpn" "testacc_ipsecvpn" {
   name           = "testacc_ipsecvpn"
   bind_interface = junos_interface_logical.testacc_ipsecvpn_bind.name
   ike {
@@ -636,17 +636,17 @@ resource junos_security_ipsec_vpn "testacc_ipsecvpn" {
     remote_ip = "192.0.3.192/26"
   }
 }
-resource junos_interface_logical "testacc_ipsecvpn_bind" {
+resource "junos_interface_logical" "testacc_ipsecvpn_bind" {
   name = junos_interface_st0_unit.testacc_ipsec_vpn.id
   family_inet {}
 }
-resource junos_interface_st0_unit testacc_ipsec_vpn {}
+resource "junos_interface_st0_unit" "testacc_ipsec_vpn" {}
 `, interFace)
 }
 
 func testAccJunosSecurityIkeIpsecConfigUpdate4(interFace string) string {
 	return fmt.Sprintf(`
-resource junos_interface_logical "testacc_ikegateway" {
+resource "junos_interface_logical" "testacc_ikegateway" {
   name = "%s.0"
   family_inet {
     address {
@@ -654,20 +654,20 @@ resource junos_interface_logical "testacc_ikegateway" {
     }
   }
 }
-resource junos_security_ike_proposal "testacc_ikeprop" {
+resource "junos_security_ike_proposal" "testacc_ikeprop" {
   name                     = "testacc_ikeprop"
   authentication_algorithm = "sha1"
   encryption_algorithm     = "aes-256-cbc"
   dh_group                 = "group1"
   lifetime_seconds         = 3600
 }
-resource junos_security_ike_policy "testacc_ikepol" {
+resource "junos_security_ike_policy" "testacc_ikepol" {
   name                = "testacc_ikepol"
   proposals           = [junos_security_ike_proposal.testacc_ikeprop.name]
   mode                = "aggressive"
   pre_shared_key_text = "mysecret"
 }
-resource junos_security_ike_gateway "testacc_ikegateway" {
+resource "junos_security_ike_gateway" "testacc_ikegateway" {
   name = "testacc_ikegateway"
   dynamic_remote {
     inet = "192.168.0.4"
@@ -680,7 +680,7 @@ resource junos_security_ike_gateway "testacc_ikegateway" {
 
 func testAccJunosSecurityIkeIpsecConfigUpdate5(interFace string) string {
 	return fmt.Sprintf(`
-resource junos_interface_logical "testacc_ikegateway" {
+resource "junos_interface_logical" "testacc_ikegateway" {
   name = "%s.0"
   family_inet {
     address {
@@ -688,20 +688,20 @@ resource junos_interface_logical "testacc_ikegateway" {
     }
   }
 }
-resource junos_security_ike_proposal "testacc_ikeprop" {
+resource "junos_security_ike_proposal" "testacc_ikeprop" {
   name                     = "testacc_ikeprop"
   authentication_algorithm = "sha1"
   encryption_algorithm     = "aes-256-cbc"
   dh_group                 = "group1"
   lifetime_seconds         = 3600
 }
-resource junos_security_ike_policy "testacc_ikepol" {
+resource "junos_security_ike_policy" "testacc_ikepol" {
   name                = "testacc_ikepol"
   proposals           = [junos_security_ike_proposal.testacc_ikeprop.name]
   mode                = "aggressive"
   pre_shared_key_text = "mysecret"
 }
-resource junos_security_ike_gateway "testacc_ikegateway" {
+resource "junos_security_ike_gateway" "testacc_ikegateway" {
   name = "testacc_ikegateway"
   dynamic_remote {
     inet6 = "2001:db8::1"
@@ -714,7 +714,7 @@ resource junos_security_ike_gateway "testacc_ikegateway" {
 
 func testAccJunosSecurityIkeIpsecConfigUpdate6(interFace string) string {
 	return fmt.Sprintf(`
-resource junos_interface_logical "testacc_ikegateway" {
+resource "junos_interface_logical" "testacc_ikegateway" {
   name = "%s.0"
   family_inet {
     address {
@@ -722,20 +722,20 @@ resource junos_interface_logical "testacc_ikegateway" {
     }
   }
 }
-resource junos_security_ike_proposal "testacc_ikeprop" {
+resource "junos_security_ike_proposal" "testacc_ikeprop" {
   name                     = "testacc_ikeprop"
   authentication_algorithm = "sha1"
   encryption_algorithm     = "aes-256-cbc"
   dh_group                 = "group1"
   lifetime_seconds         = 3600
 }
-resource junos_security_ike_policy "testacc_ikepol" {
+resource "junos_security_ike_policy" "testacc_ikepol" {
   name                = "testacc_ikepol"
   proposals           = [junos_security_ike_proposal.testacc_ikeprop.name]
   mode                = "aggressive"
   pre_shared_key_text = "mysecret"
 }
-resource junos_security_ike_gateway "testacc_ikegateway" {
+resource "junos_security_ike_gateway" "testacc_ikegateway" {
   name = "testacc_ikegateway"
   dynamic_remote {
     ike_user_type               = "group-ike-id"
@@ -750,7 +750,7 @@ resource junos_security_ike_gateway "testacc_ikegateway" {
 
 func testAccJunosSecurityIkeIpsecConfigUpdate7(interFace string) string {
 	return fmt.Sprintf(`
-resource junos_interface_logical "testacc_ikegateway" {
+resource "junos_interface_logical" "testacc_ikegateway" {
   name = "%s.0"
   family_inet {
     address {
@@ -758,20 +758,20 @@ resource junos_interface_logical "testacc_ikegateway" {
     }
   }
 }
-resource junos_security_ike_proposal "testacc_ikeprop" {
+resource "junos_security_ike_proposal" "testacc_ikeprop" {
   name                     = "testacc_ikeprop"
   authentication_algorithm = "sha1"
   encryption_algorithm     = "aes-256-cbc"
   dh_group                 = "group1"
   lifetime_seconds         = 3600
 }
-resource junos_security_ike_policy "testacc_ikepol" {
+resource "junos_security_ike_policy" "testacc_ikepol" {
   name                = "testacc_ikepol"
   proposals           = [junos_security_ike_proposal.testacc_ikeprop.name]
   mode                = "aggressive"
   pre_shared_key_text = "mysecret"
 }
-resource junos_security_ike_gateway "testacc_ikegateway" {
+resource "junos_security_ike_gateway" "testacc_ikegateway" {
   name = "testacc_ikegateway"
   dynamic_remote {
     distinguished_name {

--- a/junos/resource_security_log_stream_test.go
+++ b/junos/resource_security_log_stream_test.go
@@ -69,7 +69,7 @@ func TestAccJunosSecurityLogStream_basic(t *testing.T) {
 
 func testAccJunosSecurityLogStreamConfigPreCreate() string {
 	return `
-resource junos_security "security" {
+resource "junos_security" "security" {
   log {
     source_address = "192.0.2.2"
   }
@@ -79,13 +79,13 @@ resource junos_security "security" {
 
 func testAccJunosSecurityLogStreamConfigCreate() string {
 	return `
-resource junos_routing_instance "testacc_logstream" {
+resource "junos_routing_instance" "testacc_logstream" {
   lifecycle {
     create_before_destroy = true
   }
   name = "testacclogstream"
 }
-resource junos_security_log_stream "testacc_logstream" {
+resource "junos_security_log_stream" "testacc_logstream" {
   name     = "testacc_logstream"
   category = ["idp"]
   format   = "syslog"
@@ -102,7 +102,7 @@ resource junos_security_log_stream "testacc_logstream" {
 
 func testAccJunosSecurityLogStreamConfigUpdate() string {
 	return `
-resource junos_security_log_stream "testacc_logstream" {
+resource "junos_security_log_stream" "testacc_logstream" {
   name = "testacc_logstream"
   file {
     name             = "test"

--- a/junos/resource_security_nat_destination_test.go
+++ b/junos/resource_security_nat_destination_test.go
@@ -71,7 +71,7 @@ func TestAccJunosSecurityNatDestination_basic(t *testing.T) {
 
 func testAccJunosSecurityNatDestinationConfigCreate() string {
 	return `
-resource junos_security_nat_destination testacc_securityDNAT {
+resource "junos_security_nat_destination" "testacc_securityDNAT" {
   name        = "testacc_securityDNAT"
   description = "testacc securityDNAT"
   from {
@@ -87,24 +87,24 @@ resource junos_security_nat_destination testacc_securityDNAT {
     }
   }
 }
-resource junos_security_nat_destination_pool testacc_securityDNATPool {
+resource "junos_security_nat_destination_pool" "testacc_securityDNATPool" {
   name             = "testacc_securityDNATPool"
   description      = "testacc securityDNATPool"
   address          = "192.0.2.1/32"
   address_to       = "192.0.2.2/32"
   routing_instance = junos_routing_instance.testacc_securityDNAT.name
 }
-resource junos_security_nat_destination_pool testacc_securityDNATPool2 {
+resource "junos_security_nat_destination_pool" "testacc_securityDNATPool2" {
   name             = "testacc_securityDNATPool2"
   address          = "192.0.2.1/32"
   address_port     = 80
   routing_instance = junos_routing_instance.testacc_securityDNAT.name
 }
 
-resource junos_security_zone testacc_securityDNAT {
+resource "junos_security_zone" "testacc_securityDNAT" {
   name = "testacc_securityDNAT"
 }
-resource junos_routing_instance testacc_securityDNAT {
+resource "junos_routing_instance" "testacc_securityDNAT" {
   name = "testacc_securityDNAT"
 }
 `
@@ -112,7 +112,7 @@ resource junos_routing_instance testacc_securityDNAT {
 
 func testAccJunosSecurityNatDestinationConfigUpdate() string {
 	return `
-resource junos_security_nat_destination testacc_securityDNAT {
+resource "junos_security_nat_destination" "testacc_securityDNAT" {
   depends_on = [
     junos_security_address_book.testacc_securityDNAT
   ]
@@ -161,23 +161,23 @@ resource junos_security_nat_destination testacc_securityDNAT {
     }
   }
 }
-resource junos_security_nat_destination_pool testacc_securityDNATPool {
+resource "junos_security_nat_destination_pool" "testacc_securityDNATPool" {
   name             = "testacc_securityDNATPool"
   address          = "192.0.2.1/32"
   address_to       = "192.0.2.2/32"
   routing_instance = junos_routing_instance.testacc_securityDNAT.name
 }
-resource junos_security_nat_destination_pool testacc_securityDNATPool2 {
+resource "junos_security_nat_destination_pool" "testacc_securityDNATPool2" {
   name             = "testacc_securityDNATPool2"
   address          = "192.0.2.1/32"
   address_port     = 80
   routing_instance = junos_routing_instance.testacc_securityDNAT.name
 }
 
-resource junos_security_zone testacc_securityDNAT {
+resource "junos_security_zone" "testacc_securityDNAT" {
   name = "testacc_securityDNAT"
 }
-resource junos_routing_instance testacc_securityDNAT {
+resource "junos_routing_instance" "testacc_securityDNAT" {
   name = "testacc_securityDNAT"
 }
 resource "junos_security_address_book" "testacc_securityDNAT" {

--- a/junos/resource_security_nat_source_test.go
+++ b/junos/resource_security_nat_source_test.go
@@ -101,7 +101,7 @@ func TestAccJunosSecurityNatSource_basic(t *testing.T) {
 
 func testAccJunosSecurityNatSourceConfigCreate() string {
 	return `
-resource junos_security_nat_source testacc_securitySNAT {
+resource "junos_security_nat_source" "testacc_securitySNAT" {
   name        = "testacc_securitySNAT"
   description = "testacc securitySNAT"
   from {
@@ -125,7 +125,7 @@ resource junos_security_nat_source testacc_securitySNAT {
     }
   }
 }
-resource junos_security_nat_source_pool testacc_securitySNATPool {
+resource "junos_security_nat_source_pool" "testacc_securitySNATPool" {
   name                                   = "testacc_securitySNATPool"
   description                            = "testacc securitySNATPool"
   address                                = ["192.0.2.1/32", "192.0.2.64/27"]
@@ -136,10 +136,10 @@ resource junos_security_nat_source_pool testacc_securitySNATPool {
   pool_utilization_alarm_clear_threshold = 60
 }
 
-resource junos_security_zone testacc_securitySNAT {
+resource "junos_security_zone" "testacc_securitySNAT" {
   name = "testacc_securitySNAT"
 }
-resource junos_routing_instance testacc_securitySNAT {
+resource "junos_routing_instance" "testacc_securitySNAT" {
   name = "testacc_securitySNAT"
 }
 `
@@ -147,7 +147,7 @@ resource junos_routing_instance testacc_securitySNAT {
 
 func testAccJunosSecurityNatSourceConfigUpdate() string {
 	return `
-resource junos_security_nat_source testacc_securitySNAT {
+resource "junos_security_nat_source" "testacc_securitySNAT" {
   depends_on = [
     junos_security_address_book.testacc_securitySNAT
   ]
@@ -199,7 +199,7 @@ resource junos_security_nat_source testacc_securitySNAT {
     }
   }
 }
-resource junos_security_nat_source_pool testacc_securitySNATPool {
+resource "junos_security_nat_source_pool" "testacc_securitySNATPool" {
   name                    = "testacc_securitySNATPool"
   address                 = ["192.0.2.1/32"]
   routing_instance        = junos_routing_instance.testacc_securitySNAT.name
@@ -207,10 +207,10 @@ resource junos_security_nat_source_pool testacc_securitySNATPool {
   port_overloading_factor = 3
 }
 
-resource junos_security_zone testacc_securitySNAT {
+resource "junos_security_zone" "testacc_securitySNAT" {
   name = "testacc_securitySNAT"
 }
-resource junos_routing_instance testacc_securitySNAT {
+resource "junos_routing_instance" "testacc_securitySNAT" {
   name = "testacc_securitySNAT"
 }
 resource "junos_security_address_book" "testacc_securitySNAT" {

--- a/junos/resource_security_nat_static_rule_test.go
+++ b/junos/resource_security_nat_static_rule_test.go
@@ -67,7 +67,7 @@ func TestAccJunosSecurityNatStaticRule_basic(t *testing.T) {
 
 func testAccJunosSecurityNatStaticRuleConfigCreate() string {
 	return `
-resource junos_security_nat_static testacc_securityNATSttRule {
+resource "junos_security_nat_static" "testacc_securityNATSttRule" {
   name = "testacc_securityNATSttRule"
   from {
     type  = "zone"
@@ -75,7 +75,7 @@ resource junos_security_nat_static testacc_securityNATSttRule {
   }
   configure_rules_singly = true
 }
-resource junos_security_nat_static_rule testacc_securityNATSttRule {
+resource "junos_security_nat_static_rule" "testacc_securityNATSttRule" {
   name                = "testacc_securityNATSttRule"
   rule_set            = junos_security_nat_static.testacc_securityNATSttRule.name
   destination_address = "192.0.2.0/25"
@@ -86,10 +86,10 @@ resource junos_security_nat_static_rule testacc_securityNATSttRule {
   }
 }
 
-resource junos_security_zone testacc_securityNATSttRule {
+resource "junos_security_zone" "testacc_securityNATSttRule" {
   name = "testacc_securityNATSttRule"
 }
-resource junos_routing_instance testacc_securityNATSttRule {
+resource "junos_routing_instance" "testacc_securityNATSttRule" {
   name = "testacc_securityNATSttRule"
 }
 `
@@ -97,7 +97,7 @@ resource junos_routing_instance testacc_securityNATSttRule {
 
 func testAccJunosSecurityNatStaticRuleConfigUpdate() string {
 	return `
-resource junos_security_nat_static testacc_securityNATSttRule {
+resource "junos_security_nat_static" "testacc_securityNATSttRule" {
   name = "testacc_securityNATSttRule"
   from {
     type  = "zone"
@@ -105,7 +105,7 @@ resource junos_security_nat_static testacc_securityNATSttRule {
   }
   configure_rules_singly = true
 }
-resource junos_security_nat_static_rule testacc_securityNATSttRule {
+resource "junos_security_nat_static_rule" "testacc_securityNATSttRule" {
   name                = "testacc_securityNATSttRule"
   rule_set            = junos_security_nat_static.testacc_securityNATSttRule.name
   destination_address = "192.0.2.0/26"
@@ -115,7 +115,7 @@ resource junos_security_nat_static_rule testacc_securityNATSttRule {
     prefix           = "192.0.2.64/26"
   }
 }
-resource junos_security_nat_static_rule testacc_securityNATSttRule2 {
+resource "junos_security_nat_static_rule" "testacc_securityNATSttRule2" {
   depends_on = [
     junos_security_address_book.testacc_securityNATSttRule
   ]
@@ -135,7 +135,7 @@ resource junos_security_nat_static_rule testacc_securityNATSttRule2 {
     prefix           = "testacc_securityNATSttRule-prefix"
   }
 }
-resource junos_security_nat_static_rule testacc_securityNATSttRule3 {
+resource "junos_security_nat_static_rule" "testacc_securityNATSttRule3" {
   depends_on = [
     junos_security_address_book.testacc_securityNATSttRule
   ]

--- a/junos/resource_security_nat_static_test.go
+++ b/junos/resource_security_nat_static_test.go
@@ -74,7 +74,7 @@ func TestAccJunosSecurityNatStatic_basic(t *testing.T) {
 
 func testAccJunosSecurityNatStaticConfigCreate() string {
 	return `
-resource junos_security_nat_static testacc_securityNATStt {
+resource "junos_security_nat_static" "testacc_securityNATStt" {
   name        = "testacc_securityNATStt"
   description = "testacc securityNATStt"
   from {
@@ -92,10 +92,10 @@ resource junos_security_nat_static testacc_securityNATStt {
   }
 }
 
-resource junos_security_zone testacc_securityNATStt {
+resource "junos_security_zone" "testacc_securityNATStt" {
   name = "testacc_securityNATStt"
 }
-resource junos_routing_instance testacc_securityNATStt {
+resource "junos_routing_instance" "testacc_securityNATStt" {
   name = "testacc_securityNATStt"
 }
 `

--- a/junos/resource_security_policy_test.go
+++ b/junos/resource_security_policy_test.go
@@ -72,7 +72,7 @@ resource "junos_services_user_identification_device_identity_profile" "profile" 
     value = ["testacc_securityPolicy"]
   }
 }
-resource junos_security_policy testacc_securityPolicy {
+resource "junos_security_policy" "testacc_securityPolicy" {
   from_zone = junos_security_zone.testacc_seczonePolicy1.name
   to_zone   = junos_security_zone.testacc_seczonePolicy1.name
   policy {
@@ -88,7 +88,7 @@ resource junos_security_policy testacc_securityPolicy {
   }
 }
 
-resource junos_security_zone testacc_seczonePolicy1 {
+resource "junos_security_zone" "testacc_seczonePolicy1" {
   name = "testacc_seczonePolicy1"
   address_book {
     name    = "testacc_address1"
@@ -100,15 +100,15 @@ resource junos_security_zone testacc_seczonePolicy1 {
 
 func testAccJunosSecurityPolicyConfigUpdate() string {
 	return `
-resource junos_services_advanced_anti_malware_policy "testacc_securityPolicy" {
+resource "junos_services_advanced_anti_malware_policy" "testacc_securityPolicy" {
   name                     = "testacc_securityPolicy"
   verdict_threshold        = "recommended"
   default_notification_log = true
 }
-resource junos_security_idp_policy "testacc_securityPolicy" {
+resource "junos_security_idp_policy" "testacc_securityPolicy" {
   name = "testacc_securityPolicy"
 }
-resource junos_security_policy testacc_securityPolicy {
+resource "junos_security_policy" "testacc_securityPolicy" {
   from_zone = junos_security_zone.testacc_seczonePolicy1.name
   to_zone   = junos_security_zone.testacc_seczonePolicy1.name
   policy {
@@ -135,7 +135,7 @@ resource junos_security_policy testacc_securityPolicy {
   }
 }
 
-resource junos_security_zone testacc_seczonePolicy1 {
+resource "junos_security_zone" "testacc_seczonePolicy1" {
   name = "testacc_seczonePolicy1"
   address_book {
     name    = "testacc_address1"

--- a/junos/resource_security_screen_test.go
+++ b/junos/resource_security_screen_test.go
@@ -54,7 +54,7 @@ func TestAccJunosSecurityScreen_basic(t *testing.T) {
 
 func testAccJunosSecurityScreenConfigCreate() string {
 	return `
-resource junos_security_screen testacc_securityScreen {
+resource "junos_security_screen" "testacc_securityScreen" {
   name               = "testacc 1"
   alarm_without_drop = true
   description        = "desc testacc 1"
@@ -164,7 +164,7 @@ resource "junos_security_screen_whitelist" "testacc1" {
 
 func testAccJunosSecurityScreenConfigUpdate() string {
 	return `
-resource junos_security_screen testacc_securityScreen {
+resource "junos_security_screen" "testacc_securityScreen" {
   name               = "testacc 1"
   alarm_without_drop = true
   description        = "desc testacc 1"

--- a/junos/resource_security_test.go
+++ b/junos/resource_security_test.go
@@ -271,7 +271,7 @@ func TestAccJunosSecurity_basic(t *testing.T) {
 
 func testAccJunosSecurityConfigPreCreate() string {
 	return `
-resource junos_system "system" {
+resource "junos_system" "system" {
   tracing_dest_override_syslog_host = "192.0.2.13"
 }
 `
@@ -279,7 +279,7 @@ resource junos_system "system" {
 
 func testAccJunosSecurityConfigCreate(interFace string) string {
 	return fmt.Sprintf(`
-resource junos_interface_logical "testacc_security" {
+resource "junos_interface_logical" "testacc_security" {
   lifecycle {
     create_before_destroy = true
   }
@@ -301,7 +301,7 @@ resource "junos_services_ssl_initiation_profile" "testacc_security" {
   name = "testacc_security"
 }
 
-resource junos_security "testacc_security" {
+resource "junos_security" "testacc_security" {
   alg {
     dns_disable    = true
     ftp_disable    = true
@@ -454,7 +454,7 @@ resource junos_security "testacc_security" {
 
 func testAccJunosSecurityConfigUpdate(interFace string) string {
 	return `
-resource junos_security "testacc_security" {
+resource "junos_security" "testacc_security" {
   flow {
     ethernet_switching {
       bypass_non_ip_unicast = true
@@ -520,7 +520,7 @@ resource junos_security "testacc_security" {
     }
   }
 }
-resource junos_routing_instance testacc_security {
+resource "junos_routing_instance" "testacc_security" {
   lifecycle {
     create_before_destroy = true
   }
@@ -531,7 +531,7 @@ resource junos_routing_instance testacc_security {
 
 func testAccJunosSecurityConfigUpdate2() string {
 	return `
-resource junos_security "testacc_security" {
+resource "junos_security" "testacc_security" {
   flow {
     tcp_session {
       time_wait_state {
@@ -548,7 +548,7 @@ resource junos_security "testacc_security" {
 
 func testAccJunosSecurityConfigPostCheck() string {
 	return `
-resource junos_security "testacc_security" {
+resource "junos_security" "testacc_security" {
   alg {
     dns_disable    = true
     ftp_disable    = true

--- a/junos/resource_security_utm_custom_url_category_test.go
+++ b/junos/resource_security_utm_custom_url_category_test.go
@@ -45,11 +45,11 @@ func TestAccJunosSecurityUtmCustomURLCategory_basic(t *testing.T) {
 
 func testAccJunosSecurityUtmCustomURLCategoryConfigCreate() string {
 	return `
-resource junos_security_utm_custom_url_pattern "testacc_URLCategory1" {
+resource "junos_security_utm_custom_url_pattern" "testacc_URLCategory1" {
   name  = "testacc-custom-pattern1"
   value = ["*.google.com"]
 }
-resource junos_security_utm_custom_url_category "testacc_URLCategory" {
+resource "junos_security_utm_custom_url_category" "testacc_URLCategory" {
   name = "testacc_URLCategory"
   value = [
     junos_security_utm_custom_url_pattern.testacc_URLCategory1.name,
@@ -60,15 +60,15 @@ resource junos_security_utm_custom_url_category "testacc_URLCategory" {
 
 func testAccJunosSecurityUtmCustomURLCategoryConfigUpdate() string {
 	return `
-resource junos_security_utm_custom_url_pattern "testacc_URLCategory1" {
+resource "junos_security_utm_custom_url_pattern" "testacc_URLCategory1" {
   name  = "testacc-custom-pattern1"
   value = ["*.google.com"]
 }
-resource junos_security_utm_custom_url_pattern "testacc_URLCategory2" {
+resource "junos_security_utm_custom_url_pattern" "testacc_URLCategory2" {
   name  = "testacc-custom-pattern2"
   value = ["*.google.fr"]
 }
-resource junos_security_utm_custom_url_category "testacc_URLCategory" {
+resource "junos_security_utm_custom_url_category" "testacc_URLCategory" {
   name = "testacc_URLCategory"
   value = [
     junos_security_utm_custom_url_pattern.testacc_URLCategory1.name,

--- a/junos/resource_security_utm_custom_url_pattern_test.go
+++ b/junos/resource_security_utm_custom_url_pattern_test.go
@@ -45,7 +45,7 @@ func TestAccJunosSecurityUtmCustomURLPattern_basic(t *testing.T) {
 
 func testAccJunosSecurityUtmCustomURLPatternConfigCreate() string {
 	return `
-resource junos_security_utm_custom_url_pattern "testacc_UrlPattern" {
+resource "junos_security_utm_custom_url_pattern" "testacc_UrlPattern" {
   name  = "testacc_UrlPattern"
   value = ["*.google.com"]
 }
@@ -54,7 +54,7 @@ resource junos_security_utm_custom_url_pattern "testacc_UrlPattern" {
 
 func testAccJunosSecurityUtmCustomURLPatternConfigUpdate() string {
 	return `
-resource junos_security_utm_custom_url_pattern "testacc_UrlPattern" {
+resource "junos_security_utm_custom_url_pattern" "testacc_UrlPattern" {
   name  = "testacc_UrlPattern"
   value = ["*.google.com", "*.google.fr"]
 }

--- a/junos/resource_security_utm_policy_test.go
+++ b/junos/resource_security_utm_policy_test.go
@@ -51,7 +51,7 @@ func TestAccJunosSecurityUtmPolicy_basic(t *testing.T) {
 
 func testAccJunosSecurityUtmPolicyConfigCreate() string {
 	return `
-resource junos_security_utm_policy "testacc_Policy" {
+resource "junos_security_utm_policy" "testacc_Policy" {
   name = "testacc Policy"
   anti_virus {
     http_profile = "junos-sophos-av-defaults"
@@ -66,7 +66,7 @@ resource junos_security_utm_policy "testacc_Policy" {
 
 func testAccJunosSecurityUtmPolicyConfigUpdate() string {
 	return `
-resource junos_security_utm_policy "testacc_Policy" {
+resource "junos_security_utm_policy" "testacc_Policy" {
   name                  = "testacc Policy"
   web_filtering_profile = "junos-wf-enhanced-default"
 }

--- a/junos/resource_security_utm_profile_web_filtering_juniper_enhanced_test.go
+++ b/junos/resource_security_utm_profile_web_filtering_juniper_enhanced_test.go
@@ -99,7 +99,7 @@ func TestAccJunosSecurityUtmProfileWebFE_basic(t *testing.T) {
 
 func testAccJunosSecurityUtmProfileWebFEConfigCreate() string {
 	return `
-resource junos_security_utm_profile_web_filtering_juniper_enhanced "testacc_ProfileWebFE" {
+resource "junos_security_utm_profile_web_filtering_juniper_enhanced" "testacc_ProfileWebFE" {
   name = "testacc ProfileWebFE"
   block_message {
     url                      = "block.local"
@@ -134,7 +134,7 @@ resource junos_security_utm_profile_web_filtering_juniper_enhanced "testacc_Prof
 
 func testAccJunosSecurityUtmProfileWebFEConfigUpdate() string {
 	return `
-resource junos_security_utm_profile_web_filtering_juniper_enhanced "testacc_ProfileWebFE" {
+resource "junos_security_utm_profile_web_filtering_juniper_enhanced" "testacc_ProfileWebFE" {
   name = "testacc ProfileWebFE"
   category {
     name   = "Enhanced_Network_Errors"

--- a/junos/resource_security_utm_profile_web_filtering_juniper_local_test.go
+++ b/junos/resource_security_utm_profile_web_filtering_juniper_local_test.go
@@ -55,7 +55,7 @@ func TestAccJunosSecurityUtmProfileWebFL_basic(t *testing.T) {
 
 func testAccJunosSecurityUtmProfileWebFLConfigCreate() string {
 	return `
-resource junos_security_utm_profile_web_filtering_juniper_local "testacc_ProfileWebFL" {
+resource "junos_security_utm_profile_web_filtering_juniper_local" "testacc_ProfileWebFL" {
   name                 = "testacc ProfileWebFL"
   custom_block_message = "Blocked by Juniper"
   default_action       = "log-and-permit"
@@ -70,7 +70,7 @@ resource junos_security_utm_profile_web_filtering_juniper_local "testacc_Profile
 
 func testAccJunosSecurityUtmProfileWebFLConfigUpdate() string {
 	return `
-resource junos_security_utm_profile_web_filtering_juniper_local "testacc_ProfileWebFL" {
+resource "junos_security_utm_profile_web_filtering_juniper_local" "testacc_ProfileWebFL" {
   name                 = "testacc ProfileWebFL"
   custom_block_message = "Blocked by Juniper"
   default_action       = "log-and-permit"

--- a/junos/resource_security_utm_profile_web_filtering_websense_redirect_test.go
+++ b/junos/resource_security_utm_profile_web_filtering_websense_redirect_test.go
@@ -74,7 +74,7 @@ func TestAccJunosSecurityUtmProfileWebFWebS_basic(t *testing.T) {
 
 func testAccJunosSecurityUtmProfileWebFWebSConfigCreate() string {
 	return `
-resource junos_security_utm_profile_web_filtering_websense_redirect "testacc_ProfileWebFWebS" {
+resource "junos_security_utm_profile_web_filtering_websense_redirect" "testacc_ProfileWebFWebS" {
   name                 = "testacc ProfileWebFWebS"
   custom_block_message = "Blocked by Juniper"
   fallback_settings {
@@ -88,7 +88,7 @@ resource junos_security_utm_profile_web_filtering_websense_redirect "testacc_Pro
 
 func testAccJunosSecurityUtmProfileWebFWebSConfigUpdate() string {
 	return `
-resource junos_security_utm_profile_web_filtering_websense_redirect "testacc_ProfileWebFWebS" {
+resource "junos_security_utm_profile_web_filtering_websense_redirect" "testacc_ProfileWebFWebS" {
   name                 = "testacc ProfileWebFWebS"
   custom_block_message = "Blocked by Juniper"
   timeout              = 3

--- a/junos/resource_security_zone_book_address_set_test.go
+++ b/junos/resource_security_zone_book_address_set_test.go
@@ -31,16 +31,16 @@ func TestAccJunosSecurityZoneBookAddressSet_basic(t *testing.T) {
 
 func testAccJunosSecurityZoneBookAddressSetConfigCreate() string {
 	return `
-resource junos_security_zone "testacc_szone_bookaddressset" {
+resource "junos_security_zone" "testacc_szone_bookaddressset" {
   name                          = "testacc_szone_bookaddressset"
   address_book_configure_singly = true
 }
-resource junos_security_zone_book_address "testacc_szone_bookaddress_set" {
+resource "junos_security_zone_book_address" "testacc_szone_bookaddress_set" {
   name = "testacc_szone_bookaddress_set1"
   zone = junos_security_zone.testacc_szone_bookaddressset.name
   cidr = "192.0.2.0/25"
 }
-resource junos_security_zone_book_address_set "testacc_szone_bookaddress_set" {
+resource "junos_security_zone_book_address_set" "testacc_szone_bookaddress_set" {
   name = "testacc_szone_bookaddress_set"
   zone = junos_security_zone.testacc_szone_bookaddressset.name
   address = [
@@ -53,21 +53,21 @@ resource junos_security_zone_book_address_set "testacc_szone_bookaddress_set" {
 
 func testAccJunosSecurityZoneBookAddressSetConfigUpdate() string {
 	return `
-resource junos_security_zone "testacc_szone_bookaddressset" {
+resource "junos_security_zone" "testacc_szone_bookaddressset" {
   name                          = "testacc_szone_bookaddressset"
   address_book_configure_singly = true
 }
-resource junos_security_zone_book_address "testacc_szone_bookaddress_set" {
+resource "junos_security_zone_book_address" "testacc_szone_bookaddress_set" {
   name = "testacc_szone_bookaddress_set1"
   zone = junos_security_zone.testacc_szone_bookaddressset.name
   cidr = "192.0.2.0/25"
 }
-resource junos_security_zone_book_address "testacc_szone_bookaddress_set2" {
+resource "junos_security_zone_book_address" "testacc_szone_bookaddress_set2" {
   name = "testacc_szone_bookaddress_set2"
   zone = junos_security_zone.testacc_szone_bookaddressset.name
   cidr = "192.0.2.128/25"
 }
-resource junos_security_zone_book_address_set "testacc_szone_bookaddress_set" {
+resource "junos_security_zone_book_address_set" "testacc_szone_bookaddress_set" {
   name = "testacc_szone_bookaddress_set"
   zone = junos_security_zone.testacc_szone_bookaddressset.name
   address = [
@@ -75,7 +75,7 @@ resource junos_security_zone_book_address_set "testacc_szone_bookaddress_set" {
     junos_security_zone_book_address.testacc_szone_bookaddress_set2.name,
   ]
 }
-resource junos_security_zone_book_address_set "testacc_szone_bookaddress_setS2" {
+resource "junos_security_zone_book_address_set" "testacc_szone_bookaddress_setS2" {
   name = "testacc_szone_bookaddress_setS2"
   zone = junos_security_zone.testacc_szone_bookaddressset.name
   address = [

--- a/junos/resource_security_zone_book_address_test.go
+++ b/junos/resource_security_zone_book_address_test.go
@@ -51,44 +51,44 @@ func TestAccJunosSecurityZoneBookAddress_basic(t *testing.T) {
 
 func testAccJunosSecurityZoneBookAddressConfigCreate() string {
 	return `
-resource junos_security_zone "testacc_szone_bookaddress" {
+resource "junos_security_zone" "testacc_szone_bookaddress" {
   name                          = "testacc_szone_bookaddress"
   address_book_configure_singly = true
 }
-resource junos_security_zone_book_address "testacc_szone_bookaddress1" {
+resource "junos_security_zone_book_address" "testacc_szone_bookaddress1" {
   name        = "testacc_szone_bookaddress1"
   zone        = junos_security_zone.testacc_szone_bookaddress.name
   cidr        = "192.0.2.0/25"
   description = "testacc szone bookaddress1"
 }
-resource junos_security_zone_book_address "testacc_szone_bookaddress2" {
+resource "junos_security_zone_book_address" "testacc_szone_bookaddress2" {
   name        = "testacc_szone_bookaddress2"
   zone        = junos_security_zone.testacc_szone_bookaddress.name
   dns_name    = "test.com"
   description = "testacc szone bookaddress2"
 }
-resource junos_security_zone_book_address "testacc_szone_bookaddress3" {
+resource "junos_security_zone_book_address" "testacc_szone_bookaddress3" {
   name          = "testacc_szone_bookaddress3"
   zone          = junos_security_zone.testacc_szone_bookaddress.name
   dns_name      = "test.com"
   description   = "testacc szone bookaddress3"
   dns_ipv4_only = true
 }
-resource junos_security_zone_book_address "testacc_szone_bookaddress4" {
+resource "junos_security_zone_book_address" "testacc_szone_bookaddress4" {
   name          = "testacc_szone_bookaddress4"
   zone          = junos_security_zone.testacc_szone_bookaddress.name
   dns_name      = "test.com"
   description   = "testacc szone bookaddress4"
   dns_ipv6_only = true
 }
-resource junos_security_zone_book_address "testacc_szone_bookaddress5" {
+resource "junos_security_zone_book_address" "testacc_szone_bookaddress5" {
   name        = "testacc_szone_bookaddress5"
   zone        = junos_security_zone.testacc_szone_bookaddress.name
   range_from  = "192.0.2.10"
   range_to    = "192.0.2.12"
   description = "testacc szone bookaddress5"
 }
-resource junos_security_zone_book_address "testacc_szone_bookaddress6" {
+resource "junos_security_zone_book_address" "testacc_szone_bookaddress6" {
   name        = "testacc_szone_bookaddress6"
   zone        = junos_security_zone.testacc_szone_bookaddress.name
   wildcard    = "192.0.2.0/255.0.255.255"
@@ -99,36 +99,36 @@ resource junos_security_zone_book_address "testacc_szone_bookaddress6" {
 
 func testAccJunosSecurityZoneBookAddressConfigUpdate() string {
 	return `
-resource junos_security_zone "testacc_szone_bookaddress" {
+resource "junos_security_zone" "testacc_szone_bookaddress" {
   name                          = "testacc_szone_bookaddress"
   address_book_configure_singly = true
 }
-resource junos_security_zone_book_address "testacc_szone_bookaddress1" {
+resource "junos_security_zone_book_address" "testacc_szone_bookaddress1" {
   name        = "testacc_szone_bookaddress1"
   zone        = junos_security_zone.testacc_szone_bookaddress.name
   cidr        = "192.0.2.128/25"
   description = "testacc szone address1"
 }
-resource junos_security_zone_book_address "testacc_szone_bookaddress2" {
+resource "junos_security_zone_book_address" "testacc_szone_bookaddress2" {
   name        = "testacc_szone_bookaddress2"
   zone        = junos_security_zone.testacc_szone_bookaddress.name
   dns_name    = "test.fr"
   description = "testacc szone address2"
 }
-resource junos_security_zone_book_address "testacc_szone_bookaddress3" {
+resource "junos_security_zone_book_address" "testacc_szone_bookaddress3" {
   name        = "testacc_szone_bookaddress3"
   zone        = junos_security_zone.testacc_szone_bookaddress.name
   dns_name    = "test.net"
   description = "testacc szone address3"
 }
-resource junos_security_zone_book_address "testacc_szone_bookaddress5" {
+resource "junos_security_zone_book_address" "testacc_szone_bookaddress5" {
   name        = "testacc_szone_bookaddress5"
   zone        = junos_security_zone.testacc_szone_bookaddress.name
   range_from  = "192.0.2.20"
   range_to    = "192.0.2.22"
   description = "testacc szone ddress5"
 }
-resource junos_security_zone_book_address "testacc_szone_bookaddress6" {
+resource "junos_security_zone_book_address" "testacc_szone_bookaddress6" {
   name        = "testacc_szone_bookaddress6"
   zone        = junos_security_zone.testacc_szone_bookaddress.name
   wildcard    = "192.0.4.0/255.0.255.255"

--- a/junos/resource_security_zone_test.go
+++ b/junos/resource_security_zone_test.go
@@ -86,14 +86,14 @@ func TestAccJunosSecurityZone_basic(t *testing.T) {
 
 func testAccJunosSecurityZoneConfigCreate() string {
 	return `
-resource junos_security_screen "testaccZone" {
+resource "junos_security_screen" "testaccZone" {
   lifecycle {
     create_before_destroy = true
   }
   name        = "testaccZone"
   description = "testaccZone"
 }
-resource junos_security_zone "testacc_securityZone" {
+resource "junos_security_zone" "testacc_securityZone" {
   name = "testacc_securityZone"
   address_book {
     name        = "testacc_zone1"
@@ -152,7 +152,7 @@ resource junos_security_zone "testacc_securityZone" {
 
 func testAccJunosSecurityZoneConfigUpdate(interFace string) string {
 	return fmt.Sprintf(`
-resource junos_security_zone "testacc_securityZone" {
+resource "junos_security_zone" "testacc_securityZone" {
   name = "testacc_securityZone"
   address_book {
     name    = "testacc_zone1"
@@ -169,7 +169,7 @@ resource junos_security_zone "testacc_securityZone" {
   inbound_protocols = ["bgp"]
   inbound_services  = ["ssh"]
 }
-resource junos_interface_logical "testacc_securityZone" {
+resource "junos_interface_logical" "testacc_securityZone" {
   name          = "%s.0"
   security_zone = junos_security_zone.testacc_securityZone.name
 }
@@ -178,10 +178,10 @@ resource junos_interface_logical "testacc_securityZone" {
 
 func testAccJunosSecurityZoneConfigUpdate2(interFace string) string {
 	return fmt.Sprintf(`
-resource junos_security_zone "testacc_securityZone" {
+resource "junos_security_zone" "testacc_securityZone" {
   name = "testacc_securityZone"
 }
-resource junos_interface_logical "testacc_securityZone" {
+resource "junos_interface_logical" "testacc_securityZone" {
   name          = "%s.0"
   security_zone = junos_security_zone.testacc_securityZone.name
 }

--- a/junos/resource_static_route_test.go
+++ b/junos/resource_static_route_test.go
@@ -224,10 +224,10 @@ func TestAccJunosStaticRoute_basic(t *testing.T) {
 
 func testAccJunosStaticRouteConfigCreate() string {
 	return `
-resource junos_routing_instance testacc_staticRoute {
+resource "junos_routing_instance" "testacc_staticRoute" {
   name = "testacc_staticRoute"
 }
-resource junos_static_route testacc_staticRoute_instance {
+resource "junos_static_route" "testacc_staticRoute_instance" {
   destination      = "192.0.2.0/24"
   routing_instance = junos_routing_instance.testacc_staticRoute.name
   preference       = 100
@@ -249,7 +249,7 @@ resource junos_static_route testacc_staticRoute_instance {
   }
   community = ["no-advertise"]
 }
-resource junos_static_route testacc_staticRoute_default {
+resource "junos_static_route" "testacc_staticRoute_default" {
   destination = "192.0.2.0/24"
   preference  = 100
   metric      = 100
@@ -271,7 +271,7 @@ resource junos_static_route testacc_staticRoute_default {
   as_path_origin               = "igp"
   as_path_path                 = "65000 65000"
 }
-resource junos_static_route testacc_staticRoute_ipv6_default {
+resource "junos_static_route" "testacc_staticRoute_ipv6_default" {
   destination = "2001:db8:85a3::/48"
   preference  = 100
   metric      = 100
@@ -293,7 +293,7 @@ resource junos_static_route testacc_staticRoute_ipv6_default {
   as_path_origin               = "igp"
   as_path_path                 = "65000 65000"
 }
-resource junos_static_route testacc_staticRoute_ipv6_instance {
+resource "junos_static_route" "testacc_staticRoute_ipv6_instance" {
   destination      = "2001:db8:85a3::/48"
   routing_instance = junos_routing_instance.testacc_staticRoute.name
   preference       = 100
@@ -320,10 +320,10 @@ resource junos_static_route testacc_staticRoute_ipv6_instance {
 
 func testAccJunosStaticRouteConfigUpdate() string {
 	return `
-resource junos_routing_instance testacc_staticRoute {
+resource "junos_routing_instance" "testacc_staticRoute" {
   name = "testacc_staticRoute"
 }
-resource junos_static_route testacc_staticRoute_instance {
+resource "junos_static_route" "testacc_staticRoute_instance" {
   destination      = "192.0.2.0/24"
   routing_instance = junos_routing_instance.testacc_staticRoute.name
   preference       = 100
@@ -343,7 +343,7 @@ resource junos_static_route testacc_staticRoute_instance {
     metric     = 102
   }
 }
-resource junos_static_route testacc_staticRoute_ipv6_default {
+resource "junos_static_route" "testacc_staticRoute_ipv6_default" {
   destination    = "2001:db8:85a3::/48"
   preference     = 100
   metric         = 100
@@ -368,46 +368,46 @@ resource junos_static_route testacc_staticRoute_ipv6_default {
 
 func testAccJunosStaticRouteConfigCreate2() string {
 	return `
-resource junos_routing_instance testacc_staticRoute {
+resource "junos_routing_instance" "testacc_staticRoute" {
   name = "testacc_staticRoute"
 }
-resource junos_routing_instance testacc_staticRoute2 {
+resource "junos_routing_instance" "testacc_staticRoute2" {
   name = "testacc_staticRoute2"
 }
-resource junos_static_route testacc_staticRoute_instance {
+resource "junos_static_route" "testacc_staticRoute_instance" {
   destination      = "192.0.2.0/25"
   routing_instance = junos_routing_instance.testacc_staticRoute.name
   receive          = true
   resolve          = true
 }
-resource junos_static_route testacc_staticRoute_ipv6_default {
+resource "junos_static_route" "testacc_staticRoute_ipv6_default" {
   destination = "2001:db8:85a3::/50"
   receive     = true
   resolve     = true
 }
-resource junos_static_route testacc_staticRoute_instance2 {
+resource "junos_static_route" "testacc_staticRoute_instance2" {
   destination      = "192.0.2.0/26"
   routing_instance = junos_routing_instance.testacc_staticRoute.name
   discard          = true
 }
-resource junos_static_route testacc_staticRoute_ipv6_default2 {
+resource "junos_static_route" "testacc_staticRoute_ipv6_default2" {
   destination = "2001:db8:85a3::/52"
   discard     = true
 }
-resource junos_static_route testacc_staticRoute_default {
+resource "junos_static_route" "testacc_staticRoute_default" {
   destination = "192.0.2.0/27"
   reject      = true
 }
-resource junos_static_route testacc_staticRoute_ipv6_instance {
+resource "junos_static_route" "testacc_staticRoute_ipv6_instance" {
   destination      = "2001:db8:85a3::/54"
   routing_instance = junos_routing_instance.testacc_staticRoute.name
   reject           = true
 }
-resource junos_static_route testacc_staticRoute_default2 {
+resource "junos_static_route" "testacc_staticRoute_default2" {
   destination = "192.0.2.0/28"
   next_table  = "${junos_routing_instance.testacc_staticRoute2.name}.inet.0"
 }
-resource junos_static_route testacc_staticRoute_ipv6_instance2 {
+resource "junos_static_route" "testacc_staticRoute_ipv6_instance2" {
   destination      = "2001:db8:85a3::/56"
   routing_instance = junos_routing_instance.testacc_staticRoute.name
   next_table       = "${junos_routing_instance.testacc_staticRoute2.name}.inet6.0"

--- a/junos/resource_switch_options_test.go
+++ b/junos/resource_switch_options_test.go
@@ -31,7 +31,7 @@ func TestAccJunosSwitchOptions_basic(t *testing.T) {
 
 func testAccJunosSwitchOptionsConfigCreate() string {
 	return `
-resource junos_interface_logical "testacc_switchOpts" {
+resource "junos_interface_logical" "testacc_switchOpts" {
   lifecycle {
     create_before_destroy = true
   }

--- a/junos/resource_system_ntp_server_test.go
+++ b/junos/resource_system_ntp_server_test.go
@@ -42,7 +42,7 @@ func TestAccJunosSystemNtpServer_basic(t *testing.T) {
 
 func testAccJunosSystemNtpServerConfigCreate() string {
 	return `
-resource junos_system_ntp_server testacc_ntpServer {
+resource "junos_system_ntp_server" "testacc_ntpServer" {
   address = "192.0.2.1"
   prefer  = true
   version = 4
@@ -53,10 +53,10 @@ resource junos_system_ntp_server testacc_ntpServer {
 
 func testAccJunosSystemNtpServerConfigUpdate() string {
 	return `
-resource junos_routing_instance testacc_ntpServer {
+resource "junos_routing_instance" "testacc_ntpServer" {
   name = "testacc_ntpServer"
 }
-resource junos_system_ntp_server testacc_ntpServer {
+resource "junos_system_ntp_server" "testacc_ntpServer" {
   address          = "192.0.2.1"
   prefer           = true
   version          = 4

--- a/junos/resource_system_radius_server_test.go
+++ b/junos/resource_system_radius_server_test.go
@@ -60,7 +60,7 @@ func TestAccJunosSystemRadiusServer_basic(t *testing.T) {
 
 func testAccJunosSystemRadiusServerConfigCreate() string {
 	return `
-resource junos_system_radius_server testacc_radiusServer {
+resource "junos_system_radius_server" "testacc_radiusServer" {
   address = "192.0.2.1"
   secret  = "password"
 }
@@ -69,10 +69,10 @@ resource junos_system_radius_server testacc_radiusServer {
 
 func testAccJunosSystemRadiusServerConfigUpdate() string {
 	return `
-resource junos_routing_instance testacc_radiusServer {
+resource "junos_routing_instance" "testacc_radiusServer" {
   name = "testacc_radiusServer"
 }
-resource junos_system_radius_server testacc_radiusServer {
+resource "junos_system_radius_server" "testacc_radiusServer" {
   address                  = "192.0.2.1"
   secret                   = "password"
   preauthentication_secret = "password"

--- a/junos/resource_system_root_authentication_test.go
+++ b/junos/resource_system_root_authentication_test.go
@@ -44,7 +44,7 @@ func TestAccJunosSystemRootAuthentication_basic(t *testing.T) {
 
 func testAccJunosSystemRootAuthenticationCreate() string {
 	return `
-resource junos_system_root_authentication "root_auth" {
+resource "junos_system_root_authentication" "root_auth" {
   encrypted_password = "$6$XXXX"
   ssh_public_keys = [
     "ssh-rsa XXXX",
@@ -55,7 +55,7 @@ resource junos_system_root_authentication "root_auth" {
 
 func testAccJunosSystemRootAuthenticationUpdate() string {
 	return `
-resource junos_system_root_authentication "root_auth" {
+resource "junos_system_root_authentication" "root_auth" {
   encrypted_password = "$6$XXX"
   no_public_keys     = true
 }
@@ -64,7 +64,7 @@ resource junos_system_root_authentication "root_auth" {
 
 func testAccJunosSystemRootAuthenticationPostCheck() string {
 	return `
-resource junos_system_root_authentication "root_auth" {
+resource "junos_system_root_authentication" "root_auth" {
   encrypted_password = "$6$XXX"
 }
 `

--- a/junos/resource_system_syslog_file_test.go
+++ b/junos/resource_system_syslog_file_test.go
@@ -113,7 +113,7 @@ func TestAccJunosSystemSyslogFile_basic(t *testing.T) {
 
 func testAccJunosSystemSyslogFileConfigCreate() string {
 	return `
-resource junos_system_syslog_file testacc_syslogFile {
+resource "junos_system_syslog_file" "testacc_syslogFile" {
   filename                     = "testacc"
   allow_duplicates             = true
   explicit_priority            = true
@@ -139,7 +139,7 @@ resource junos_system_syslog_file testacc_syslogFile {
 
 func testAccJunosSystemSyslogFileConfigUpdate() string {
 	return `
-resource junos_system_syslog_file testacc_syslogFile {
+resource "junos_system_syslog_file" "testacc_syslogFile" {
   filename                     = "testacc"
   allow_duplicates             = true
   match                        = "match testacc"
@@ -160,7 +160,7 @@ resource junos_system_syslog_file testacc_syslogFile {
   structured_data {}
   archive {}
 }
-resource junos_system_syslog_file testacc_syslogFile2 {
+resource "junos_system_syslog_file" "testacc_syslogFile2" {
   filename          = "testacc2"
   explicit_priority = true
 }
@@ -169,10 +169,10 @@ resource junos_system_syslog_file testacc_syslogFile2 {
 
 func testAccJunosSystemSyslogFileConfigUpdate2() string {
 	return `
-resource junos_routing_instance testacc_syslogFile {
+resource "junos_routing_instance" "testacc_syslogFile" {
   name = "testacc_syslogFile"
 }
-resource junos_system_syslog_file testacc_syslogFile {
+resource "junos_system_syslog_file" "testacc_syslogFile" {
   filename                     = "testacc"
   allow_duplicates             = true
   match                        = "match testacc"

--- a/junos/resource_system_syslog_host_test.go
+++ b/junos/resource_system_syslog_host_test.go
@@ -97,7 +97,7 @@ func TestAccJunosSystemSyslogHost_basic(t *testing.T) {
 
 func testAccJunosSystemSyslogHostConfigCreate() string {
 	return `
-resource junos_system_syslog_host testacc_syslogHost {
+resource "junos_system_syslog_host" "testacc_syslogHost" {
   host = "192.0.2.1"
   port = 514
 }
@@ -106,7 +106,7 @@ resource junos_system_syslog_host testacc_syslogHost {
 
 func testAccJunosSystemSyslogHostConfigUpdate() string {
 	return `
-resource junos_system_syslog_host testacc_syslogHost {
+resource "junos_system_syslog_host" "testacc_syslogHost" {
   host = "192.0.2.1"
   structured_data {
     brief = true
@@ -117,7 +117,7 @@ resource junos_system_syslog_host testacc_syslogHost {
 
 func testAccJunosSystemSyslogHostConfigUpdate2() string {
 	return `
-resource junos_system_syslog_host testacc_syslogHost {
+resource "junos_system_syslog_host" "testacc_syslogHost" {
   host                         = "192.0.2.1"
   port                         = 514
   allow_duplicates             = true

--- a/junos/resource_system_test.go
+++ b/junos/resource_system_test.go
@@ -251,12 +251,12 @@ func TestAccJunosSystem_basic(t *testing.T) {
 // nolint: lll
 func testAccJunosSystemConfigCreate() string {
 	return `
-data junos_system_information "srx" {}
+data "junos_system_information" "srx" {}
 locals {
   netconfSSHCltAliveCountMax    = "${tonumber(replace(data.junos_system_information.srx.os_version, "/\\..*$/", "")) >= 21 ? 100 : null}"
   netconfSSHClientAliveInterval = "${tonumber(replace(data.junos_system_information.srx.os_version, "/\\..*$/", "")) >= 21 ? 1000 : null}"
 }
-resource junos_system "testacc_system" {
+resource "junos_system" "testacc_system" {
   host_name = "testacc-terraform"
   archival_configuration {
     archive_site {
@@ -422,7 +422,7 @@ resource junos_system "testacc_system" {
 
 func testAccJunosSystemConfigUpdate() string {
 	return `
-resource junos_system "testacc_system" {
+resource "junos_system" "testacc_system" {
   host_name = "testacc-terraform"
   archival_configuration {
     archive_site {

--- a/junos/resource_vlan_test.go
+++ b/junos/resource_vlan_test.go
@@ -65,7 +65,7 @@ func TestAccJunosVlan_basic(t *testing.T) {
 
 func testAccJunosVlanSwConfigCreate() string {
 	return `
-resource junos_firewall_filter "testacc_vlansw" {
+resource "junos_firewall_filter" "testacc_vlansw" {
   lifecycle {
     create_before_destroy = true
   }
@@ -78,13 +78,13 @@ resource junos_firewall_filter "testacc_vlansw" {
     }
   }
 }
-resource junos_interface_logical "testacc_vlansw" {
+resource "junos_interface_logical" "testacc_vlansw" {
   lifecycle {
     create_before_destroy = true
   }
   name = "irb.1000"
 }
-resource junos_vlan "testacc_vlansw" {
+resource "junos_vlan" "testacc_vlansw" {
   name                  = "testacc_vlansw"
   description           = "testacc_vlansw"
   vlan_id               = 1000
@@ -99,7 +99,7 @@ resource junos_vlan "testacc_vlansw" {
 
 func testAccJunosVlanSwConfigUpdate() string {
 	return `
-resource junos_vlan "testacc_vlansw" {
+resource "junos_vlan" "testacc_vlansw" {
   name         = "testacc_vlansw"
   description  = "testacc_vlansw"
   vlan_id_list = ["1001-1002"]

--- a/junos/resource_vstp_interface_test.go
+++ b/junos/resource_vstp_interface_test.go
@@ -68,7 +68,7 @@ resource "junos_vstp_interface" "testacc_vstp_interface" {
 resource "junos_vstp_vlan" "testacc_vstp_interface2" {
   vlan_id = "10"
 }
-resource junos_interface_physical testacc_vstp_interface2 {
+resource "junos_interface_physical" "testacc_vstp_interface2" {
   name         = "%s"
   description  = "testacc_vstp_interface2"
   vlan_members = ["15"]
@@ -128,7 +128,7 @@ resource "junos_vstp_interface" "testacc_vstp_interface" {
 resource "junos_vstp_vlan" "testacc_vstp_interface2" {
   vlan_id = "10"
 }
-resource junos_interface_physical testacc_vstp_interface2 {
+resource "junos_interface_physical" "testacc_vstp_interface2" {
   name         = "%s"
   description  = "testacc_vstp_interface2"
   vlan_members = ["15"]


### PR DESCRIPTION
- [workflows] detect resource/data-source blocks without double quote
- [docs] fix missing double quote on resource type in example
- [testacc] fix misisng double quote on resource type/name in test config