### PR TITLE
move/add validation on list of primitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ ENHANCEMENTS:
 
 * resource/`junos_*`: move validation of some list of string to Plan phase and not during Apply
 * resource/`junos_aggregate_route`: add validation to elements of `policy` argument
+* resource/`junos_application_set`: add validation to elements of `applications` argument
 * resource/`junos_system_root_authentication`: add `plain_text_password` argument to be able to set password in plain text format (Fixes #368)
 * release now with golang 1.18
 * provider: normalize reading `JUNOS_FAKEUPDATE_ALSO` and `JUNOS_FAKEDELETE_ALSO` environment variables (use SDK function)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ ENHANCEMENTS:
 * resource/`junos_routing_options`: add validation to elements of `forwarding_table.0.export`, `instance_export` and `instance_import` arguments
 * resource/`junos_security_address_book`: add validation to elements of `attach_zone`, `address_set.*.address` and `address_set.*.address_set` arguments
 * resource/`junos_security_zone`: add validation to elements of `address_book_set.*.address` and `address_book_set.*.address_set` arguments
+* resource/`junos_security_zone_book_address_set`: add validation to elements of `address` and `address_set` arguments
 * resource/`junos_system_root_authentication`: add `plain_text_password` argument to be able to set password in plain text format (Fixes #368)
 * release now with golang 1.18
 * provider: normalize reading `JUNOS_FAKEUPDATE_ALSO` and `JUNOS_FAKEDELETE_ALSO` environment variables (use SDK function)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ ENHANCEMENTS:
 * resource/`junos_rib_group`: add validation to elements of `import_policy` argument
 * resource/`junos_routing_instance`: add validation to elements of `instance_export`, `instance_import`, `vrf_export` and `vrf_import` arguments
 * resource/`junos_routing_options`: add validation to elements of `forwarding_table.0.export`, `instance_export` and `instance_import` arguments
+* resource/`junos_security_address_book`: add validation to elements of `attach_zone`, `address_set.*.address` and `address_set.*.address_set` arguments
 * resource/`junos_system_root_authentication`: add `plain_text_password` argument to be able to set password in plain text format (Fixes #368)
 * release now with golang 1.18
 * provider: normalize reading `JUNOS_FAKEUPDATE_ALSO` and `JUNOS_FAKEDELETE_ALSO` environment variables (use SDK function)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ ENHANCEMENTS:
 * resource/`junos_policyoptions_policy_statement`: add validation to elements of some list of string
 * resource/`junos_rib_group`: add validation to elements of `import_policy` argument
 * resource/`junos_routing_instance`: add validation to elements of `instance_export`, `instance_import`, `vrf_export` and `vrf_import` arguments
+* resource/`junos_routing_options`: add validation to elements of `forwarding_table.0.export`, `instance_export` and `instance_import` arguments
 * resource/`junos_system_root_authentication`: add `plain_text_password` argument to be able to set password in plain text format (Fixes #368)
 * release now with golang 1.18
 * provider: normalize reading `JUNOS_FAKEUPDATE_ALSO` and `JUNOS_FAKEDELETE_ALSO` environment variables (use SDK function)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ ENHANCEMENTS:
 * resource/`junos_evpn`: add validation to elements of `vrf_export` and `vrf_import` arguments
 * resource/`junos_firewall_filter`: add validation to elements of `*prefix_list*` arguments
 * resource/`junos_generate_route`: add validation to elements of `policy` argument
+* resource/`junos_ospf`: add validation to elements of `export` and `import` arguments
 * resource/`junos_system_root_authentication`: add `plain_text_password` argument to be able to set password in plain text format (Fixes #368)
 * release now with golang 1.18
 * provider: normalize reading `JUNOS_FAKEUPDATE_ALSO` and `JUNOS_FAKEDELETE_ALSO` environment variables (use SDK function)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ ENHANCEMENTS:
 * resource/`junos_ospf`: add validation to elements of `export` and `import` arguments
 * resource/`junos_policyoptions_policy_statement`: add validation to elements of some list of string
 * resource/`junos_rib_group`: add validation to elements of `import_policy` argument
+* resource/`junos_routing_instance`: add validation to elements of `instance_export`, `instance_import`, `vrf_export` and `vrf_import` arguments
 * resource/`junos_system_root_authentication`: add `plain_text_password` argument to be able to set password in plain text format (Fixes #368)
 * release now with golang 1.18
 * provider: normalize reading `JUNOS_FAKEUPDATE_ALSO` and `JUNOS_FAKEDELETE_ALSO` environment variables (use SDK function)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ ENHANCEMENTS:
 * resource/`junos_routing_instance`: add validation to elements of `instance_export`, `instance_import`, `vrf_export` and `vrf_import` arguments
 * resource/`junos_routing_options`: add validation to elements of `forwarding_table.0.export`, `instance_export` and `instance_import` arguments
 * resource/`junos_security_address_book`: add validation to elements of `attach_zone`, `address_set.*.address` and `address_set.*.address_set` arguments
+* resource/`junos_security_zone`: add validation to elements of `address_book_set.*.address` and `address_book_set.*.address_set` arguments
 * resource/`junos_system_root_authentication`: add `plain_text_password` argument to be able to set password in plain text format (Fixes #368)
 * release now with golang 1.18
 * provider: normalize reading `JUNOS_FAKEUPDATE_ALSO` and `JUNOS_FAKEDELETE_ALSO` environment variables (use SDK function)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ENHANCEMENTS:
 
 * resource/`junos_*`: move validation of some list of string to Plan phase and not during Apply
+* resource/`junos_aggregate_route`: add validation to elements of `policy` argument
 * resource/`junos_system_root_authentication`: add `plain_text_password` argument to be able to set password in plain text format (Fixes #368)
 * release now with golang 1.18
 * provider: normalize reading `JUNOS_FAKEUPDATE_ALSO` and `JUNOS_FAKEDELETE_ALSO` environment variables (use SDK function)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ ENHANCEMENTS:
 * resource/`junos_chassis_cluster`: add validation to elements of `member_interfaces` argument
 * resource/`junos_evpn`: add validation to elements of `vrf_export` and `vrf_import` arguments
 * resource/`junos_firewall_filter`: add validation to elements of `*prefix_list*` arguments
+* resource/`junos_generate_route`: add validation to elements of `policy` argument
 * resource/`junos_system_root_authentication`: add `plain_text_password` argument to be able to set password in plain text format (Fixes #368)
 * release now with golang 1.18
 * provider: normalize reading `JUNOS_FAKEUPDATE_ALSO` and `JUNOS_FAKEDELETE_ALSO` environment variables (use SDK function)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ENHANCEMENTS:
 
+* resource/`junos_*`: move validation of some list of string to Plan phase and not during Apply
 * resource/`junos_system_root_authentication`: add `plain_text_password` argument to be able to set password in plain text format (Fixes #368)
 * release now with golang 1.18
 * provider: normalize reading `JUNOS_FAKEUPDATE_ALSO` and `JUNOS_FAKEDELETE_ALSO` environment variables (use SDK function)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ ENHANCEMENTS:
 * resource/`junos_bgp_group`: add validation to elements of `export` and `import` arguments
 * resource/`junos_bgp_neighbor`: add validation to elements of `export` and `import` arguments
 * resource/`junos_chassis_cluster`: add validation to elements of `member_interfaces` argument
+* resource/`junos_evpn`: add validation to elements of `vrf_export` and `vrf_import` arguments
 * resource/`junos_system_root_authentication`: add `plain_text_password` argument to be able to set password in plain text format (Fixes #368)
 * release now with golang 1.18
 * provider: normalize reading `JUNOS_FAKEUPDATE_ALSO` and `JUNOS_FAKEDELETE_ALSO` environment variables (use SDK function)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ ENHANCEMENTS:
 * resource/`junos_generate_route`: add validation to elements of `policy` argument
 * resource/`junos_ospf`: add validation to elements of `export` and `import` arguments
 * resource/`junos_policyoptions_policy_statement`: add validation to elements of some list of string
+* resource/`junos_rib_group`: add validation to elements of `import_policy` argument
 * resource/`junos_system_root_authentication`: add `plain_text_password` argument to be able to set password in plain text format (Fixes #368)
 * release now with golang 1.18
 * provider: normalize reading `JUNOS_FAKEUPDATE_ALSO` and `JUNOS_FAKEDELETE_ALSO` environment variables (use SDK function)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ ENHANCEMENTS:
 * resource/`junos_firewall_filter`: add validation to elements of `*prefix_list*` arguments
 * resource/`junos_generate_route`: add validation to elements of `policy` argument
 * resource/`junos_ospf`: add validation to elements of `export` and `import` arguments
+* resource/`junos_policyoptions_policy_statement`: add validation to elements of some list of string
 * resource/`junos_system_root_authentication`: add `plain_text_password` argument to be able to set password in plain text format (Fixes #368)
 * release now with golang 1.18
 * provider: normalize reading `JUNOS_FAKEUPDATE_ALSO` and `JUNOS_FAKEDELETE_ALSO` environment variables (use SDK function)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ ENHANCEMENTS:
 * resource/`junos_bgp_neighbor`: add validation to elements of `export` and `import` arguments
 * resource/`junos_chassis_cluster`: add validation to elements of `member_interfaces` argument
 * resource/`junos_evpn`: add validation to elements of `vrf_export` and `vrf_import` arguments
+* resource/`junos_firewall_filter`: add validation to elements of `*prefix_list*` arguments
 * resource/`junos_system_root_authentication`: add `plain_text_password` argument to be able to set password in plain text format (Fixes #368)
 * release now with golang 1.18
 * provider: normalize reading `JUNOS_FAKEUPDATE_ALSO` and `JUNOS_FAKEDELETE_ALSO` environment variables (use SDK function)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ ENHANCEMENTS:
 * resource/`junos_application_set`: add validation to elements of `applications` argument
 * resource/`junos_bgp_group`: add validation to elements of `export` and `import` arguments
 * resource/`junos_bgp_neighbor`: add validation to elements of `export` and `import` arguments
+* resource/`junos_chassis_cluster`: add validation to elements of `member_interfaces` argument
 * resource/`junos_system_root_authentication`: add `plain_text_password` argument to be able to set password in plain text format (Fixes #368)
 * release now with golang 1.18
 * provider: normalize reading `JUNOS_FAKEUPDATE_ALSO` and `JUNOS_FAKEDELETE_ALSO` environment variables (use SDK function)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ ENHANCEMENTS:
 * resource/`junos_*`: move validation of some list of string to Plan phase and not during Apply
 * resource/`junos_aggregate_route`: add validation to elements of `policy` argument
 * resource/`junos_application_set`: add validation to elements of `applications` argument
+* resource/`junos_bgp_group`: add validation to elements of `export` and `import` arguments
+* resource/`junos_bgp_neighbor`: add validation to elements of `export` and `import` arguments
 * resource/`junos_system_root_authentication`: add `plain_text_password` argument to be able to set password in plain text format (Fixes #368)
 * release now with golang 1.18
 * provider: normalize reading `JUNOS_FAKEUPDATE_ALSO` and `JUNOS_FAKEDELETE_ALSO` environment variables (use SDK function)

--- a/junos/func_common.go
+++ b/junos/func_common.go
@@ -67,6 +67,23 @@ func validateIPwithMask(ip string) error {
 	return nil
 }
 
+func validateCIDRNetworkFunc() schema.SchemaValidateDiagFunc {
+	return func(i interface{}, path cty.Path) diag.Diagnostics {
+		var diags diag.Diagnostics
+		v := i.(string)
+		err := validateCIDRNetwork(v)
+		if err != nil {
+			diags = append(diags, diag.Diagnostic{
+				Severity:      diag.Error,
+				Summary:       err.Error(),
+				AttributePath: path,
+			})
+		}
+
+		return diags
+	}
+}
+
 func validateCIDRNetwork(network string) error {
 	if !strings.Contains(network, "/") {
 		return fmt.Errorf("%v missing mask", network)

--- a/junos/func_common.go
+++ b/junos/func_common.go
@@ -99,15 +99,29 @@ func validateCIDRNetwork(network string) error {
 	return nil
 }
 
-func validateCIDR(cidr string) error {
-	if !strings.Contains(cidr, "/") {
-		return fmt.Errorf("%v missing mask", cidr)
-	}
-	if _, _, err := net.ParseCIDR(cidr); err != nil {
-		return fmt.Errorf("%v is not a valid CIDR", cidr)
-	}
+func validateCIDRFunc() schema.SchemaValidateDiagFunc {
+	return func(i interface{}, path cty.Path) diag.Diagnostics {
+		var diags diag.Diagnostics
+		v := i.(string)
+		if !strings.Contains(v, "/") {
+			diags = append(diags, diag.Diagnostic{
+				Severity:      diag.Error,
+				Summary:       fmt.Sprintf("%v missing mask", v),
+				AttributePath: path,
+			})
 
-	return nil
+			return diags
+		}
+		if _, _, err := net.ParseCIDR(v); err != nil {
+			diags = append(diags, diag.Diagnostic{
+				Severity:      diag.Error,
+				Summary:       fmt.Sprintf("%v is not a valid CIDR", v),
+				AttributePath: path,
+			})
+		}
+
+		return diags
+	}
 }
 
 func validateWildcardFunc() schema.SchemaValidateDiagFunc {

--- a/junos/resource_access_address_assignment_pool.go
+++ b/junos/resource_access_address_assignment_pool.go
@@ -79,7 +79,10 @@ func resourceAccessAddressAssignPool() *schema.Resource {
 									"dns_server": {
 										Type:     schema.TypeList,
 										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
+										Elem: &schema.Schema{
+											Type:         schema.TypeString,
+											ValidateFunc: validateIsIPv6Address,
+										},
 									},
 									"domain_name": {
 										Type:             schema.TypeString,
@@ -124,7 +127,10 @@ func resourceAccessAddressAssignPool() *schema.Resource {
 									"name_server": {
 										Type:     schema.TypeList,
 										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
+										Elem: &schema.Schema{
+											Type:         schema.TypeString,
+											ValidateFunc: validation.IsIPv4Address,
+										},
 									},
 									"netbios_node_type": {
 										Type:         schema.TypeString,
@@ -139,7 +145,13 @@ func resourceAccessAddressAssignPool() *schema.Resource {
 									"option": {
 										Type:     schema.TypeSet,
 										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
+										Elem: &schema.Schema{
+											Type: schema.TypeString,
+											ValidateFunc: validation.StringMatch(regexp.MustCompile(
+												`^\d+ (array )?(byte|flag|hex-string|integer|ip-address|short|string|unsigned-integer|unsigned-short) .*$`),
+												"need to match '^\\d+ (array )?"+
+													"(byte|flag|hex-string|integer|ip-address|short|string|unsigned-integer|unsigned-short) .*$'"),
+										},
 									},
 									"option_match_82_circuit_id": {
 										Type:     schema.TypeList,
@@ -205,7 +217,10 @@ func resourceAccessAddressAssignPool() *schema.Resource {
 									"router": {
 										Type:     schema.TypeList,
 										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
+										Elem: &schema.Schema{
+											Type:         schema.TypeString,
+											ValidateFunc: validation.IsIPv4Address,
+										},
 									},
 									"server_identifier": {
 										Type:         schema.TypeString,
@@ -215,7 +230,10 @@ func resourceAccessAddressAssignPool() *schema.Resource {
 									"sip_server_inet_address": {
 										Type:     schema.TypeList,
 										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
+										Elem: &schema.Schema{
+											Type:         schema.TypeString,
+											ValidateFunc: validation.IsIPv4Address,
+										},
 									},
 									"sip_server_inet_domain_name": {
 										Type:     schema.TypeList,
@@ -225,7 +243,10 @@ func resourceAccessAddressAssignPool() *schema.Resource {
 									"sip_server_inet6_address": {
 										Type:     schema.TypeList,
 										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
+										Elem: &schema.Schema{
+											Type:         schema.TypeString,
+											ValidateFunc: validateIsIPv6Address,
+										},
 									},
 									"sip_server_inet6_domain_name": {
 										Type:             schema.TypeString,
@@ -300,7 +321,10 @@ func resourceAccessAddressAssignPool() *schema.Resource {
 									"wins_server": {
 										Type:     schema.TypeList,
 										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
+										Elem: &schema.Schema{
+											Type:         schema.TypeString,
+											ValidateFunc: validation.IsIPv4Address,
+										},
 									},
 								},
 							},
@@ -883,9 +907,6 @@ func setAccessAddressAssignPoolFamilyDhcpAttributes(dhcpAttr map[string]interfac
 		if familyType == inetW {
 			return configSet, fmt.Errorf("dhcp_attributes.0.dns_server not compatible when type = inet")
 		}
-		if _, errs := validateIsIPv6Address(v, "dhcp_attributes.0.dns_server"); len(errs) > 0 {
-			return configSet, errs[0]
-		}
 
 		configSet = append(configSet, setPrefix+"dns-server "+v.(string))
 	}
@@ -908,9 +929,6 @@ func setAccessAddressAssignPoolFamilyDhcpAttributes(dhcpAttr map[string]interfac
 		configSet = append(configSet, setPrefix+"maximum-lease-time infinite")
 	}
 	for _, v := range dhcpAttr["name_server"].([]interface{}) {
-		if _, errs := validation.IsIPv4Address(v, "dhcp_attributes.0.name_server"); len(errs) > 0 {
-			return configSet, errs[0]
-		}
 		configSet = append(configSet, setPrefix+"name-server "+v.(string))
 	}
 	if v := dhcpAttr["netbios_node_type"].(string); v != "" {
@@ -920,12 +938,6 @@ func setAccessAddressAssignPoolFamilyDhcpAttributes(dhcpAttr map[string]interfac
 		configSet = append(configSet, setPrefix+"next-server "+v)
 	}
 	for _, v := range sortSetOfString(dhcpAttr["option"].(*schema.Set).List()) {
-		r := regexp.MustCompile(
-			`^\d+ (array )?(byte|flag|hex-string|integer|ip-address|short|string|unsigned-integer|unsigned-short) .*$`)
-		if !r.MatchString(v) {
-			return configSet, fmt.Errorf("option '%s' is invalid, need to match "+
-				"'^\\d+ (array )?(byte|flag|hex-string|integer|ip-address|short|string|unsigned-integer|unsigned-short) .*$'", v)
-		}
 		configSet = append(configSet, setPrefix+"option "+v)
 	}
 	optionMatch82CircuitIDValueList := make([]string, 0)
@@ -971,26 +983,17 @@ func setAccessAddressAssignPoolFamilyDhcpAttributes(dhcpAttr map[string]interfac
 		configSet = append(configSet, setPrefix+"propagate-settings \""+v+"\"")
 	}
 	for _, v := range dhcpAttr["router"].([]interface{}) {
-		if _, errs := validation.IsIPv4Address(v.(string), "dhcp_attributes.0.router"); len(errs) > 0 {
-			return configSet, errs[0]
-		}
 		configSet = append(configSet, setPrefix+"router "+v.(string))
 	}
 	if v := dhcpAttr["server_identifier"].(string); v != "" {
 		configSet = append(configSet, setPrefix+"server-identifier "+v)
 	}
 	for _, v := range dhcpAttr["sip_server_inet_address"].([]interface{}) {
-		if _, errs := validation.IsIPv4Address(v.(string), "dhcp_attributes.0.sip_server_inet_address"); len(errs) > 0 {
-			return configSet, errs[0]
-		}
 		configSet = append(configSet, setPrefix+"sip-server ip-address "+v.(string))
 	}
 	for _, v := range dhcpAttr["sip_server_inet6_address"].([]interface{}) {
 		if familyType == inetW {
 			return configSet, fmt.Errorf("dhcp_attributes.0.sip_server_inet6_address not compatible when type = inet")
-		}
-		if _, errs := validateIsIPv6Address(v.(string), "dhcp_attributes.0.sip_server_inet6_address"); len(errs) > 0 {
-			return configSet, errs[0]
 		}
 		configSet = append(configSet, setPrefix+"sip-server-address "+v.(string))
 	}
@@ -1031,9 +1034,6 @@ func setAccessAddressAssignPoolFamilyDhcpAttributes(dhcpAttr map[string]interfac
 		configSet = append(configSet, setPrefix+"valid-lifetime infinite")
 	}
 	for _, v := range dhcpAttr["wins_server"].([]interface{}) {
-		if _, errs := validation.IsIPv4Address(v.(string), "dhcp_attributes.0.wins_server"); len(errs) > 0 {
-			return configSet, errs[0]
-		}
 		configSet = append(configSet, setPrefix+"wins-server "+v.(string))
 	}
 	if len(configSet) == 0 {

--- a/junos/resource_aggregate_route.go
+++ b/junos/resource_aggregate_route.go
@@ -113,7 +113,10 @@ func resourceAggregateRoute() *schema.Resource {
 			"policy": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatDefault),
+				},
 			},
 			"preference": {
 				Type:     schema.TypeInt,

--- a/junos/resource_application_set.go
+++ b/junos/resource_application_set.go
@@ -34,7 +34,10 @@ func resourceApplicationSet() *schema.Resource {
 				Type:     schema.TypeList,
 				Required: true,
 				MinItems: 1,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatDefault),
+				},
 			},
 		},
 	}

--- a/junos/resource_bgp_group.go
+++ b/junos/resource_bgp_group.go
@@ -188,7 +188,10 @@ func resourceBgpGroup() *schema.Resource {
 			"export": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatDefault),
+				},
 			},
 			"family_evpn": {
 				Type:     schema.TypeList,
@@ -437,7 +440,10 @@ func resourceBgpGroup() *schema.Resource {
 			"import": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatDefault),
+				},
 			},
 			"keep_all": {
 				Type:          schema.TypeBool,

--- a/junos/resource_bgp_neighbor.go
+++ b/junos/resource_bgp_neighbor.go
@@ -186,7 +186,10 @@ func resourceBgpNeighbor() *schema.Resource {
 			"export": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatDefault),
+				},
 			},
 			"family_evpn": {
 				Type:     schema.TypeList,
@@ -429,7 +432,10 @@ func resourceBgpNeighbor() *schema.Resource {
 			"import": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatDefault),
+				},
 			},
 			"keep_all": {
 				Type:          schema.TypeBool,

--- a/junos/resource_chassis_cluster.go
+++ b/junos/resource_chassis_cluster.go
@@ -44,7 +44,18 @@ func resourceChassisCluster() *schema.Resource {
 							Type:     schema.TypeList,
 							Required: true,
 							MinItems: 1,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+								ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+									value := v.(string)
+									if strings.Count(value, ".") > 0 {
+										errors = append(errors, fmt.Errorf(
+											"%q in %q cannot have a dot", value, k))
+									}
+
+									return
+								},
+							},
 						},
 						"description": {
 							Type:     schema.TypeString,
@@ -63,7 +74,18 @@ func resourceChassisCluster() *schema.Resource {
 							Type:     schema.TypeList,
 							Required: true,
 							MinItems: 1,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+								ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+									value := v.(string)
+									if strings.Count(value, ".") > 0 {
+										errors = append(errors, fmt.Errorf(
+											"%q in %q cannot have a dot", value, k))
+									}
+
+									return
+								},
+							},
 						},
 						"description": {
 							Type:     schema.TypeString,

--- a/junos/resource_evpn.go
+++ b/junos/resource_evpn.go
@@ -74,12 +74,18 @@ func resourceEvpn() *schema.Resource {
 						"vrf_export": {
 							Type:     schema.TypeList,
 							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+							Elem: &schema.Schema{
+								Type:             schema.TypeString,
+								ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatDefault),
+							},
 						},
 						"vrf_import": {
 							Type:     schema.TypeList,
 							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+							Elem: &schema.Schema{
+								Type:             schema.TypeString,
+								ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatDefault),
+							},
 						},
 						"vrf_target": {
 							Type:     schema.TypeString,

--- a/junos/resource_firewall_filter.go
+++ b/junos/resource_firewall_filter.go
@@ -69,22 +69,34 @@ func resourceFirewallFilter() *schema.Resource {
 									"address": {
 										Type:     schema.TypeSet,
 										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
+										Elem: &schema.Schema{
+											Type:             schema.TypeString,
+											ValidateDiagFunc: validateCIDRNetworkFunc(),
+										},
 									},
 									"address_except": {
 										Type:     schema.TypeSet,
 										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
+										Elem: &schema.Schema{
+											Type:             schema.TypeString,
+											ValidateDiagFunc: validateCIDRNetworkFunc(),
+										},
 									},
 									"destination_address": {
 										Type:     schema.TypeSet,
 										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
+										Elem: &schema.Schema{
+											Type:             schema.TypeString,
+											ValidateDiagFunc: validateCIDRNetworkFunc(),
+										},
 									},
 									"destination_address_except": {
 										Type:     schema.TypeSet,
 										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
+										Elem: &schema.Schema{
+											Type:             schema.TypeString,
+											ValidateDiagFunc: validateCIDRNetworkFunc(),
+										},
 									},
 									"destination_port": {
 										Type:     schema.TypeSet,
@@ -99,12 +111,18 @@ func resourceFirewallFilter() *schema.Resource {
 									"destination_prefix_list": {
 										Type:     schema.TypeSet,
 										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
+										Elem: &schema.Schema{
+											Type:             schema.TypeString,
+											ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatDefault),
+										},
 									},
 									"destination_prefix_list_except": {
 										Type:     schema.TypeSet,
 										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
+										Elem: &schema.Schema{
+											Type:             schema.TypeString,
+											ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatDefault),
+										},
 									},
 									"icmp_code": {
 										Type:     schema.TypeSet,
@@ -153,12 +171,18 @@ func resourceFirewallFilter() *schema.Resource {
 									"prefix_list": {
 										Type:     schema.TypeSet,
 										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
+										Elem: &schema.Schema{
+											Type:             schema.TypeString,
+											ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatDefault),
+										},
 									},
 									"prefix_list_except": {
 										Type:     schema.TypeSet,
 										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
+										Elem: &schema.Schema{
+											Type:             schema.TypeString,
+											ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatDefault),
+										},
 									},
 									"protocol": {
 										Type:     schema.TypeSet,
@@ -173,12 +197,18 @@ func resourceFirewallFilter() *schema.Resource {
 									"source_address": {
 										Type:     schema.TypeSet,
 										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
+										Elem: &schema.Schema{
+											Type:             schema.TypeString,
+											ValidateDiagFunc: validateCIDRNetworkFunc(),
+										},
 									},
 									"source_address_except": {
 										Type:     schema.TypeSet,
 										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
+										Elem: &schema.Schema{
+											Type:             schema.TypeString,
+											ValidateDiagFunc: validateCIDRNetworkFunc(),
+										},
 									},
 									"source_port": {
 										Type:     schema.TypeSet,
@@ -193,12 +223,18 @@ func resourceFirewallFilter() *schema.Resource {
 									"source_prefix_list": {
 										Type:     schema.TypeSet,
 										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
+										Elem: &schema.Schema{
+											Type:             schema.TypeString,
+											ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatDefault),
+										},
 									},
 									"source_prefix_list_except": {
 										Type:     schema.TypeSet,
 										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
+										Elem: &schema.Schema{
+											Type:             schema.TypeString,
+											ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatDefault),
+										},
 									},
 									"tcp_established": {
 										Type:     schema.TypeBool,
@@ -597,31 +633,15 @@ func fillFirewallFilterData(d *schema.ResourceData, filterOptions filterOptions)
 func setFirewallFilterOptsFrom(setPrefixTermFrom string, configSet []string, fromMap map[string]interface{},
 ) ([]string, error) {
 	for _, address := range sortSetOfString(fromMap["address"].(*schema.Set).List()) {
-		err := validateCIDRNetwork(address)
-		if err != nil {
-			return nil, err
-		}
 		configSet = append(configSet, setPrefixTermFrom+"address "+address)
 	}
 	for _, address := range sortSetOfString(fromMap["address_except"].(*schema.Set).List()) {
-		err := validateCIDRNetwork(address)
-		if err != nil {
-			return nil, err
-		}
 		configSet = append(configSet, setPrefixTermFrom+"address "+address+" except")
 	}
 	for _, address := range sortSetOfString(fromMap["destination_address"].(*schema.Set).List()) {
-		err := validateCIDRNetwork(address)
-		if err != nil {
-			return nil, err
-		}
 		configSet = append(configSet, setPrefixTermFrom+"destination-address "+address)
 	}
 	for _, address := range sortSetOfString(fromMap["destination_address_except"].(*schema.Set).List()) {
-		err := validateCIDRNetwork(address)
-		if err != nil {
-			return nil, err
-		}
 		configSet = append(configSet, setPrefixTermFrom+"destination-address "+address+" except")
 	}
 	if len(fromMap["destination_port"].(*schema.Set).List()) > 0 &&
@@ -700,17 +720,9 @@ func setFirewallFilterOptsFrom(setPrefixTermFrom string, configSet []string, fro
 		configSet = append(configSet, setPrefixTermFrom+"protocol-except "+protocol)
 	}
 	for _, address := range sortSetOfString(fromMap["source_address"].(*schema.Set).List()) {
-		err := validateCIDRNetwork(address)
-		if err != nil {
-			return nil, err
-		}
 		configSet = append(configSet, setPrefixTermFrom+"source-address "+address)
 	}
 	for _, address := range sortSetOfString(fromMap["source_address_except"].(*schema.Set).List()) {
-		err := validateCIDRNetwork(address)
-		if err != nil {
-			return nil, err
-		}
 		configSet = append(configSet, setPrefixTermFrom+"source-address "+address+" except")
 	}
 	if len(fromMap["source_port"].(*schema.Set).List()) > 0 &&

--- a/junos/resource_generate_route.go
+++ b/junos/resource_generate_route.go
@@ -120,7 +120,10 @@ func resourceGenerateRoute() *schema.Resource {
 			"policy": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatDefault),
+				},
 			},
 			"preference": {
 				Type:     schema.TypeInt,

--- a/junos/resource_interface_logical.go
+++ b/junos/resource_interface_logical.go
@@ -96,7 +96,10 @@ func resourceInterfaceLogical() *schema.Resource {
 													Type:     schema.TypeList,
 													Required: true,
 													MinItems: 1,
-													Elem:     &schema.Schema{Type: schema.TypeString},
+													Elem: &schema.Schema{
+														Type:         schema.TypeString,
+														ValidateFunc: validation.IsIPAddress,
+													},
 												},
 												"accept_data": {
 													Type:     schema.TypeBool,
@@ -372,7 +375,10 @@ func resourceInterfaceLogical() *schema.Resource {
 													Type:     schema.TypeList,
 													Required: true,
 													MinItems: 1,
-													Elem:     &schema.Schema{Type: schema.TypeString},
+													Elem: &schema.Schema{
+														Type:         schema.TypeString,
+														ValidateFunc: validation.IsIPAddress,
+													},
 												},
 												"virtual_link_local_address": {
 													Type:         schema.TypeString,
@@ -1780,10 +1786,6 @@ func setFamilyAddress(inetAddress map[string]interface{}, setPrefix, family stri
 			case inetW:
 				setNameAddVrrp = setPrefixAddress + " vrrp-group " + strconv.Itoa(vrrpGroupMap["identifier"].(int))
 				for _, ip := range vrrpGroupMap["virtual_address"].([]interface{}) {
-					_, errs := validation.IsIPAddress(ip, "virtual_address")
-					if len(errs) > 0 {
-						return configSet, errs[0]
-					}
 					configSet = append(configSet, setNameAddVrrp+" virtual-address "+ip.(string))
 				}
 				if vrrpGroupMap["advertise_interval"].(int) != 0 {
@@ -1801,10 +1803,6 @@ func setFamilyAddress(inetAddress map[string]interface{}, setPrefix, family stri
 			case inet6W:
 				setNameAddVrrp = setPrefixAddress + " vrrp-inet6-group " + strconv.Itoa(vrrpGroupMap["identifier"].(int))
 				for _, ip := range vrrpGroupMap["virtual_address"].([]interface{}) {
-					_, errs := validation.IsIPAddress(ip, "virtual_address")
-					if len(errs) > 0 {
-						return configSet, errs[0]
-					}
 					configSet = append(configSet, setNameAddVrrp+" virtual-inet6-address "+ip.(string))
 				}
 				configSet = append(configSet, setNameAddVrrp+" virtual-link-local-address "+

--- a/junos/resource_ospf.go
+++ b/junos/resource_ospf.go
@@ -110,7 +110,10 @@ func resourceOspf() *schema.Resource {
 			"export": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatDefault),
+				},
 			},
 			"external_preference": {
 				Type:         schema.TypeInt,
@@ -163,7 +166,10 @@ func resourceOspf() *schema.Resource {
 			"import": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatDefault),
+				},
 			},
 			"labeled_preference": {
 				Type:         schema.TypeInt,

--- a/junos/resource_policyoptions_policy_statement.go
+++ b/junos/resource_policyoptions_policy_statement.go
@@ -114,17 +114,26 @@ func schemaPolicyoptionsPolicyStatementFrom() map[string]*schema.Schema {
 		"bgp_as_path": {
 			Type:     schema.TypeSet,
 			Optional: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
+			Elem: &schema.Schema{
+				Type:             schema.TypeString,
+				ValidateDiagFunc: validateNameObjectJunos([]string{"default"}, 64, formatDefault),
+			},
 		},
 		"bgp_as_path_group": {
 			Type:     schema.TypeSet,
 			Optional: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
+			Elem: &schema.Schema{
+				Type:             schema.TypeString,
+				ValidateDiagFunc: validateNameObjectJunos([]string{"default"}, 64, formatDefault),
+			},
 		},
 		"bgp_community": {
 			Type:     schema.TypeSet,
 			Optional: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
+			Elem: &schema.Schema{
+				Type:             schema.TypeString,
+				ValidateDiagFunc: validateNameObjectJunos([]string{"default"}, 64, formatDefault),
+			},
 		},
 		"bgp_origin": {
 			Type:         schema.TypeString,
@@ -144,8 +153,9 @@ func schemaPolicyoptionsPolicyStatementFrom() map[string]*schema.Schema {
 			Optional: true,
 		},
 		"routing_instance": {
-			Type:     schema.TypeString,
-			Optional: true,
+			Type:             schema.TypeString,
+			Optional:         true,
+			ValidateDiagFunc: validateNameObjectJunos([]string{"default"}, 64, formatDefault),
 		},
 		"interface": {
 			Type:     schema.TypeSet,
@@ -173,7 +183,10 @@ func schemaPolicyoptionsPolicyStatementFrom() map[string]*schema.Schema {
 		"policy": {
 			Type:     schema.TypeList,
 			Optional: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
+			Elem: &schema.Schema{
+				Type:             schema.TypeString,
+				ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatDefault),
+			},
 		},
 		"preference": {
 			Type:     schema.TypeInt,
@@ -182,7 +195,10 @@ func schemaPolicyoptionsPolicyStatementFrom() map[string]*schema.Schema {
 		"prefix_list": {
 			Type:     schema.TypeSet,
 			Optional: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
+			Elem: &schema.Schema{
+				Type:             schema.TypeString,
+				ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatDefault),
+			},
 		},
 		"protocol": {
 			Type:     schema.TypeSet,
@@ -333,17 +349,26 @@ func schemaPolicyoptionsPolicyStatementTo() map[string]*schema.Schema {
 		"bgp_as_path": {
 			Type:     schema.TypeSet,
 			Optional: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
+			Elem: &schema.Schema{
+				Type:             schema.TypeString,
+				ValidateDiagFunc: validateNameObjectJunos([]string{"default"}, 64, formatDefault),
+			},
 		},
 		"bgp_as_path_group": {
 			Type:     schema.TypeSet,
 			Optional: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
+			Elem: &schema.Schema{
+				Type:             schema.TypeString,
+				ValidateDiagFunc: validateNameObjectJunos([]string{"default"}, 64, formatDefault),
+			},
 		},
 		"bgp_community": {
 			Type:     schema.TypeSet,
 			Optional: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
+			Elem: &schema.Schema{
+				Type:             schema.TypeString,
+				ValidateDiagFunc: validateNameObjectJunos([]string{"default"}, 64, formatDefault),
+			},
 		},
 		"bgp_origin": {
 			Type:         schema.TypeString,
@@ -363,8 +388,9 @@ func schemaPolicyoptionsPolicyStatementTo() map[string]*schema.Schema {
 			Optional: true,
 		},
 		"routing_instance": {
-			Type:     schema.TypeString,
-			Optional: true,
+			Type:             schema.TypeString,
+			Optional:         true,
+			ValidateDiagFunc: validateNameObjectJunos([]string{"default"}, 64, formatDefault),
 		},
 		"interface": {
 			Type:     schema.TypeSet,
@@ -392,7 +418,10 @@ func schemaPolicyoptionsPolicyStatementTo() map[string]*schema.Schema {
 		"policy": {
 			Type:     schema.TypeList,
 			Optional: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
+			Elem: &schema.Schema{
+				Type:             schema.TypeString,
+				ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatDefault),
+			},
 		},
 		"preference": {
 			Type:     schema.TypeInt,

--- a/junos/resource_policyoptions_prefix_list.go
+++ b/junos/resource_policyoptions_prefix_list.go
@@ -43,7 +43,10 @@ func resourcePolicyoptionsPrefixList() *schema.Resource {
 			"prefix": {
 				Type:     schema.TypeSet,
 				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validateCIDRNetworkFunc(),
+				},
 			},
 		},
 	}
@@ -266,10 +269,6 @@ func setPolicyoptionsPrefixList(d *schema.ResourceData, m interface{}, jnprSess 
 		configSet = append(configSet, setPrefix+" dynamic-db")
 	}
 	for _, v := range sortSetOfString(d.Get("prefix").(*schema.Set).List()) {
-		err := validateCIDRNetwork(v)
-		if err != nil {
-			return err
-		}
 		configSet = append(configSet, setPrefix+" "+v)
 	}
 

--- a/junos/resource_rib_group.go
+++ b/junos/resource_rib_group.go
@@ -35,7 +35,10 @@ func resourceRibGroup() *schema.Resource {
 			"import_policy": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatDefault),
+				},
 			},
 			"import_rib": {
 				Type:     schema.TypeList,

--- a/junos/resource_routing_instance.go
+++ b/junos/resource_routing_instance.go
@@ -80,12 +80,18 @@ func resourceRoutingInstance() *schema.Resource {
 			"instance_export": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatDefault),
+				},
 			},
 			"instance_import": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatDefault),
+				},
 			},
 			"route_distinguisher": {
 				Type:     schema.TypeString,
@@ -96,12 +102,18 @@ func resourceRoutingInstance() *schema.Resource {
 			"vrf_export": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatDefault),
+				},
 			},
 			"vrf_import": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatDefault),
+				},
 			},
 			"vrf_target": {
 				Type:     schema.TypeString,

--- a/junos/resource_routing_options.go
+++ b/junos/resource_routing_options.go
@@ -95,7 +95,10 @@ func resourceRoutingOptions() *schema.Resource {
 						"export": {
 							Type:     schema.TypeList,
 							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+							Elem: &schema.Schema{
+								Type:             schema.TypeString,
+								ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatDefault),
+							},
 						},
 						"indirect_next_hop": {
 							Type:          schema.TypeBool,
@@ -162,12 +165,18 @@ func resourceRoutingOptions() *schema.Resource {
 			"instance_export": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatDefault),
+				},
 			},
 			"instance_import": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatDefault),
+				},
 			},
 			"router_id": {
 				Type:         schema.TypeString,

--- a/junos/resource_security_address_book.go
+++ b/junos/resource_security_address_book.go
@@ -45,7 +45,10 @@ func resourceSecurityAddressBook() *schema.Resource {
 			"attach_zone": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatDefault),
+				},
 			},
 			"network_address": {
 				Type:     schema.TypeSet,
@@ -156,12 +159,18 @@ func resourceSecurityAddressBook() *schema.Resource {
 						"address": {
 							Type:     schema.TypeSet,
 							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+							Elem: &schema.Schema{
+								Type:             schema.TypeString,
+								ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatAddressName),
+							},
 						},
 						"address_set": {
 							Type:     schema.TypeSet,
 							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+							Elem: &schema.Schema{
+								Type:             schema.TypeString,
+								ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatAddressName),
+							},
 						},
 						"description": {
 							Type:     schema.TypeString,

--- a/junos/resource_security_ike_gateway.go
+++ b/junos/resource_security_ike_gateway.go
@@ -53,11 +53,14 @@ func resourceIkeGateway() *schema.Resource {
 				Required: true,
 			},
 			"address": {
-				Type:         schema.TypeList,
-				Optional:     true,
-				MinItems:     1,
-				MaxItems:     5,
-				Elem:         &schema.Schema{Type: schema.TypeString},
+				Type:     schema.TypeList,
+				Optional: true,
+				MinItems: 1,
+				MaxItems: 5,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.IsIPAddress,
+				},
 				ExactlyOneOf: []string{"address", "dynamic_remote"},
 			},
 			"dynamic_remote": {
@@ -480,10 +483,6 @@ func setIkeGateway(d *schema.ResourceData, m interface{}, jnprSess *NetconfObjec
 	configSet = append(configSet, setPrefix+" ike-policy "+d.Get("policy").(string))
 	configSet = append(configSet, setPrefix+" external-interface "+d.Get("external_interface").(string))
 	for _, v := range d.Get("address").([]interface{}) {
-		_, errs := validation.IsIPAddress(v, "address")
-		if len(errs) > 0 {
-			return errs[0]
-		}
 		configSet = append(configSet, setPrefix+" address "+v.(string))
 	}
 	for _, v := range d.Get("dynamic_remote").([]interface{}) {

--- a/junos/resource_security_nat_destination.go
+++ b/junos/resource_security_nat_destination.go
@@ -92,7 +92,10 @@ func resourceSecurityNatDestination() *schema.Resource {
 						"source_address": {
 							Type:     schema.TypeSet,
 							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+							Elem: &schema.Schema{
+								Type:             schema.TypeString,
+								ValidateDiagFunc: validateCIDRNetworkFunc(),
+							},
 						},
 						"source_address_name": {
 							Type:     schema.TypeSet,
@@ -379,9 +382,6 @@ func setSecurityNatDestination(d *schema.ResourceData, m interface{}, jnprSess *
 			configSet = append(configSet, setPrefixRule+" match protocol "+vv)
 		}
 		for _, vv := range sortSetOfString(rule["source_address"].(*schema.Set).List()) {
-			if err := validateCIDRNetwork(vv); err != nil {
-				return err
-			}
 			configSet = append(configSet, setPrefixRule+" match source-address "+vv)
 		}
 		for _, vv := range sortSetOfString(rule["source_address_name"].(*schema.Set).List()) {

--- a/junos/resource_security_nat_source.go
+++ b/junos/resource_security_nat_source.go
@@ -100,7 +100,10 @@ func resourceSecurityNatSource() *schema.Resource {
 									"destination_address": {
 										Type:     schema.TypeSet,
 										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
+										Elem: &schema.Schema{
+											Type:             schema.TypeString,
+											ValidateDiagFunc: validateCIDRNetworkFunc(),
+										},
 									},
 									"destination_address_name": {
 										Type:     schema.TypeSet,
@@ -120,7 +123,10 @@ func resourceSecurityNatSource() *schema.Resource {
 									"source_address": {
 										Type:     schema.TypeSet,
 										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
+										Elem: &schema.Schema{
+											Type:             schema.TypeString,
+											ValidateDiagFunc: validateCIDRNetworkFunc(),
+										},
 									},
 									"source_address_name": {
 										Type:     schema.TypeSet,
@@ -410,10 +416,6 @@ func setSecurityNatSource(d *schema.ResourceData, m interface{}, jnprSess *Netco
 				configSet = append(configSet, setPrefixRule+" match application \""+vv+"\"")
 			}
 			for _, address := range sortSetOfString(match["destination_address"].(*schema.Set).List()) {
-				err := validateCIDRNetwork(address)
-				if err != nil {
-					return err
-				}
 				configSet = append(configSet, setPrefixRule+" match destination-address "+address)
 			}
 			for _, vv := range sortSetOfString(match["destination_address_name"].(*schema.Set).List()) {
@@ -429,10 +431,6 @@ func setSecurityNatSource(d *schema.ResourceData, m interface{}, jnprSess *Netco
 				configSet = append(configSet, setPrefixRule+" match protocol "+proto)
 			}
 			for _, address := range sortSetOfString(match["source_address"].(*schema.Set).List()) {
-				err := validateCIDRNetwork(address)
-				if err != nil {
-					return err
-				}
 				configSet = append(configSet, setPrefixRule+" match source-address "+address)
 			}
 			for _, vv := range sortSetOfString(match["source_address_name"].(*schema.Set).List()) {

--- a/junos/resource_security_nat_source_pool.go
+++ b/junos/resource_security_nat_source_pool.go
@@ -45,7 +45,10 @@ func resourceSecurityNatSourcePool() *schema.Resource {
 				Type:     schema.TypeList,
 				Required: true,
 				MinItems: 1,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validateCIDRFunc(),
+				},
 			},
 			"address_pooling": {
 				Type:         schema.TypeString,
@@ -303,10 +306,6 @@ func setSecurityNatSourcePool(d *schema.ResourceData, m interface{}, jnprSess *N
 
 	setPrefix := "set security nat source pool " + d.Get("name").(string)
 	for _, v := range d.Get("address").([]interface{}) {
-		err := validateCIDR(v.(string))
-		if err != nil {
-			return err
-		}
 		configSet = append(configSet, setPrefix+" address "+v.(string))
 	}
 	if d.Get("address_pooling").(string) != "" {

--- a/junos/resource_security_nat_static.go
+++ b/junos/resource_security_nat_static.go
@@ -95,7 +95,10 @@ func resourceSecurityNatStatic() *schema.Resource {
 						"source_address": {
 							Type:     schema.TypeSet,
 							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+							Elem: &schema.Schema{
+								Type:             schema.TypeString,
+								ValidateDiagFunc: validateCIDRNetworkFunc(),
+							},
 						},
 						"source_address_name": {
 							Type:     schema.TypeSet,
@@ -438,9 +441,6 @@ func setSecurityNatStatic(d *schema.ResourceData, m interface{}, jnprSess *Netco
 				return fmt.Errorf("destination_port need to be set with destination_port_to in rule %s", rule["name"].(string))
 			}
 			for _, vv := range sortSetOfString(rule["source_address"].(*schema.Set).List()) {
-				if err := validateCIDRNetwork(vv); err != nil {
-					return err
-				}
 				configSet = append(configSet, setPrefixRule+" match source-address "+vv)
 			}
 			for _, vv := range sortSetOfString(rule["source_address_name"].(*schema.Set).List()) {

--- a/junos/resource_security_nat_static_rule.go
+++ b/junos/resource_security_nat_static_rule.go
@@ -72,7 +72,10 @@ func resourceSecurityNatStaticRule() *schema.Resource {
 			"source_address": {
 				Type:     schema.TypeSet,
 				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validateCIDRNetworkFunc(),
+				},
 			},
 			"source_address_name": {
 				Type:     schema.TypeSet,
@@ -372,9 +375,6 @@ func setSecurityNatStaticRule(d *schema.ResourceData, m interface{}, jnprSess *N
 		return fmt.Errorf("destination_port need to be not 0 with destination_port_to")
 	}
 	for _, v := range sortSetOfString(d.Get("source_address").(*schema.Set).List()) {
-		if err := validateCIDRNetwork(v); err != nil {
-			return err
-		}
 		configSet = append(configSet, setPrefix+"match source-address "+v)
 	}
 	for _, v := range sortSetOfString(d.Get("source_address_name").(*schema.Set).List()) {

--- a/junos/resource_security_screen.go
+++ b/junos/resource_security_screen.go
@@ -162,7 +162,11 @@ func resourceSecurityScreen() *schema.Resource {
 												"user_defined_option_type": {
 													Type:     schema.TypeList,
 													Optional: true,
-													Elem:     &schema.Schema{Type: schema.TypeString},
+													Elem: &schema.Schema{
+														Type: schema.TypeString,
+														ValidateFunc: validation.StringMatch(regexp.MustCompile(userDefinedOptionTypeRegex),
+															"doesn't match '(1..255)' or '(1..255) to (1..255)'"),
+													},
 												},
 											},
 										},
@@ -204,7 +208,11 @@ func resourceSecurityScreen() *schema.Resource {
 												"user_defined_option_type": {
 													Type:     schema.TypeList,
 													Optional: true,
-													Elem:     &schema.Schema{Type: schema.TypeString},
+													Elem: &schema.Schema{
+														Type: schema.TypeString,
+														ValidateFunc: validation.StringMatch(regexp.MustCompile(userDefinedOptionTypeRegex),
+															"doesn't match '(1..255)' or '(1..255) to (1..255)'"),
+													},
 												},
 											},
 										},
@@ -228,7 +236,11 @@ func resourceSecurityScreen() *schema.Resource {
 									"user_defined_header_type": {
 										Type:     schema.TypeList,
 										Optional: true,
-										Elem:     &schema.Schema{Type: schema.TypeString},
+										Elem: &schema.Schema{
+											Type: schema.TypeString,
+											ValidateFunc: validation.StringMatch(regexp.MustCompile(userDefinedHeaderTypeRegex),
+												"doesn't match '(0..255)' or '(0..255) to (0..255)'"),
+										},
 									},
 								},
 							},
@@ -482,12 +494,18 @@ func resourceSecurityScreen() *schema.Resource {
 												"destination_address": {
 													Type:     schema.TypeSet,
 													Optional: true,
-													Elem:     &schema.Schema{Type: schema.TypeString},
+													Elem: &schema.Schema{
+														Type:             schema.TypeString,
+														ValidateDiagFunc: validateCIDRNetworkFunc(),
+													},
 												},
 												"source_address": {
 													Type:     schema.TypeSet,
 													Optional: true,
-													Elem:     &schema.Schema{Type: schema.TypeString},
+													Elem: &schema.Schema{
+														Type:             schema.TypeString,
+														ValidateDiagFunc: validateCIDRNetworkFunc(),
+													},
 												},
 											},
 										},
@@ -923,10 +941,6 @@ func setSecurityScreenIP(ip map[string]interface{}, setPrefix string) ([]string,
 						"tunnel-encapsulation-limit-option")
 				}
 				for _, v3 := range ipIPv6ExtHeaderDestHeader["user_defined_option_type"].([]interface{}) {
-					if r := regexp.MustCompile(userDefinedOptionTypeRegex); !r.Match([]byte(v3.(string))) {
-						return configSet, fmt.Errorf(
-							"user_defined_option_type %v doesn't match '(1..255)' or '(1..255) to (1..255)'", v3.(string))
-					}
 					configSet = append(configSet,
 						setPrefix+"ipv6-extension-header destination-header user-defined-option-type "+v3.(string))
 				}
@@ -958,10 +972,6 @@ func setSecurityScreenIP(ip map[string]interface{}, setPrefix string) ([]string,
 					configSet = append(configSet, setPrefix+"ipv6-extension-header hop-by-hop-header router-alert-option")
 				}
 				for _, v3 := range ipIPv6ExtHeaderHopByHopHeader["user_defined_option_type"].([]interface{}) {
-					if r := regexp.MustCompile(userDefinedOptionTypeRegex); !r.Match([]byte(v3.(string))) {
-						return configSet, fmt.Errorf(
-							"user_defined_option_type %v doesn't match '(1..255)' or '(1..255) to (1..255)'", v3.(string))
-					}
 					configSet = append(configSet,
 						setPrefix+"ipv6-extension-header hop-by-hop-header user-defined-option-type "+v3.(string))
 				}
@@ -980,10 +990,6 @@ func setSecurityScreenIP(ip map[string]interface{}, setPrefix string) ([]string,
 			configSet = append(configSet, setPrefix+"ipv6-extension-header shim6-header")
 		}
 		for _, v2 := range ipIPv6ExtHeader["user_defined_header_type"].([]interface{}) {
-			if r := regexp.MustCompile(userDefinedHeaderTypeRegex); !r.Match([]byte(v2.(string))) {
-				return configSet, fmt.Errorf(
-					"user_defined_header_type %v doesn't match '(0..255)' or '(0..255) to (0..255)'", v2.(string))
-			}
 			configSet = append(configSet, setPrefix+"ipv6-extension-header user-defined-header-type "+v2.(string))
 		}
 	}
@@ -1173,16 +1179,10 @@ func setSecurityScreenTCP(tcp map[string]interface{}, setPrefix string) ([]strin
 				}
 				whitelistNameList = append(whitelistNameList, whitelist["name"].(string))
 				for _, destination := range sortSetOfString(whitelist["destination_address"].(*schema.Set).List()) {
-					if err := validateCIDRNetwork(destination); err != nil {
-						return configSet, err
-					}
 					configSet = append(configSet, setPrefix+"syn-flood white-list "+whitelist["name"].(string)+
 						" destination-address "+destination)
 				}
 				for _, source := range sortSetOfString(whitelist["source_address"].(*schema.Set).List()) {
-					if err := validateCIDRNetwork(source); err != nil {
-						return configSet, err
-					}
 					configSet = append(configSet, setPrefix+"syn-flood white-list "+whitelist["name"].(string)+
 						" source-address "+source)
 				}

--- a/junos/resource_security_screen_whitelist.go
+++ b/junos/resource_security_screen_whitelist.go
@@ -34,7 +34,10 @@ func resourceSecurityScreenWhiteList() *schema.Resource {
 				Type:     schema.TypeSet,
 				Required: true,
 				MinItems: 1,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validateCIDRNetworkFunc(),
+				},
 			},
 		},
 	}
@@ -253,9 +256,6 @@ func setSecurityScreenWhiteList(d *schema.ResourceData, m interface{}, jnprSess 
 	setPrefix := "set security screen white-list " + d.Get("name").(string) + " "
 
 	for _, v := range sortSetOfString(d.Get("address").(*schema.Set).List()) {
-		if err := validateCIDRNetwork(v); err != nil {
-			return err
-		}
 		configSet = append(configSet, setPrefix+"address "+v)
 	}
 

--- a/junos/resource_security_zone.go
+++ b/junos/resource_security_zone.go
@@ -154,12 +154,18 @@ func resourceSecurityZone() *schema.Resource {
 						"address": {
 							Type:     schema.TypeSet,
 							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+							Elem: &schema.Schema{
+								Type:             schema.TypeString,
+								ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatAddressName),
+							},
 						},
 						"address_set": {
 							Type:     schema.TypeSet,
 							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+							Elem: &schema.Schema{
+								Type:             schema.TypeString,
+								ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatAddressName),
+							},
 						},
 						"description": {
 							Type:     schema.TypeString,

--- a/junos/resource_security_zone_book_address_set.go
+++ b/junos/resource_security_zone_book_address_set.go
@@ -43,13 +43,19 @@ func resourceSecurityZoneBookAddressSet() *schema.Resource {
 				Type:         schema.TypeSet,
 				Optional:     true,
 				AtLeastOneOf: []string{"address", "address_set"},
-				Elem:         &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatAddressName),
+				},
 			},
 			"address_set": {
 				Type:         schema.TypeSet,
 				Optional:     true,
 				AtLeastOneOf: []string{"address", "address_set"},
-				Elem:         &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatAddressName),
+				},
 			},
 			"description": {
 				Type:     schema.TypeString,


### PR DESCRIPTION

ENHANCEMENTS:

* resource/`junos_*`: move validation of some list of string to Plan phase and not during Apply
* resource/`junos_aggregate_route`: add validation to elements of `policy` argument
* resource/`junos_application_set`: add validation to elements of `applications` argument
* resource/`junos_bgp_group`: add validation to elements of `export` and `import` arguments
* resource/`junos_bgp_neighbor`: add validation to elements of `export` and `import` arguments
* resource/`junos_chassis_cluster`: add validation to elements of `member_interfaces` argument
* resource/`junos_evpn`: add validation to elements of `vrf_export` and `vrf_import` arguments
* resource/`junos_firewall_filter`: add validation to elements of `*prefix_list*` arguments
* resource/`junos_generate_route`: add validation to elements of `policy` argument
* resource/`junos_ospf`: add validation to elements of `export` and `import` arguments
* resource/`junos_policyoptions_policy_statement`: add validation to elements of some list of string
* resource/`junos_rib_group`: add validation to elements of `import_policy` argument
* resource/`junos_routing_instance`: add validation to elements of `instance_export`, `instance_import`, `vrf_export` and `vrf_import` arguments
* resource/`junos_routing_options`: add validation to elements of `forwarding_table.0.export`, `instance_export` and `instance_import` arguments
* resource/`junos_security_address_book`: add validation to elements of `attach_zone`, `address_set.*.address` and `address_set.*.address_set` arguments
* resource/`junos_security_zone`: add validation to elements of `address_book_set.*.address` and `address_book_set.*.address_set` arguments
* resource/`junos_security_zone_book_address_set`: add validation to elements of `address` and `address_set` arguments