### PR TITLE
Fix #368: add plain_text_password argument on junos_system_root_authentication resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ENHANCEMENTS:
 
+* resource/`junos_system_root_authentication`: add `plain_text_password` argument to be able to set password in plain text format (Fixes #368)
 * release now with golang 1.18
 * provider: normalize reading `JUNOS_FAKEUPDATE_ALSO` and `JUNOS_FAKEDELETE_ALSO` environment variables (use SDK function)
 

--- a/docs/resources/system_root_authentication.md
+++ b/docs/resources/system_root_authentication.md
@@ -27,8 +27,18 @@ resource "junos_system_root_authentication" "root_auth" {
 
 The following arguments are supported:
 
-- **encrypted_password** (Required, String)  
-  Encrypted password string.
+-> **Note:** One of `encrypted_password` or `plain_text_password` arguments is required.
+
+- **encrypted_password** (Optional, String)  
+  Encrypted password string.  
+  If `plain_text_password` is used in Terraform config,
+  the value of this argument is left blank to avoid conflict.
+- **plain_text_password** (Optional, String, Sensitive)  
+  Plain text password (auto encrypted by Junos device)  
+  Due to encryption, when Terraform refreshes the resource, the plain text password can't be read,
+  so the provider can't detect a change of the password itself outside of Terraform.  
+  To be able to detect a change of the password outside of Terraform,
+  preferably use `encrypted_password` argument.  
 - **no_public_keys** (Optional, Boolean)  
   Disables ssh public key based authentication.
 - **ssh_public_keys** (Optional, Set of String)  

--- a/junos/resource_system_root_authentication.go
+++ b/junos/resource_system_root_authentication.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -27,8 +28,17 @@ func resourceSystemRootAuthentication() *schema.Resource {
 		},
 		Schema: map[string]*schema.Schema{
 			"encrypted_password": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+				ExactlyOneOf: []string{"encrypted_password", "plain_text_password"},
+			},
+			"plain_text_password": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Sensitive:    true,
+				ValidateFunc: validation.StringIsNotEmpty,
+				ExactlyOneOf: []string{"encrypted_password", "plain_text_password"},
 			},
 			"no_public_keys": {
 				Type:     schema.TypeBool,
@@ -51,6 +61,12 @@ func resourceSystemRootAuthenticationCreate(ctx context.Context, d *schema.Resou
 ) diag.Diagnostics {
 	sess := m.(*Session)
 	if sess.junosFakeCreateSetFile != "" {
+		// To be able detect a plain text password not accepted by system
+		if d.Get("plain_text_password").(string) != "" {
+			if err := delSystemRootAuthenticationPassword(m, nil); err != nil {
+				return diag.FromErr(err)
+			}
+		}
 		if err := setSystemRootAuthentication(d, m, nil); err != nil {
 			return diag.FromErr(err)
 		}
@@ -65,6 +81,14 @@ func resourceSystemRootAuthenticationCreate(ctx context.Context, d *schema.Resou
 	defer sess.closeSession(jnprSess)
 	sess.configLock(jnprSess)
 	var diagWarns diag.Diagnostics
+	// To be able detect a plain text password not accepted by system
+	if d.Get("plain_text_password").(string) != "" {
+		if err := delSystemRootAuthenticationPassword(m, jnprSess); err != nil {
+			appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
+
+			return append(diagWarns, diag.FromErr(err)...)
+		}
+	}
 	if err := setSystemRootAuthentication(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
 
@@ -180,7 +204,11 @@ func setSystemRootAuthentication(d *schema.ResourceData, m interface{}, jnprSess
 	configSet := make([]string, 0)
 	setPrefix := "set system root-authentication "
 
-	configSet = append(configSet, setPrefix+"encrypted-password \""+d.Get("encrypted_password").(string)+"\"")
+	if v := d.Get("plain_text_password").(string); v != "" {
+		configSet = append(configSet, setPrefix+"plain-text-password-value \""+v+"\"")
+	} else {
+		configSet = append(configSet, setPrefix+"encrypted-password \""+d.Get("encrypted_password").(string)+"\"")
+	}
 	if d.Get("no_public_keys").(bool) {
 		configSet = append(configSet, setPrefix+"no-public-keys")
 	}
@@ -253,9 +281,19 @@ func delSystemRootAuthentication(m interface{}, jnprSess *NetconfObject) error {
 	return sess.configSet(configSet, jnprSess)
 }
 
+func delSystemRootAuthenticationPassword(m interface{}, jnprSess *NetconfObject) error {
+	sess := m.(*Session)
+	configSet := make([]string, 0, 1)
+	configSet = append(configSet, "delete system root-authentication encrypted-password")
+
+	return sess.configSet(configSet, jnprSess)
+}
+
 func fillSystemRootAuthenticationData(d *schema.ResourceData, systemRootAuthOptions systemRootAuthOptions) {
-	if tfErr := d.Set("encrypted_password", systemRootAuthOptions.encryptedPassword); tfErr != nil {
-		panic(tfErr)
+	if d.Get("plain_text_password").(string) == "" {
+		if tfErr := d.Set("encrypted_password", systemRootAuthOptions.encryptedPassword); tfErr != nil {
+			panic(tfErr)
+		}
 	}
 	if tfErr := d.Set("no_public_keys", systemRootAuthOptions.noPublicKeys); tfErr != nil {
 		panic(tfErr)

--- a/junos/resource_system_root_authentication_test.go
+++ b/junos/resource_system_root_authentication_test.go
@@ -35,7 +35,7 @@ func TestAccJunosSystemRootAuthentication_basic(t *testing.T) {
 					),
 				},
 				{
-					Config: testAccJunosSystemRootAuthenticationPostCheck(),
+					Config: testAccJunosSystemRootAuthenticationUpdate2(),
 				},
 			},
 		})
@@ -62,10 +62,10 @@ resource "junos_system_root_authentication" "root_auth" {
 `
 }
 
-func testAccJunosSystemRootAuthenticationPostCheck() string {
+func testAccJunosSystemRootAuthenticationUpdate2() string {
 	return `
 resource "junos_system_root_authentication" "root_auth" {
-  encrypted_password = "$6$XXX"
+  plain_text_password = "testPassword1234"
 }
 `
 }


### PR DESCRIPTION
* resource/`junos_system_root_authentication`: add `plain_text_password` argument to be able to set password in plain text format (Fixes #368)