### PR TITLE
Use context cancellation by Ctrl-C to stop waiting threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ ENHANCEMENTS:
 * release now with golang 1.18
 * provider: normalize reading `JUNOS_FAKEUPDATE_ALSO` and `JUNOS_FAKEDELETE_ALSO` environment variables (use SDK function)
 * provider: add `ssh_timeout_to_establish` argument to configure a timeout for establishing TCP connections when initiating SSH connections
+* provider: A gracefully shutting down of Terraform with `Ctrl-c` now stop threads waiting for candidate configuration lock (stop after a loop of `cmd_sleep_lock` seconds)
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ ENHANCEMENTS:
 * release now with golang 1.18
 * provider: normalize reading `JUNOS_FAKEUPDATE_ALSO` and `JUNOS_FAKEDELETE_ALSO` environment variables (use SDK function)
 * provider: add `ssh_timeout_to_establish` argument to configure a timeout for establishing TCP connections when initiating SSH connections
-* provider: A gracefully shutting down of Terraform with `Ctrl-c` now stop threads waiting for candidate configuration lock (stop after a loop of `cmd_sleep_lock` seconds)
+* provider: A gracefully shutting down of Terraform with `Ctrl-c` now stop threads waiting for candidate configuration lock (stop after a loop of `cmd_sleep_lock` seconds)  
+  and cancel the TCP connection attempt to establish SSH session if it's not yet complete
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ ENHANCEMENTS:
 * resource/`junos_system_root_authentication`: add `plain_text_password` argument to be able to set password in plain text format (Fixes #368)
 * release now with golang 1.18
 * provider: normalize reading `JUNOS_FAKEUPDATE_ALSO` and `JUNOS_FAKEDELETE_ALSO` environment variables (use SDK function)
+* provider: add `ssh_timeout_to_establish` argument to configure a timeout for establishing TCP connections when initiating SSH connections
 
 BUG FIXES:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -154,6 +154,11 @@ The following arguments are supported in the `provider` block:
   `aes128-cbc`
   ]
 
+- **ssh_timeout_to_establish** (Optional, Number)  
+  Seconds to wait for establishing TCP connections when initiating SSH connections.  
+  It can also be sourced from the `JUNOS_SSH_TIMEOUT_TO_ESTABLISH` environment variable.  
+  Defaults to `0` (no timeout).
+
 ---
 
 ### Debug & workaround options

--- a/junos/config.go
+++ b/junos/config.go
@@ -57,7 +57,7 @@ func (c *configProvider) prepareSession() (*Session, diag.Diagnostics) {
 	// junosFilePermission
 	filePermission, err := strconv.ParseInt(c.junosFilePermission, 8, 64)
 	if err != nil {
-		return sess, diag.FromErr(fmt.Errorf("failed to convert value from '%s' to int64 : %w",
+		return sess, diag.FromErr(fmt.Errorf("failed to convert value from '%s' to int64: %w",
 			c.junosFilePermission, err))
 	}
 	sess.junosFilePermission = filePermission

--- a/junos/config.go
+++ b/junos/config.go
@@ -15,6 +15,7 @@ type configProvider struct {
 	junosCmdSleepShort       int
 	junosCmdSleepLock        int
 	junosSSHSleepClosed      int
+	junosSSHTimeoutToEstab   int
 	junosIP                  string
 	junosUserName            string
 	junosPassword            string
@@ -31,19 +32,20 @@ type configProvider struct {
 // prepareSession : prepare information to connect to Junos Device and more.
 func (c *configProvider) prepareSession() (*Session, diag.Diagnostics) {
 	sess := &Session{
-		junosIP:             c.junosIP,
-		junosPort:           c.junosPort,
-		junosUserName:       c.junosUserName,
-		junosPassword:       c.junosPassword,
-		junosSSHKeyPEM:      c.junosSSHKeyPEM,
-		junosKeyPass:        c.junosKeyPass,
-		junosGroupIntDel:    c.junosGroupIntDel,
-		junosSleepLock:      c.junosCmdSleepLock,
-		junosSleepShort:     c.junosCmdSleepShort,
-		junosSleepSSHClosed: c.junosSSHSleepClosed,
-		junosSSHCiphers:     c.junosSSHCiphers,
-		junosFakeUpdateAlso: c.junosFakeUpdateAlso,
-		junosFakeDeleteAlso: c.junosFakeDeleteAlso,
+		junosIP:                c.junosIP,
+		junosPort:              c.junosPort,
+		junosUserName:          c.junosUserName,
+		junosPassword:          c.junosPassword,
+		junosSSHKeyPEM:         c.junosSSHKeyPEM,
+		junosKeyPass:           c.junosKeyPass,
+		junosGroupIntDel:       c.junosGroupIntDel,
+		junosSleepLock:         c.junosCmdSleepLock,
+		junosSleepShort:        c.junosCmdSleepShort,
+		junosSleepSSHClosed:    c.junosSSHSleepClosed,
+		junosSSHCiphers:        c.junosSSHCiphers,
+		junosSSHTimeoutToEstab: c.junosSSHTimeoutToEstab,
+		junosFakeUpdateAlso:    c.junosFakeUpdateAlso,
+		junosFakeDeleteAlso:    c.junosFakeDeleteAlso,
 	}
 	// junosSSHKeyFile
 	sshKeyFile := c.junosSSHKeyFile

--- a/junos/constants.go
+++ b/junos/constants.go
@@ -31,5 +31,5 @@ const (
 	ospfV2 = "ospf"
 	ospfV3 = "ospf3"
 
-	failedConvAtoiError = "failed to convert value from '%s' to integer : %w"
+	failedConvAtoiError = "failed to convert value from '%s' to integer: %w"
 )

--- a/junos/data_source_interface.go
+++ b/junos/data_source_interface.go
@@ -354,7 +354,7 @@ func dataSourceInterfaceRead(ctx context.Context, d *schema.ResourceData, m inte
 		return diag.FromErr(fmt.Errorf("no arguments provided, 'config_interface' and 'match' empty"))
 	}
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/junos/data_source_interface.go
+++ b/junos/data_source_interface.go
@@ -13,7 +13,7 @@ import (
 
 func dataSourceInterface() *schema.Resource {
 	return &schema.Resource{
-		ReadContext:        dataSourceInterfaceRead,
+		ReadWithoutTimeout: dataSourceInterfaceRead,
 		DeprecationMessage: "use junos_interface_physical or junos_interface_logical data source instead",
 		Schema: map[string]*schema.Schema{
 			"config_interface": {

--- a/junos/data_source_interface.go
+++ b/junos/data_source_interface.go
@@ -405,7 +405,7 @@ func searchInterfaceID(configInterface, match string, m interface{}, jnprSess *N
 		itemTrim := strings.TrimPrefix(item, "set interfaces ")
 		matched, err := regexp.MatchString(match, itemTrim)
 		if err != nil {
-			return "", fmt.Errorf("failed to regexp with %s : %w", match, err)
+			return "", fmt.Errorf("failed to regexp with '%s': %w", match, err)
 		}
 		if !matched {
 			continue

--- a/junos/data_source_interface_logical.go
+++ b/junos/data_source_interface_logical.go
@@ -14,7 +14,7 @@ import (
 
 func dataSourceInterfaceLogical() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceInterfaceLogicalRead,
+		ReadWithoutTimeout: dataSourceInterfaceLogicalRead,
 		Schema: map[string]*schema.Schema{
 			"config_interface": {
 				Type:     schema.TypeString,

--- a/junos/data_source_interface_logical.go
+++ b/junos/data_source_interface_logical.go
@@ -570,7 +570,7 @@ func searchInterfaceLogicalID(configInterface, match string, m interface{}, jnpr
 		itemTrim := strings.TrimPrefix(item, "set interfaces ")
 		matched, err := regexp.MatchString(match, itemTrim)
 		if err != nil {
-			return "", fmt.Errorf("failed to regexp with %s : %w", match, err)
+			return "", fmt.Errorf("failed to regexp with '%s': %w", match, err)
 		}
 		if !matched {
 			continue

--- a/junos/data_source_interface_logical.go
+++ b/junos/data_source_interface_logical.go
@@ -518,7 +518,7 @@ func dataSourceInterfaceLogicalRead(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(fmt.Errorf("no arguments provided, 'config_interface' and 'match' empty"))
 	}
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/junos/data_source_interface_physical.go
+++ b/junos/data_source_interface_physical.go
@@ -13,7 +13,7 @@ import (
 
 func dataSourceInterfacePhysical() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceInterfacePhysicalRead,
+		ReadWithoutTimeout: dataSourceInterfacePhysicalRead,
 		Schema: map[string]*schema.Schema{
 			"config_interface": {
 				Type:     schema.TypeString,

--- a/junos/data_source_interface_physical.go
+++ b/junos/data_source_interface_physical.go
@@ -339,7 +339,7 @@ func dataSourceInterfacePhysicalRead(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(fmt.Errorf("no arguments provided, 'config_interface' and 'match' empty"))
 	}
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/junos/data_source_interface_physical.go
+++ b/junos/data_source_interface_physical.go
@@ -390,7 +390,7 @@ func searchInterfacePhysicalID(configInterface, match string, m interface{}, jnp
 		itemTrim := strings.TrimPrefix(item, "set interfaces ")
 		matched, err := regexp.MatchString(match, itemTrim)
 		if err != nil {
-			return "", fmt.Errorf("failed to regexp with %s : %w", match, err)
+			return "", fmt.Errorf("failed to regexp with '%s': %w", match, err)
 		}
 		if !matched {
 			continue

--- a/junos/data_source_interfaces_physical_present.go
+++ b/junos/data_source_interfaces_physical_present.go
@@ -73,7 +73,7 @@ func dataSourceInterfacesPhysicalPresent() *schema.Resource {
 func dataSourceInterfacesPhysicalPresentRead(ctx context.Context, d *schema.ResourceData, m interface{},
 ) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/junos/data_source_interfaces_physical_present.go
+++ b/junos/data_source_interfaces_physical_present.go
@@ -18,7 +18,7 @@ type interfacesPresentOpts struct {
 
 func dataSourceInterfacesPhysicalPresent() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceInterfacesPhysicalPresentRead,
+		ReadWithoutTimeout: dataSourceInterfacesPhysicalPresentRead,
 		Schema: map[string]*schema.Schema{
 			"match_name": {
 				Type:     schema.TypeString,

--- a/junos/data_source_interfaces_physical_present.go
+++ b/junos/data_source_interfaces_physical_present.go
@@ -113,13 +113,13 @@ func searchInterfacesPhysicalPresent(d *schema.ResourceData, m interface{}, jnpr
 	var iface getInterfaceTerseReply
 	err = xml.Unmarshal([]byte(replyData), &iface.InterfaceInfo)
 	if err != nil {
-		return result, fmt.Errorf("failed to xml unmarshal reply data %s : %w", replyData, err)
+		return result, fmt.Errorf("failed to xml unmarshal reply data '%s': %w", replyData, err)
 	}
 	for _, iFace := range iface.InterfaceInfo.PhysicalInterface {
 		if mName := d.Get("match_name").(string); mName != "" {
 			matched, err := regexp.MatchString(mName, strings.Trim(iFace.Name, " \n\t"))
 			if err != nil {
-				return result, fmt.Errorf("failed to regexp with %s : %w", mName, err)
+				return result, fmt.Errorf("failed to regexp with '%s': %w", mName, err)
 			}
 			if !matched {
 				continue

--- a/junos/data_source_routing_instance.go
+++ b/junos/data_source_routing_instance.go
@@ -10,7 +10,7 @@ import (
 
 func dataSourceRoutingInstance() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceRoutingInstanceRead,
+		ReadWithoutTimeout: dataSourceRoutingInstanceRead,
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:             schema.TypeString,

--- a/junos/data_source_routing_instance.go
+++ b/junos/data_source_routing_instance.go
@@ -84,7 +84,7 @@ func dataSourceRoutingInstance() *schema.Resource {
 
 func dataSourceRoutingInstanceRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/junos/data_source_security_zone.go
+++ b/junos/data_source_security_zone.go
@@ -10,7 +10,7 @@ import (
 
 func dataSourceSecurityZone() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceSecurityZoneRead,
+		ReadWithoutTimeout: dataSourceSecurityZoneRead,
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:             schema.TypeString,

--- a/junos/data_source_security_zone.go
+++ b/junos/data_source_security_zone.go
@@ -201,7 +201,7 @@ func dataSourceSecurityZone() *schema.Resource {
 
 func dataSourceSecurityZoneRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/junos/data_source_system_information.go
+++ b/junos/data_source_system_information.go
@@ -38,7 +38,7 @@ func dataSourceSystemInformation() *schema.Resource {
 
 func dataSourceSystemInformationRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	j, err := sess.startNewSession()
+	j, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/junos/data_source_system_information.go
+++ b/junos/data_source_system_information.go
@@ -9,7 +9,7 @@ import (
 
 func dataSourceSystemInformation() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: dataSourceSystemInformationRead,
+		ReadWithoutTimeout: dataSourceSystemInformationRead,
 
 		Schema: map[string]*schema.Schema{
 			"hardware_model": {

--- a/junos/func_common.go
+++ b/junos/func_common.go
@@ -344,7 +344,7 @@ func replaceTildeToHomeDir(path *string) error {
 	if strings.HasPrefix(*path, "~") {
 		homeDir, err := os.UserHomeDir()
 		if err != nil {
-			return fmt.Errorf("failed to read user home directory : %w", err)
+			return fmt.Errorf("failed to read user home directory: %w", err)
 		}
 		*path = homeDir + strings.TrimPrefix(*path, "~")
 	}

--- a/junos/func_resource_bgp.go
+++ b/junos/func_resource_bgp.go
@@ -293,7 +293,7 @@ func readBgpOptsSimple(item string, confRead *bgpOptions) error {
 		var err error
 		confRead.authenticationKey, err = jdecode.Decode(strings.Trim(strings.TrimPrefix(item, "authentication-key "), "\""))
 		if err != nil {
-			return fmt.Errorf("failed to decode authentication-key : %w", err)
+			return fmt.Errorf("failed to decode authentication-key: %w", err)
 		}
 	case strings.HasPrefix(item, "authentication-key-chain "):
 		confRead.authenticationKeyChain = strings.TrimPrefix(item, "authentication-key-chain ")

--- a/junos/netconf.go
+++ b/junos/netconf.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/jeremmfr/go-netconf/netconf"
@@ -58,6 +59,7 @@ type netconfAuthMethod struct {
 	PrivateKeyFile string
 	Passphrase     string
 	Ciphers        []string
+	Timeout        int
 }
 
 type commitResults struct {
@@ -150,6 +152,7 @@ func genSSHClientConfig(auth *netconfAuthMethod) (*ssh.ClientConfig, error) {
 	for _, v := range configs[2:] {
 		configs[0].Auth = append(configs[0].Auth, v.Auth...)
 	}
+	configs[0].Timeout = time.Duration(auth.Timeout) * time.Second
 
 	return configs[0], nil
 }

--- a/junos/provider.go
+++ b/junos/provider.go
@@ -76,6 +76,11 @@ func Provider() *schema.Provider {
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				DefaultFunc: defaultSSHCiphers(),
 			},
+			"ssh_timeout_to_establish": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("JUNOS_SSH_TIMEOUT_TO_ESTABLISH", 0),
+			},
 			"file_permission": {
 				Type:             schema.TypeString,
 				Optional:         true,
@@ -247,6 +252,7 @@ func configureProvider(ctx context.Context, d *schema.ResourceData) (interface{}
 		junosCmdSleepShort:       d.Get("cmd_sleep_short").(int),
 		junosCmdSleepLock:        d.Get("cmd_sleep_lock").(int),
 		junosSSHSleepClosed:      d.Get("ssh_sleep_closed").(int),
+		junosSSHTimeoutToEstab:   d.Get("ssh_timeout_to_establish").(int),
 		junosFilePermission:      d.Get("file_permission").(string),
 		junosDebugNetconfLogPath: d.Get("debug_netconf_log_path").(string),
 		junosFakeCreateSetFile:   d.Get("fake_create_with_setfile").(string),

--- a/junos/resource_access_address_assignment_pool.go
+++ b/junos/resource_access_address_assignment_pool.go
@@ -460,7 +460,7 @@ func resourceAccessAddressAssignPoolCreate(ctx context.Context, d *schema.Resour
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -527,7 +527,7 @@ func resourceAccessAddressAssignPoolCreate(ctx context.Context, d *schema.Resour
 
 func resourceAccessAddressAssignPoolRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -570,7 +570,7 @@ func resourceAccessAddressAssignPoolUpdate(ctx context.Context, d *schema.Resour
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -613,7 +613,7 @@ func resourceAccessAddressAssignPoolDelete(ctx context.Context, d *schema.Resour
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -642,7 +642,7 @@ func resourceAccessAddressAssignPoolDelete(ctx context.Context, d *schema.Resour
 func resourceAccessAddressAssignPoolImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_access_address_assignment_pool.go
+++ b/junos/resource_access_address_assignment_pool.go
@@ -24,10 +24,10 @@ type accessAddressAssignPoolOptions struct {
 
 func resourceAccessAddressAssignPool() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceAccessAddressAssignPoolCreate,
-		ReadContext:   resourceAccessAddressAssignPoolRead,
-		UpdateContext: resourceAccessAddressAssignPoolUpdate,
-		DeleteContext: resourceAccessAddressAssignPoolDelete,
+		CreateWithoutTimeout: resourceAccessAddressAssignPoolCreate,
+		ReadWithoutTimeout:   resourceAccessAddressAssignPoolRead,
+		UpdateWithoutTimeout: resourceAccessAddressAssignPoolUpdate,
+		DeleteWithoutTimeout: resourceAccessAddressAssignPoolDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceAccessAddressAssignPoolImport,
 		},
@@ -465,7 +465,9 @@ func resourceAccessAddressAssignPoolCreate(ctx context.Context, d *schema.Resour
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if d.Get("routing_instance").(string) != defaultW {
 		instanceExists, err := checkRoutingInstanceExists(d.Get("routing_instance").(string), m, jnprSess)
@@ -573,7 +575,9 @@ func resourceAccessAddressAssignPoolUpdate(ctx context.Context, d *schema.Resour
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delAccessAddressAssignPool(d.Get("name").(string), d.Get("routing_instance").(string),
 		m, jnprSess); err != nil {
@@ -614,7 +618,9 @@ func resourceAccessAddressAssignPoolDelete(ctx context.Context, d *schema.Resour
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delAccessAddressAssignPool(d.Get("name").(string), d.Get("routing_instance").(string),
 		m, jnprSess); err != nil {

--- a/junos/resource_aggregate_route.go
+++ b/junos/resource_aggregate_route.go
@@ -133,7 +133,7 @@ func resourceAggregateRouteCreate(ctx context.Context, d *schema.ResourceData, m
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -199,7 +199,7 @@ func resourceAggregateRouteCreate(ctx context.Context, d *schema.ResourceData, m
 
 func resourceAggregateRouteRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -241,7 +241,7 @@ func resourceAggregateRouteUpdate(ctx context.Context, d *schema.ResourceData, m
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -283,7 +283,7 @@ func resourceAggregateRouteDelete(ctx context.Context, d *schema.ResourceData, m
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -312,7 +312,7 @@ func resourceAggregateRouteDelete(ctx context.Context, d *schema.ResourceData, m
 func resourceAggregateRouteImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_aggregate_route.go
+++ b/junos/resource_aggregate_route.go
@@ -32,10 +32,10 @@ type aggregateRouteOptions struct {
 
 func resourceAggregateRoute() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceAggregateRouteCreate,
-		ReadContext:   resourceAggregateRouteRead,
-		UpdateContext: resourceAggregateRouteUpdate,
-		DeleteContext: resourceAggregateRouteDelete,
+		CreateWithoutTimeout: resourceAggregateRouteCreate,
+		ReadWithoutTimeout:   resourceAggregateRouteRead,
+		UpdateWithoutTimeout: resourceAggregateRouteUpdate,
+		DeleteWithoutTimeout: resourceAggregateRouteDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceAggregateRouteImport,
 		},
@@ -138,7 +138,9 @@ func resourceAggregateRouteCreate(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if d.Get("routing_instance").(string) != defaultW {
 		instanceExists, err := checkRoutingInstanceExists(d.Get("routing_instance").(string), m, jnprSess)
@@ -244,7 +246,9 @@ func resourceAggregateRouteUpdate(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delAggregateRoute(d.Get("destination").(string), d.Get("routing_instance").(string),
 		m, jnprSess); err != nil {
@@ -284,7 +288,9 @@ func resourceAggregateRouteDelete(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delAggregateRoute(d.Get("destination").(string), d.Get("routing_instance").(string),
 		m, jnprSess); err != nil {

--- a/junos/resource_application.go
+++ b/junos/resource_application.go
@@ -185,7 +185,7 @@ func resourceApplicationCreate(ctx context.Context, d *schema.ResourceData, m in
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -233,7 +233,7 @@ func resourceApplicationCreate(ctx context.Context, d *schema.ResourceData, m in
 
 func resourceApplicationRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -272,7 +272,7 @@ func resourceApplicationUpdate(ctx context.Context, d *schema.ResourceData, m in
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -312,7 +312,7 @@ func resourceApplicationDelete(ctx context.Context, d *schema.ResourceData, m in
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -340,7 +340,7 @@ func resourceApplicationDelete(ctx context.Context, d *schema.ResourceData, m in
 func resourceApplicationImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_application.go
+++ b/junos/resource_application.go
@@ -30,10 +30,10 @@ type applicationOptions struct {
 
 func resourceApplication() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceApplicationCreate,
-		ReadContext:   resourceApplicationRead,
-		UpdateContext: resourceApplicationUpdate,
-		DeleteContext: resourceApplicationDelete,
+		CreateWithoutTimeout: resourceApplicationCreate,
+		ReadWithoutTimeout:   resourceApplicationRead,
+		UpdateWithoutTimeout: resourceApplicationUpdate,
+		DeleteWithoutTimeout: resourceApplicationDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceApplicationImport,
 		},
@@ -190,7 +190,9 @@ func resourceApplicationCreate(ctx context.Context, d *schema.ResourceData, m in
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	appExists, err := checkApplicationExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -275,7 +277,9 @@ func resourceApplicationUpdate(ctx context.Context, d *schema.ResourceData, m in
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delApplication(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -313,7 +317,9 @@ func resourceApplicationDelete(ctx context.Context, d *schema.ResourceData, m in
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delApplication(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_application_set.go
+++ b/junos/resource_application_set.go
@@ -50,7 +50,7 @@ func resourceApplicationSetCreate(ctx context.Context, d *schema.ResourceData, m
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -98,7 +98,7 @@ func resourceApplicationSetCreate(ctx context.Context, d *schema.ResourceData, m
 
 func resourceApplicationSetRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -138,7 +138,7 @@ func resourceApplicationSetUpdate(ctx context.Context, d *schema.ResourceData, m
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -178,7 +178,7 @@ func resourceApplicationSetDelete(ctx context.Context, d *schema.ResourceData, m
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -206,7 +206,7 @@ func resourceApplicationSetDelete(ctx context.Context, d *schema.ResourceData, m
 func resourceApplicationSetImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_application_set.go
+++ b/junos/resource_application_set.go
@@ -16,10 +16,10 @@ type applicationSetOptions struct {
 
 func resourceApplicationSet() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceApplicationSetCreate,
-		ReadContext:   resourceApplicationSetRead,
-		UpdateContext: resourceApplicationSetUpdate,
-		DeleteContext: resourceApplicationSetDelete,
+		CreateWithoutTimeout: resourceApplicationSetCreate,
+		ReadWithoutTimeout:   resourceApplicationSetRead,
+		UpdateWithoutTimeout: resourceApplicationSetUpdate,
+		DeleteWithoutTimeout: resourceApplicationSetDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceApplicationSetImport,
 		},
@@ -55,7 +55,9 @@ func resourceApplicationSetCreate(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	appSetExists, err := checkApplicationSetExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -141,7 +143,9 @@ func resourceApplicationSetUpdate(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delApplicationSet(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -179,7 +183,9 @@ func resourceApplicationSetDelete(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delApplicationSet(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_bgp_group.go
+++ b/junos/resource_bgp_group.go
@@ -12,10 +12,10 @@ import (
 
 func resourceBgpGroup() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceBgpGroupCreate,
-		ReadContext:   resourceBgpGroupRead,
-		UpdateContext: resourceBgpGroupUpdate,
-		DeleteContext: resourceBgpGroupDelete,
+		CreateWithoutTimeout: resourceBgpGroupCreate,
+		ReadWithoutTimeout:   resourceBgpGroupRead,
+		UpdateWithoutTimeout: resourceBgpGroupUpdate,
+		DeleteWithoutTimeout: resourceBgpGroupDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceBgpGroupImport,
 		},
@@ -612,7 +612,9 @@ func resourceBgpGroupCreate(ctx context.Context, d *schema.ResourceData, m inter
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if d.Get("routing_instance").(string) != defaultW {
 		instanceExists, err := checkRoutingInstanceExists(d.Get("routing_instance").(string), m, jnprSess)
@@ -712,7 +714,9 @@ func resourceBgpGroupUpdate(ctx context.Context, d *schema.ResourceData, m inter
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delBgpOpts(d, "group", m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -750,7 +754,9 @@ func resourceBgpGroupDelete(ctx context.Context, d *schema.ResourceData, m inter
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delBgpGroup(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_bgp_group.go
+++ b/junos/resource_bgp_group.go
@@ -607,7 +607,7 @@ func resourceBgpGroupCreate(ctx context.Context, d *schema.ResourceData, m inter
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -670,7 +670,7 @@ func resourceBgpGroupCreate(ctx context.Context, d *schema.ResourceData, m inter
 
 func resourceBgpGroupRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -709,7 +709,7 @@ func resourceBgpGroupUpdate(ctx context.Context, d *schema.ResourceData, m inter
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -749,7 +749,7 @@ func resourceBgpGroupDelete(ctx context.Context, d *schema.ResourceData, m inter
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -777,7 +777,7 @@ func resourceBgpGroupDelete(ctx context.Context, d *schema.ResourceData, m inter
 func resourceBgpGroupImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_bgp_neighbor.go
+++ b/junos/resource_bgp_neighbor.go
@@ -601,7 +601,7 @@ func resourceBgpNeighborCreate(ctx context.Context, d *schema.ResourceData, m in
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -680,7 +680,7 @@ func resourceBgpNeighborCreate(ctx context.Context, d *schema.ResourceData, m in
 
 func resourceBgpNeighborRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -720,7 +720,7 @@ func resourceBgpNeighborUpdate(ctx context.Context, d *schema.ResourceData, m in
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -760,7 +760,7 @@ func resourceBgpNeighborDelete(ctx context.Context, d *schema.ResourceData, m in
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -788,7 +788,7 @@ func resourceBgpNeighborDelete(ctx context.Context, d *schema.ResourceData, m in
 func resourceBgpNeighborImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_bgp_neighbor.go
+++ b/junos/resource_bgp_neighbor.go
@@ -12,10 +12,10 @@ import (
 
 func resourceBgpNeighbor() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceBgpNeighborCreate,
-		ReadContext:   resourceBgpNeighborRead,
-		UpdateContext: resourceBgpNeighborUpdate,
-		DeleteContext: resourceBgpNeighborDelete,
+		CreateWithoutTimeout: resourceBgpNeighborCreate,
+		ReadWithoutTimeout:   resourceBgpNeighborRead,
+		UpdateWithoutTimeout: resourceBgpNeighborUpdate,
+		DeleteWithoutTimeout: resourceBgpNeighborDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceBgpNeighborImport,
 		},
@@ -606,7 +606,9 @@ func resourceBgpNeighborCreate(ctx context.Context, d *schema.ResourceData, m in
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if d.Get("routing_instance").(string) != defaultW {
 		instanceExists, err := checkRoutingInstanceExists(d.Get("routing_instance").(string), m, jnprSess)
@@ -723,7 +725,9 @@ func resourceBgpNeighborUpdate(ctx context.Context, d *schema.ResourceData, m in
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delBgpOpts(d, "neighbor", m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -761,7 +765,9 @@ func resourceBgpNeighborDelete(ctx context.Context, d *schema.ResourceData, m in
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delBgpNeighbor(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_bridge_domain.go
+++ b/junos/resource_bridge_domain.go
@@ -29,10 +29,10 @@ type bridgeDomainOptions struct {
 
 func resourceBridgeDomain() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceBridgeDomainCreate,
-		ReadContext:   resourceBridgeDomainRead,
-		UpdateContext: resourceBridgeDomainUpdate,
-		DeleteContext: resourceBridgeDomainDelete,
+		CreateWithoutTimeout: resourceBridgeDomainCreate,
+		ReadWithoutTimeout:   resourceBridgeDomainRead,
+		UpdateWithoutTimeout: resourceBridgeDomainUpdate,
+		DeleteWithoutTimeout: resourceBridgeDomainDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceBridgeDomainImport,
 		},
@@ -168,7 +168,9 @@ func resourceBridgeDomainCreate(ctx context.Context, d *schema.ResourceData, m i
 		return diag.FromErr(fmt.Errorf("bridge domain "+
 			"not compatible with Junos device %s", jnprSess.SystemInformation.HardwareModel))
 	}
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if d.Get("routing_instance").(string) != defaultW {
 		instanceExists, err := checkRoutingInstanceExists(d.Get("routing_instance").(string), m, jnprSess)
@@ -280,7 +282,9 @@ func resourceBridgeDomainUpdate(ctx context.Context, d *schema.ResourceData, m i
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if d.HasChange("vxlan") {
 		oldVxlan, _ := d.GetChange("vxlan")
@@ -328,7 +332,9 @@ func resourceBridgeDomainDelete(ctx context.Context, d *schema.ResourceData, m i
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delBridgeDomain(d.Get("name").(string), d.Get("routing_instance").(string), d.Get("vxlan").([]interface{}),
 		m, jnprSess); err != nil {

--- a/junos/resource_bridge_domain.go
+++ b/junos/resource_bridge_domain.go
@@ -159,7 +159,7 @@ func resourceBridgeDomainCreate(ctx context.Context, d *schema.ResourceData, m i
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -229,7 +229,7 @@ func resourceBridgeDomainCreate(ctx context.Context, d *schema.ResourceData, m i
 
 func resourceBridgeDomainRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -277,7 +277,7 @@ func resourceBridgeDomainUpdate(ctx context.Context, d *schema.ResourceData, m i
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -327,7 +327,7 @@ func resourceBridgeDomainDelete(ctx context.Context, d *schema.ResourceData, m i
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -356,7 +356,7 @@ func resourceBridgeDomainDelete(ctx context.Context, d *schema.ResourceData, m i
 func resourceBridgeDomainImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_chassis_cluster.go
+++ b/junos/resource_chassis_cluster.go
@@ -207,7 +207,7 @@ func resourceChassisClusterCreate(ctx context.Context, d *schema.ResourceData, m
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -239,7 +239,7 @@ func resourceChassisClusterCreate(ctx context.Context, d *schema.ResourceData, m
 
 func resourceChassisClusterRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -275,7 +275,7 @@ func resourceChassisClusterUpdate(ctx context.Context, d *schema.ResourceData, m
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -315,7 +315,7 @@ func resourceChassisClusterDelete(ctx context.Context, d *schema.ResourceData, m
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -343,7 +343,7 @@ func resourceChassisClusterDelete(ctx context.Context, d *schema.ResourceData, m
 func resourceChassisClusterImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_chassis_cluster.go
+++ b/junos/resource_chassis_cluster.go
@@ -26,10 +26,10 @@ type chassisClusterOptions struct {
 
 func resourceChassisCluster() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceChassisClusterCreate,
-		ReadContext:   resourceChassisClusterRead,
-		UpdateContext: resourceChassisClusterUpdate,
-		DeleteContext: resourceChassisClusterDelete,
+		CreateWithoutTimeout: resourceChassisClusterCreate,
+		ReadWithoutTimeout:   resourceChassisClusterRead,
+		UpdateWithoutTimeout: resourceChassisClusterUpdate,
+		DeleteWithoutTimeout: resourceChassisClusterDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceChassisClusterImport,
 		},
@@ -216,7 +216,9 @@ func resourceChassisClusterCreate(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(fmt.Errorf("chassis cluster "+
 			"not compatible with Junos device %s", jnprSess.SystemInformation.HardwareModel))
 	}
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := setChassisCluster(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -278,7 +280,9 @@ func resourceChassisClusterUpdate(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delChassisCluster(m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -316,7 +320,9 @@ func resourceChassisClusterDelete(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delChassisCluster(m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_chassis_redundancy.go
+++ b/junos/resource_chassis_redundancy.go
@@ -25,10 +25,10 @@ type chassisRedundancyOptions struct {
 
 func resourceChassisRedundancy() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceChassisRedundancyCreate,
-		ReadContext:   resourceChassisRedundancyRead,
-		UpdateContext: resourceChassisRedundancyUpdate,
-		DeleteContext: resourceChassisRedundancyDelete,
+		CreateWithoutTimeout: resourceChassisRedundancyCreate,
+		ReadWithoutTimeout:   resourceChassisRedundancyRead,
+		UpdateWithoutTimeout: resourceChassisRedundancyUpdate,
+		DeleteWithoutTimeout: resourceChassisRedundancyDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceChassisRedundancyImport,
 		},
@@ -102,7 +102,9 @@ func resourceChassisRedundancyCreate(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := setChassisRedundancy(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -164,7 +166,9 @@ func resourceChassisRedundancyUpdate(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delChassisRedundancy(m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -202,7 +206,9 @@ func resourceChassisRedundancyDelete(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delChassisRedundancy(m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_chassis_redundancy.go
+++ b/junos/resource_chassis_redundancy.go
@@ -97,7 +97,7 @@ func resourceChassisRedundancyCreate(ctx context.Context, d *schema.ResourceData
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -125,7 +125,7 @@ func resourceChassisRedundancyCreate(ctx context.Context, d *schema.ResourceData
 
 func resourceChassisRedundancyRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -161,7 +161,7 @@ func resourceChassisRedundancyUpdate(ctx context.Context, d *schema.ResourceData
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -201,7 +201,7 @@ func resourceChassisRedundancyDelete(ctx context.Context, d *schema.ResourceData
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -229,7 +229,7 @@ func resourceChassisRedundancyDelete(ctx context.Context, d *schema.ResourceData
 func resourceChassisRedundancyImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_eventoptions_destination.go
+++ b/junos/resource_eventoptions_destination.go
@@ -322,7 +322,7 @@ func readEventoptionsDestination(name string, m interface{}, jnprSess *NetconfOb
 				if len(itemTrimSplit) > 2 {
 					password, err := jdecode.Decode(strings.Trim(itemTrimSplit[3], "\""))
 					if err != nil {
-						return confRead, fmt.Errorf("failed to decode secret : %w", err)
+						return confRead, fmt.Errorf("failed to decode secret: %w", err)
 					}
 					confRead.archiveSite = append(confRead.archiveSite, map[string]interface{}{
 						"url":      strings.Trim(itemTrimSplit[1], "\""),

--- a/junos/resource_eventoptions_destination.go
+++ b/junos/resource_eventoptions_destination.go
@@ -73,7 +73,7 @@ func resourceEventoptionsDestinationCreate(ctx context.Context, d *schema.Resour
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -123,7 +123,7 @@ func resourceEventoptionsDestinationCreate(ctx context.Context, d *schema.Resour
 
 func resourceEventoptionsDestinationRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -164,7 +164,7 @@ func resourceEventoptionsDestinationUpdate(ctx context.Context, d *schema.Resour
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -205,7 +205,7 @@ func resourceEventoptionsDestinationDelete(ctx context.Context, d *schema.Resour
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -233,7 +233,7 @@ func resourceEventoptionsDestinationDelete(ctx context.Context, d *schema.Resour
 func resourceEventoptionsDestinationImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_eventoptions_destination.go
+++ b/junos/resource_eventoptions_destination.go
@@ -21,10 +21,10 @@ type eventoptionsDestinationOptions struct {
 
 func resourceEventoptionsDestination() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceEventoptionsDestinationCreate,
-		ReadContext:   resourceEventoptionsDestinationRead,
-		UpdateContext: resourceEventoptionsDestinationUpdate,
-		DeleteContext: resourceEventoptionsDestinationDelete,
+		CreateWithoutTimeout: resourceEventoptionsDestinationCreate,
+		ReadWithoutTimeout:   resourceEventoptionsDestinationRead,
+		UpdateWithoutTimeout: resourceEventoptionsDestinationUpdate,
+		DeleteWithoutTimeout: resourceEventoptionsDestinationDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceEventoptionsDestinationImport,
 		},
@@ -78,7 +78,9 @@ func resourceEventoptionsDestinationCreate(ctx context.Context, d *schema.Resour
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	eventoptionsDestinationExists, err := checkEventoptionsDestinationExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -167,7 +169,9 @@ func resourceEventoptionsDestinationUpdate(ctx context.Context, d *schema.Resour
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delEventoptionsDestination(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -206,7 +210,9 @@ func resourceEventoptionsDestinationDelete(ctx context.Context, d *schema.Resour
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delEventoptionsDestination(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_eventoptions_generate_event.go
+++ b/junos/resource_eventoptions_generate_event.go
@@ -21,10 +21,10 @@ type eventoptionsGenerateEventOptions struct {
 
 func resourceEventoptionsGenerateEvent() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceEventoptionsGenerateEventCreate,
-		ReadContext:   resourceEventoptionsGenerateEventRead,
-		UpdateContext: resourceEventoptionsGenerateEventUpdate,
-		DeleteContext: resourceEventoptionsGenerateEventDelete,
+		CreateWithoutTimeout: resourceEventoptionsGenerateEventCreate,
+		ReadWithoutTimeout:   resourceEventoptionsGenerateEventRead,
+		UpdateWithoutTimeout: resourceEventoptionsGenerateEventUpdate,
+		DeleteWithoutTimeout: resourceEventoptionsGenerateEventDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceEventoptionsGenerateEventImport,
 		},
@@ -71,7 +71,9 @@ func resourceEventoptionsGenerateEventCreate(ctx context.Context, d *schema.Reso
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	eventoptionsGenerateEventExists, err := checkEventoptionsGenerateEventExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -161,7 +163,9 @@ func resourceEventoptionsGenerateEventUpdate(ctx context.Context, d *schema.Reso
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delEventoptionsGenerateEvent(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -200,7 +204,9 @@ func resourceEventoptionsGenerateEventDelete(ctx context.Context, d *schema.Reso
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delEventoptionsGenerateEvent(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_eventoptions_generate_event.go
+++ b/junos/resource_eventoptions_generate_event.go
@@ -66,7 +66,7 @@ func resourceEventoptionsGenerateEventCreate(ctx context.Context, d *schema.Reso
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -117,7 +117,7 @@ func resourceEventoptionsGenerateEventCreate(ctx context.Context, d *schema.Reso
 func resourceEventoptionsGenerateEventRead(ctx context.Context, d *schema.ResourceData, m interface{},
 ) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -158,7 +158,7 @@ func resourceEventoptionsGenerateEventUpdate(ctx context.Context, d *schema.Reso
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -199,7 +199,7 @@ func resourceEventoptionsGenerateEventDelete(ctx context.Context, d *schema.Reso
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -227,7 +227,7 @@ func resourceEventoptionsGenerateEventDelete(ctx context.Context, d *schema.Reso
 func resourceEventoptionsGenerateEventImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_eventoptions_policy.go
+++ b/junos/resource_eventoptions_policy.go
@@ -22,10 +22,10 @@ type eventoptionsPolicyOptions struct {
 
 func resourceEventoptionsPolicy() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceEventoptionsPolicyCreate,
-		ReadContext:   resourceEventoptionsPolicyRead,
-		UpdateContext: resourceEventoptionsPolicyUpdate,
-		DeleteContext: resourceEventoptionsPolicyDelete,
+		CreateWithoutTimeout: resourceEventoptionsPolicyCreate,
+		ReadWithoutTimeout:   resourceEventoptionsPolicyRead,
+		UpdateWithoutTimeout: resourceEventoptionsPolicyUpdate,
+		DeleteWithoutTimeout: resourceEventoptionsPolicyDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceEventoptionsPolicyImport,
 		},
@@ -481,7 +481,9 @@ func resourceEventoptionsPolicyCreate(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	eventoptionsPolicyExists, err := checkEventoptionsPolicyExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -569,7 +571,9 @@ func resourceEventoptionsPolicyUpdate(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delEventoptionsPolicy(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -607,7 +611,9 @@ func resourceEventoptionsPolicyDelete(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delEventoptionsPolicy(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_eventoptions_policy.go
+++ b/junos/resource_eventoptions_policy.go
@@ -476,7 +476,7 @@ func resourceEventoptionsPolicyCreate(ctx context.Context, d *schema.ResourceDat
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -526,7 +526,7 @@ func resourceEventoptionsPolicyCreate(ctx context.Context, d *schema.ResourceDat
 
 func resourceEventoptionsPolicyRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -566,7 +566,7 @@ func resourceEventoptionsPolicyUpdate(ctx context.Context, d *schema.ResourceDat
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -606,7 +606,7 @@ func resourceEventoptionsPolicyDelete(ctx context.Context, d *schema.ResourceDat
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -634,7 +634,7 @@ func resourceEventoptionsPolicyDelete(ctx context.Context, d *schema.ResourceDat
 func resourceEventoptionsPolicyImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_evpn.go
+++ b/junos/resource_evpn.go
@@ -120,7 +120,7 @@ func resourceEvpnCreate(ctx context.Context, d *schema.ResourceData, m interface
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -162,7 +162,7 @@ func resourceEvpnCreate(ctx context.Context, d *schema.ResourceData, m interface
 
 func resourceEvpnRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -216,7 +216,7 @@ func resourceEvpnUpdate(ctx context.Context, d *schema.ResourceData, m interface
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -256,7 +256,7 @@ func resourceEvpnDelete(ctx context.Context, d *schema.ResourceData, m interface
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -284,7 +284,7 @@ func resourceEvpnDelete(ctx context.Context, d *schema.ResourceData, m interface
 func resourceEvpnImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_evpn.go
+++ b/junos/resource_evpn.go
@@ -22,10 +22,10 @@ type evpnOptions struct {
 
 func resourceEvpn() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceEvpnCreate,
-		ReadContext:   resourceEvpnRead,
-		UpdateContext: resourceEvpnUpdate,
-		DeleteContext: resourceEvpnDelete,
+		CreateWithoutTimeout: resourceEvpnCreate,
+		ReadWithoutTimeout:   resourceEvpnRead,
+		UpdateWithoutTimeout: resourceEvpnUpdate,
+		DeleteWithoutTimeout: resourceEvpnDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceEvpnImport,
 		},
@@ -125,7 +125,9 @@ func resourceEvpnCreate(ctx context.Context, d *schema.ResourceData, m interface
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if d.Get("routing_instance").(string) != defaultW {
 		instanceExists, err := checkRoutingInstanceExists(d.Get("routing_instance").(string), m, jnprSess)
@@ -219,7 +221,9 @@ func resourceEvpnUpdate(ctx context.Context, d *schema.ResourceData, m interface
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delEvpn(false, d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -257,7 +261,9 @@ func resourceEvpnDelete(ctx context.Context, d *schema.ResourceData, m interface
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delEvpn(true, d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_firewall_filter.go
+++ b/junos/resource_firewall_filter.go
@@ -20,10 +20,10 @@ type filterOptions struct {
 
 func resourceFirewallFilter() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceFirewallFilterCreate,
-		ReadContext:   resourceFirewallFilterRead,
-		UpdateContext: resourceFirewallFilterUpdate,
-		DeleteContext: resourceFirewallFilterDelete,
+		CreateWithoutTimeout: resourceFirewallFilterCreate,
+		ReadWithoutTimeout:   resourceFirewallFilterRead,
+		UpdateWithoutTimeout: resourceFirewallFilterUpdate,
+		DeleteWithoutTimeout: resourceFirewallFilterDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceFirewallFilterImport,
 		},
@@ -288,7 +288,9 @@ func resourceFirewallFilterCreate(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	firewallFilterExists, err := checkFirewallFilterExists(d.Get("name").(string), d.Get("family").(string), m, jnprSess)
 	if err != nil {
@@ -375,7 +377,9 @@ func resourceFirewallFilterUpdate(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delFirewallFilter(d.Get("name").(string), d.Get("family").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -413,7 +417,9 @@ func resourceFirewallFilterDelete(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delFirewallFilter(d.Get("name").(string), d.Get("family").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_firewall_filter.go
+++ b/junos/resource_firewall_filter.go
@@ -283,7 +283,7 @@ func resourceFirewallFilterCreate(ctx context.Context, d *schema.ResourceData, m
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -332,7 +332,7 @@ func resourceFirewallFilterCreate(ctx context.Context, d *schema.ResourceData, m
 
 func resourceFirewallFilterRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -372,7 +372,7 @@ func resourceFirewallFilterUpdate(ctx context.Context, d *schema.ResourceData, m
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -412,7 +412,7 @@ func resourceFirewallFilterDelete(ctx context.Context, d *schema.ResourceData, m
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -440,7 +440,7 @@ func resourceFirewallFilterDelete(ctx context.Context, d *schema.ResourceData, m
 func resourceFirewallFilterImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_firewall_policer.go
+++ b/junos/resource_firewall_policer.go
@@ -20,10 +20,10 @@ type policerOptions struct {
 
 func resourceFirewallPolicer() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceFirewallPolicerCreate,
-		ReadContext:   resourceFirewallPolicerRead,
-		UpdateContext: resourceFirewallPolicerUpdate,
-		DeleteContext: resourceFirewallPolicerDelete,
+		CreateWithoutTimeout: resourceFirewallPolicerCreate,
+		ReadWithoutTimeout:   resourceFirewallPolicerRead,
+		UpdateWithoutTimeout: resourceFirewallPolicerUpdate,
+		DeleteWithoutTimeout: resourceFirewallPolicerDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceFirewallPolicerImport,
 		},
@@ -110,7 +110,9 @@ func resourceFirewallPolicerCreate(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	firewallPolicerExists, err := checkFirewallPolicerExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -197,7 +199,9 @@ func resourceFirewallPolicerUpdate(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delFirewallPolicer(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -235,7 +239,9 @@ func resourceFirewallPolicerDelete(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delFirewallPolicer(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_firewall_policer.go
+++ b/junos/resource_firewall_policer.go
@@ -105,7 +105,7 @@ func resourceFirewallPolicerCreate(ctx context.Context, d *schema.ResourceData, 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -154,7 +154,7 @@ func resourceFirewallPolicerCreate(ctx context.Context, d *schema.ResourceData, 
 
 func resourceFirewallPolicerRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -194,7 +194,7 @@ func resourceFirewallPolicerUpdate(ctx context.Context, d *schema.ResourceData, 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -234,7 +234,7 @@ func resourceFirewallPolicerDelete(ctx context.Context, d *schema.ResourceData, 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -262,7 +262,7 @@ func resourceFirewallPolicerDelete(ctx context.Context, d *schema.ResourceData, 
 func resourceFirewallPolicerImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_forwardingoptions_sampling_instance.go
+++ b/junos/resource_forwardingoptions_sampling_instance.go
@@ -26,10 +26,10 @@ type samplingInstanceOptions struct {
 
 func resourceForwardingoptionsSamplingInstance() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceForwardingoptionsSamplingInstanceCreate,
-		ReadContext:   resourceForwardingoptionsSamplingInstanceRead,
-		UpdateContext: resourceForwardingoptionsSamplingInstanceUpdate,
-		DeleteContext: resourceForwardingoptionsSamplingInstanceDelete,
+		CreateWithoutTimeout: resourceForwardingoptionsSamplingInstanceCreate,
+		ReadWithoutTimeout:   resourceForwardingoptionsSamplingInstanceRead,
+		UpdateWithoutTimeout: resourceForwardingoptionsSamplingInstanceUpdate,
+		DeleteWithoutTimeout: resourceForwardingoptionsSamplingInstanceDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceForwardingoptionsSamplingInstanceImport,
 		},
@@ -643,7 +643,9 @@ func resourceForwardingoptionsSamplingInstanceCreate(ctx context.Context, d *sch
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	fwdoptsSamplingInstanceExists, err := checkForwardingoptionsSamplingInstanceExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -735,7 +737,9 @@ func resourceForwardingoptionsSamplingInstanceUpdate(ctx context.Context, d *sch
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delForwardingoptionsSamplingInstance(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -775,7 +779,9 @@ func resourceForwardingoptionsSamplingInstanceDelete(ctx context.Context, d *sch
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delForwardingoptionsSamplingInstance(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_forwardingoptions_sampling_instance.go
+++ b/junos/resource_forwardingoptions_sampling_instance.go
@@ -638,7 +638,7 @@ func resourceForwardingoptionsSamplingInstanceCreate(ctx context.Context, d *sch
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -690,7 +690,7 @@ func resourceForwardingoptionsSamplingInstanceCreate(ctx context.Context, d *sch
 func resourceForwardingoptionsSamplingInstanceRead(ctx context.Context, d *schema.ResourceData, m interface{},
 ) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -732,7 +732,7 @@ func resourceForwardingoptionsSamplingInstanceUpdate(ctx context.Context, d *sch
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -774,7 +774,7 @@ func resourceForwardingoptionsSamplingInstanceDelete(ctx context.Context, d *sch
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -802,7 +802,7 @@ func resourceForwardingoptionsSamplingInstanceDelete(ctx context.Context, d *sch
 func resourceForwardingoptionsSamplingInstanceImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_generate_route.go
+++ b/junos/resource_generate_route.go
@@ -33,10 +33,10 @@ type generateRouteOptions struct {
 
 func resourceGenerateRoute() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceGenerateRouteCreate,
-		ReadContext:   resourceGenerateRouteRead,
-		UpdateContext: resourceGenerateRouteUpdate,
-		DeleteContext: resourceGenerateRouteDelete,
+		CreateWithoutTimeout: resourceGenerateRouteCreate,
+		ReadWithoutTimeout:   resourceGenerateRouteRead,
+		UpdateWithoutTimeout: resourceGenerateRouteUpdate,
+		DeleteWithoutTimeout: resourceGenerateRouteDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceGenerateRouteImport,
 		},
@@ -145,7 +145,9 @@ func resourceGenerateRouteCreate(ctx context.Context, d *schema.ResourceData, m 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if d.Get("routing_instance").(string) != defaultW {
 		instanceExists, err := checkRoutingInstanceExists(d.Get("routing_instance").(string), m, jnprSess)
@@ -250,7 +252,9 @@ func resourceGenerateRouteUpdate(ctx context.Context, d *schema.ResourceData, m 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delGenerateRoute(
 		d.Get("destination").(string), d.Get("routing_instance").(string), m, jnprSess); err != nil {
@@ -291,7 +295,9 @@ func resourceGenerateRouteDelete(ctx context.Context, d *schema.ResourceData, m 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delGenerateRoute(
 		d.Get("destination").(string), d.Get("routing_instance").(string), m, jnprSess); err != nil {

--- a/junos/resource_generate_route.go
+++ b/junos/resource_generate_route.go
@@ -140,7 +140,7 @@ func resourceGenerateRouteCreate(ctx context.Context, d *schema.ResourceData, m 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -205,7 +205,7 @@ func resourceGenerateRouteCreate(ctx context.Context, d *schema.ResourceData, m 
 
 func resourceGenerateRouteRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -247,7 +247,7 @@ func resourceGenerateRouteUpdate(ctx context.Context, d *schema.ResourceData, m 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -290,7 +290,7 @@ func resourceGenerateRouteDelete(ctx context.Context, d *schema.ResourceData, m 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -319,7 +319,7 @@ func resourceGenerateRouteDelete(ctx context.Context, d *schema.ResourceData, m 
 func resourceGenerateRouteImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_group_dual_system.go
+++ b/junos/resource_group_dual_system.go
@@ -22,10 +22,10 @@ type groupDualSystemOptions struct {
 
 func resourceGroupDualSystem() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceGroupDualSystemCreate,
-		ReadContext:   resourceGroupDualSystemRead,
-		UpdateContext: resourceGroupDualSystemUpdate,
-		DeleteContext: resourceGroupDualSystemDelete,
+		CreateWithoutTimeout: resourceGroupDualSystemCreate,
+		ReadWithoutTimeout:   resourceGroupDualSystemRead,
+		UpdateWithoutTimeout: resourceGroupDualSystemUpdate,
+		DeleteWithoutTimeout: resourceGroupDualSystemDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceGroupDualSystemImport,
 		},
@@ -196,7 +196,9 @@ func resourceGroupDualSystemCreate(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	groupDualSystemExists, err := checkGroupDualSystemExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -290,7 +292,9 @@ func resourceGroupDualSystemUpdate(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delGroupDualSystem(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -346,7 +350,9 @@ func resourceGroupDualSystemDelete(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delGroupDualSystem(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_group_dual_system.go
+++ b/junos/resource_group_dual_system.go
@@ -191,7 +191,7 @@ func resourceGroupDualSystemCreate(ctx context.Context, d *schema.ResourceData, 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -240,7 +240,7 @@ func resourceGroupDualSystemCreate(ctx context.Context, d *schema.ResourceData, 
 
 func resourceGroupDualSystemRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -287,7 +287,7 @@ func resourceGroupDualSystemUpdate(ctx context.Context, d *schema.ResourceData, 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -345,7 +345,7 @@ func resourceGroupDualSystemDelete(ctx context.Context, d *schema.ResourceData, 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -384,7 +384,7 @@ func resourceGroupDualSystemDelete(ctx context.Context, d *schema.ResourceData, 
 func resourceGroupDualSystemImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_igmp_snooping_vlan.go
+++ b/junos/resource_igmp_snooping_vlan.go
@@ -29,10 +29,10 @@ type igmpSnoopingVlanOptions struct {
 
 func resourceIgmpSnoopingVlan() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceIgmpSnoopingVlanCreate,
-		ReadContext:   resourceIgmpSnoopingVlanRead,
-		UpdateContext: resourceIgmpSnoopingVlanUpdate,
-		DeleteContext: resourceIgmpSnoopingVlanDelete,
+		CreateWithoutTimeout: resourceIgmpSnoopingVlanCreate,
+		ReadWithoutTimeout:   resourceIgmpSnoopingVlanRead,
+		UpdateWithoutTimeout: resourceIgmpSnoopingVlanUpdate,
+		DeleteWithoutTimeout: resourceIgmpSnoopingVlanDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceIgmpSnoopingVlanImport,
 		},
@@ -167,7 +167,9 @@ func resourceIgmpSnoopingVlanCreate(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if d.Get("routing_instance").(string) != defaultW {
 		instanceExists, err := checkRoutingInstanceExists(d.Get("routing_instance").(string), m, jnprSess)
@@ -283,7 +285,9 @@ func resourceIgmpSnoopingVlanUpdate(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delIgmpSnoopingVlan(d.Get("name").(string), d.Get("routing_instance").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -321,7 +325,9 @@ func resourceIgmpSnoopingVlanDelete(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delIgmpSnoopingVlan(d.Get("name").(string), d.Get("routing_instance").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_igmp_snooping_vlan.go
+++ b/junos/resource_igmp_snooping_vlan.go
@@ -162,7 +162,7 @@ func resourceIgmpSnoopingVlanCreate(ctx context.Context, d *schema.ResourceData,
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -239,7 +239,7 @@ func resourceIgmpSnoopingVlanCreate(ctx context.Context, d *schema.ResourceData,
 
 func resourceIgmpSnoopingVlanRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -280,7 +280,7 @@ func resourceIgmpSnoopingVlanUpdate(ctx context.Context, d *schema.ResourceData,
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -320,7 +320,7 @@ func resourceIgmpSnoopingVlanDelete(ctx context.Context, d *schema.ResourceData,
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -348,7 +348,7 @@ func resourceIgmpSnoopingVlanDelete(ctx context.Context, d *schema.ResourceData,
 func resourceIgmpSnoopingVlanImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_interface.go
+++ b/junos/resource_interface.go
@@ -42,10 +42,10 @@ type interfaceOptions struct {
 
 func resourceInterface() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceInterfaceCreate,
-		ReadContext:   resourceInterfaceRead,
-		UpdateContext: resourceInterfaceUpdate,
-		DeleteContext: resourceInterfaceDelete,
+		CreateWithoutTimeout: resourceInterfaceCreate,
+		ReadWithoutTimeout:   resourceInterfaceRead,
+		UpdateWithoutTimeout: resourceInterfaceUpdate,
+		DeleteWithoutTimeout: resourceInterfaceDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceInterfaceImport,
 		},
@@ -461,7 +461,9 @@ func resourceInterfaceCreate(ctx context.Context, d *schema.ResourceData, m inte
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if intExists {
 		ncInt, emptyInt, err := checkInterfaceNC(d.Get("name").(string), m, jnprSess)
@@ -621,7 +623,9 @@ func resourceInterfaceUpdate(ctx context.Context, d *schema.ResourceData, m inte
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delInterfaceOpts(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -781,7 +785,9 @@ func resourceInterfaceDelete(ctx context.Context, d *schema.ResourceData, m inte
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delInterface(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_interface.go
+++ b/junos/resource_interface.go
@@ -1345,12 +1345,12 @@ func delInterface(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject
 			}
 			aeInt, err := strconv.Atoi(strings.TrimPrefix(d.Get("ether802_3ad").(string), "ae"))
 			if err != nil {
-				return fmt.Errorf("failed to convert AE id of ether802_3ad argument '%s' in integer : %w",
+				return fmt.Errorf("failed to convert AE id of ether802_3ad argument '%s' in integer: %w",
 					d.Get("ether802_3ad").(string), err)
 			}
 			aggregatedCountInt, err := strconv.Atoi(aggregatedCount)
 			if err != nil {
-				return fmt.Errorf("failed to convert internal variable aggregatedCountInt in integer : %w", err)
+				return fmt.Errorf("failed to convert internal variable aggregatedCountInt in integer: %w", err)
 			}
 			if aggregatedCountInt < aeInt+1 {
 				oAEintNC, oAEintEmpty, err := checkInterfaceNC(d.Get("ether802_3ad").(string), m, jnprSess)
@@ -1617,7 +1617,7 @@ func readFamilyInetAddressOld(item string, inetAddress []map[string]interface{},
 			vrrpGroup["authentication_key"], err = jdecode.Decode(strings.Trim(strings.TrimPrefix(itemTrimVrrp,
 				"authentication-key "), "\""))
 			if err != nil {
-				return inetAddress, fmt.Errorf("failed to decode authentication-key : %w", err)
+				return inetAddress, fmt.Errorf("failed to decode authentication-key: %w", err)
 			}
 		case strings.HasPrefix(itemTrimVrrp, "authentication-type "):
 			vrrpGroup["authentication_type"] = strings.TrimPrefix(itemTrimVrrp, "authentication-type ")
@@ -1780,7 +1780,7 @@ func aggregatedCountSearchMax(newAE, oldAE, interFace string, m interface{}, jnp
 	newAENum := strings.TrimPrefix(newAE, "ae")
 	newAENumInt, err := strconv.Atoi(newAENum)
 	if err != nil {
-		return "", fmt.Errorf("failed to convert internal variable newAENum to integer : %w", err)
+		return "", fmt.Errorf("failed to convert internal variable newAENum to integer: %w", err)
 	}
 	intShowInt, err := sess.command("show interfaces terse", jnprSess)
 	if err != nil {
@@ -1811,7 +1811,7 @@ func aggregatedCountSearchMax(newAE, oldAE, interFace string, m interface{}, jnp
 	if len(intShowAE) > 0 {
 		lastAeInt, err := strconv.Atoi(strings.TrimPrefix(intShowAE[len(intShowAE)-1], "ae"))
 		if err != nil {
-			return "", fmt.Errorf("failed to convert internal variable lastAeInt to integer : %w", err)
+			return "", fmt.Errorf("failed to convert internal variable lastAeInt to integer: %w", err)
 		}
 		if lastAeInt > newAENumInt {
 			return strconv.Itoa(lastAeInt + 1), nil

--- a/junos/resource_interface.go
+++ b/junos/resource_interface.go
@@ -452,7 +452,7 @@ func resourceInterfaceCreate(ctx context.Context, d *schema.ResourceData, m inte
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -570,7 +570,7 @@ func resourceInterfaceCreate(ctx context.Context, d *schema.ResourceData, m inte
 
 func resourceInterfaceRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -618,7 +618,7 @@ func resourceInterfaceReadWJnprSess(d *schema.ResourceData, m interface{}, jnprS
 func resourceInterfaceUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	d.Partial(true)
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -780,7 +780,7 @@ func resourceInterfaceUpdate(ctx context.Context, d *schema.ResourceData, m inte
 
 func resourceInterfaceDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -828,7 +828,7 @@ func resourceInterfaceDelete(ctx context.Context, d *schema.ResourceData, m inte
 func resourceInterfaceImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_interface_logical.go
+++ b/junos/resource_interface_logical.go
@@ -1580,7 +1580,7 @@ func readFamilyInetAddress(item string, inetAddress []map[string]interface{}, fa
 			vrrpGroup["authentication_key"], err = jdecode.Decode(strings.Trim(strings.TrimPrefix(itemTrimVrrp,
 				"authentication-key "), "\""))
 			if err != nil {
-				return inetAddress, fmt.Errorf("failed to decode authentication-key : %w", err)
+				return inetAddress, fmt.Errorf("failed to decode authentication-key: %w", err)
 			}
 		case strings.HasPrefix(itemTrimVrrp, "authentication-type "):
 			vrrpGroup["authentication_type"] = strings.TrimPrefix(itemTrimVrrp, "authentication-type ")

--- a/junos/resource_interface_logical.go
+++ b/junos/resource_interface_logical.go
@@ -27,10 +27,10 @@ type interfaceLogicalOptions struct {
 
 func resourceInterfaceLogical() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceInterfaceLogicalCreate,
-		ReadContext:   resourceInterfaceLogicalRead,
-		UpdateContext: resourceInterfaceLogicalUpdate,
-		DeleteContext: resourceInterfaceLogicalDelete,
+		CreateWithoutTimeout: resourceInterfaceLogicalCreate,
+		ReadWithoutTimeout:   resourceInterfaceLogicalRead,
+		UpdateWithoutTimeout: resourceInterfaceLogicalUpdate,
+		DeleteWithoutTimeout: resourceInterfaceLogicalDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceInterfaceLogicalImport,
 		},
@@ -630,7 +630,9 @@ func resourceInterfaceLogicalCreate(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	ncInt, emptyInt, _, err := checkInterfaceLogicalNCEmpty(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -806,7 +808,9 @@ func resourceInterfaceLogicalUpdate(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delInterfaceLogicalOpts(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -905,7 +909,9 @@ func resourceInterfaceLogicalDelete(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delInterfaceLogical(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_interface_logical.go
+++ b/junos/resource_interface_logical.go
@@ -625,7 +625,7 @@ func resourceInterfaceLogicalCreate(ctx context.Context, d *schema.ResourceData,
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -723,7 +723,7 @@ func resourceInterfaceLogicalCreate(ctx context.Context, d *schema.ResourceData,
 
 func resourceInterfaceLogicalRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -803,7 +803,7 @@ func resourceInterfaceLogicalUpdate(ctx context.Context, d *schema.ResourceData,
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -904,7 +904,7 @@ func resourceInterfaceLogicalDelete(ctx context.Context, d *schema.ResourceData,
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -935,7 +935,7 @@ func resourceInterfaceLogicalImport(ctx context.Context, d *schema.ResourceData,
 		return nil, fmt.Errorf("name of interface %s need to have 1 dot", d.Id())
 	}
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_interface_physical.go
+++ b/junos/resource_interface_physical.go
@@ -31,10 +31,10 @@ type interfacePhysicalOptions struct {
 
 func resourceInterfacePhysical() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceInterfacePhysicalCreate,
-		ReadContext:   resourceInterfacePhysicalRead,
-		UpdateContext: resourceInterfacePhysicalUpdate,
-		DeleteContext: resourceInterfacePhysicalDelete,
+		CreateWithoutTimeout: resourceInterfacePhysicalCreate,
+		ReadWithoutTimeout:   resourceInterfacePhysicalRead,
+		UpdateWithoutTimeout: resourceInterfacePhysicalUpdate,
+		DeleteWithoutTimeout: resourceInterfacePhysicalDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceInterfacePhysicalImport,
 		},
@@ -505,7 +505,9 @@ func resourceInterfacePhysicalCreate(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	ncInt, emptyInt, err := checkInterfacePhysicalNCEmpty(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -629,7 +631,9 @@ func resourceInterfacePhysicalUpdate(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delInterfacePhysicalOpts(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -672,7 +676,9 @@ func resourceInterfacePhysicalDelete(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delInterfacePhysical(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_interface_physical.go
+++ b/junos/resource_interface_physical.go
@@ -1298,7 +1298,7 @@ func readInterfacePhysicalEsi(confRead *interfacePhysicalOptions, item string) e
 	var err error
 	identifier, err := regexp.MatchString(`^([\d\w]{2}:){9}[\d\w]{2}`, itemTrim)
 	if err != nil {
-		return fmt.Errorf("esi_identifier regexp error : %w", err)
+		return fmt.Errorf("esi_identifier regexp error: %w", err)
 	}
 	switch {
 	case identifier:
@@ -1777,7 +1777,7 @@ func interfaceAggregatedCountSearchMax(newAE, oldAE, interFace string, m interfa
 	newAENum := strings.TrimPrefix(newAE, "ae")
 	newAENumInt, err := strconv.Atoi(newAENum)
 	if err != nil {
-		return "", fmt.Errorf("failed to convert ae interaface '%v' to integer : %w", newAE, err)
+		return "", fmt.Errorf("failed to convert ae interaface '%v' to integer: %w", newAE, err)
 	}
 	showConfig, err := sess.command(cmdShowConfig+"interfaces"+pipeDisplaySetRelative, jnprSess)
 	if err != nil {
@@ -1819,7 +1819,7 @@ func interfaceAggregatedCountSearchMax(newAE, oldAE, interFace string, m interfa
 		balt.SortStringsByLengthInc(listAEFound)
 		lastAeInt, err := strconv.Atoi(strings.TrimPrefix(listAEFound[len(listAEFound)-1], "ae"))
 		if err != nil {
-			return "", fmt.Errorf("failed to convert internal variable lastAeInt to integer : %w", err)
+			return "", fmt.Errorf("failed to convert internal variable lastAeInt to integer: %w", err)
 		}
 		if lastAeInt > newAENumInt {
 			return strconv.Itoa(lastAeInt + 1), nil

--- a/junos/resource_interface_physical.go
+++ b/junos/resource_interface_physical.go
@@ -500,7 +500,7 @@ func resourceInterfacePhysicalCreate(ctx context.Context, d *schema.ResourceData
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -564,7 +564,7 @@ func resourceInterfacePhysicalCreate(ctx context.Context, d *schema.ResourceData
 
 func resourceInterfacePhysicalRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -626,7 +626,7 @@ func resourceInterfacePhysicalUpdate(ctx context.Context, d *schema.ResourceData
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -671,7 +671,7 @@ func resourceInterfacePhysicalDelete(ctx context.Context, d *schema.ResourceData
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -721,7 +721,7 @@ func resourceInterfacePhysicalImport(ctx context.Context, d *schema.ResourceData
 		return nil, fmt.Errorf("name of interface %s need to doesn't have a dot", d.Id())
 	}
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_interface_physical_disable.go
+++ b/junos/resource_interface_physical_disable.go
@@ -11,9 +11,9 @@ import (
 
 func resourceInterfacePhysicalDisable() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceInterfacePhysicalDisableCreate,
-		ReadContext:   resourceInterfacePhysicalDisableRead,
-		DeleteContext: resourceInterfacePhysicalDisableDelete,
+		CreateWithoutTimeout: resourceInterfacePhysicalDisableCreate,
+		ReadWithoutTimeout:   resourceInterfacePhysicalDisableRead,
+		DeleteWithoutTimeout: resourceInterfacePhysicalDisableDelete,
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
@@ -49,7 +49,9 @@ func resourceInterfacePhysicalDisableCreate(ctx context.Context, d *schema.Resou
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	ncInt, emptyInt, err := checkInterfacePhysicalNCEmpty(d.Get("name").(string), m, jnprSess)
 	if err != nil {

--- a/junos/resource_interface_physical_disable.go
+++ b/junos/resource_interface_physical_disable.go
@@ -44,7 +44,7 @@ func resourceInterfacePhysicalDisableCreate(ctx context.Context, d *schema.Resou
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -111,7 +111,7 @@ func resourceInterfacePhysicalDisableCreate(ctx context.Context, d *schema.Resou
 
 func resourceInterfacePhysicalDisableRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/junos/resource_interface_st0_unit.go
+++ b/junos/resource_interface_st0_unit.go
@@ -13,9 +13,9 @@ import (
 
 func resourceInterfaceSt0Unit() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceInterfaceSt0UnitCreate,
-		ReadContext:   resourceInterfaceSt0UnitRead,
-		DeleteContext: resourceInterfaceSt0UnitDelete,
+		CreateWithoutTimeout: resourceInterfaceSt0UnitCreate,
+		ReadWithoutTimeout:   resourceInterfaceSt0UnitRead,
+		DeleteWithoutTimeout: resourceInterfaceSt0UnitDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceInterfaceSt0UnitImport,
 		},
@@ -29,7 +29,9 @@ func resourceInterfaceSt0UnitCreate(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	newSt0, err := searchInterfaceSt0UnitToCreate(m, jnprSess)
 	if err != nil {
@@ -100,7 +102,9 @@ func resourceInterfaceSt0UnitDelete(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	ncInt, emptyInt, _, err := checkInterfaceLogicalNCEmpty(d.Id(), m, jnprSess)
 	if err != nil {

--- a/junos/resource_interface_st0_unit.go
+++ b/junos/resource_interface_st0_unit.go
@@ -37,7 +37,7 @@ func resourceInterfaceSt0UnitCreate(ctx context.Context, d *schema.ResourceData,
 	if err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
 
-		return append(diagWarns, diag.FromErr(fmt.Errorf("error for find new st0 unit interface : %w", err))...)
+		return append(diagWarns, diag.FromErr(fmt.Errorf("error to find new st0 unit interface: %w", err))...)
 	}
 	if err := sess.configSet([]string{"set interfaces " + newSt0}, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_interface_st0_unit.go
+++ b/junos/resource_interface_st0_unit.go
@@ -24,7 +24,7 @@ func resourceInterfaceSt0Unit() *schema.Resource {
 
 func resourceInterfaceSt0UnitCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -70,7 +70,7 @@ func resourceInterfaceSt0UnitCreate(ctx context.Context, d *schema.ResourceData,
 
 func resourceInterfaceSt0UnitRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -97,7 +97,7 @@ func resourceInterfaceSt0UnitDelete(ctx context.Context, d *schema.ResourceData,
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -139,7 +139,7 @@ func resourceInterfaceSt0UnitImport(ctx context.Context, d *schema.ResourceData,
 	if !strings.HasPrefix(d.Id(), "st0.") {
 		return nil, fmt.Errorf("id must be start with 'st0.'")
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_layer2_control.go
+++ b/junos/resource_layer2_control.go
@@ -122,7 +122,7 @@ func resourceLayer2ControlCreate(ctx context.Context, d *schema.ResourceData, m 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -150,7 +150,7 @@ func resourceLayer2ControlCreate(ctx context.Context, d *schema.ResourceData, m 
 
 func resourceLayer2ControlRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -186,7 +186,7 @@ func resourceLayer2ControlUpdate(ctx context.Context, d *schema.ResourceData, m 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -226,7 +226,7 @@ func resourceLayer2ControlDelete(ctx context.Context, d *schema.ResourceData, m 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -254,7 +254,7 @@ func resourceLayer2ControlDelete(ctx context.Context, d *schema.ResourceData, m 
 func resourceLayer2ControlImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_layer2_control.go
+++ b/junos/resource_layer2_control.go
@@ -20,10 +20,10 @@ type layer2ControlOptions struct {
 
 func resourceLayer2Control() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceLayer2ControlCreate,
-		ReadContext:   resourceLayer2ControlRead,
-		UpdateContext: resourceLayer2ControlUpdate,
-		DeleteContext: resourceLayer2ControlDelete,
+		CreateWithoutTimeout: resourceLayer2ControlCreate,
+		ReadWithoutTimeout:   resourceLayer2ControlRead,
+		UpdateWithoutTimeout: resourceLayer2ControlUpdate,
+		DeleteWithoutTimeout: resourceLayer2ControlDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceLayer2ControlImport,
 		},
@@ -127,7 +127,9 @@ func resourceLayer2ControlCreate(ctx context.Context, d *schema.ResourceData, m 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := setLayer2Control(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -189,7 +191,9 @@ func resourceLayer2ControlUpdate(ctx context.Context, d *schema.ResourceData, m 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delLayer2Control(m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -227,7 +231,9 @@ func resourceLayer2ControlDelete(ctx context.Context, d *schema.ResourceData, m 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delLayer2Control(m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_lldp_interface.go
+++ b/junos/resource_lldp_interface.go
@@ -95,7 +95,7 @@ func resourceLldpInterfaceCreate(ctx context.Context, d *schema.ResourceData, m 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -145,7 +145,7 @@ func resourceLldpInterfaceCreate(ctx context.Context, d *schema.ResourceData, m 
 
 func resourceLldpInterfaceRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -185,7 +185,7 @@ func resourceLldpInterfaceUpdate(ctx context.Context, d *schema.ResourceData, m 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -225,7 +225,7 @@ func resourceLldpInterfaceDelete(ctx context.Context, d *schema.ResourceData, m 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -253,7 +253,7 @@ func resourceLldpInterfaceDelete(ctx context.Context, d *schema.ResourceData, m 
 func resourceLldpInterfaceImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_lldp_interface.go
+++ b/junos/resource_lldp_interface.go
@@ -20,10 +20,10 @@ type lldpInterfaceOptions struct {
 
 func resourceLldpInterface() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceLldpInterfaceCreate,
-		ReadContext:   resourceLldpInterfaceRead,
-		UpdateContext: resourceLldpInterfaceUpdate,
-		DeleteContext: resourceLldpInterfaceDelete,
+		CreateWithoutTimeout: resourceLldpInterfaceCreate,
+		ReadWithoutTimeout:   resourceLldpInterfaceRead,
+		UpdateWithoutTimeout: resourceLldpInterfaceUpdate,
+		DeleteWithoutTimeout: resourceLldpInterfaceDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceLldpInterfaceImport,
 		},
@@ -100,7 +100,9 @@ func resourceLldpInterfaceCreate(ctx context.Context, d *schema.ResourceData, m 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	lldpInterfaceExists, err := checkLldpInterfaceExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -188,7 +190,9 @@ func resourceLldpInterfaceUpdate(ctx context.Context, d *schema.ResourceData, m 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delLldpInterface(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -226,7 +230,9 @@ func resourceLldpInterfaceDelete(ctx context.Context, d *schema.ResourceData, m 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delLldpInterface(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_lldpmed_interface.go
+++ b/junos/resource_lldpmed_interface.go
@@ -21,10 +21,10 @@ type lldpMedInterfaceOptions struct {
 
 func resourceLldpMedInterface() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceLldpMedInterfaceCreate,
-		ReadContext:   resourceLldpMedInterfaceRead,
-		UpdateContext: resourceLldpMedInterfaceUpdate,
-		DeleteContext: resourceLldpMedInterfaceDelete,
+		CreateWithoutTimeout: resourceLldpMedInterfaceCreate,
+		ReadWithoutTimeout:   resourceLldpMedInterfaceRead,
+		UpdateWithoutTimeout: resourceLldpMedInterfaceUpdate,
+		DeleteWithoutTimeout: resourceLldpMedInterfaceDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceLldpMedInterfaceImport,
 		},
@@ -145,7 +145,9 @@ func resourceLldpMedInterfaceCreate(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	lldpMedInterfaceExists, err := checkLldpMedInterfaceExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -233,7 +235,9 @@ func resourceLldpMedInterfaceUpdate(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delLldpMedInterface(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -271,7 +275,9 @@ func resourceLldpMedInterfaceDelete(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delLldpMedInterface(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_lldpmed_interface.go
+++ b/junos/resource_lldpmed_interface.go
@@ -140,7 +140,7 @@ func resourceLldpMedInterfaceCreate(ctx context.Context, d *schema.ResourceData,
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -190,7 +190,7 @@ func resourceLldpMedInterfaceCreate(ctx context.Context, d *schema.ResourceData,
 
 func resourceLldpMedInterfaceRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -230,7 +230,7 @@ func resourceLldpMedInterfaceUpdate(ctx context.Context, d *schema.ResourceData,
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -270,7 +270,7 @@ func resourceLldpMedInterfaceDelete(ctx context.Context, d *schema.ResourceData,
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -298,7 +298,7 @@ func resourceLldpMedInterfaceDelete(ctx context.Context, d *schema.ResourceData,
 func resourceLldpMedInterfaceImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_null_commit_file.go
+++ b/junos/resource_null_commit_file.go
@@ -101,11 +101,11 @@ func readNullCommitFile(filename string) ([]string, error) {
 		return []string{}, err
 	}
 	if _, err := os.Stat(filename); os.IsNotExist(err) {
-		return []string{}, fmt.Errorf("file `%s` doesn't exist", filename)
+		return []string{}, fmt.Errorf("file '%s' doesn't exist", filename)
 	}
 	fileReadByte, err := ioutil.ReadFile(filename)
 	if err != nil {
-		return []string{}, fmt.Errorf("could not read file `%s` : %w", filename, err)
+		return []string{}, fmt.Errorf("could not read file '%s': %w", filename, err)
 	}
 
 	return strings.Split(string(fileReadByte), "\n"), nil
@@ -117,10 +117,10 @@ func cleanNullCommitFile(filename string, sess *Session) error {
 	}
 	f, err := os.OpenFile(filename, os.O_TRUNC, os.FileMode(sess.junosFilePermission))
 	if err != nil {
-		return fmt.Errorf("could not open file `%s` to truncate after commit : %w", filename, err)
+		return fmt.Errorf("could not open file '%s' to truncate after commit: %w", filename, err)
 	}
 	if err := f.Close(); err != nil {
-		return fmt.Errorf("could not close file handler for `%s` after truncation : %w", filename, err)
+		return fmt.Errorf("could not close file handler for '%s' after truncation: %w", filename, err)
 	}
 
 	return nil

--- a/junos/resource_null_commit_file.go
+++ b/junos/resource_null_commit_file.go
@@ -13,9 +13,9 @@ import (
 
 func resourceNullCommitFile() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceNullCommitFileCreate,
-		ReadContext:   resourceNullCommitFileRead,
-		DeleteContext: resourceNullCommitFileDelete,
+		CreateWithoutTimeout: resourceNullCommitFileCreate,
+		ReadWithoutTimeout:   resourceNullCommitFileRead,
+		DeleteWithoutTimeout: resourceNullCommitFileDelete,
 		Schema: map[string]*schema.Schema{
 			"filename": {
 				Type:     schema.TypeString,
@@ -50,7 +50,9 @@ func resourceNullCommitFileCreate(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	fileName := d.Get("filename").(string)
 	configSet, err := readNullCommitFile(fileName)

--- a/junos/resource_null_commit_file.go
+++ b/junos/resource_null_commit_file.go
@@ -45,7 +45,7 @@ func resourceNullCommitFile() *schema.Resource {
 
 func resourceNullCommitFileCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/junos/resource_ospf.go
+++ b/junos/resource_ospf.go
@@ -39,10 +39,10 @@ type ospfOptions struct {
 
 func resourceOspf() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceOspfCreate,
-		ReadContext:   resourceOspfRead,
-		UpdateContext: resourceOspfUpdate,
-		DeleteContext: resourceOspfDelete,
+		CreateWithoutTimeout: resourceOspfCreate,
+		ReadWithoutTimeout:   resourceOspfRead,
+		UpdateWithoutTimeout: resourceOspfUpdate,
+		DeleteWithoutTimeout: resourceOspfDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceOspfImport,
 		},
@@ -290,7 +290,9 @@ func resourceOspfCreate(ctx context.Context, d *schema.ResourceData, m interface
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if d.Get("routing_instance").(string) != defaultW {
 		instanceExists, err := checkRoutingInstanceExists(d.Get("routing_instance").(string), m, jnprSess)
@@ -379,7 +381,9 @@ func resourceOspfUpdate(ctx context.Context, d *schema.ResourceData, m interface
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delOspf(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -418,7 +422,9 @@ func resourceOspfDelete(ctx context.Context, d *schema.ResourceData, m interface
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delOspf(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_ospf.go
+++ b/junos/resource_ospf.go
@@ -285,7 +285,7 @@ func resourceOspfCreate(ctx context.Context, d *schema.ResourceData, m interface
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -327,7 +327,7 @@ func resourceOspfCreate(ctx context.Context, d *schema.ResourceData, m interface
 
 func resourceOspfRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -376,7 +376,7 @@ func resourceOspfUpdate(ctx context.Context, d *schema.ResourceData, m interface
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -417,7 +417,7 @@ func resourceOspfDelete(ctx context.Context, d *schema.ResourceData, m interface
 		return nil
 	}
 
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -445,7 +445,7 @@ func resourceOspfDelete(ctx context.Context, d *schema.ResourceData, m interface
 func resourceOspfImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_ospf_area.go
+++ b/junos/resource_ospf_area.go
@@ -882,7 +882,7 @@ func readOspfArea(idArea, version, routingInstance string, m interface{}, jnprSe
 					interfaceOptions["authentication_simple_password"], err = jdecode.Decode(strings.Trim(strings.TrimPrefix(
 						itemTrimInterface, "authentication simple-password "), "\""))
 					if err != nil {
-						return confRead, fmt.Errorf("failed to decode authentication simple-password : %w", err)
+						return confRead, fmt.Errorf("failed to decode authentication simple-password: %w", err)
 					}
 				case strings.HasPrefix(itemTrimInterface, "authentication md5 "):
 					itemTrimInterfaceSplit := strings.Split(strings.TrimPrefix(itemTrimInterface, "authentication md5 "), " ")
@@ -904,7 +904,7 @@ func readOspfArea(idArea, version, routingInstance string, m interface{}, jnprSe
 						authMD5["key"], err = jdecode.Decode(strings.Trim(strings.TrimPrefix(
 							itemTrimAuthMD5, "key "), "\""))
 						if err != nil {
-							return confRead, fmt.Errorf("failed to decode authentication md5 key : %w", err)
+							return confRead, fmt.Errorf("failed to decode authentication md5 key: %w", err)
 						}
 					case strings.HasPrefix(itemTrimAuthMD5, "start-time "):
 						authMD5["start_time"] = strings.Split(strings.Trim(strings.TrimPrefix(

--- a/junos/resource_ospf_area.go
+++ b/junos/resource_ospf_area.go
@@ -350,7 +350,7 @@ func resourceOspfAreaCreate(ctx context.Context, d *schema.ResourceData, m inter
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -403,7 +403,7 @@ func resourceOspfAreaCreate(ctx context.Context, d *schema.ResourceData, m inter
 
 func resourceOspfAreaRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -443,7 +443,7 @@ func resourceOspfAreaUpdate(ctx context.Context, d *schema.ResourceData, m inter
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -483,7 +483,7 @@ func resourceOspfAreaDelete(ctx context.Context, d *schema.ResourceData, m inter
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -511,7 +511,7 @@ func resourceOspfAreaDelete(ctx context.Context, d *schema.ResourceData, m inter
 func resourceOspfAreaImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_ospf_area.go
+++ b/junos/resource_ospf_area.go
@@ -23,10 +23,10 @@ type ospfAreaOptions struct {
 
 func resourceOspfArea() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceOspfAreaCreate,
-		ReadContext:   resourceOspfAreaRead,
-		UpdateContext: resourceOspfAreaUpdate,
-		DeleteContext: resourceOspfAreaDelete,
+		CreateWithoutTimeout: resourceOspfAreaCreate,
+		ReadWithoutTimeout:   resourceOspfAreaRead,
+		UpdateWithoutTimeout: resourceOspfAreaUpdate,
+		DeleteWithoutTimeout: resourceOspfAreaDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceOspfAreaImport,
 		},
@@ -355,7 +355,9 @@ func resourceOspfAreaCreate(ctx context.Context, d *schema.ResourceData, m inter
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	ospfAreaExists, err := checkOspfAreaExists(d.Get("area_id").(string), d.Get("version").(string),
 		d.Get("routing_instance").(string), m, jnprSess)
@@ -446,7 +448,9 @@ func resourceOspfAreaUpdate(ctx context.Context, d *schema.ResourceData, m inter
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delOspfArea(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -484,7 +488,9 @@ func resourceOspfAreaDelete(ctx context.Context, d *schema.ResourceData, m inter
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delOspfArea(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_policyoptions_as_path.go
+++ b/junos/resource_policyoptions_as_path.go
@@ -53,7 +53,7 @@ func resourcePolicyoptionsAsPathCreate(ctx context.Context, d *schema.ResourceDa
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -103,7 +103,7 @@ func resourcePolicyoptionsAsPathCreate(ctx context.Context, d *schema.ResourceDa
 
 func resourcePolicyoptionsAsPathRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -143,7 +143,7 @@ func resourcePolicyoptionsAsPathUpdate(ctx context.Context, d *schema.ResourceDa
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -183,7 +183,7 @@ func resourcePolicyoptionsAsPathDelete(ctx context.Context, d *schema.ResourceDa
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -211,7 +211,7 @@ func resourcePolicyoptionsAsPathDelete(ctx context.Context, d *schema.ResourceDa
 func resourcePolicyoptionsAsPathImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_policyoptions_as_path.go
+++ b/junos/resource_policyoptions_as_path.go
@@ -17,10 +17,10 @@ type asPathOptions struct {
 
 func resourcePolicyoptionsAsPath() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourcePolicyoptionsAsPathCreate,
-		ReadContext:   resourcePolicyoptionsAsPathRead,
-		UpdateContext: resourcePolicyoptionsAsPathUpdate,
-		DeleteContext: resourcePolicyoptionsAsPathDelete,
+		CreateWithoutTimeout: resourcePolicyoptionsAsPathCreate,
+		ReadWithoutTimeout:   resourcePolicyoptionsAsPathRead,
+		UpdateWithoutTimeout: resourcePolicyoptionsAsPathUpdate,
+		DeleteWithoutTimeout: resourcePolicyoptionsAsPathDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourcePolicyoptionsAsPathImport,
 		},
@@ -58,7 +58,9 @@ func resourcePolicyoptionsAsPathCreate(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	policyoptsAsPathExists, err := checkPolicyoptionsAsPathExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -146,7 +148,9 @@ func resourcePolicyoptionsAsPathUpdate(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delPolicyoptionsAsPath(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -184,7 +188,9 @@ func resourcePolicyoptionsAsPathDelete(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delPolicyoptionsAsPath(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_policyoptions_as_path_group.go
+++ b/junos/resource_policyoptions_as_path_group.go
@@ -68,7 +68,7 @@ func resourcePolicyoptionsAsPathGroupCreate(ctx context.Context, d *schema.Resou
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -118,7 +118,7 @@ func resourcePolicyoptionsAsPathGroupCreate(ctx context.Context, d *schema.Resou
 
 func resourcePolicyoptionsAsPathGroupRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -159,7 +159,7 @@ func resourcePolicyoptionsAsPathGroupUpdate(ctx context.Context, d *schema.Resou
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -200,7 +200,7 @@ func resourcePolicyoptionsAsPathGroupDelete(ctx context.Context, d *schema.Resou
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -228,7 +228,7 @@ func resourcePolicyoptionsAsPathGroupDelete(ctx context.Context, d *schema.Resou
 func resourcePolicyoptionsAsPathGroupImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_policyoptions_as_path_group.go
+++ b/junos/resource_policyoptions_as_path_group.go
@@ -18,10 +18,10 @@ type asPathGroupOptions struct {
 
 func resourcePolicyoptionsAsPathGroup() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourcePolicyoptionsAsPathGroupCreate,
-		ReadContext:   resourcePolicyoptionsAsPathGroupRead,
-		UpdateContext: resourcePolicyoptionsAsPathGroupUpdate,
-		DeleteContext: resourcePolicyoptionsAsPathGroupDelete,
+		CreateWithoutTimeout: resourcePolicyoptionsAsPathGroupCreate,
+		ReadWithoutTimeout:   resourcePolicyoptionsAsPathGroupRead,
+		UpdateWithoutTimeout: resourcePolicyoptionsAsPathGroupUpdate,
+		DeleteWithoutTimeout: resourcePolicyoptionsAsPathGroupDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourcePolicyoptionsAsPathGroupImport,
 		},
@@ -73,7 +73,9 @@ func resourcePolicyoptionsAsPathGroupCreate(ctx context.Context, d *schema.Resou
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	policyoptsAsPathGroupExists, err := checkPolicyoptionsAsPathGroupExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -162,7 +164,9 @@ func resourcePolicyoptionsAsPathGroupUpdate(ctx context.Context, d *schema.Resou
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delPolicyoptionsAsPathGroup(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -201,7 +205,9 @@ func resourcePolicyoptionsAsPathGroupDelete(ctx context.Context, d *schema.Resou
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delPolicyoptionsAsPathGroup(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_policyoptions_community.go
+++ b/junos/resource_policyoptions_community.go
@@ -17,10 +17,10 @@ type communityOptions struct {
 
 func resourcePolicyoptionsCommunity() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourcePolicyoptionsCommunityCreate,
-		ReadContext:   resourcePolicyoptionsCommunityRead,
-		UpdateContext: resourcePolicyoptionsCommunityUpdate,
-		DeleteContext: resourcePolicyoptionsCommunityDelete,
+		CreateWithoutTimeout: resourcePolicyoptionsCommunityCreate,
+		ReadWithoutTimeout:   resourcePolicyoptionsCommunityRead,
+		UpdateWithoutTimeout: resourcePolicyoptionsCommunityUpdate,
+		DeleteWithoutTimeout: resourcePolicyoptionsCommunityDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourcePolicyoptionsCommunityImport,
 		},
@@ -60,7 +60,9 @@ func resourcePolicyoptionsCommunityCreate(ctx context.Context, d *schema.Resourc
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	policyoptsCommunityExists, err := checkPolicyoptionsCommunityExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -148,7 +150,9 @@ func resourcePolicyoptionsCommunityUpdate(ctx context.Context, d *schema.Resourc
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delPolicyoptionsCommunity(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -186,7 +190,9 @@ func resourcePolicyoptionsCommunityDelete(ctx context.Context, d *schema.Resourc
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delPolicyoptionsCommunity(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_policyoptions_community.go
+++ b/junos/resource_policyoptions_community.go
@@ -55,7 +55,7 @@ func resourcePolicyoptionsCommunityCreate(ctx context.Context, d *schema.Resourc
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -105,7 +105,7 @@ func resourcePolicyoptionsCommunityCreate(ctx context.Context, d *schema.Resourc
 
 func resourcePolicyoptionsCommunityRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -145,7 +145,7 @@ func resourcePolicyoptionsCommunityUpdate(ctx context.Context, d *schema.Resourc
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -185,7 +185,7 @@ func resourcePolicyoptionsCommunityDelete(ctx context.Context, d *schema.Resourc
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -213,7 +213,7 @@ func resourcePolicyoptionsCommunityDelete(ctx context.Context, d *schema.Resourc
 func resourcePolicyoptionsCommunityImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_policyoptions_policy_statement.go
+++ b/junos/resource_policyoptions_policy_statement.go
@@ -22,10 +22,10 @@ type policyStatementOptions struct {
 
 func resourcePolicyoptionsPolicyStatement() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourcePolicyoptionsPolicyStatementCreate,
-		ReadContext:   resourcePolicyoptionsPolicyStatementRead,
-		UpdateContext: resourcePolicyoptionsPolicyStatementUpdate,
-		DeleteContext: resourcePolicyoptionsPolicyStatementDelete,
+		CreateWithoutTimeout: resourcePolicyoptionsPolicyStatementCreate,
+		ReadWithoutTimeout:   resourcePolicyoptionsPolicyStatementRead,
+		UpdateWithoutTimeout: resourcePolicyoptionsPolicyStatementUpdate,
+		DeleteWithoutTimeout: resourcePolicyoptionsPolicyStatementDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourcePolicyoptionsPolicyStatementImport,
 		},
@@ -427,7 +427,9 @@ func resourcePolicyoptionsPolicyStatementCreate(ctx context.Context, d *schema.R
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	policyStatementExists, err := checkPolicyStatementExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -552,7 +554,9 @@ func resourcePolicyoptionsPolicyStatementUpdate(ctx context.Context, d *schema.R
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delPolicyStatement(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -612,7 +616,9 @@ func resourcePolicyoptionsPolicyStatementDelete(ctx context.Context, d *schema.R
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delPolicyStatement(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_policyoptions_policy_statement.go
+++ b/junos/resource_policyoptions_policy_statement.go
@@ -422,7 +422,7 @@ func resourcePolicyoptionsPolicyStatementCreate(ctx context.Context, d *schema.R
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -480,7 +480,7 @@ func resourcePolicyoptionsPolicyStatementCreate(ctx context.Context, d *schema.R
 func resourcePolicyoptionsPolicyStatementRead(ctx context.Context, d *schema.ResourceData, m interface{},
 ) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -549,7 +549,7 @@ func resourcePolicyoptionsPolicyStatementUpdate(ctx context.Context, d *schema.R
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -611,7 +611,7 @@ func resourcePolicyoptionsPolicyStatementDelete(ctx context.Context, d *schema.R
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -646,7 +646,7 @@ func resourcePolicyoptionsPolicyStatementDelete(ctx context.Context, d *schema.R
 func resourcePolicyoptionsPolicyStatementImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_policyoptions_prefix_list.go
+++ b/junos/resource_policyoptions_prefix_list.go
@@ -18,10 +18,10 @@ type prefixListOptions struct {
 
 func resourcePolicyoptionsPrefixList() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourcePolicyoptionsPrefixListCreate,
-		ReadContext:   resourcePolicyoptionsPrefixListRead,
-		UpdateContext: resourcePolicyoptionsPrefixListUpdate,
-		DeleteContext: resourcePolicyoptionsPrefixListDelete,
+		CreateWithoutTimeout: resourcePolicyoptionsPrefixListCreate,
+		ReadWithoutTimeout:   resourcePolicyoptionsPrefixListRead,
+		UpdateWithoutTimeout: resourcePolicyoptionsPrefixListUpdate,
+		DeleteWithoutTimeout: resourcePolicyoptionsPrefixListDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourcePolicyoptionsPrefixListImport,
 		},
@@ -65,7 +65,9 @@ func resourcePolicyoptionsPrefixListCreate(ctx context.Context, d *schema.Resour
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	policyoptsPrefixListExists, err := checkPolicyoptionsPrefixListExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -154,7 +156,9 @@ func resourcePolicyoptionsPrefixListUpdate(ctx context.Context, d *schema.Resour
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delPolicyoptionsPrefixList(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -193,7 +197,9 @@ func resourcePolicyoptionsPrefixListDelete(ctx context.Context, d *schema.Resour
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delPolicyoptionsPrefixList(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_policyoptions_prefix_list.go
+++ b/junos/resource_policyoptions_prefix_list.go
@@ -60,7 +60,7 @@ func resourcePolicyoptionsPrefixListCreate(ctx context.Context, d *schema.Resour
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -110,7 +110,7 @@ func resourcePolicyoptionsPrefixListCreate(ctx context.Context, d *schema.Resour
 
 func resourcePolicyoptionsPrefixListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -151,7 +151,7 @@ func resourcePolicyoptionsPrefixListUpdate(ctx context.Context, d *schema.Resour
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -192,7 +192,7 @@ func resourcePolicyoptionsPrefixListDelete(ctx context.Context, d *schema.Resour
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -220,7 +220,7 @@ func resourcePolicyoptionsPrefixListDelete(ctx context.Context, d *schema.Resour
 func resourcePolicyoptionsPrefixListImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_rib_group.go
+++ b/junos/resource_rib_group.go
@@ -18,10 +18,10 @@ type ribGroupOptions struct {
 
 func resourceRibGroup() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceRibGroupCreate,
-		ReadContext:   resourceRibGroupRead,
-		UpdateContext: resourceRibGroupUpdate,
-		DeleteContext: resourceRibGroupDelete,
+		CreateWithoutTimeout: resourceRibGroupCreate,
+		ReadWithoutTimeout:   resourceRibGroupRead,
+		UpdateWithoutTimeout: resourceRibGroupUpdate,
+		DeleteWithoutTimeout: resourceRibGroupDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceRibGroupImport,
 		},
@@ -68,7 +68,9 @@ func resourceRibGroupCreate(ctx context.Context, d *schema.ResourceData, m inter
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	ribGroupExists, err := checkRibGroupExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -168,7 +170,9 @@ func resourceRibGroupUpdate(ctx context.Context, d *schema.ResourceData, m inter
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if d.HasChange("import_policy") {
 		err = delRibGroupElement("import-policy", d.Get("name").(string), m, jnprSess)
@@ -225,7 +229,9 @@ func resourceRibGroupDelete(ctx context.Context, d *schema.ResourceData, m inter
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delRibGroup(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_rib_group.go
+++ b/junos/resource_rib_group.go
@@ -63,7 +63,7 @@ func resourceRibGroupCreate(ctx context.Context, d *schema.ResourceData, m inter
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -111,7 +111,7 @@ func resourceRibGroupCreate(ctx context.Context, d *schema.ResourceData, m inter
 
 func resourceRibGroupRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -165,7 +165,7 @@ func resourceRibGroupUpdate(ctx context.Context, d *schema.ResourceData, m inter
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -224,7 +224,7 @@ func resourceRibGroupDelete(ctx context.Context, d *schema.ResourceData, m inter
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -252,7 +252,7 @@ func resourceRibGroupDelete(ctx context.Context, d *schema.ResourceData, m inter
 func resourceRibGroupImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_routing_instance.go
+++ b/junos/resource_routing_instance.go
@@ -152,7 +152,7 @@ func resourceRoutingInstanceCreate(ctx context.Context, d *schema.ResourceData, 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -200,7 +200,7 @@ func resourceRoutingInstanceCreate(ctx context.Context, d *schema.ResourceData, 
 
 func resourceRoutingInstanceRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -240,7 +240,7 @@ func resourceRoutingInstanceUpdate(ctx context.Context, d *schema.ResourceData, 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -280,7 +280,7 @@ func resourceRoutingInstanceDelete(ctx context.Context, d *schema.ResourceData, 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -308,7 +308,7 @@ func resourceRoutingInstanceDelete(ctx context.Context, d *schema.ResourceData, 
 func resourceRoutingInstanceImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_routing_instance.go
+++ b/junos/resource_routing_instance.go
@@ -31,10 +31,10 @@ type instanceOptions struct {
 
 func resourceRoutingInstance() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceRoutingInstanceCreate,
-		ReadContext:   resourceRoutingInstanceRead,
-		UpdateContext: resourceRoutingInstanceUpdate,
-		DeleteContext: resourceRoutingInstanceDelete,
+		CreateWithoutTimeout: resourceRoutingInstanceCreate,
+		ReadWithoutTimeout:   resourceRoutingInstanceRead,
+		UpdateWithoutTimeout: resourceRoutingInstanceUpdate,
+		DeleteWithoutTimeout: resourceRoutingInstanceDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceRoutingInstanceImport,
 		},
@@ -157,7 +157,9 @@ func resourceRoutingInstanceCreate(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	routingInstanceExists, err := checkRoutingInstanceExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -243,7 +245,9 @@ func resourceRoutingInstanceUpdate(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delRoutingInstanceOpts(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -281,7 +285,9 @@ func resourceRoutingInstanceDelete(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delRoutingInstance(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_routing_options.go
+++ b/junos/resource_routing_options.go
@@ -188,7 +188,7 @@ func resourceRoutingOptionsCreate(ctx context.Context, d *schema.ResourceData, m
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -216,7 +216,7 @@ func resourceRoutingOptionsCreate(ctx context.Context, d *schema.ResourceData, m
 
 func resourceRoutingOptionsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -275,7 +275,7 @@ func resourceRoutingOptionsUpdate(ctx context.Context, d *schema.ResourceData, m
 
 		return diagWarns
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -315,7 +315,7 @@ func resourceRoutingOptionsDelete(ctx context.Context, d *schema.ResourceData, m
 
 			return nil
 		}
-		jnprSess, err := sess.startNewSession()
+		jnprSess, err := sess.startNewSession(ctx)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -344,7 +344,7 @@ func resourceRoutingOptionsDelete(ctx context.Context, d *schema.ResourceData, m
 func resourceRoutingOptionsImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_routing_options.go
+++ b/junos/resource_routing_options.go
@@ -23,10 +23,10 @@ type routingOptionsOptions struct {
 
 func resourceRoutingOptions() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceRoutingOptionsCreate,
-		ReadContext:   resourceRoutingOptionsRead,
-		UpdateContext: resourceRoutingOptionsUpdate,
-		DeleteContext: resourceRoutingOptionsDelete,
+		CreateWithoutTimeout: resourceRoutingOptionsCreate,
+		ReadWithoutTimeout:   resourceRoutingOptionsRead,
+		UpdateWithoutTimeout: resourceRoutingOptionsUpdate,
+		DeleteWithoutTimeout: resourceRoutingOptionsDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceRoutingOptionsImport,
 		},
@@ -193,7 +193,9 @@ func resourceRoutingOptionsCreate(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := setRoutingOptions(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -278,7 +280,9 @@ func resourceRoutingOptionsUpdate(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	if err := delRoutingOptions(fwTableExportConfigSingly, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
 
@@ -316,7 +320,9 @@ func resourceRoutingOptionsDelete(ctx context.Context, d *schema.ResourceData, m
 			return diag.FromErr(err)
 		}
 		defer sess.closeSession(jnprSess)
-		sess.configLock(jnprSess)
+		if err := sess.configLock(ctx, jnprSess); err != nil {
+			return diag.FromErr(err)
+		}
 		var diagWarns diag.Diagnostics
 		if err := delRoutingOptions(d.Get("forwarding_table_export_configure_singly").(bool), m, jnprSess); err != nil {
 			appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_rstp.go
+++ b/junos/resource_rstp.go
@@ -33,10 +33,10 @@ type rstpOptions struct {
 
 func resourceRstp() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceRstpCreate,
-		ReadContext:   resourceRstpRead,
-		UpdateContext: resourceRstpUpdate,
-		DeleteContext: resourceRstpDelete,
+		CreateWithoutTimeout: resourceRstpCreate,
+		ReadWithoutTimeout:   resourceRstpRead,
+		UpdateWithoutTimeout: resourceRstpUpdate,
+		DeleteWithoutTimeout: resourceRstpDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceRstpImport,
 		},
@@ -149,7 +149,9 @@ func resourceRstpCreate(ctx context.Context, d *schema.ResourceData, m interface
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if d.Get("routing_instance").(string) != defaultW {
 		instanceExists, err := checkRoutingInstanceExists(d.Get("routing_instance").(string), m, jnprSess)
@@ -238,7 +240,9 @@ func resourceRstpUpdate(ctx context.Context, d *schema.ResourceData, m interface
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delRstp(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -276,7 +280,9 @@ func resourceRstpDelete(ctx context.Context, d *schema.ResourceData, m interface
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delRstp(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_rstp.go
+++ b/junos/resource_rstp.go
@@ -144,7 +144,7 @@ func resourceRstpCreate(ctx context.Context, d *schema.ResourceData, m interface
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -186,7 +186,7 @@ func resourceRstpCreate(ctx context.Context, d *schema.ResourceData, m interface
 
 func resourceRstpRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -235,7 +235,7 @@ func resourceRstpUpdate(ctx context.Context, d *schema.ResourceData, m interface
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -275,7 +275,7 @@ func resourceRstpDelete(ctx context.Context, d *schema.ResourceData, m interface
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -303,7 +303,7 @@ func resourceRstpDelete(ctx context.Context, d *schema.ResourceData, m interface
 func resourceRstpImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_rstp_interface.go
+++ b/junos/resource_rstp_interface.go
@@ -105,7 +105,7 @@ func resourceRstpInterfaceCreate(ctx context.Context, d *schema.ResourceData, m 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -182,7 +182,7 @@ func resourceRstpInterfaceCreate(ctx context.Context, d *schema.ResourceData, m 
 
 func resourceRstpInterfaceRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -223,7 +223,7 @@ func resourceRstpInterfaceUpdate(ctx context.Context, d *schema.ResourceData, m 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -263,7 +263,7 @@ func resourceRstpInterfaceDelete(ctx context.Context, d *schema.ResourceData, m 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -291,7 +291,7 @@ func resourceRstpInterfaceDelete(ctx context.Context, d *schema.ResourceData, m 
 func resourceRstpInterfaceImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_rstp_interface.go
+++ b/junos/resource_rstp_interface.go
@@ -26,10 +26,10 @@ type rstpInterfaceOptions struct {
 
 func resourceRstpInterface() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceRstpInterfaceCreate,
-		ReadContext:   resourceRstpInterfaceRead,
-		UpdateContext: resourceRstpInterfaceUpdate,
-		DeleteContext: resourceRstpInterfaceDelete,
+		CreateWithoutTimeout: resourceRstpInterfaceCreate,
+		ReadWithoutTimeout:   resourceRstpInterfaceRead,
+		UpdateWithoutTimeout: resourceRstpInterfaceUpdate,
+		DeleteWithoutTimeout: resourceRstpInterfaceDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceRstpInterfaceImport,
 		},
@@ -110,7 +110,9 @@ func resourceRstpInterfaceCreate(ctx context.Context, d *schema.ResourceData, m 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if d.Get("routing_instance").(string) != defaultW {
 		instanceExists, err := checkRoutingInstanceExists(d.Get("routing_instance").(string), m, jnprSess)
@@ -226,7 +228,9 @@ func resourceRstpInterfaceUpdate(ctx context.Context, d *schema.ResourceData, m 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delRstpInterface(d.Get("name").(string), d.Get("routing_instance").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -264,7 +268,9 @@ func resourceRstpInterfaceDelete(ctx context.Context, d *schema.ResourceData, m 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delRstpInterface(d.Get("name").(string), d.Get("routing_instance").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_security.go
+++ b/junos/resource_security.go
@@ -846,7 +846,7 @@ func resourceSecurityCreate(ctx context.Context, d *schema.ResourceData, m inter
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -878,7 +878,7 @@ func resourceSecurityCreate(ctx context.Context, d *schema.ResourceData, m inter
 
 func resourceSecurityRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -913,7 +913,7 @@ func resourceSecurityUpdate(ctx context.Context, d *schema.ResourceData, m inter
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -954,7 +954,7 @@ func resourceSecurityDelete(ctx context.Context, d *schema.ResourceData, m inter
 
 			return nil
 		}
-		jnprSess, err := sess.startNewSession()
+		jnprSess, err := sess.startNewSession(ctx)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -983,7 +983,7 @@ func resourceSecurityDelete(ctx context.Context, d *schema.ResourceData, m inter
 func resourceSecurityImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_security.go
+++ b/junos/resource_security.go
@@ -29,10 +29,10 @@ type securityOptions struct {
 
 func resourceSecurity() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSecurityCreate,
-		ReadContext:   resourceSecurityRead,
-		UpdateContext: resourceSecurityUpdate,
-		DeleteContext: resourceSecurityDelete,
+		CreateWithoutTimeout: resourceSecurityCreate,
+		ReadWithoutTimeout:   resourceSecurityRead,
+		UpdateWithoutTimeout: resourceSecurityUpdate,
+		DeleteWithoutTimeout: resourceSecurityDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSecurityImport,
 		},
@@ -855,7 +855,9 @@ func resourceSecurityCreate(ctx context.Context, d *schema.ResourceData, m inter
 		return diag.FromErr(fmt.Errorf("security not compatible with Junos device %s",
 			jnprSess.SystemInformation.HardwareModel))
 	}
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := setSecurity(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -916,7 +918,9 @@ func resourceSecurityUpdate(ctx context.Context, d *schema.ResourceData, m inter
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSecurity(m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -955,7 +959,9 @@ func resourceSecurityDelete(ctx context.Context, d *schema.ResourceData, m inter
 			return diag.FromErr(err)
 		}
 		defer sess.closeSession(jnprSess)
-		sess.configLock(jnprSess)
+		if err := sess.configLock(ctx, jnprSess); err != nil {
+			return diag.FromErr(err)
+		}
 		var diagWarns diag.Diagnostics
 		if err := delSecurity(m, jnprSess); err != nil {
 			appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_security_address_book.go
+++ b/junos/resource_security_address_book.go
@@ -185,7 +185,7 @@ func resourceSecurityAddressBookCreate(ctx context.Context, d *schema.ResourceDa
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -238,7 +238,7 @@ func resourceSecurityAddressBookCreate(ctx context.Context, d *schema.ResourceDa
 
 func resourceSecurityAddressBookRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -278,7 +278,7 @@ func resourceSecurityAddressBookUpdate(ctx context.Context, d *schema.ResourceDa
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -318,7 +318,7 @@ func resourceSecurityAddressBookDelete(ctx context.Context, d *schema.ResourceDa
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -346,7 +346,7 @@ func resourceSecurityAddressBookDelete(ctx context.Context, d *schema.ResourceDa
 func resourceSecurityAddressBookImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_security_address_book.go
+++ b/junos/resource_security_address_book.go
@@ -24,10 +24,10 @@ type addressBookOptions struct {
 
 func resourceSecurityAddressBook() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSecurityAddressBookCreate,
-		ReadContext:   resourceSecurityAddressBookRead,
-		UpdateContext: resourceSecurityAddressBookUpdate,
-		DeleteContext: resourceSecurityAddressBookDelete,
+		CreateWithoutTimeout: resourceSecurityAddressBookCreate,
+		ReadWithoutTimeout:   resourceSecurityAddressBookRead,
+		UpdateWithoutTimeout: resourceSecurityAddressBookUpdate,
+		DeleteWithoutTimeout: resourceSecurityAddressBookDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSecurityAddressBookImport,
 		},
@@ -194,7 +194,9 @@ func resourceSecurityAddressBookCreate(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(fmt.Errorf("security policy not compatible with Junos device %s",
 			jnprSess.SystemInformation.HardwareModel))
 	}
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	addressBookExists, err := checkSecurityAddressBookExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -281,7 +283,9 @@ func resourceSecurityAddressBookUpdate(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSecurityAddressBook(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -319,7 +323,9 @@ func resourceSecurityAddressBookDelete(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSecurityAddressBook(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_security_dynamic_address_feed_server.go
+++ b/junos/resource_security_dynamic_address_feed_server.go
@@ -23,10 +23,10 @@ type dynamicAddressFeedServerOptions struct {
 
 func resourceSecurityDynamicAddressFeedServer() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSecurityDynamicAddressFeedServerCreate,
-		ReadContext:   resourceSecurityDynamicAddressFeedServerRead,
-		UpdateContext: resourceSecurityDynamicAddressFeedServerUpdate,
-		DeleteContext: resourceSecurityDynamicAddressFeedServerDelete,
+		CreateWithoutTimeout: resourceSecurityDynamicAddressFeedServerCreate,
+		ReadWithoutTimeout:   resourceSecurityDynamicAddressFeedServerRead,
+		UpdateWithoutTimeout: resourceSecurityDynamicAddressFeedServerUpdate,
+		DeleteWithoutTimeout: resourceSecurityDynamicAddressFeedServerDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSecurityDynamicAddressFeedServerImport,
 		},
@@ -112,7 +112,9 @@ func resourceSecurityDynamicAddressFeedServerCreate(ctx context.Context, d *sche
 		return diag.FromErr(fmt.Errorf("security dynamic-address feed-server "+
 			"not compatible with Junos device %s", jnprSess.SystemInformation.HardwareModel))
 	}
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	securityDynamicAddressFeedServerExists, err := checkSecurityDynamicAddressFeedServersExists(
 		d.Get("name").(string), m, jnprSess)
@@ -205,7 +207,9 @@ func resourceSecurityDynamicAddressFeedServerUpdate(ctx context.Context, d *sche
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSecurityDynamicAddressFeedServer(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -244,7 +248,9 @@ func resourceSecurityDynamicAddressFeedServerDelete(ctx context.Context, d *sche
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSecurityDynamicAddressFeedServer(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_security_dynamic_address_feed_server.go
+++ b/junos/resource_security_dynamic_address_feed_server.go
@@ -103,7 +103,7 @@ func resourceSecurityDynamicAddressFeedServerCreate(ctx context.Context, d *sche
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -160,7 +160,7 @@ func resourceSecurityDynamicAddressFeedServerCreate(ctx context.Context, d *sche
 func resourceSecurityDynamicAddressFeedServerRead(ctx context.Context, d *schema.ResourceData, m interface{},
 ) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -202,7 +202,7 @@ func resourceSecurityDynamicAddressFeedServerUpdate(ctx context.Context, d *sche
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -243,7 +243,7 @@ func resourceSecurityDynamicAddressFeedServerDelete(ctx context.Context, d *sche
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -271,7 +271,7 @@ func resourceSecurityDynamicAddressFeedServerDelete(ctx context.Context, d *sche
 func resourceSecurityDynamicAddressFeedServerImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_security_dynamic_address_name.go
+++ b/junos/resource_security_dynamic_address_name.go
@@ -99,7 +99,7 @@ func resourceSecurityDynamicAddressNameCreate(ctx context.Context, d *schema.Res
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -154,7 +154,7 @@ func resourceSecurityDynamicAddressNameCreate(ctx context.Context, d *schema.Res
 func resourceSecurityDynamicAddressNameRead(ctx context.Context, d *schema.ResourceData, m interface{},
 ) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -195,7 +195,7 @@ func resourceSecurityDynamicAddressNameUpdate(ctx context.Context, d *schema.Res
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -236,7 +236,7 @@ func resourceSecurityDynamicAddressNameDelete(ctx context.Context, d *schema.Res
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -264,7 +264,7 @@ func resourceSecurityDynamicAddressNameDelete(ctx context.Context, d *schema.Res
 func resourceSecurityDynamicAddressNameImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_security_dynamic_address_name.go
+++ b/junos/resource_security_dynamic_address_name.go
@@ -20,10 +20,10 @@ type dynamicAddressNameOptions struct {
 
 func resourceSecurityDynamicAddressName() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSecurityDynamicAddressNameCreate,
-		ReadContext:   resourceSecurityDynamicAddressNameRead,
-		UpdateContext: resourceSecurityDynamicAddressNameUpdate,
-		DeleteContext: resourceSecurityDynamicAddressNameDelete,
+		CreateWithoutTimeout: resourceSecurityDynamicAddressNameCreate,
+		ReadWithoutTimeout:   resourceSecurityDynamicAddressNameRead,
+		UpdateWithoutTimeout: resourceSecurityDynamicAddressNameUpdate,
+		DeleteWithoutTimeout: resourceSecurityDynamicAddressNameDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSecurityDynamicAddressNameImport,
 		},
@@ -108,7 +108,9 @@ func resourceSecurityDynamicAddressNameCreate(ctx context.Context, d *schema.Res
 		return diag.FromErr(fmt.Errorf("security dynamic-address address-name "+
 			"not compatible with Junos device %s", jnprSess.SystemInformation.HardwareModel))
 	}
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	securityDynamicAddressNameExists, err := checkSecurityDynamicAddressNamesExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -198,7 +200,9 @@ func resourceSecurityDynamicAddressNameUpdate(ctx context.Context, d *schema.Res
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSecurityDynamicAddressName(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -237,7 +241,9 @@ func resourceSecurityDynamicAddressNameDelete(ctx context.Context, d *schema.Res
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSecurityDynamicAddressName(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_security_global_policy.go
+++ b/junos/resource_security_global_policy.go
@@ -17,10 +17,10 @@ type globalPolicyOptions struct {
 
 func resourceSecurityGlobalPolicy() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSecurityGlobalPolicyCreate,
-		ReadContext:   resourceSecurityGlobalPolicyRead,
-		UpdateContext: resourceSecurityGlobalPolicyUpdate,
-		DeleteContext: resourceSecurityGlobalPolicyDelete,
+		CreateWithoutTimeout: resourceSecurityGlobalPolicyCreate,
+		ReadWithoutTimeout:   resourceSecurityGlobalPolicyRead,
+		UpdateWithoutTimeout: resourceSecurityGlobalPolicyUpdate,
+		DeleteWithoutTimeout: resourceSecurityGlobalPolicyDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSecurityGlobalPolicyImport,
 		},
@@ -205,7 +205,9 @@ func resourceSecurityGlobalPolicyCreate(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(fmt.Errorf("security policies global not compatible with Junos device %s",
 			jnprSess.SystemInformation.HardwareModel))
 	}
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	glbPolicy, err := readSecurityGlobalPolicy(m, jnprSess)
 	if err != nil {
@@ -279,7 +281,9 @@ func resourceSecurityGlobalPolicyUpdate(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSecurityGlobalPolicy(m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -318,7 +322,9 @@ func resourceSecurityGlobalPolicyDelete(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSecurityGlobalPolicy(m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_security_global_policy.go
+++ b/junos/resource_security_global_policy.go
@@ -196,7 +196,7 @@ func resourceSecurityGlobalPolicyCreate(ctx context.Context, d *schema.ResourceD
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -240,7 +240,7 @@ func resourceSecurityGlobalPolicyCreate(ctx context.Context, d *schema.ResourceD
 
 func resourceSecurityGlobalPolicyRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -276,7 +276,7 @@ func resourceSecurityGlobalPolicyUpdate(ctx context.Context, d *schema.ResourceD
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -317,7 +317,7 @@ func resourceSecurityGlobalPolicyDelete(ctx context.Context, d *schema.ResourceD
 		return nil
 	}
 
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -345,7 +345,7 @@ func resourceSecurityGlobalPolicyDelete(ctx context.Context, d *schema.ResourceD
 func resourceSecurityGlobalPolicyImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_security_idp_custom_attack.go
+++ b/junos/resource_security_idp_custom_attack.go
@@ -26,10 +26,10 @@ type idpCustomAttackOptions struct {
 
 func resourceSecurityIdpCustomAttack() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSecurityIdpCustomAttackCreate,
-		ReadContext:   resourceSecurityIdpCustomAttackRead,
-		UpdateContext: resourceSecurityIdpCustomAttackUpdate,
-		DeleteContext: resourceSecurityIdpCustomAttackDelete,
+		CreateWithoutTimeout: resourceSecurityIdpCustomAttackCreate,
+		ReadWithoutTimeout:   resourceSecurityIdpCustomAttackRead,
+		UpdateWithoutTimeout: resourceSecurityIdpCustomAttackUpdate,
+		DeleteWithoutTimeout: resourceSecurityIdpCustomAttackDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSecurityIdpCustomAttackImport,
 		},
@@ -835,7 +835,9 @@ func resourceSecurityIdpCustomAttackCreate(ctx context.Context, d *schema.Resour
 		return diag.FromErr(fmt.Errorf("security idp custom-attack not compatible with Junos device %s",
 			jnprSess.SystemInformation.HardwareModel))
 	}
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	idpCustomAttackExists, err := checkSecurityIdpCustomAttackExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -923,7 +925,9 @@ func resourceSecurityIdpCustomAttackUpdate(ctx context.Context, d *schema.Resour
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSecurityIdpCustomAttack(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -962,7 +966,9 @@ func resourceSecurityIdpCustomAttackDelete(ctx context.Context, d *schema.Resour
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSecurityIdpCustomAttack(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_security_idp_custom_attack.go
+++ b/junos/resource_security_idp_custom_attack.go
@@ -826,7 +826,7 @@ func resourceSecurityIdpCustomAttackCreate(ctx context.Context, d *schema.Resour
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -879,7 +879,7 @@ func resourceSecurityIdpCustomAttackCreate(ctx context.Context, d *schema.Resour
 
 func resourceSecurityIdpCustomAttackRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -920,7 +920,7 @@ func resourceSecurityIdpCustomAttackUpdate(ctx context.Context, d *schema.Resour
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -961,7 +961,7 @@ func resourceSecurityIdpCustomAttackDelete(ctx context.Context, d *schema.Resour
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -989,7 +989,7 @@ func resourceSecurityIdpCustomAttackDelete(ctx context.Context, d *schema.Resour
 func resourceSecurityIdpCustomAttackImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_security_idp_custom_attack_group.go
+++ b/junos/resource_security_idp_custom_attack_group.go
@@ -50,7 +50,7 @@ func resourceSecurityIdpCustomAttackGroupCreate(ctx context.Context, d *schema.R
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -104,7 +104,7 @@ func resourceSecurityIdpCustomAttackGroupCreate(ctx context.Context, d *schema.R
 func resourceSecurityIdpCustomAttackGroupRead(ctx context.Context, d *schema.ResourceData, m interface{},
 ) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -146,7 +146,7 @@ func resourceSecurityIdpCustomAttackGroupUpdate(ctx context.Context, d *schema.R
 		return nil
 	}
 
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -187,7 +187,7 @@ func resourceSecurityIdpCustomAttackGroupDelete(ctx context.Context, d *schema.R
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -215,7 +215,7 @@ func resourceSecurityIdpCustomAttackGroupDelete(ctx context.Context, d *schema.R
 func resourceSecurityIdpCustomAttackGroupImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_security_idp_custom_attack_group.go
+++ b/junos/resource_security_idp_custom_attack_group.go
@@ -16,10 +16,10 @@ type idpCustomAttackGroupOptions struct {
 
 func resourceSecurityIdpCustomAttackGroup() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSecurityIdpCustomAttackGroupCreate,
-		ReadContext:   resourceSecurityIdpCustomAttackGroupRead,
-		UpdateContext: resourceSecurityIdpCustomAttackGroupUpdate,
-		DeleteContext: resourceSecurityIdpCustomAttackGroupDelete,
+		CreateWithoutTimeout: resourceSecurityIdpCustomAttackGroupCreate,
+		ReadWithoutTimeout:   resourceSecurityIdpCustomAttackGroupRead,
+		UpdateWithoutTimeout: resourceSecurityIdpCustomAttackGroupUpdate,
+		DeleteWithoutTimeout: resourceSecurityIdpCustomAttackGroupDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSecurityIdpCustomAttackGroupImport,
 		},
@@ -59,7 +59,9 @@ func resourceSecurityIdpCustomAttackGroupCreate(ctx context.Context, d *schema.R
 		return diag.FromErr(fmt.Errorf("security idp custom-attack-group not compatible with Junos device %s",
 			jnprSess.SystemInformation.HardwareModel))
 	}
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	idpCustomAttackGroupExists, err := checkSecurityIdpCustomAttackGroupExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -149,7 +151,9 @@ func resourceSecurityIdpCustomAttackGroupUpdate(ctx context.Context, d *schema.R
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSecurityIdpCustomAttackGroup(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -188,7 +192,9 @@ func resourceSecurityIdpCustomAttackGroupDelete(ctx context.Context, d *schema.R
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSecurityIdpCustomAttackGroup(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_security_idp_policy.go
+++ b/junos/resource_security_idp_policy.go
@@ -287,7 +287,7 @@ func resourceSecurityIdpPolicyCreate(ctx context.Context, d *schema.ResourceData
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -341,7 +341,7 @@ func resourceSecurityIdpPolicyCreate(ctx context.Context, d *schema.ResourceData
 
 func resourceSecurityIdpPolicyRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -381,7 +381,7 @@ func resourceSecurityIdpPolicyUpdate(ctx context.Context, d *schema.ResourceData
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -421,7 +421,7 @@ func resourceSecurityIdpPolicyDelete(ctx context.Context, d *schema.ResourceData
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -449,7 +449,7 @@ func resourceSecurityIdpPolicyDelete(ctx context.Context, d *schema.ResourceData
 func resourceSecurityIdpPolicyImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_security_idp_policy.go
+++ b/junos/resource_security_idp_policy.go
@@ -20,10 +20,10 @@ type idpPolicyOptions struct {
 
 func resourceSecurityIdpPolicy() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSecurityIdpPolicyCreate,
-		ReadContext:   resourceSecurityIdpPolicyRead,
-		UpdateContext: resourceSecurityIdpPolicyUpdate,
-		DeleteContext: resourceSecurityIdpPolicyDelete,
+		CreateWithoutTimeout: resourceSecurityIdpPolicyCreate,
+		ReadWithoutTimeout:   resourceSecurityIdpPolicyRead,
+		UpdateWithoutTimeout: resourceSecurityIdpPolicyUpdate,
+		DeleteWithoutTimeout: resourceSecurityIdpPolicyDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSecurityIdpPolicyImport,
 		},
@@ -296,7 +296,9 @@ func resourceSecurityIdpPolicyCreate(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(fmt.Errorf("security idp policy not compatible with Junos device %s",
 			jnprSess.SystemInformation.HardwareModel))
 	}
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	idpPolicyExists, err := checkSecurityIdpPolicyExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -384,7 +386,9 @@ func resourceSecurityIdpPolicyUpdate(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSecurityIdpPolicy(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -422,7 +426,9 @@ func resourceSecurityIdpPolicyDelete(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSecurityIdpPolicy(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_security_ike_gateway.go
+++ b/junos/resource_security_ike_gateway.go
@@ -699,7 +699,7 @@ func readIkeGateway(ikeGateway string, m interface{}, jnprSess *NetconfObject) (
 					confRead.aaa[0]["client_password"], err = jdecode.Decode(strings.Trim(strings.TrimPrefix(itemTrim,
 						"aaa client password "), "\""))
 					if err != nil {
-						return confRead, fmt.Errorf("failed to decode aaa client password : %w", err)
+						return confRead, fmt.Errorf("failed to decode aaa client password: %w", err)
 					}
 				case strings.HasPrefix(itemTrim, "aaa client username "):
 					confRead.aaa[0]["client_username"] = strings.TrimPrefix(itemTrim, "aaa client username ")

--- a/junos/resource_security_ike_gateway.go
+++ b/junos/resource_security_ike_gateway.go
@@ -30,10 +30,10 @@ type ikeGatewayOptions struct {
 
 func resourceIkeGateway() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceIkeGatewayCreate,
-		ReadContext:   resourceIkeGatewayRead,
-		UpdateContext: resourceIkeGatewayUpdate,
-		DeleteContext: resourceIkeGatewayDelete,
+		CreateWithoutTimeout: resourceIkeGatewayCreate,
+		ReadWithoutTimeout:   resourceIkeGatewayRead,
+		UpdateWithoutTimeout: resourceIkeGatewayUpdate,
+		DeleteWithoutTimeout: resourceIkeGatewayDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceIkeGatewayImport,
 		},
@@ -292,7 +292,9 @@ func resourceIkeGatewayCreate(ctx context.Context, d *schema.ResourceData, m int
 		return diag.FromErr(fmt.Errorf("security ike gateway not compatible with Junos device %s",
 			jnprSess.SystemInformation.HardwareModel))
 	}
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	ikeGatewayExists, err := checkIkeGatewayExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -378,7 +380,9 @@ func resourceIkeGatewayUpdate(ctx context.Context, d *schema.ResourceData, m int
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delIkeGateway(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -416,7 +420,9 @@ func resourceIkeGatewayDelete(ctx context.Context, d *schema.ResourceData, m int
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delIkeGateway(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_security_ike_gateway.go
+++ b/junos/resource_security_ike_gateway.go
@@ -283,7 +283,7 @@ func resourceIkeGatewayCreate(ctx context.Context, d *schema.ResourceData, m int
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -336,7 +336,7 @@ func resourceIkeGatewayCreate(ctx context.Context, d *schema.ResourceData, m int
 
 func resourceIkeGatewayRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -375,7 +375,7 @@ func resourceIkeGatewayUpdate(ctx context.Context, d *schema.ResourceData, m int
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -415,7 +415,7 @@ func resourceIkeGatewayDelete(ctx context.Context, d *schema.ResourceData, m int
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -443,7 +443,7 @@ func resourceIkeGatewayDelete(ctx context.Context, d *schema.ResourceData, m int
 func resourceIkeGatewayImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_security_ike_policy.go
+++ b/junos/resource_security_ike_policy.go
@@ -93,7 +93,7 @@ func resourceIkePolicyCreate(ctx context.Context, d *schema.ResourceData, m inte
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -145,7 +145,7 @@ func resourceIkePolicyCreate(ctx context.Context, d *schema.ResourceData, m inte
 
 func resourceIkePolicyRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -184,7 +184,7 @@ func resourceIkePolicyUpdate(ctx context.Context, d *schema.ResourceData, m inte
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -225,7 +225,7 @@ func resourceIkePolicyDelete(ctx context.Context, d *schema.ResourceData, m inte
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -253,7 +253,7 @@ func resourceIkePolicyDelete(ctx context.Context, d *schema.ResourceData, m inte
 func resourceIkePolicyImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_security_ike_policy.go
+++ b/junos/resource_security_ike_policy.go
@@ -346,13 +346,13 @@ func readIkePolicy(ikePolicy string, m interface{}, jnprSess *NetconfObject) (ik
 				confRead.preSharedKeyHexa, err = jdecode.Decode(strings.Trim(strings.TrimPrefix(itemTrim,
 					"pre-shared-key hexadecimal "), "\""))
 				if err != nil {
-					return confRead, fmt.Errorf("failed to decode pre-shared-key hexadecimal : %w", err)
+					return confRead, fmt.Errorf("failed to decode pre-shared-key hexadecimal: %w", err)
 				}
 			case strings.HasPrefix(itemTrim, "pre-shared-key ascii-text "):
 				confRead.preSharedKeyText, err = jdecode.Decode(strings.Trim(strings.TrimPrefix(itemTrim,
 					"pre-shared-key ascii-text "), "\""))
 				if err != nil {
-					return confRead, fmt.Errorf("failed to decode pre-shared-key ascii-text : %w", err)
+					return confRead, fmt.Errorf("failed to decode pre-shared-key ascii-text: %w", err)
 				}
 			}
 		}

--- a/junos/resource_security_ike_policy.go
+++ b/junos/resource_security_ike_policy.go
@@ -34,10 +34,10 @@ func listProposalSet() []string {
 
 func resourceIkePolicy() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceIkePolicyCreate,
-		ReadContext:   resourceIkePolicyRead,
-		UpdateContext: resourceIkePolicyUpdate,
-		DeleteContext: resourceIkePolicyDelete,
+		CreateWithoutTimeout: resourceIkePolicyCreate,
+		ReadWithoutTimeout:   resourceIkePolicyRead,
+		UpdateWithoutTimeout: resourceIkePolicyUpdate,
+		DeleteWithoutTimeout: resourceIkePolicyDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceIkePolicyImport,
 		},
@@ -102,7 +102,9 @@ func resourceIkePolicyCreate(ctx context.Context, d *schema.ResourceData, m inte
 		return diag.FromErr(fmt.Errorf("security ike policy not compatible with Junos device %s",
 			jnprSess.SystemInformation.HardwareModel))
 	}
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	ikePolicyExists, err := checkIkePolicyExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -187,7 +189,9 @@ func resourceIkePolicyUpdate(ctx context.Context, d *schema.ResourceData, m inte
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delIkePolicy(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -226,7 +230,9 @@ func resourceIkePolicyDelete(ctx context.Context, d *schema.ResourceData, m inte
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delIkePolicy(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_security_ike_proposal.go
+++ b/junos/resource_security_ike_proposal.go
@@ -72,7 +72,7 @@ func resourceIkeProposalCreate(ctx context.Context, d *schema.ResourceData, m in
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -125,7 +125,7 @@ func resourceIkeProposalCreate(ctx context.Context, d *schema.ResourceData, m in
 
 func resourceIkeProposalRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -164,7 +164,7 @@ func resourceIkeProposalUpdate(ctx context.Context, d *schema.ResourceData, m in
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -204,7 +204,7 @@ func resourceIkeProposalDelete(ctx context.Context, d *schema.ResourceData, m in
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -232,7 +232,7 @@ func resourceIkeProposalDelete(ctx context.Context, d *schema.ResourceData, m in
 func resourceIkeProposalImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_security_ike_proposal.go
+++ b/junos/resource_security_ike_proposal.go
@@ -22,10 +22,10 @@ type ikeProposalOptions struct {
 
 func resourceIkeProposal() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceIkeProposalCreate,
-		ReadContext:   resourceIkeProposalRead,
-		UpdateContext: resourceIkeProposalUpdate,
-		DeleteContext: resourceIkeProposalDelete,
+		CreateWithoutTimeout: resourceIkeProposalCreate,
+		ReadWithoutTimeout:   resourceIkeProposalRead,
+		UpdateWithoutTimeout: resourceIkeProposalUpdate,
+		DeleteWithoutTimeout: resourceIkeProposalDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceIkeProposalImport,
 		},
@@ -81,7 +81,9 @@ func resourceIkeProposalCreate(ctx context.Context, d *schema.ResourceData, m in
 		return diag.FromErr(fmt.Errorf("security ike proposal not compatible with Junos device %s",
 			jnprSess.SystemInformation.HardwareModel))
 	}
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	ikeProposalExists, err := checkIkeProposalExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -167,7 +169,9 @@ func resourceIkeProposalUpdate(ctx context.Context, d *schema.ResourceData, m in
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delIkeProposal(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -205,7 +209,9 @@ func resourceIkeProposalDelete(ctx context.Context, d *schema.ResourceData, m in
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delIkeProposal(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_security_ipsec_policy.go
+++ b/junos/resource_security_ipsec_policy.go
@@ -64,7 +64,7 @@ func resourceIpsecPolicyCreate(ctx context.Context, d *schema.ResourceData, m in
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -117,7 +117,7 @@ func resourceIpsecPolicyCreate(ctx context.Context, d *schema.ResourceData, m in
 
 func resourceIpsecPolicyRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -156,7 +156,7 @@ func resourceIpsecPolicyUpdate(ctx context.Context, d *schema.ResourceData, m in
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -196,7 +196,7 @@ func resourceIpsecPolicyDelete(ctx context.Context, d *schema.ResourceData, m in
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -224,7 +224,7 @@ func resourceIpsecPolicyDelete(ctx context.Context, d *schema.ResourceData, m in
 func resourceIpsecPolicyImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_security_ipsec_policy.go
+++ b/junos/resource_security_ipsec_policy.go
@@ -19,10 +19,10 @@ type ipsecPolicyOptions struct {
 
 func resourceIpsecPolicy() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceIpsecPolicyCreate,
-		ReadContext:   resourceIpsecPolicyRead,
-		UpdateContext: resourceIpsecPolicyUpdate,
-		DeleteContext: resourceIpsecPolicyDelete,
+		CreateWithoutTimeout: resourceIpsecPolicyCreate,
+		ReadWithoutTimeout:   resourceIpsecPolicyRead,
+		UpdateWithoutTimeout: resourceIpsecPolicyUpdate,
+		DeleteWithoutTimeout: resourceIpsecPolicyDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceIpsecPolicyImport,
 		},
@@ -73,7 +73,9 @@ func resourceIpsecPolicyCreate(ctx context.Context, d *schema.ResourceData, m in
 		return diag.FromErr(fmt.Errorf("security ipsec policy not compatible with Junos device %s",
 			jnprSess.SystemInformation.HardwareModel))
 	}
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	ipsecPolicyExists, err := checkIpsecPolicyExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -159,7 +161,9 @@ func resourceIpsecPolicyUpdate(ctx context.Context, d *schema.ResourceData, m in
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delIpsecPolicy(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -197,7 +201,9 @@ func resourceIpsecPolicyDelete(ctx context.Context, d *schema.ResourceData, m in
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delIpsecPolicy(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_security_ipsec_proposal.go
+++ b/junos/resource_security_ipsec_proposal.go
@@ -73,7 +73,7 @@ func resourceIpsecProposalCreate(ctx context.Context, d *schema.ResourceData, m 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -126,7 +126,7 @@ func resourceIpsecProposalCreate(ctx context.Context, d *schema.ResourceData, m 
 
 func resourceIpsecProposalRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -166,7 +166,7 @@ func resourceIpsecProposalUpdate(ctx context.Context, d *schema.ResourceData, m 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -206,7 +206,7 @@ func resourceIpsecProposalDelete(ctx context.Context, d *schema.ResourceData, m 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -234,7 +234,7 @@ func resourceIpsecProposalDelete(ctx context.Context, d *schema.ResourceData, m 
 func resourceIpsecProposalImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_security_ipsec_proposal.go
+++ b/junos/resource_security_ipsec_proposal.go
@@ -22,10 +22,10 @@ type ipsecProposalOptions struct {
 
 func resourceIpsecProposal() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceIpsecProposalCreate,
-		ReadContext:   resourceIpsecProposalRead,
-		UpdateContext: resourceIpsecProposalUpdate,
-		DeleteContext: resourceIpsecProposalDelete,
+		CreateWithoutTimeout: resourceIpsecProposalCreate,
+		ReadWithoutTimeout:   resourceIpsecProposalRead,
+		UpdateWithoutTimeout: resourceIpsecProposalUpdate,
+		DeleteWithoutTimeout: resourceIpsecProposalDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceIpsecProposalImport,
 		},
@@ -82,7 +82,9 @@ func resourceIpsecProposalCreate(ctx context.Context, d *schema.ResourceData, m 
 		return diag.FromErr(fmt.Errorf("security ipsec proposal not compatible with Junos device %s",
 			jnprSess.SystemInformation.HardwareModel))
 	}
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	ipsecProposalExists, err := checkIpsecProposalExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -169,7 +171,9 @@ func resourceIpsecProposalUpdate(ctx context.Context, d *schema.ResourceData, m 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delIpsecProposal(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -207,7 +211,9 @@ func resourceIpsecProposalDelete(ctx context.Context, d *schema.ResourceData, m 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delIpsecProposal(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_security_ipsec_vpn.go
+++ b/junos/resource_security_ipsec_vpn.go
@@ -24,10 +24,10 @@ type ipsecVpnOptions struct {
 
 func resourceIpsecVpn() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceIpsecVpnCreate,
-		ReadContext:   resourceIpsecVpnRead,
-		UpdateContext: resourceIpsecVpnUpdate,
-		DeleteContext: resourceIpsecVpnDelete,
+		CreateWithoutTimeout: resourceIpsecVpnCreate,
+		ReadWithoutTimeout:   resourceIpsecVpnRead,
+		UpdateWithoutTimeout: resourceIpsecVpnUpdate,
+		DeleteWithoutTimeout: resourceIpsecVpnDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceIpsecVpnImport,
 		},
@@ -166,7 +166,9 @@ func resourceIpsecVpnCreate(ctx context.Context, d *schema.ResourceData, m inter
 		return diag.FromErr(fmt.Errorf("security ipsec vpn not compatible with Junos device %s",
 			jnprSess.SystemInformation.HardwareModel))
 	}
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	ipsecVpnExists, err := checkIpsecVpnExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -286,7 +288,9 @@ func resourceIpsecVpnUpdate(ctx context.Context, d *schema.ResourceData, m inter
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	if err := delIpsecVpnConf(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
 
@@ -339,7 +343,9 @@ func resourceIpsecVpnDelete(ctx context.Context, d *schema.ResourceData, m inter
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delIpsecVpn(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_security_ipsec_vpn.go
+++ b/junos/resource_security_ipsec_vpn.go
@@ -157,7 +157,7 @@ func resourceIpsecVpnCreate(ctx context.Context, d *schema.ResourceData, m inter
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -221,7 +221,7 @@ func resourceIpsecVpnCreate(ctx context.Context, d *schema.ResourceData, m inter
 
 func resourceIpsecVpnRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -283,7 +283,7 @@ func resourceIpsecVpnUpdate(ctx context.Context, d *schema.ResourceData, m inter
 
 		return diagWarns
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -338,7 +338,7 @@ func resourceIpsecVpnDelete(ctx context.Context, d *schema.ResourceData, m inter
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -366,7 +366,7 @@ func resourceIpsecVpnDelete(ctx context.Context, d *schema.ResourceData, m inter
 func resourceIpsecVpnImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_security_ipsec_vpn.go
+++ b/junos/resource_security_ipsec_vpn.go
@@ -186,7 +186,7 @@ func resourceIpsecVpnCreate(ctx context.Context, d *schema.ResourceData, m inter
 		if err != nil {
 			appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
 
-			return append(diagWarns, diag.FromErr(fmt.Errorf("error for find new bind interface : %w", err))...)
+			return append(diagWarns, diag.FromErr(fmt.Errorf("error to find new bind interface: %w", err))...)
 		}
 		tfErr := d.Set("bind_interface", newSt0)
 		if tfErr != nil {

--- a/junos/resource_security_log_stream.go
+++ b/junos/resource_security_log_stream.go
@@ -132,7 +132,7 @@ func resourceSecurityLogStreamCreate(ctx context.Context, d *schema.ResourceData
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -185,7 +185,7 @@ func resourceSecurityLogStreamCreate(ctx context.Context, d *schema.ResourceData
 
 func resourceSecurityLogStreamRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -225,7 +225,7 @@ func resourceSecurityLogStreamUpdate(ctx context.Context, d *schema.ResourceData
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -265,7 +265,7 @@ func resourceSecurityLogStreamDelete(ctx context.Context, d *schema.ResourceData
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -293,7 +293,7 @@ func resourceSecurityLogStreamDelete(ctx context.Context, d *schema.ResourceData
 func resourceSecurityLogStreamImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_security_log_stream.go
+++ b/junos/resource_security_log_stream.go
@@ -24,10 +24,10 @@ type securityLogStreamOptions struct {
 
 func resourceSecurityLogStream() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSecurityLogStreamCreate,
-		ReadContext:   resourceSecurityLogStreamRead,
-		UpdateContext: resourceSecurityLogStreamUpdate,
-		DeleteContext: resourceSecurityLogStreamDelete,
+		CreateWithoutTimeout: resourceSecurityLogStreamCreate,
+		ReadWithoutTimeout:   resourceSecurityLogStreamRead,
+		UpdateWithoutTimeout: resourceSecurityLogStreamUpdate,
+		DeleteWithoutTimeout: resourceSecurityLogStreamDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSecurityLogStreamImport,
 		},
@@ -141,7 +141,9 @@ func resourceSecurityLogStreamCreate(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(fmt.Errorf("security log stream "+
 			"not compatible with Junos device %s", jnprSess.SystemInformation.HardwareModel))
 	}
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	securityLogStreamExists, err := checkSecurityLogStreamExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -228,7 +230,9 @@ func resourceSecurityLogStreamUpdate(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delLogStream(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -266,7 +270,9 @@ func resourceSecurityLogStreamDelete(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delLogStream(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_security_nat_destination.go
+++ b/junos/resource_security_nat_destination.go
@@ -21,10 +21,10 @@ type natDestinationOptions struct {
 
 func resourceSecurityNatDestination() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSecurityNatDestinationCreate,
-		ReadContext:   resourceSecurityNatDestinationRead,
-		UpdateContext: resourceSecurityNatDestinationUpdate,
-		DeleteContext: resourceSecurityNatDestinationDelete,
+		CreateWithoutTimeout: resourceSecurityNatDestinationCreate,
+		ReadWithoutTimeout:   resourceSecurityNatDestinationRead,
+		UpdateWithoutTimeout: resourceSecurityNatDestinationUpdate,
+		DeleteWithoutTimeout: resourceSecurityNatDestinationDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSecurityNatDestinationImport,
 		},
@@ -148,7 +148,9 @@ func resourceSecurityNatDestinationCreate(ctx context.Context, d *schema.Resourc
 		return diag.FromErr(fmt.Errorf("security nat destination not compatible with Junos device %s",
 			jnprSess.SystemInformation.HardwareModel))
 	}
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	securityNatDestinationExists, err := checkSecurityNatDestinationExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -236,7 +238,9 @@ func resourceSecurityNatDestinationUpdate(ctx context.Context, d *schema.Resourc
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSecurityNatDestination(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -274,7 +278,9 @@ func resourceSecurityNatDestinationDelete(ctx context.Context, d *schema.Resourc
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSecurityNatDestination(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_security_nat_destination.go
+++ b/junos/resource_security_nat_destination.go
@@ -139,7 +139,7 @@ func resourceSecurityNatDestinationCreate(ctx context.Context, d *schema.Resourc
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -193,7 +193,7 @@ func resourceSecurityNatDestinationCreate(ctx context.Context, d *schema.Resourc
 
 func resourceSecurityNatDestinationRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -233,7 +233,7 @@ func resourceSecurityNatDestinationUpdate(ctx context.Context, d *schema.Resourc
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -273,7 +273,7 @@ func resourceSecurityNatDestinationDelete(ctx context.Context, d *schema.Resourc
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -301,7 +301,7 @@ func resourceSecurityNatDestinationDelete(ctx context.Context, d *schema.Resourc
 func resourceSecurityNatDestinationImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_security_nat_destination_pool.go
+++ b/junos/resource_security_nat_destination_pool.go
@@ -77,7 +77,7 @@ func resourceSecurityNatDestinationPoolCreate(ctx context.Context, d *schema.Res
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -132,7 +132,7 @@ func resourceSecurityNatDestinationPoolCreate(ctx context.Context, d *schema.Res
 func resourceSecurityNatDestinationPoolRead(ctx context.Context, d *schema.ResourceData, m interface{},
 ) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -173,7 +173,7 @@ func resourceSecurityNatDestinationPoolUpdate(ctx context.Context, d *schema.Res
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -214,7 +214,7 @@ func resourceSecurityNatDestinationPoolDelete(ctx context.Context, d *schema.Res
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -242,7 +242,7 @@ func resourceSecurityNatDestinationPoolDelete(ctx context.Context, d *schema.Res
 func resourceSecurityNatDestinationPoolImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_security_nat_destination_pool.go
+++ b/junos/resource_security_nat_destination_pool.go
@@ -22,10 +22,10 @@ type natDestinationPoolOptions struct {
 
 func resourceSecurityNatDestinationPool() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSecurityNatDestinationPoolCreate,
-		ReadContext:   resourceSecurityNatDestinationPoolRead,
-		UpdateContext: resourceSecurityNatDestinationPoolUpdate,
-		DeleteContext: resourceSecurityNatDestinationPoolDelete,
+		CreateWithoutTimeout: resourceSecurityNatDestinationPoolCreate,
+		ReadWithoutTimeout:   resourceSecurityNatDestinationPoolRead,
+		UpdateWithoutTimeout: resourceSecurityNatDestinationPoolUpdate,
+		DeleteWithoutTimeout: resourceSecurityNatDestinationPoolDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSecurityNatDestinationPoolImport,
 		},
@@ -86,7 +86,9 @@ func resourceSecurityNatDestinationPoolCreate(ctx context.Context, d *schema.Res
 		return diag.FromErr(fmt.Errorf("security nat destination pool not compatible with Junos device %s",
 			jnprSess.SystemInformation.HardwareModel))
 	}
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	securityNatDestinationPoolExists, err := checkSecurityNatDestinationPoolExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -176,7 +178,9 @@ func resourceSecurityNatDestinationPoolUpdate(ctx context.Context, d *schema.Res
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSecurityNatDestinationPool(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -215,7 +219,9 @@ func resourceSecurityNatDestinationPoolDelete(ctx context.Context, d *schema.Res
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSecurityNatDestinationPool(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_security_nat_source.go
+++ b/junos/resource_security_nat_source.go
@@ -175,7 +175,7 @@ func resourceSecurityNatSourceCreate(ctx context.Context, d *schema.ResourceData
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -228,7 +228,7 @@ func resourceSecurityNatSourceCreate(ctx context.Context, d *schema.ResourceData
 
 func resourceSecurityNatSourceRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -268,7 +268,7 @@ func resourceSecurityNatSourceUpdate(ctx context.Context, d *schema.ResourceData
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -308,7 +308,7 @@ func resourceSecurityNatSourceDelete(ctx context.Context, d *schema.ResourceData
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -336,7 +336,7 @@ func resourceSecurityNatSourceDelete(ctx context.Context, d *schema.ResourceData
 func resourceSecurityNatSourceImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_security_nat_source.go
+++ b/junos/resource_security_nat_source.go
@@ -22,10 +22,10 @@ type natSourceOptions struct {
 
 func resourceSecurityNatSource() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSecurityNatSourceCreate,
-		ReadContext:   resourceSecurityNatSourceRead,
-		UpdateContext: resourceSecurityNatSourceUpdate,
-		DeleteContext: resourceSecurityNatSourceDelete,
+		CreateWithoutTimeout: resourceSecurityNatSourceCreate,
+		ReadWithoutTimeout:   resourceSecurityNatSourceRead,
+		UpdateWithoutTimeout: resourceSecurityNatSourceUpdate,
+		DeleteWithoutTimeout: resourceSecurityNatSourceDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSecurityNatSourceImport,
 		},
@@ -184,7 +184,9 @@ func resourceSecurityNatSourceCreate(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(fmt.Errorf("security nat source not compatible with Junos device %s",
 			jnprSess.SystemInformation.HardwareModel))
 	}
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	securityNatSourceExists, err := checkSecurityNatSourceExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -271,7 +273,9 @@ func resourceSecurityNatSourceUpdate(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSecurityNatSource(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -309,7 +313,9 @@ func resourceSecurityNatSourceDelete(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSecurityNatSource(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_security_nat_source_pool.go
+++ b/junos/resource_security_nat_source_pool.go
@@ -103,7 +103,7 @@ func resourceSecurityNatSourcePoolCreate(ctx context.Context, d *schema.Resource
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -157,7 +157,7 @@ func resourceSecurityNatSourcePoolCreate(ctx context.Context, d *schema.Resource
 
 func resourceSecurityNatSourcePoolRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -197,7 +197,7 @@ func resourceSecurityNatSourcePoolUpdate(ctx context.Context, d *schema.Resource
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -237,7 +237,7 @@ func resourceSecurityNatSourcePoolDelete(ctx context.Context, d *schema.Resource
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -265,7 +265,7 @@ func resourceSecurityNatSourcePoolDelete(ctx context.Context, d *schema.Resource
 func resourceSecurityNatSourcePoolImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_security_nat_source_pool.go
+++ b/junos/resource_security_nat_source_pool.go
@@ -27,10 +27,10 @@ type natSourcePoolOptions struct {
 
 func resourceSecurityNatSourcePool() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSecurityNatSourcePoolCreate,
-		ReadContext:   resourceSecurityNatSourcePoolRead,
-		UpdateContext: resourceSecurityNatSourcePoolUpdate,
-		DeleteContext: resourceSecurityNatSourcePoolDelete,
+		CreateWithoutTimeout: resourceSecurityNatSourcePoolCreate,
+		ReadWithoutTimeout:   resourceSecurityNatSourcePoolRead,
+		UpdateWithoutTimeout: resourceSecurityNatSourcePoolUpdate,
+		DeleteWithoutTimeout: resourceSecurityNatSourcePoolDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSecurityNatSourcePoolImport,
 		},
@@ -112,7 +112,9 @@ func resourceSecurityNatSourcePoolCreate(ctx context.Context, d *schema.Resource
 		return diag.FromErr(fmt.Errorf("security nat source pool not compatible with Junos device %s",
 			jnprSess.SystemInformation.HardwareModel))
 	}
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	securityNatSourcePoolExists, err := checkSecurityNatSourcePoolExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -200,7 +202,9 @@ func resourceSecurityNatSourcePoolUpdate(ctx context.Context, d *schema.Resource
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSecurityNatSourcePool(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -238,7 +242,9 @@ func resourceSecurityNatSourcePoolDelete(ctx context.Context, d *schema.Resource
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSecurityNatSourcePool(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_security_nat_static.go
+++ b/junos/resource_security_nat_static.go
@@ -161,7 +161,7 @@ func resourceSecurityNatStaticCreate(ctx context.Context, d *schema.ResourceData
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -214,7 +214,7 @@ func resourceSecurityNatStaticCreate(ctx context.Context, d *schema.ResourceData
 
 func resourceSecurityNatStaticRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -282,7 +282,7 @@ func resourceSecurityNatStaticUpdate(ctx context.Context, d *schema.ResourceData
 
 		return diagWarns
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -329,7 +329,7 @@ func resourceSecurityNatStaticDelete(ctx context.Context, d *schema.ResourceData
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -357,7 +357,7 @@ func resourceSecurityNatStaticDelete(ctx context.Context, d *schema.ResourceData
 func resourceSecurityNatStaticImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_security_nat_static.go
+++ b/junos/resource_security_nat_static.go
@@ -23,10 +23,10 @@ type natStaticOptions struct {
 
 func resourceSecurityNatStatic() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSecurityNatStaticCreate,
-		ReadContext:   resourceSecurityNatStaticRead,
-		UpdateContext: resourceSecurityNatStaticUpdate,
-		DeleteContext: resourceSecurityNatStaticDelete,
+		CreateWithoutTimeout: resourceSecurityNatStaticCreate,
+		ReadWithoutTimeout:   resourceSecurityNatStaticRead,
+		UpdateWithoutTimeout: resourceSecurityNatStaticUpdate,
+		DeleteWithoutTimeout: resourceSecurityNatStaticDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSecurityNatStaticImport,
 		},
@@ -170,7 +170,9 @@ func resourceSecurityNatStaticCreate(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(fmt.Errorf("security nat static not compatible with Junos device %s",
 			jnprSess.SystemInformation.HardwareModel))
 	}
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	securityNatStaticExists, err := checkSecurityNatStaticExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -285,7 +287,9 @@ func resourceSecurityNatStaticUpdate(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	if configureRulesSingly {
 		if err := delSecurityNatStaticWithoutRules(d.Get("name").(string), m, jnprSess); err != nil {
 			appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -330,7 +334,9 @@ func resourceSecurityNatStaticDelete(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSecurityNatStatic(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_security_nat_static_rule.go
+++ b/junos/resource_security_nat_static_rule.go
@@ -133,7 +133,7 @@ func resourceSecurityNatStaticRuleCreate(ctx context.Context, d *schema.Resource
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -203,7 +203,7 @@ func resourceSecurityNatStaticRuleCreate(ctx context.Context, d *schema.Resource
 
 func resourceSecurityNatStaticRuleRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -244,7 +244,7 @@ func resourceSecurityNatStaticRuleUpdate(ctx context.Context, d *schema.Resource
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -285,7 +285,7 @@ func resourceSecurityNatStaticRuleDelete(ctx context.Context, d *schema.Resource
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -313,7 +313,7 @@ func resourceSecurityNatStaticRuleDelete(ctx context.Context, d *schema.Resource
 func resourceSecurityNatStaticRuleImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_security_nat_static_rule.go
+++ b/junos/resource_security_nat_static_rule.go
@@ -27,10 +27,10 @@ type natStaticRuleOptions struct {
 
 func resourceSecurityNatStaticRule() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSecurityNatStaticRuleCreate,
-		ReadContext:   resourceSecurityNatStaticRuleRead,
-		UpdateContext: resourceSecurityNatStaticRuleUpdate,
-		DeleteContext: resourceSecurityNatStaticRuleDelete,
+		CreateWithoutTimeout: resourceSecurityNatStaticRuleCreate,
+		ReadWithoutTimeout:   resourceSecurityNatStaticRuleRead,
+		UpdateWithoutTimeout: resourceSecurityNatStaticRuleUpdate,
+		DeleteWithoutTimeout: resourceSecurityNatStaticRuleDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSecurityNatStaticRuleImport,
 		},
@@ -142,7 +142,9 @@ func resourceSecurityNatStaticRuleCreate(ctx context.Context, d *schema.Resource
 		return diag.FromErr(fmt.Errorf("security nat static rule in rule-set not compatible with Junos device %s",
 			jnprSess.SystemInformation.HardwareModel))
 	}
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	natStaticExists, err := checkSecurityNatStaticExists(d.Get("rule_set").(string), m, jnprSess)
 	if err != nil {
@@ -247,7 +249,9 @@ func resourceSecurityNatStaticRuleUpdate(ctx context.Context, d *schema.Resource
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSecurityNatStaticRule(d.Get("rule_set").(string), d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -286,7 +290,9 @@ func resourceSecurityNatStaticRuleDelete(ctx context.Context, d *schema.Resource
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSecurityNatStaticRule(d.Get("rule_set").(string), d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_security_policy.go
+++ b/junos/resource_security_policy.go
@@ -202,7 +202,7 @@ func resourceSecurityPolicyCreate(ctx context.Context, d *schema.ResourceData, m
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -258,7 +258,7 @@ func resourceSecurityPolicyCreate(ctx context.Context, d *schema.ResourceData, m
 
 func resourceSecurityPolicyRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -299,7 +299,7 @@ func resourceSecurityPolicyUpdate(ctx context.Context, d *schema.ResourceData, m
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -351,7 +351,7 @@ func resourceSecurityPolicyDelete(ctx context.Context, d *schema.ResourceData, m
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -379,7 +379,7 @@ func resourceSecurityPolicyDelete(ctx context.Context, d *schema.ResourceData, m
 func resourceSecurityPolicyImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_security_policy.go
+++ b/junos/resource_security_policy.go
@@ -19,10 +19,10 @@ type policyOptions struct {
 
 func resourceSecurityPolicy() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSecurityPolicyCreate,
-		ReadContext:   resourceSecurityPolicyRead,
-		UpdateContext: resourceSecurityPolicyUpdate,
-		DeleteContext: resourceSecurityPolicyDelete,
+		CreateWithoutTimeout: resourceSecurityPolicyCreate,
+		ReadWithoutTimeout:   resourceSecurityPolicyRead,
+		UpdateWithoutTimeout: resourceSecurityPolicyUpdate,
+		DeleteWithoutTimeout: resourceSecurityPolicyDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSecurityPolicyImport,
 		},
@@ -211,7 +211,9 @@ func resourceSecurityPolicyCreate(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(fmt.Errorf("security policy not compatible with Junos device %s",
 			jnprSess.SystemInformation.HardwareModel))
 	}
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	securityPolicyExists, err := checkSecurityPolicyExists(d.Get("from_zone").(string), d.Get("to_zone").(string),
 		m, jnprSess)
@@ -302,7 +304,9 @@ func resourceSecurityPolicyUpdate(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	listLinesToPairPolicy := make([]string, 0)
 	if err := readSecurityPolicyTunnelPairPolicyLines(&listLinesToPairPolicy,
@@ -352,7 +356,9 @@ func resourceSecurityPolicyDelete(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSecurityPolicy(d.Get("from_zone").(string), d.Get("to_zone").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_security_policy_tunnel_pair_policy.go
+++ b/junos/resource_security_policy_tunnel_pair_policy.go
@@ -65,7 +65,7 @@ func resourceSecurityPolicyTunnelPairPolicyCreate(ctx context.Context, d *schema
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -147,7 +147,7 @@ func resourceSecurityPolicyTunnelPairPolicyCreate(ctx context.Context, d *schema
 func resourceSecurityPolicyTunnelPairPolicyRead(ctx context.Context, d *schema.ResourceData, m interface{},
 ) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -186,7 +186,7 @@ func resourceSecurityPolicyTunnelPairPolicyDelete(ctx context.Context, d *schema
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -214,7 +214,7 @@ func resourceSecurityPolicyTunnelPairPolicyDelete(ctx context.Context, d *schema
 func resourceSecurityPolicyTunnelPairPolicyImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_security_policy_tunnel_pair_policy.go
+++ b/junos/resource_security_policy_tunnel_pair_policy.go
@@ -18,9 +18,9 @@ type policyPairPolicyOptions struct {
 
 func resourceSecurityPolicyTunnelPairPolicy() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSecurityPolicyTunnelPairPolicyCreate,
-		ReadContext:   resourceSecurityPolicyTunnelPairPolicyRead,
-		DeleteContext: resourceSecurityPolicyTunnelPairPolicyDelete,
+		CreateWithoutTimeout: resourceSecurityPolicyTunnelPairPolicyCreate,
+		ReadWithoutTimeout:   resourceSecurityPolicyTunnelPairPolicyRead,
+		DeleteWithoutTimeout: resourceSecurityPolicyTunnelPairPolicyDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSecurityPolicyTunnelPairPolicyImport,
 		},
@@ -74,7 +74,9 @@ func resourceSecurityPolicyTunnelPairPolicyCreate(ctx context.Context, d *schema
 		return diag.FromErr(fmt.Errorf("security policy tunnel pair policy not compatible with Junos device %s",
 			jnprSess.SystemInformation.HardwareModel))
 	}
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	securityPolicyExists, err := checkSecurityPolicyExists(d.Get("zone_a").(string), d.Get("zone_b").(string), m, jnprSess)
 	if err != nil {
@@ -189,7 +191,9 @@ func resourceSecurityPolicyTunnelPairPolicyDelete(ctx context.Context, d *schema
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSecurityPolicyTunnelPairPolicy(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_security_screen.go
+++ b/junos/resource_security_screen.go
@@ -590,7 +590,7 @@ func resourceSecurityScreenCreate(ctx context.Context, d *schema.ResourceData, m
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -643,7 +643,7 @@ func resourceSecurityScreenCreate(ctx context.Context, d *schema.ResourceData, m
 
 func resourceSecurityScreenRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -683,7 +683,7 @@ func resourceSecurityScreenUpdate(ctx context.Context, d *schema.ResourceData, m
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -723,7 +723,7 @@ func resourceSecurityScreenDelete(ctx context.Context, d *schema.ResourceData, m
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -751,7 +751,7 @@ func resourceSecurityScreenDelete(ctx context.Context, d *schema.ResourceData, m
 func resourceSecurityScreenImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_security_screen.go
+++ b/junos/resource_security_screen.go
@@ -31,10 +31,10 @@ type screenOptions struct {
 
 func resourceSecurityScreen() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSecurityScreenCreate,
-		ReadContext:   resourceSecurityScreenRead,
-		UpdateContext: resourceSecurityScreenUpdate,
-		DeleteContext: resourceSecurityScreenDelete,
+		CreateWithoutTimeout: resourceSecurityScreenCreate,
+		ReadWithoutTimeout:   resourceSecurityScreenRead,
+		UpdateWithoutTimeout: resourceSecurityScreenUpdate,
+		DeleteWithoutTimeout: resourceSecurityScreenDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSecurityScreenImport,
 		},
@@ -599,7 +599,9 @@ func resourceSecurityScreenCreate(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(fmt.Errorf("security screen not compatible with Junos device %s",
 			jnprSess.SystemInformation.HardwareModel))
 	}
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	securityScreenExists, err := checkSecurityScreenExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -686,7 +688,9 @@ func resourceSecurityScreenUpdate(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSecurityScreen(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -724,7 +728,9 @@ func resourceSecurityScreenDelete(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSecurityScreen(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_security_screen_whitelist.go
+++ b/junos/resource_security_screen_whitelist.go
@@ -16,10 +16,10 @@ type screenWhiteListOptions struct {
 
 func resourceSecurityScreenWhiteList() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSecurityScreenWhiteListCreate,
-		ReadContext:   resourceSecurityScreenWhiteListRead,
-		UpdateContext: resourceSecurityScreenWhiteListUpdate,
-		DeleteContext: resourceSecurityScreenWhiteListDelete,
+		CreateWithoutTimeout: resourceSecurityScreenWhiteListCreate,
+		ReadWithoutTimeout:   resourceSecurityScreenWhiteListRead,
+		UpdateWithoutTimeout: resourceSecurityScreenWhiteListUpdate,
+		DeleteWithoutTimeout: resourceSecurityScreenWhiteListDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSecurityScreenWhiteListImport,
 		},
@@ -60,7 +60,9 @@ func resourceSecurityScreenWhiteListCreate(ctx context.Context, d *schema.Resour
 		return diag.FromErr(fmt.Errorf("security screen white-list not compatible with Junos device %s",
 			jnprSess.SystemInformation.HardwareModel))
 	}
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	securityScreenWhiteListExists, err := checkSecurityScreenWhiteListExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -150,7 +152,9 @@ func resourceSecurityScreenWhiteListUpdate(ctx context.Context, d *schema.Resour
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSecurityScreenWhiteList(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -189,7 +193,9 @@ func resourceSecurityScreenWhiteListDelete(ctx context.Context, d *schema.Resour
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSecurityScreenWhiteList(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_security_screen_whitelist.go
+++ b/junos/resource_security_screen_whitelist.go
@@ -51,7 +51,7 @@ func resourceSecurityScreenWhiteListCreate(ctx context.Context, d *schema.Resour
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -106,7 +106,7 @@ func resourceSecurityScreenWhiteListCreate(ctx context.Context, d *schema.Resour
 func resourceSecurityScreenWhiteListRead(ctx context.Context, d *schema.ResourceData, m interface{},
 ) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -147,7 +147,7 @@ func resourceSecurityScreenWhiteListUpdate(ctx context.Context, d *schema.Resour
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -188,7 +188,7 @@ func resourceSecurityScreenWhiteListDelete(ctx context.Context, d *schema.Resour
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -216,7 +216,7 @@ func resourceSecurityScreenWhiteListDelete(ctx context.Context, d *schema.Resour
 func resourceSecurityScreenWhiteListImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_security_utm_custom_url_category.go
+++ b/junos/resource_security_utm_custom_url_category.go
@@ -16,10 +16,10 @@ type utmCustomURLCategoryOptions struct {
 
 func resourceSecurityUtmCustomURLCategory() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSecurityUtmCustomURLCategoryCreate,
-		ReadContext:   resourceSecurityUtmCustomURLCategoryRead,
-		UpdateContext: resourceSecurityUtmCustomURLCategoryUpdate,
-		DeleteContext: resourceSecurityUtmCustomURLCategoryDelete,
+		CreateWithoutTimeout: resourceSecurityUtmCustomURLCategoryCreate,
+		ReadWithoutTimeout:   resourceSecurityUtmCustomURLCategoryRead,
+		UpdateWithoutTimeout: resourceSecurityUtmCustomURLCategoryUpdate,
+		DeleteWithoutTimeout: resourceSecurityUtmCustomURLCategoryDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSecurityUtmCustomURLCategoryImport,
 		},
@@ -60,7 +60,9 @@ func resourceSecurityUtmCustomURLCategoryCreate(ctx context.Context, d *schema.R
 		return diag.FromErr(fmt.Errorf("security utm custom-objects custom-url-category "+
 			"not compatible with Junos device %s", jnprSess.SystemInformation.HardwareModel))
 	}
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	utmCustomURLCategoryExists, err := checkUtmCustomURLCategorysExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -150,7 +152,9 @@ func resourceSecurityUtmCustomURLCategoryUpdate(ctx context.Context, d *schema.R
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delUtmCustomURLCategory(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -189,7 +193,9 @@ func resourceSecurityUtmCustomURLCategoryDelete(ctx context.Context, d *schema.R
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delUtmCustomURLCategory(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_security_utm_custom_url_category.go
+++ b/junos/resource_security_utm_custom_url_category.go
@@ -51,7 +51,7 @@ func resourceSecurityUtmCustomURLCategoryCreate(ctx context.Context, d *schema.R
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -106,7 +106,7 @@ func resourceSecurityUtmCustomURLCategoryCreate(ctx context.Context, d *schema.R
 func resourceSecurityUtmCustomURLCategoryRead(ctx context.Context, d *schema.ResourceData, m interface{},
 ) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -147,7 +147,7 @@ func resourceSecurityUtmCustomURLCategoryUpdate(ctx context.Context, d *schema.R
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -188,7 +188,7 @@ func resourceSecurityUtmCustomURLCategoryDelete(ctx context.Context, d *schema.R
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -216,7 +216,7 @@ func resourceSecurityUtmCustomURLCategoryDelete(ctx context.Context, d *schema.R
 func resourceSecurityUtmCustomURLCategoryImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_security_utm_custom_url_pattern.go
+++ b/junos/resource_security_utm_custom_url_pattern.go
@@ -16,10 +16,10 @@ type utmCustomURLPatternOptions struct {
 
 func resourceSecurityUtmCustomURLPattern() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSecurityUtmCustomURLPatternCreate,
-		ReadContext:   resourceSecurityUtmCustomURLPatternRead,
-		UpdateContext: resourceSecurityUtmCustomURLPatternUpdate,
-		DeleteContext: resourceSecurityUtmCustomURLPatternDelete,
+		CreateWithoutTimeout: resourceSecurityUtmCustomURLPatternCreate,
+		ReadWithoutTimeout:   resourceSecurityUtmCustomURLPatternRead,
+		UpdateWithoutTimeout: resourceSecurityUtmCustomURLPatternUpdate,
+		DeleteWithoutTimeout: resourceSecurityUtmCustomURLPatternDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSecurityUtmCustomURLPatternImport,
 		},
@@ -60,7 +60,9 @@ func resourceSecurityUtmCustomURLPatternCreate(ctx context.Context, d *schema.Re
 		return diag.FromErr(fmt.Errorf("security utm custom-objects url-pattern "+
 			"not compatible with Junos device %s", jnprSess.SystemInformation.HardwareModel))
 	}
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	utmCustomURLPatternExists, err := checkUtmCustomURLPatternsExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -149,7 +151,9 @@ func resourceSecurityUtmCustomURLPatternUpdate(ctx context.Context, d *schema.Re
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delUtmCustomURLPattern(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -188,7 +192,9 @@ func resourceSecurityUtmCustomURLPatternDelete(ctx context.Context, d *schema.Re
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delUtmCustomURLPattern(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_security_utm_custom_url_pattern.go
+++ b/junos/resource_security_utm_custom_url_pattern.go
@@ -51,7 +51,7 @@ func resourceSecurityUtmCustomURLPatternCreate(ctx context.Context, d *schema.Re
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -105,7 +105,7 @@ func resourceSecurityUtmCustomURLPatternCreate(ctx context.Context, d *schema.Re
 func resourceSecurityUtmCustomURLPatternRead(ctx context.Context, d *schema.ResourceData, m interface{},
 ) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -146,7 +146,7 @@ func resourceSecurityUtmCustomURLPatternUpdate(ctx context.Context, d *schema.Re
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -187,7 +187,7 @@ func resourceSecurityUtmCustomURLPatternDelete(ctx context.Context, d *schema.Re
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -215,7 +215,7 @@ func resourceSecurityUtmCustomURLPatternDelete(ctx context.Context, d *schema.Re
 func resourceSecurityUtmCustomURLPatternImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_security_utm_policy.go
+++ b/junos/resource_security_utm_policy.go
@@ -22,10 +22,10 @@ type utmPolicyOptions struct {
 
 func resourceSecurityUtmPolicy() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSecurityUtmPolicyCreate,
-		ReadContext:   resourceSecurityUtmPolicyRead,
-		UpdateContext: resourceSecurityUtmPolicyUpdate,
-		DeleteContext: resourceSecurityUtmPolicyDelete,
+		CreateWithoutTimeout: resourceSecurityUtmPolicyCreate,
+		ReadWithoutTimeout:   resourceSecurityUtmPolicyRead,
+		UpdateWithoutTimeout: resourceSecurityUtmPolicyUpdate,
+		DeleteWithoutTimeout: resourceSecurityUtmPolicyDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSecurityUtmPolicyImport,
 		},
@@ -152,7 +152,9 @@ func resourceSecurityUtmPolicyCreate(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(fmt.Errorf("security utm utm-policy "+
 			"not compatible with Junos device %s", jnprSess.SystemInformation.HardwareModel))
 	}
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	utmPolicyExists, err := checkUtmPolicysExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -240,7 +242,9 @@ func resourceSecurityUtmPolicyUpdate(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delUtmPolicy(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -278,7 +282,9 @@ func resourceSecurityUtmPolicyDelete(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delUtmPolicy(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_security_utm_policy.go
+++ b/junos/resource_security_utm_policy.go
@@ -143,7 +143,7 @@ func resourceSecurityUtmPolicyCreate(ctx context.Context, d *schema.ResourceData
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -197,7 +197,7 @@ func resourceSecurityUtmPolicyCreate(ctx context.Context, d *schema.ResourceData
 
 func resourceSecurityUtmPolicyRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -237,7 +237,7 @@ func resourceSecurityUtmPolicyUpdate(ctx context.Context, d *schema.ResourceData
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -277,7 +277,7 @@ func resourceSecurityUtmPolicyDelete(ctx context.Context, d *schema.ResourceData
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -305,7 +305,7 @@ func resourceSecurityUtmPolicyDelete(ctx context.Context, d *schema.ResourceData
 func resourceSecurityUtmPolicyImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_security_utm_profile_web_filtering_juniper_enhanced.go
+++ b/junos/resource_security_utm_profile_web_filtering_juniper_enhanced.go
@@ -28,10 +28,10 @@ type utmProfileWebFilteringEnhancedOptions struct {
 
 func resourceSecurityUtmProfileWebFilteringEnhanced() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSecurityUtmProfileWebFilteringEnhancedCreate,
-		ReadContext:   resourceSecurityUtmProfileWebFilteringEnhancedRead,
-		UpdateContext: resourceSecurityUtmProfileWebFilteringEnhancedUpdate,
-		DeleteContext: resourceSecurityUtmProfileWebFilteringEnhancedDelete,
+		CreateWithoutTimeout: resourceSecurityUtmProfileWebFilteringEnhancedCreate,
+		ReadWithoutTimeout:   resourceSecurityUtmProfileWebFilteringEnhancedRead,
+		UpdateWithoutTimeout: resourceSecurityUtmProfileWebFilteringEnhancedUpdate,
+		DeleteWithoutTimeout: resourceSecurityUtmProfileWebFilteringEnhancedDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSecurityUtmProfileWebFilteringEnhancedImport,
 		},
@@ -208,7 +208,9 @@ func resourceSecurityUtmProfileWebFilteringEnhancedCreate(ctx context.Context, d
 		return diag.FromErr(fmt.Errorf("security utm feature-profile web-filtering juniper-enhanced "+
 			"not compatible with Junos device %s", jnprSess.SystemInformation.HardwareModel))
 	}
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	utmProfileWebFEnhancedExists, err := checkUtmProfileWebFEnhancedExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -299,7 +301,9 @@ func resourceSecurityUtmProfileWebFilteringEnhancedUpdate(ctx context.Context, d
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delUtmProfileWebFEnhanced(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -338,7 +342,9 @@ func resourceSecurityUtmProfileWebFilteringEnhancedDelete(ctx context.Context, d
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delUtmProfileWebFEnhanced(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_security_utm_profile_web_filtering_juniper_enhanced.go
+++ b/junos/resource_security_utm_profile_web_filtering_juniper_enhanced.go
@@ -199,7 +199,7 @@ func resourceSecurityUtmProfileWebFilteringEnhancedCreate(ctx context.Context, d
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -254,7 +254,7 @@ func resourceSecurityUtmProfileWebFilteringEnhancedCreate(ctx context.Context, d
 func resourceSecurityUtmProfileWebFilteringEnhancedRead(ctx context.Context, d *schema.ResourceData, m interface{},
 ) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -296,7 +296,7 @@ func resourceSecurityUtmProfileWebFilteringEnhancedUpdate(ctx context.Context, d
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -337,7 +337,7 @@ func resourceSecurityUtmProfileWebFilteringEnhancedDelete(ctx context.Context, d
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -365,7 +365,7 @@ func resourceSecurityUtmProfileWebFilteringEnhancedDelete(ctx context.Context, d
 func resourceSecurityUtmProfileWebFilteringEnhancedImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_security_utm_profile_web_filtering_juniper_local.go
+++ b/junos/resource_security_utm_profile_web_filtering_juniper_local.go
@@ -92,7 +92,7 @@ func resourceSecurityUtmProfileWebFilteringLocalCreate(ctx context.Context, d *s
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -147,7 +147,7 @@ func resourceSecurityUtmProfileWebFilteringLocalCreate(ctx context.Context, d *s
 func resourceSecurityUtmProfileWebFilteringLocalRead(ctx context.Context, d *schema.ResourceData, m interface{},
 ) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -189,7 +189,7 @@ func resourceSecurityUtmProfileWebFilteringLocalUpdate(ctx context.Context, d *s
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -230,7 +230,7 @@ func resourceSecurityUtmProfileWebFilteringLocalDelete(ctx context.Context, d *s
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -258,7 +258,7 @@ func resourceSecurityUtmProfileWebFilteringLocalDelete(ctx context.Context, d *s
 func resourceSecurityUtmProfileWebFilteringLocalImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_security_utm_profile_web_filtering_juniper_local.go
+++ b/junos/resource_security_utm_profile_web_filtering_juniper_local.go
@@ -21,10 +21,10 @@ type utmProfileWebFilteringLocalOptions struct {
 
 func resourceSecurityUtmProfileWebFilteringLocal() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSecurityUtmProfileWebFilteringLocalCreate,
-		ReadContext:   resourceSecurityUtmProfileWebFilteringLocalRead,
-		UpdateContext: resourceSecurityUtmProfileWebFilteringLocalUpdate,
-		DeleteContext: resourceSecurityUtmProfileWebFilteringLocalDelete,
+		CreateWithoutTimeout: resourceSecurityUtmProfileWebFilteringLocalCreate,
+		ReadWithoutTimeout:   resourceSecurityUtmProfileWebFilteringLocalRead,
+		UpdateWithoutTimeout: resourceSecurityUtmProfileWebFilteringLocalUpdate,
+		DeleteWithoutTimeout: resourceSecurityUtmProfileWebFilteringLocalDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSecurityUtmProfileWebFilteringLocalImport,
 		},
@@ -101,7 +101,9 @@ func resourceSecurityUtmProfileWebFilteringLocalCreate(ctx context.Context, d *s
 		return diag.FromErr(fmt.Errorf("security utm feature-profile web-filtering juniper-local "+
 			"not compatible with Junos device %s", jnprSess.SystemInformation.HardwareModel))
 	}
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	utmProfileWebFLocalExists, err := checkUtmProfileWebFLocalExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -192,7 +194,9 @@ func resourceSecurityUtmProfileWebFilteringLocalUpdate(ctx context.Context, d *s
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delUtmProfileWebFLocal(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -231,7 +235,9 @@ func resourceSecurityUtmProfileWebFilteringLocalDelete(ctx context.Context, d *s
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delUtmProfileWebFLocal(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_security_utm_profile_web_filtering_websense_redirect.go
+++ b/junos/resource_security_utm_profile_web_filtering_websense_redirect.go
@@ -23,10 +23,10 @@ type utmProfileWebFilteringWebsenseOptions struct {
 
 func resourceSecurityUtmProfileWebFilteringWebsense() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSecurityUtmProfileWebFilteringWebsenseCreate,
-		ReadContext:   resourceSecurityUtmProfileWebFilteringWebsenseRead,
-		UpdateContext: resourceSecurityUtmProfileWebFilteringWebsenseUpdate,
-		DeleteContext: resourceSecurityUtmProfileWebFilteringWebsenseDelete,
+		CreateWithoutTimeout: resourceSecurityUtmProfileWebFilteringWebsenseCreate,
+		ReadWithoutTimeout:   resourceSecurityUtmProfileWebFilteringWebsenseRead,
+		UpdateWithoutTimeout: resourceSecurityUtmProfileWebFilteringWebsenseUpdate,
+		DeleteWithoutTimeout: resourceSecurityUtmProfileWebFilteringWebsenseDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSecurityUtmProfileWebFilteringWebsenseImport,
 		},
@@ -125,7 +125,9 @@ func resourceSecurityUtmProfileWebFilteringWebsenseCreate(ctx context.Context, d
 		return diag.FromErr(fmt.Errorf("security utm feature-profile web-filtering websense-redirect "+
 			"not compatible with Junos device %s", jnprSess.SystemInformation.HardwareModel))
 	}
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	utmProfileWebFWebsenseExists, err := checkUtmProfileWebFWebsenseExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -216,7 +218,9 @@ func resourceSecurityUtmProfileWebFilteringWebsenseUpdate(ctx context.Context, d
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delUtmProfileWebFWebsense(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -255,7 +259,9 @@ func resourceSecurityUtmProfileWebFilteringWebsenseDelete(ctx context.Context, d
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delUtmProfileWebFWebsense(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_security_utm_profile_web_filtering_websense_redirect.go
+++ b/junos/resource_security_utm_profile_web_filtering_websense_redirect.go
@@ -116,7 +116,7 @@ func resourceSecurityUtmProfileWebFilteringWebsenseCreate(ctx context.Context, d
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -171,7 +171,7 @@ func resourceSecurityUtmProfileWebFilteringWebsenseCreate(ctx context.Context, d
 func resourceSecurityUtmProfileWebFilteringWebsenseRead(ctx context.Context, d *schema.ResourceData, m interface{},
 ) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -213,7 +213,7 @@ func resourceSecurityUtmProfileWebFilteringWebsenseUpdate(ctx context.Context, d
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -254,7 +254,7 @@ func resourceSecurityUtmProfileWebFilteringWebsenseDelete(ctx context.Context, d
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -282,7 +282,7 @@ func resourceSecurityUtmProfileWebFilteringWebsenseDelete(ctx context.Context, d
 func resourceSecurityUtmProfileWebFilteringWebsenseImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_security_zone.go
+++ b/junos/resource_security_zone.go
@@ -33,10 +33,10 @@ type zoneOptions struct {
 
 func resourceSecurityZone() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSecurityZoneCreate,
-		ReadContext:   resourceSecurityZoneRead,
-		UpdateContext: resourceSecurityZoneUpdate,
-		DeleteContext: resourceSecurityZoneDelete,
+		CreateWithoutTimeout: resourceSecurityZoneCreate,
+		ReadWithoutTimeout:   resourceSecurityZoneRead,
+		UpdateWithoutTimeout: resourceSecurityZoneUpdate,
+		DeleteWithoutTimeout: resourceSecurityZoneDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSecurityZoneImport,
 		},
@@ -253,7 +253,9 @@ func resourceSecurityZoneCreate(ctx context.Context, d *schema.ResourceData, m i
 		return diag.FromErr(fmt.Errorf("security zone not compatible with Junos device %s",
 			jnprSess.SystemInformation.HardwareModel))
 	}
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	securityZoneExists, err := checkSecurityZonesExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -363,7 +365,9 @@ func resourceSecurityZoneUpdate(ctx context.Context, d *schema.ResourceData, m i
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	if err := delSecurityZoneOpts(
 		d.Get("name").(string), addressBookConfiguredSingly, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -401,7 +405,9 @@ func resourceSecurityZoneDelete(ctx context.Context, d *schema.ResourceData, m i
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSecurityZone(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_security_zone.go
+++ b/junos/resource_security_zone.go
@@ -244,7 +244,7 @@ func resourceSecurityZoneCreate(ctx context.Context, d *schema.ResourceData, m i
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -297,7 +297,7 @@ func resourceSecurityZoneCreate(ctx context.Context, d *schema.ResourceData, m i
 
 func resourceSecurityZoneRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -360,7 +360,7 @@ func resourceSecurityZoneUpdate(ctx context.Context, d *schema.ResourceData, m i
 
 		return diagWarns
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -400,7 +400,7 @@ func resourceSecurityZoneDelete(ctx context.Context, d *schema.ResourceData, m i
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -428,7 +428,7 @@ func resourceSecurityZoneDelete(ctx context.Context, d *schema.ResourceData, m i
 func resourceSecurityZoneImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_security_zone_book_address.go
+++ b/junos/resource_security_zone_book_address.go
@@ -25,10 +25,10 @@ type zoneBookAddressOptions struct {
 
 func resourceSecurityZoneBookAddress() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSecurityZoneBookAddressCreate,
-		ReadContext:   resourceSecurityZoneBookAddressRead,
-		UpdateContext: resourceSecurityZoneBookAddressUpdate,
-		DeleteContext: resourceSecurityZoneBookAddressDelete,
+		CreateWithoutTimeout: resourceSecurityZoneBookAddressCreate,
+		ReadWithoutTimeout:   resourceSecurityZoneBookAddressRead,
+		UpdateWithoutTimeout: resourceSecurityZoneBookAddressUpdate,
+		DeleteWithoutTimeout: resourceSecurityZoneBookAddressDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSecurityZoneBookAddressImport,
 		},
@@ -115,7 +115,9 @@ func resourceSecurityZoneBookAddressCreate(ctx context.Context, d *schema.Resour
 		return diag.FromErr(fmt.Errorf("security zone address-book address not compatible with Junos device %s",
 			jnprSess.SystemInformation.HardwareModel))
 	}
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	zonesExists, err := checkSecurityZonesExists(d.Get("zone").(string), m, jnprSess)
 	if err != nil {
@@ -220,7 +222,9 @@ func resourceSecurityZoneBookAddressUpdate(ctx context.Context, d *schema.Resour
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSecurityZoneBookAddress(d.Get("zone").(string), d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -259,7 +263,9 @@ func resourceSecurityZoneBookAddressDelete(ctx context.Context, d *schema.Resour
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSecurityZoneBookAddress(d.Get("zone").(string), d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_security_zone_book_address.go
+++ b/junos/resource_security_zone_book_address.go
@@ -106,7 +106,7 @@ func resourceSecurityZoneBookAddressCreate(ctx context.Context, d *schema.Resour
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -176,7 +176,7 @@ func resourceSecurityZoneBookAddressCreate(ctx context.Context, d *schema.Resour
 
 func resourceSecurityZoneBookAddressRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -217,7 +217,7 @@ func resourceSecurityZoneBookAddressUpdate(ctx context.Context, d *schema.Resour
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -258,7 +258,7 @@ func resourceSecurityZoneBookAddressDelete(ctx context.Context, d *schema.Resour
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -286,7 +286,7 @@ func resourceSecurityZoneBookAddressDelete(ctx context.Context, d *schema.Resour
 func resourceSecurityZoneBookAddressImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_security_zone_book_address_set.go
+++ b/junos/resource_security_zone_book_address_set.go
@@ -19,10 +19,10 @@ type zoneBookAddressSetOptions struct {
 
 func resourceSecurityZoneBookAddressSet() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSecurityZoneBookAddressSetCreate,
-		ReadContext:   resourceSecurityZoneBookAddressSetRead,
-		UpdateContext: resourceSecurityZoneBookAddressSetUpdate,
-		DeleteContext: resourceSecurityZoneBookAddressSetDelete,
+		CreateWithoutTimeout: resourceSecurityZoneBookAddressSetCreate,
+		ReadWithoutTimeout:   resourceSecurityZoneBookAddressSetRead,
+		UpdateWithoutTimeout: resourceSecurityZoneBookAddressSetUpdate,
+		DeleteWithoutTimeout: resourceSecurityZoneBookAddressSetDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSecurityZoneBookAddressSetImport,
 		},
@@ -79,7 +79,9 @@ func resourceSecurityZoneBookAddressSetCreate(ctx context.Context, d *schema.Res
 		return diag.FromErr(fmt.Errorf("security zone address-book address-set not compatible with Junos device %s",
 			jnprSess.SystemInformation.HardwareModel))
 	}
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	zonesExists, err := checkSecurityZonesExists(d.Get("zone").(string), m, jnprSess)
 	if err != nil {
@@ -186,7 +188,9 @@ func resourceSecurityZoneBookAddressSetUpdate(ctx context.Context, d *schema.Res
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSecurityZoneBookAddressSet(d.Get("zone").(string), d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -225,7 +229,9 @@ func resourceSecurityZoneBookAddressSetDelete(ctx context.Context, d *schema.Res
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSecurityZoneBookAddressSet(d.Get("zone").(string), d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_security_zone_book_address_set.go
+++ b/junos/resource_security_zone_book_address_set.go
@@ -70,7 +70,7 @@ func resourceSecurityZoneBookAddressSetCreate(ctx context.Context, d *schema.Res
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -141,7 +141,7 @@ func resourceSecurityZoneBookAddressSetCreate(ctx context.Context, d *schema.Res
 func resourceSecurityZoneBookAddressSetRead(ctx context.Context, d *schema.ResourceData, m interface{},
 ) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -183,7 +183,7 @@ func resourceSecurityZoneBookAddressSetUpdate(ctx context.Context, d *schema.Res
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -224,7 +224,7 @@ func resourceSecurityZoneBookAddressSetDelete(ctx context.Context, d *schema.Res
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -252,7 +252,7 @@ func resourceSecurityZoneBookAddressSetDelete(ctx context.Context, d *schema.Res
 func resourceSecurityZoneBookAddressSetImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_services.go
+++ b/junos/resource_services.go
@@ -23,10 +23,10 @@ type servicesOptions struct {
 
 func resourceServices() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceServicesCreate,
-		ReadContext:   resourceServicesRead,
-		UpdateContext: resourceServicesUpdate,
-		DeleteContext: resourceServicesDelete,
+		CreateWithoutTimeout: resourceServicesCreate,
+		ReadWithoutTimeout:   resourceServicesRead,
+		UpdateWithoutTimeout: resourceServicesUpdate,
+		DeleteWithoutTimeout: resourceServicesDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceServicesImport,
 		},
@@ -629,7 +629,9 @@ func resourceServicesCreate(ctx context.Context, d *schema.ResourceData, m inter
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := setServices(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -690,7 +692,9 @@ func resourceServicesUpdate(ctx context.Context, d *schema.ResourceData, m inter
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delServices(d, m, jnprSess, false); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -729,7 +733,9 @@ func resourceServicesDelete(ctx context.Context, d *schema.ResourceData, m inter
 			return diag.FromErr(err)
 		}
 		defer sess.closeSession(jnprSess)
-		sess.configLock(jnprSess)
+		if err := sess.configLock(ctx, jnprSess); err != nil {
+			return diag.FromErr(err)
+		}
 		var diagWarns diag.Diagnostics
 		if err := delServices(d, m, jnprSess, true); err != nil {
 			appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_services.go
+++ b/junos/resource_services.go
@@ -624,7 +624,7 @@ func resourceServicesCreate(ctx context.Context, d *schema.ResourceData, m inter
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -652,7 +652,7 @@ func resourceServicesCreate(ctx context.Context, d *schema.ResourceData, m inter
 
 func resourceServicesRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -687,7 +687,7 @@ func resourceServicesUpdate(ctx context.Context, d *schema.ResourceData, m inter
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -728,7 +728,7 @@ func resourceServicesDelete(ctx context.Context, d *schema.ResourceData, m inter
 
 			return nil
 		}
-		jnprSess, err := sess.startNewSession()
+		jnprSess, err := sess.startNewSession(ctx)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -757,7 +757,7 @@ func resourceServicesDelete(ctx context.Context, d *schema.ResourceData, m inter
 func resourceServicesImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_services.go
+++ b/junos/resource_services.go
@@ -1471,7 +1471,7 @@ func readServicesSecurityIntel(confRead *servicesOptions, itemTrimSecurityIntel 
 		confRead.securityIntelligence[0]["url_parameter"], err = jdecode.Decode(strings.Trim(strings.TrimPrefix(
 			itemTrim, "url-parameter "), "\""))
 		if err != nil {
-			return fmt.Errorf("failed to decode url-parameter : %w", err)
+			return fmt.Errorf("failed to decode url-parameter: %w", err)
 		}
 	}
 
@@ -1797,7 +1797,7 @@ func readServicesUserIdentification(confRead *servicesOptions, itemTrimUserIdent
 				userIdentIdentityMgmtConnect["primary_client_secret"], err = jdecode.Decode(
 					strings.Trim(strings.TrimPrefix(itemTrimIdentMgmt, "connection primary client-secret "), "\""))
 				if err != nil {
-					return fmt.Errorf("failed to decode primary client-secret : %w", err)
+					return fmt.Errorf("failed to decode primary client-secret: %w", err)
 				}
 			case strings.HasPrefix(itemTrimIdentMgmt, "connection connect-method "):
 				userIdentIdentityMgmtConnect["connect_method"] = strings.TrimPrefix(itemTrimIdentMgmt, "connection connect-method ")
@@ -1827,7 +1827,7 @@ func readServicesUserIdentification(confRead *servicesOptions, itemTrimUserIdent
 				userIdentIdentityMgmtConnect["secondary_client_secret"], err = jdecode.Decode(
 					strings.Trim(strings.TrimPrefix(itemTrimIdentMgmt, "connection secondary client-secret "), "\""))
 				if err != nil {
-					return fmt.Errorf("failed to decode secondary client-secret : %w", err)
+					return fmt.Errorf("failed to decode secondary client-secret: %w", err)
 				}
 			case strings.HasPrefix(itemTrimIdentMgmt, "connection token-api "):
 				userIdentIdentityMgmtConnect["token_api"] = strings.Trim(strings.TrimPrefix(

--- a/junos/resource_services_advanced_anti_malware_policy.go
+++ b/junos/resource_services_advanced_anti_malware_policy.go
@@ -33,10 +33,10 @@ type svcAdvancedAntiMalwarePolicyOptions struct {
 
 func resourceServicesAdvancedAntiMalwarePolicy() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceServicesAdvancedAntiMalwarePolicyCreate,
-		ReadContext:   resourceServicesAdvancedAntiMalwarePolicyRead,
-		UpdateContext: resourceServicesAdvancedAntiMalwarePolicyUpdate,
-		DeleteContext: resourceServicesAdvancedAntiMalwarePolicyDelete,
+		CreateWithoutTimeout: resourceServicesAdvancedAntiMalwarePolicyCreate,
+		ReadWithoutTimeout:   resourceServicesAdvancedAntiMalwarePolicyRead,
+		UpdateWithoutTimeout: resourceServicesAdvancedAntiMalwarePolicyUpdate,
+		DeleteWithoutTimeout: resourceServicesAdvancedAntiMalwarePolicyDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceServicesAdvancedAntiMalwarePolicyImport,
 		},
@@ -152,7 +152,9 @@ func resourceServicesAdvancedAntiMalwarePolicyCreate(ctx context.Context, d *sch
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	svcAdvancedAntiMalwarePolicyExists, err := checkServicesAdvancedAntiMalwarePolicyExists(
 		d.Get("name").(string), m, jnprSess)
@@ -247,7 +249,9 @@ func resourceServicesAdvancedAntiMalwarePolicyUpdate(ctx context.Context, d *sch
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delServicesAdvancedAntiMalwarePolicy(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -286,7 +290,9 @@ func resourceServicesAdvancedAntiMalwarePolicyDelete(ctx context.Context, d *sch
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delServicesAdvancedAntiMalwarePolicy(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_services_advanced_anti_malware_policy.go
+++ b/junos/resource_services_advanced_anti_malware_policy.go
@@ -147,7 +147,7 @@ func resourceServicesAdvancedAntiMalwarePolicyCreate(ctx context.Context, d *sch
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -202,7 +202,7 @@ func resourceServicesAdvancedAntiMalwarePolicyCreate(ctx context.Context, d *sch
 func resourceServicesAdvancedAntiMalwarePolicyRead(ctx context.Context, d *schema.ResourceData, m interface{},
 ) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -244,7 +244,7 @@ func resourceServicesAdvancedAntiMalwarePolicyUpdate(ctx context.Context, d *sch
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -285,7 +285,7 @@ func resourceServicesAdvancedAntiMalwarePolicyDelete(ctx context.Context, d *sch
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -313,7 +313,7 @@ func resourceServicesAdvancedAntiMalwarePolicyDelete(ctx context.Context, d *sch
 func resourceServicesAdvancedAntiMalwarePolicyImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_services_flowmonitoring_vipfix_template.go
+++ b/junos/resource_services_flowmonitoring_vipfix_template.go
@@ -32,10 +32,10 @@ type flowMonitoringVIPFixTemplateOptions struct {
 
 func resourceServicesFlowMonitoringVIPFixTemplate() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceServicesFlowMonitoringVIPFixTemplateCreate,
-		ReadContext:   resourceServicesFlowMonitoringVIPFixTemplateRead,
-		UpdateContext: resourceServicesFlowMonitoringVIPFixTemplateUpdate,
-		DeleteContext: resourceServicesFlowMonitoringVIPFixTemplateDelete,
+		CreateWithoutTimeout: resourceServicesFlowMonitoringVIPFixTemplateCreate,
+		ReadWithoutTimeout:   resourceServicesFlowMonitoringVIPFixTemplateRead,
+		UpdateWithoutTimeout: resourceServicesFlowMonitoringVIPFixTemplateUpdate,
+		DeleteWithoutTimeout: resourceServicesFlowMonitoringVIPFixTemplateDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceServicesFlowMonitoringVIPFixTemplateImport,
 		},
@@ -146,7 +146,9 @@ func resourceServicesFlowMonitoringVIPFixTemplateCreate(ctx context.Context, d *
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	flowMonitoringVIPFixTemplateExists, err := checkServicesFlowMonitoringVIPFixTemplateExists(
 		d.Get("name").(string), m, jnprSess)
@@ -241,7 +243,9 @@ func resourceServicesFlowMonitoringVIPFixTemplateUpdate(ctx context.Context, d *
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delServicesFlowMonitoringVIPFixTemplate(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -280,7 +284,9 @@ func resourceServicesFlowMonitoringVIPFixTemplateDelete(ctx context.Context, d *
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delServicesFlowMonitoringVIPFixTemplate(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_services_flowmonitoring_vipfix_template.go
+++ b/junos/resource_services_flowmonitoring_vipfix_template.go
@@ -141,7 +141,7 @@ func resourceServicesFlowMonitoringVIPFixTemplateCreate(ctx context.Context, d *
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -195,7 +195,7 @@ func resourceServicesFlowMonitoringVIPFixTemplateCreate(ctx context.Context, d *
 func resourceServicesFlowMonitoringVIPFixTemplateRead(ctx context.Context, d *schema.ResourceData, m interface{},
 ) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -238,7 +238,7 @@ func resourceServicesFlowMonitoringVIPFixTemplateUpdate(ctx context.Context, d *
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -279,7 +279,7 @@ func resourceServicesFlowMonitoringVIPFixTemplateDelete(ctx context.Context, d *
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -307,7 +307,7 @@ func resourceServicesFlowMonitoringVIPFixTemplateDelete(ctx context.Context, d *
 func resourceServicesFlowMonitoringVIPFixTemplateImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_services_proxy_profile.go
+++ b/junos/resource_services_proxy_profile.go
@@ -56,7 +56,7 @@ func resourceServicesProxyProfileCreate(ctx context.Context, d *schema.ResourceD
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -107,7 +107,7 @@ func resourceServicesProxyProfileCreate(ctx context.Context, d *schema.ResourceD
 func resourceServicesProxyProfileRead(ctx context.Context, d *schema.ResourceData, m interface{},
 ) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -148,7 +148,7 @@ func resourceServicesProxyProfileUpdate(ctx context.Context, d *schema.ResourceD
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -189,7 +189,7 @@ func resourceServicesProxyProfileDelete(ctx context.Context, d *schema.ResourceD
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -217,7 +217,7 @@ func resourceServicesProxyProfileDelete(ctx context.Context, d *schema.ResourceD
 func resourceServicesProxyProfileImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_services_proxy_profile.go
+++ b/junos/resource_services_proxy_profile.go
@@ -19,10 +19,10 @@ type proxyProfileOptions struct {
 
 func resourceServicesProxyProfile() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceServicesProxyProfileCreate,
-		ReadContext:   resourceServicesProxyProfileRead,
-		UpdateContext: resourceServicesProxyProfileUpdate,
-		DeleteContext: resourceServicesProxyProfileDelete,
+		CreateWithoutTimeout: resourceServicesProxyProfileCreate,
+		ReadWithoutTimeout:   resourceServicesProxyProfileRead,
+		UpdateWithoutTimeout: resourceServicesProxyProfileUpdate,
+		DeleteWithoutTimeout: resourceServicesProxyProfileDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceServicesProxyProfileImport,
 		},
@@ -61,7 +61,9 @@ func resourceServicesProxyProfileCreate(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	proxyProfileExists, err := checkServicesProxyProfileExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -151,7 +153,9 @@ func resourceServicesProxyProfileUpdate(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delServicesProxyProfile(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -190,7 +194,9 @@ func resourceServicesProxyProfileDelete(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delServicesProxyProfile(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_services_rpm_probe.go
+++ b/junos/resource_services_rpm_probe.go
@@ -329,7 +329,7 @@ func resourceServicesRpmProbeCreate(ctx context.Context, d *schema.ResourceData,
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -380,7 +380,7 @@ func resourceServicesRpmProbeCreate(ctx context.Context, d *schema.ResourceData,
 func resourceServicesRpmProbeRead(ctx context.Context, d *schema.ResourceData, m interface{},
 ) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -421,7 +421,7 @@ func resourceServicesRpmProbeUpdate(ctx context.Context, d *schema.ResourceData,
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -462,7 +462,7 @@ func resourceServicesRpmProbeDelete(ctx context.Context, d *schema.ResourceData,
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -490,7 +490,7 @@ func resourceServicesRpmProbeDelete(ctx context.Context, d *schema.ResourceData,
 func resourceServicesRpmProbeImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_services_rpm_probe.go
+++ b/junos/resource_services_rpm_probe.go
@@ -21,10 +21,10 @@ type rpmProbeOptions struct {
 
 func resourceServicesRpmProbe() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceServicesRpmProbeCreate,
-		ReadContext:   resourceServicesRpmProbeRead,
-		UpdateContext: resourceServicesRpmProbeUpdate,
-		DeleteContext: resourceServicesRpmProbeDelete,
+		CreateWithoutTimeout: resourceServicesRpmProbeCreate,
+		ReadWithoutTimeout:   resourceServicesRpmProbeRead,
+		UpdateWithoutTimeout: resourceServicesRpmProbeUpdate,
+		DeleteWithoutTimeout: resourceServicesRpmProbeDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceServicesRpmProbeImport,
 		},
@@ -334,7 +334,9 @@ func resourceServicesRpmProbeCreate(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	rpmProbeExists, err := checkServicesRpmProbeExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -424,7 +426,9 @@ func resourceServicesRpmProbeUpdate(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delServicesRpmProbe(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -463,7 +467,9 @@ func resourceServicesRpmProbeDelete(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delServicesRpmProbe(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_services_security_intelligence_policy.go
+++ b/junos/resource_services_security_intelligence_policy.go
@@ -68,7 +68,7 @@ func resourceServicesSecurityIntellPolicyCreate(ctx context.Context, d *schema.R
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -119,7 +119,7 @@ func resourceServicesSecurityIntellPolicyCreate(ctx context.Context, d *schema.R
 func resourceServicesSecurityIntellPolicyRead(ctx context.Context, d *schema.ResourceData, m interface{},
 ) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -160,7 +160,7 @@ func resourceServicesSecurityIntellPolicyUpdate(ctx context.Context, d *schema.R
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -201,7 +201,7 @@ func resourceServicesSecurityIntellPolicyDelete(ctx context.Context, d *schema.R
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -229,7 +229,7 @@ func resourceServicesSecurityIntellPolicyDelete(ctx context.Context, d *schema.R
 func resourceServicesSecurityIntellPolicyImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_services_security_intelligence_policy.go
+++ b/junos/resource_services_security_intelligence_policy.go
@@ -19,10 +19,10 @@ type securityIntellPolicyOptions struct {
 
 func resourceServicesSecurityIntellPolicy() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceServicesSecurityIntellPolicyCreate,
-		ReadContext:   resourceServicesSecurityIntellPolicyRead,
-		UpdateContext: resourceServicesSecurityIntellPolicyUpdate,
-		DeleteContext: resourceServicesSecurityIntellPolicyDelete,
+		CreateWithoutTimeout: resourceServicesSecurityIntellPolicyCreate,
+		ReadWithoutTimeout:   resourceServicesSecurityIntellPolicyRead,
+		UpdateWithoutTimeout: resourceServicesSecurityIntellPolicyUpdate,
+		DeleteWithoutTimeout: resourceServicesSecurityIntellPolicyDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceServicesSecurityIntellPolicyImport,
 		},
@@ -73,7 +73,9 @@ func resourceServicesSecurityIntellPolicyCreate(ctx context.Context, d *schema.R
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	securityIntellPolicyExists, err := checkServicesSecurityIntellPolicyExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -163,7 +165,9 @@ func resourceServicesSecurityIntellPolicyUpdate(ctx context.Context, d *schema.R
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delServicesSecurityIntellPolicy(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -202,7 +206,9 @@ func resourceServicesSecurityIntellPolicyDelete(ctx context.Context, d *schema.R
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delServicesSecurityIntellPolicy(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_services_security_intelligence_profile.go
+++ b/junos/resource_services_security_intelligence_profile.go
@@ -23,10 +23,10 @@ type securityIntellProfileOptions struct {
 
 func resourceServicesSecurityIntellProfile() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceServicesSecurityIntellProfileCreate,
-		ReadContext:   resourceServicesSecurityIntellProfileRead,
-		UpdateContext: resourceServicesSecurityIntellProfileUpdate,
-		DeleteContext: resourceServicesSecurityIntellProfileDelete,
+		CreateWithoutTimeout: resourceServicesSecurityIntellProfileCreate,
+		ReadWithoutTimeout:   resourceServicesSecurityIntellProfileRead,
+		UpdateWithoutTimeout: resourceServicesSecurityIntellProfileUpdate,
+		DeleteWithoutTimeout: resourceServicesSecurityIntellProfileDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceServicesSecurityIntellProfileImport,
 		},
@@ -134,7 +134,9 @@ func resourceServicesSecurityIntellProfileCreate(ctx context.Context, d *schema.
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	securityIntellProfileExists, err := checkServicesSecurityIntellProfileExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -224,7 +226,9 @@ func resourceServicesSecurityIntellProfileUpdate(ctx context.Context, d *schema.
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delServicesSecurityIntellProfile(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -263,7 +267,9 @@ func resourceServicesSecurityIntellProfileDelete(ctx context.Context, d *schema.
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delServicesSecurityIntellProfile(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_services_security_intelligence_profile.go
+++ b/junos/resource_services_security_intelligence_profile.go
@@ -129,7 +129,7 @@ func resourceServicesSecurityIntellProfileCreate(ctx context.Context, d *schema.
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -180,7 +180,7 @@ func resourceServicesSecurityIntellProfileCreate(ctx context.Context, d *schema.
 func resourceServicesSecurityIntellProfileRead(ctx context.Context, d *schema.ResourceData, m interface{},
 ) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -221,7 +221,7 @@ func resourceServicesSecurityIntellProfileUpdate(ctx context.Context, d *schema.
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -262,7 +262,7 @@ func resourceServicesSecurityIntellProfileDelete(ctx context.Context, d *schema.
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -290,7 +290,7 @@ func resourceServicesSecurityIntellProfileDelete(ctx context.Context, d *schema.
 func resourceServicesSecurityIntellProfileImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_services_ssl_initiation_profile.go
+++ b/junos/resource_services_ssl_initiation_profile.go
@@ -24,10 +24,10 @@ type svcSSLInitiationProfileOptions struct {
 
 func resourceServicesSSLInitiationProfile() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceServicesSSLInitiationProfileCreate,
-		ReadContext:   resourceServicesSSLInitiationProfileRead,
-		UpdateContext: resourceServicesSSLInitiationProfileUpdate,
-		DeleteContext: resourceServicesSSLInitiationProfileDelete,
+		CreateWithoutTimeout: resourceServicesSSLInitiationProfileCreate,
+		ReadWithoutTimeout:   resourceServicesSSLInitiationProfileRead,
+		UpdateWithoutTimeout: resourceServicesSSLInitiationProfileUpdate,
+		DeleteWithoutTimeout: resourceServicesSSLInitiationProfileDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceServicesSSLInitiationProfileImport,
 		},
@@ -116,7 +116,9 @@ func resourceServicesSSLInitiationProfileCreate(ctx context.Context, d *schema.R
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	svcSSLInitiationProfileExists, err := checkServicesSSLInitiationProfileExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -208,7 +210,9 @@ func resourceServicesSSLInitiationProfileUpdate(ctx context.Context, d *schema.R
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delServicesSSLInitiationProfile(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -247,7 +251,9 @@ func resourceServicesSSLInitiationProfileDelete(ctx context.Context, d *schema.R
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delServicesSSLInitiationProfile(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_services_ssl_initiation_profile.go
+++ b/junos/resource_services_ssl_initiation_profile.go
@@ -111,7 +111,7 @@ func resourceServicesSSLInitiationProfileCreate(ctx context.Context, d *schema.R
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -164,7 +164,7 @@ func resourceServicesSSLInitiationProfileCreate(ctx context.Context, d *schema.R
 func resourceServicesSSLInitiationProfileRead(ctx context.Context, d *schema.ResourceData, m interface{},
 ) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -205,7 +205,7 @@ func resourceServicesSSLInitiationProfileUpdate(ctx context.Context, d *schema.R
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -246,7 +246,7 @@ func resourceServicesSSLInitiationProfileDelete(ctx context.Context, d *schema.R
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -274,7 +274,7 @@ func resourceServicesSSLInitiationProfileDelete(ctx context.Context, d *schema.R
 func resourceServicesSSLInitiationProfileImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_services_user_identification_ad_access_domain.go
+++ b/junos/resource_services_user_identification_ad_access_domain.go
@@ -24,10 +24,10 @@ type svcUserIdentAdAccessDomainOptions struct {
 
 func resourceServicesUserIdentAdAccessDomain() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceServicesUserIdentAdAccessDomainCreate,
-		ReadContext:   resourceServicesUserIdentAdAccessDomainRead,
-		UpdateContext: resourceServicesUserIdentAdAccessDomainUpdate,
-		DeleteContext: resourceServicesUserIdentAdAccessDomainDelete,
+		CreateWithoutTimeout: resourceServicesUserIdentAdAccessDomainCreate,
+		ReadWithoutTimeout:   resourceServicesUserIdentAdAccessDomainRead,
+		UpdateWithoutTimeout: resourceServicesUserIdentAdAccessDomainUpdate,
+		DeleteWithoutTimeout: resourceServicesUserIdentAdAccessDomainDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceServicesUserIdentAdAccessDomainImport,
 		},
@@ -141,7 +141,9 @@ func resourceServicesUserIdentAdAccessDomainCreate(ctx context.Context, d *schem
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	svcUserIdentAdAccessDomainExists, err := checkServicesUserIdentAdAccessDomainExists(
 		d.Get("name").(string), m, jnprSess)
@@ -235,7 +237,9 @@ func resourceServicesUserIdentAdAccessDomainUpdate(ctx context.Context, d *schem
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delServicesUserIdentAdAccessDomain(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -274,7 +278,9 @@ func resourceServicesUserIdentAdAccessDomainDelete(ctx context.Context, d *schem
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delServicesUserIdentAdAccessDomain(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_services_user_identification_ad_access_domain.go
+++ b/junos/resource_services_user_identification_ad_access_domain.go
@@ -420,7 +420,7 @@ func readServicesUserIdentAdAccessDomain(domain string, m interface{}, jnprSess 
 				var err error
 				confRead.userPassword, err = jdecode.Decode(strings.Trim(strings.TrimPrefix(itemTrim, "user password "), "\""))
 				if err != nil {
-					return confRead, fmt.Errorf("failed to decode user password : %w", err)
+					return confRead, fmt.Errorf("failed to decode user password: %w", err)
 				}
 			case strings.HasPrefix(itemTrim, "user "):
 				confRead.userName = strings.TrimPrefix(itemTrim, "user ")
@@ -481,7 +481,7 @@ func readServicesUserIdentAdAccessDomain(domain string, m interface{}, jnprSess 
 					confRead.userGroupMappingLdap[0]["user_password"], err = jdecode.Decode(strings.Trim(strings.TrimPrefix(
 						itemTrim, "user-group-mapping ldap user password "), "\""))
 					if err != nil {
-						return confRead, fmt.Errorf("failed to decode user password : %w", err)
+						return confRead, fmt.Errorf("failed to decode user password: %w", err)
 					}
 				case strings.HasPrefix(itemTrim, "user-group-mapping ldap user "):
 					confRead.userGroupMappingLdap[0]["user_name"] = strings.TrimPrefix(itemTrim, "user-group-mapping ldap user ")

--- a/junos/resource_services_user_identification_ad_access_domain.go
+++ b/junos/resource_services_user_identification_ad_access_domain.go
@@ -136,7 +136,7 @@ func resourceServicesUserIdentAdAccessDomainCreate(ctx context.Context, d *schem
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -190,7 +190,7 @@ func resourceServicesUserIdentAdAccessDomainCreate(ctx context.Context, d *schem
 func resourceServicesUserIdentAdAccessDomainRead(ctx context.Context, d *schema.ResourceData, m interface{},
 ) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -232,7 +232,7 @@ func resourceServicesUserIdentAdAccessDomainUpdate(ctx context.Context, d *schem
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -273,7 +273,7 @@ func resourceServicesUserIdentAdAccessDomainDelete(ctx context.Context, d *schem
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -301,7 +301,7 @@ func resourceServicesUserIdentAdAccessDomainDelete(ctx context.Context, d *schem
 func resourceServicesUserIdentAdAccessDomainImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_services_user_identification_device_identity_profile.go
+++ b/junos/resource_services_user_identification_device_identity_profile.go
@@ -18,10 +18,10 @@ type svcUserIdentDevIdentProfileOptions struct {
 
 func resourceServicesUserIdentDeviceIdentityProfile() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceServicesUserIdentDeviceIdentityProfileCreate,
-		ReadContext:   resourceServicesUserIdentDeviceIdentityProfileRead,
-		UpdateContext: resourceServicesUserIdentDeviceIdentityProfileUpdate,
-		DeleteContext: resourceServicesUserIdentDeviceIdentityProfileDelete,
+		CreateWithoutTimeout: resourceServicesUserIdentDeviceIdentityProfileCreate,
+		ReadWithoutTimeout:   resourceServicesUserIdentDeviceIdentityProfileRead,
+		UpdateWithoutTimeout: resourceServicesUserIdentDeviceIdentityProfileUpdate,
+		DeleteWithoutTimeout: resourceServicesUserIdentDeviceIdentityProfileDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceServicesUserIdentDeviceIdentityProfileImport,
 		},
@@ -77,7 +77,9 @@ func resourceServicesUserIdentDeviceIdentityProfileCreate(ctx context.Context, d
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	svcUserIdentDevIdentProfileExists, err := checkServicesUserIdentDeviceIdentityProfileExists(
 		d.Get("name").(string), m, jnprSess)
@@ -173,7 +175,9 @@ func resourceServicesUserIdentDeviceIdentityProfileUpdate(ctx context.Context, d
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delServicesUserIdentDeviceIdentityProfile(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -213,7 +217,9 @@ func resourceServicesUserIdentDeviceIdentityProfileDelete(ctx context.Context, d
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delServicesUserIdentDeviceIdentityProfile(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_services_user_identification_device_identity_profile.go
+++ b/junos/resource_services_user_identification_device_identity_profile.go
@@ -72,7 +72,7 @@ func resourceServicesUserIdentDeviceIdentityProfileCreate(ctx context.Context, d
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -127,7 +127,7 @@ func resourceServicesUserIdentDeviceIdentityProfileCreate(ctx context.Context, d
 func resourceServicesUserIdentDeviceIdentityProfileRead(ctx context.Context, d *schema.ResourceData, m interface{},
 ) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -170,7 +170,7 @@ func resourceServicesUserIdentDeviceIdentityProfileUpdate(ctx context.Context, d
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -212,7 +212,7 @@ func resourceServicesUserIdentDeviceIdentityProfileDelete(ctx context.Context, d
 		return nil
 	}
 
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -240,7 +240,7 @@ func resourceServicesUserIdentDeviceIdentityProfileDelete(ctx context.Context, d
 func resourceServicesUserIdentDeviceIdentityProfileImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_snmp.go
+++ b/junos/resource_snmp.go
@@ -31,10 +31,10 @@ type snmpOptions struct {
 
 func resourceSnmp() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSnmpCreate,
-		ReadContext:   resourceSnmpRead,
-		UpdateContext: resourceSnmpUpdate,
-		DeleteContext: resourceSnmpDelete,
+		CreateWithoutTimeout: resourceSnmpCreate,
+		ReadWithoutTimeout:   resourceSnmpRead,
+		UpdateWithoutTimeout: resourceSnmpUpdate,
+		DeleteWithoutTimeout: resourceSnmpDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSnmpImport,
 		},
@@ -171,7 +171,9 @@ func resourceSnmpCreate(ctx context.Context, d *schema.ResourceData, m interface
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := setSnmp(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -232,7 +234,9 @@ func resourceSnmpUpdate(ctx context.Context, d *schema.ResourceData, m interface
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSnmp(m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -271,7 +275,9 @@ func resourceSnmpDelete(ctx context.Context, d *schema.ResourceData, m interface
 			return diag.FromErr(err)
 		}
 		defer sess.closeSession(jnprSess)
-		sess.configLock(jnprSess)
+		if err := sess.configLock(ctx, jnprSess); err != nil {
+			return diag.FromErr(err)
+		}
 		var diagWarns diag.Diagnostics
 		if err := delSnmp(m, jnprSess); err != nil {
 			appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_snmp.go
+++ b/junos/resource_snmp.go
@@ -166,7 +166,7 @@ func resourceSnmpCreate(ctx context.Context, d *schema.ResourceData, m interface
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -194,7 +194,7 @@ func resourceSnmpCreate(ctx context.Context, d *schema.ResourceData, m interface
 
 func resourceSnmpRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -229,7 +229,7 @@ func resourceSnmpUpdate(ctx context.Context, d *schema.ResourceData, m interface
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -270,7 +270,7 @@ func resourceSnmpDelete(ctx context.Context, d *schema.ResourceData, m interface
 
 			return nil
 		}
-		jnprSess, err := sess.startNewSession()
+		jnprSess, err := sess.startNewSession(ctx)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -299,7 +299,7 @@ func resourceSnmpDelete(ctx context.Context, d *schema.ResourceData, m interface
 func resourceSnmpImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_snmp_clientlist.go
+++ b/junos/resource_snmp_clientlist.go
@@ -16,10 +16,10 @@ type snmpClientlistOptions struct {
 
 func resourceSnmpClientlist() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSnmpClientlistCreate,
-		ReadContext:   resourceSnmpClientlistRead,
-		UpdateContext: resourceSnmpClientlistUpdate,
-		DeleteContext: resourceSnmpClientlistDelete,
+		CreateWithoutTimeout: resourceSnmpClientlistCreate,
+		ReadWithoutTimeout:   resourceSnmpClientlistRead,
+		UpdateWithoutTimeout: resourceSnmpClientlistUpdate,
+		DeleteWithoutTimeout: resourceSnmpClientlistDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSnmpClientlistImport,
 		},
@@ -53,7 +53,9 @@ func resourceSnmpClientlistCreate(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	snmpClientlistExists, err := checkSnmpClientlistExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -140,7 +142,9 @@ func resourceSnmpClientlistUpdate(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSnmpClientlist(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -178,7 +182,9 @@ func resourceSnmpClientlistDelete(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSnmpClientlist(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_snmp_clientlist.go
+++ b/junos/resource_snmp_clientlist.go
@@ -48,7 +48,7 @@ func resourceSnmpClientlistCreate(ctx context.Context, d *schema.ResourceData, m
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -97,7 +97,7 @@ func resourceSnmpClientlistCreate(ctx context.Context, d *schema.ResourceData, m
 
 func resourceSnmpClientlistRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -137,7 +137,7 @@ func resourceSnmpClientlistUpdate(ctx context.Context, d *schema.ResourceData, m
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -177,7 +177,7 @@ func resourceSnmpClientlistDelete(ctx context.Context, d *schema.ResourceData, m
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -205,7 +205,7 @@ func resourceSnmpClientlistDelete(ctx context.Context, d *schema.ResourceData, m
 func resourceSnmpClientlistImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_snmp_community.go
+++ b/junos/resource_snmp_community.go
@@ -96,7 +96,7 @@ func resourceSnmpCommunityCreate(ctx context.Context, d *schema.ResourceData, m 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -145,7 +145,7 @@ func resourceSnmpCommunityCreate(ctx context.Context, d *schema.ResourceData, m 
 
 func resourceSnmpCommunityRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -185,7 +185,7 @@ func resourceSnmpCommunityUpdate(ctx context.Context, d *schema.ResourceData, m 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -225,7 +225,7 @@ func resourceSnmpCommunityDelete(ctx context.Context, d *schema.ResourceData, m 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -253,7 +253,7 @@ func resourceSnmpCommunityDelete(ctx context.Context, d *schema.ResourceData, m 
 func resourceSnmpCommunityImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_snmp_community.go
+++ b/junos/resource_snmp_community.go
@@ -22,10 +22,10 @@ type snmpCommunityOptions struct {
 
 func resourceSnmpCommunity() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSnmpCommunityCreate,
-		ReadContext:   resourceSnmpCommunityRead,
-		UpdateContext: resourceSnmpCommunityUpdate,
-		DeleteContext: resourceSnmpCommunityDelete,
+		CreateWithoutTimeout: resourceSnmpCommunityCreate,
+		ReadWithoutTimeout:   resourceSnmpCommunityRead,
+		UpdateWithoutTimeout: resourceSnmpCommunityUpdate,
+		DeleteWithoutTimeout: resourceSnmpCommunityDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSnmpCommunityImport,
 		},
@@ -101,7 +101,9 @@ func resourceSnmpCommunityCreate(ctx context.Context, d *schema.ResourceData, m 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	snmpCommunityExists, err := checkSnmpCommunityExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -188,7 +190,9 @@ func resourceSnmpCommunityUpdate(ctx context.Context, d *schema.ResourceData, m 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSnmpCommunity(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -226,7 +230,9 @@ func resourceSnmpCommunityDelete(ctx context.Context, d *schema.ResourceData, m 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSnmpCommunity(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_snmp_v3_community.go
+++ b/junos/resource_snmp_v3_community.go
@@ -63,7 +63,7 @@ func resourceSnmpV3CommunityCreate(ctx context.Context, d *schema.ResourceData, 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -113,7 +113,7 @@ func resourceSnmpV3CommunityCreate(ctx context.Context, d *schema.ResourceData, 
 
 func resourceSnmpV3CommunityRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -153,7 +153,7 @@ func resourceSnmpV3CommunityUpdate(ctx context.Context, d *schema.ResourceData, 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -193,7 +193,7 @@ func resourceSnmpV3CommunityDelete(ctx context.Context, d *schema.ResourceData, 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -221,7 +221,7 @@ func resourceSnmpV3CommunityDelete(ctx context.Context, d *schema.ResourceData, 
 func resourceSnmpV3CommunityImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_snmp_v3_community.go
+++ b/junos/resource_snmp_v3_community.go
@@ -307,7 +307,7 @@ func readSnmpV3Community(communityIndex string, m interface{}, jnprSess *Netconf
 				var err error
 				confRead.communityName, err = jdecode.Decode(strings.Trim(strings.TrimPrefix(itemTrim, "community-name "), "\""))
 				if err != nil {
-					return confRead, fmt.Errorf("failed to decode community-name : %w", err)
+					return confRead, fmt.Errorf("failed to decode community-name: %w", err)
 				}
 			case strings.HasPrefix(itemTrim, "context "):
 				confRead.context = strings.Trim(strings.TrimPrefix(itemTrim, "context "), "\"")

--- a/junos/resource_snmp_v3_community.go
+++ b/junos/resource_snmp_v3_community.go
@@ -20,10 +20,10 @@ type snmpV3CommunityOptions struct {
 
 func resourceSnmpV3Community() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSnmpV3CommunityCreate,
-		ReadContext:   resourceSnmpV3CommunityRead,
-		UpdateContext: resourceSnmpV3CommunityUpdate,
-		DeleteContext: resourceSnmpV3CommunityDelete,
+		CreateWithoutTimeout: resourceSnmpV3CommunityCreate,
+		ReadWithoutTimeout:   resourceSnmpV3CommunityRead,
+		UpdateWithoutTimeout: resourceSnmpV3CommunityUpdate,
+		DeleteWithoutTimeout: resourceSnmpV3CommunityDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSnmpV3CommunityImport,
 		},
@@ -68,7 +68,9 @@ func resourceSnmpV3CommunityCreate(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	snmpV3CommunityExists, err := checkSnmpV3CommunityExists(d.Get("community_index").(string), m, jnprSess)
 	if err != nil {
@@ -156,7 +158,9 @@ func resourceSnmpV3CommunityUpdate(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSnmpV3Community(d.Get("community_index").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -194,7 +198,9 @@ func resourceSnmpV3CommunityDelete(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSnmpV3Community(d.Get("community_index").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_snmp_v3_usm_user.go
+++ b/junos/resource_snmp_v3_usm_user.go
@@ -115,7 +115,7 @@ func resourceSnmpV3UsmUserCreate(ctx context.Context, d *schema.ResourceData, m 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -181,7 +181,7 @@ func resourceSnmpV3UsmUserCreate(ctx context.Context, d *schema.ResourceData, m 
 
 func resourceSnmpV3UsmUserRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -231,7 +231,7 @@ func resourceSnmpV3UsmUserUpdate(ctx context.Context, d *schema.ResourceData, m 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -273,7 +273,7 @@ func resourceSnmpV3UsmUserDelete(ctx context.Context, d *schema.ResourceData, m 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -302,7 +302,7 @@ func resourceSnmpV3UsmUserDelete(ctx context.Context, d *schema.ResourceData, m 
 func resourceSnmpV3UsmUserImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_snmp_v3_usm_user.go
+++ b/junos/resource_snmp_v3_usm_user.go
@@ -472,7 +472,7 @@ func readSnmpV3UsmUser(confSrc snmpV3UsmUserOptions, m interface{}, jnprSess *Ne
 					confRead.authenticationKey, err = jdecode.Decode(strings.Trim(strings.TrimPrefix(
 						itemTrim, "authentication-md5 authentication-key "), "\""))
 					if err != nil {
-						return confRead, fmt.Errorf("failed to decode authentication-key : %w", err)
+						return confRead, fmt.Errorf("failed to decode authentication-key: %w", err)
 					}
 				}
 			case itemTrim == "authentication-none":
@@ -486,7 +486,7 @@ func readSnmpV3UsmUser(confSrc snmpV3UsmUserOptions, m interface{}, jnprSess *Ne
 					confRead.authenticationKey, err = jdecode.Decode(strings.Trim(strings.TrimPrefix(
 						itemTrim, "authentication-sha authentication-key "), "\""))
 					if err != nil {
-						return confRead, fmt.Errorf("failed to decode authentication-key : %w", err)
+						return confRead, fmt.Errorf("failed to decode authentication-key: %w", err)
 					}
 				}
 			case strings.HasPrefix(itemTrim, "privacy-3des privacy-key "):
@@ -498,7 +498,7 @@ func readSnmpV3UsmUser(confSrc snmpV3UsmUserOptions, m interface{}, jnprSess *Ne
 					confRead.privacyKey, err = jdecode.Decode(strings.Trim(strings.TrimPrefix(
 						itemTrim, "privacy-3des privacy-key "), "\""))
 					if err != nil {
-						return confRead, fmt.Errorf("failed to decode privacy-key : %w", err)
+						return confRead, fmt.Errorf("failed to decode privacy-key: %w", err)
 					}
 				}
 			case strings.HasPrefix(itemTrim, "privacy-aes128 privacy-key "):
@@ -510,7 +510,7 @@ func readSnmpV3UsmUser(confSrc snmpV3UsmUserOptions, m interface{}, jnprSess *Ne
 					confRead.privacyKey, err = jdecode.Decode(strings.Trim(strings.TrimPrefix(
 						itemTrim, "privacy-aes128 privacy-key "), "\""))
 					if err != nil {
-						return confRead, fmt.Errorf("failed to decode privacy-key : %w", err)
+						return confRead, fmt.Errorf("failed to decode privacy-key: %w", err)
 					}
 				}
 			case strings.HasPrefix(itemTrim, "privacy-des privacy-key "):
@@ -522,7 +522,7 @@ func readSnmpV3UsmUser(confSrc snmpV3UsmUserOptions, m interface{}, jnprSess *Ne
 					confRead.privacyKey, err = jdecode.Decode(strings.Trim(strings.TrimPrefix(
 						itemTrim, "privacy-des privacy-key "), "\""))
 					if err != nil {
-						return confRead, fmt.Errorf("failed to decode privacy-key : %w", err)
+						return confRead, fmt.Errorf("failed to decode privacy-key: %w", err)
 					}
 				}
 			case itemTrim == "privacy-none":

--- a/junos/resource_snmp_v3_usm_user.go
+++ b/junos/resource_snmp_v3_usm_user.go
@@ -25,10 +25,10 @@ type snmpV3UsmUserOptions struct {
 
 func resourceSnmpV3UsmUser() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSnmpV3UsmUserCreate,
-		ReadContext:   resourceSnmpV3UsmUserRead,
-		UpdateContext: resourceSnmpV3UsmUserUpdate,
-		DeleteContext: resourceSnmpV3UsmUserDelete,
+		CreateWithoutTimeout: resourceSnmpV3UsmUserCreate,
+		ReadWithoutTimeout:   resourceSnmpV3UsmUserRead,
+		UpdateWithoutTimeout: resourceSnmpV3UsmUserUpdate,
+		DeleteWithoutTimeout: resourceSnmpV3UsmUserDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSnmpV3UsmUserImport,
 		},
@@ -120,7 +120,9 @@ func resourceSnmpV3UsmUserCreate(ctx context.Context, d *schema.ResourceData, m 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	snmpV3UsmUserExists, err := checkSnmpV3UsmUserExists(
 		d.Get("name").(string), d.Get("engine_type").(string), d.Get("engine_id").(string), m, jnprSess)
@@ -234,7 +236,9 @@ func resourceSnmpV3UsmUserUpdate(ctx context.Context, d *schema.ResourceData, m 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSnmpV3UsmUser(
 		d.Get("name").(string), d.Get("engine_type").(string), d.Get("engine_id").(string), m, jnprSess); err != nil {
@@ -274,7 +278,9 @@ func resourceSnmpV3UsmUserDelete(ctx context.Context, d *schema.ResourceData, m 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSnmpV3UsmUser(
 		d.Get("name").(string), d.Get("engine_type").(string), d.Get("engine_id").(string), m, jnprSess); err != nil {

--- a/junos/resource_snmp_v3_vacm_accessgroup.go
+++ b/junos/resource_snmp_v3_vacm_accessgroup.go
@@ -19,10 +19,10 @@ type snmpV3VacmAccessGroupOptions struct {
 
 func resourceSnmpV3VacmAccessGroup() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSnmpV3VacmAccessGroupCreate,
-		ReadContext:   resourceSnmpV3VacmAccessGroupRead,
-		UpdateContext: resourceSnmpV3VacmAccessGroupUpdate,
-		DeleteContext: resourceSnmpV3VacmAccessGroupDelete,
+		CreateWithoutTimeout: resourceSnmpV3VacmAccessGroupCreate,
+		ReadWithoutTimeout:   resourceSnmpV3VacmAccessGroupRead,
+		UpdateWithoutTimeout: resourceSnmpV3VacmAccessGroupUpdate,
+		DeleteWithoutTimeout: resourceSnmpV3VacmAccessGroupDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSnmpV3VacmAccessGroupImport,
 		},
@@ -143,7 +143,9 @@ func resourceSnmpV3VacmAccessGroupCreate(ctx context.Context, d *schema.Resource
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	snmpV3VacmAccessGroupExists, err := checkSnmpV3VacmAccessGroupExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -231,7 +233,9 @@ func resourceSnmpV3VacmAccessGroupUpdate(ctx context.Context, d *schema.Resource
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSnmpV3VacmAccessGroup(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -269,7 +273,9 @@ func resourceSnmpV3VacmAccessGroupDelete(ctx context.Context, d *schema.Resource
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSnmpV3VacmAccessGroup(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_snmp_v3_vacm_accessgroup.go
+++ b/junos/resource_snmp_v3_vacm_accessgroup.go
@@ -138,7 +138,7 @@ func resourceSnmpV3VacmAccessGroupCreate(ctx context.Context, d *schema.Resource
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -188,7 +188,7 @@ func resourceSnmpV3VacmAccessGroupCreate(ctx context.Context, d *schema.Resource
 
 func resourceSnmpV3VacmAccessGroupRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -228,7 +228,7 @@ func resourceSnmpV3VacmAccessGroupUpdate(ctx context.Context, d *schema.Resource
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -268,7 +268,7 @@ func resourceSnmpV3VacmAccessGroupDelete(ctx context.Context, d *schema.Resource
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -296,7 +296,7 @@ func resourceSnmpV3VacmAccessGroupDelete(ctx context.Context, d *schema.Resource
 func resourceSnmpV3VacmAccessGroupImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_snmp_v3_vacm_securitytogroup.go
+++ b/junos/resource_snmp_v3_vacm_securitytogroup.go
@@ -19,10 +19,10 @@ type snmpV3VacmSecurityToGroupOptions struct {
 
 func resourceSnmpV3VacmSecurityToGroup() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSnmpV3VacmSecurityToGroupCreate,
-		ReadContext:   resourceSnmpV3VacmSecurityToGroupRead,
-		UpdateContext: resourceSnmpV3VacmSecurityToGroupUpdate,
-		DeleteContext: resourceSnmpV3VacmSecurityToGroupDelete,
+		CreateWithoutTimeout: resourceSnmpV3VacmSecurityToGroupCreate,
+		ReadWithoutTimeout:   resourceSnmpV3VacmSecurityToGroupRead,
+		UpdateWithoutTimeout: resourceSnmpV3VacmSecurityToGroupUpdate,
+		DeleteWithoutTimeout: resourceSnmpV3VacmSecurityToGroupDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSnmpV3VacmSecurityToGroupImport,
 		},
@@ -62,7 +62,9 @@ func resourceSnmpV3VacmSecurityToGroupCreate(ctx context.Context, d *schema.Reso
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	snmpV3VacmSecurityToGroupExists, err := checkSnmpV3VacmSecurityToGroupExists(
 		d.Get("model").(string), d.Get("name").(string), m, jnprSess)
@@ -157,7 +159,9 @@ func resourceSnmpV3VacmSecurityToGroupUpdate(ctx context.Context, d *schema.Reso
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSnmpV3VacmSecurityToGroup(d.Get("model").(string), d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -196,7 +200,9 @@ func resourceSnmpV3VacmSecurityToGroupDelete(ctx context.Context, d *schema.Reso
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSnmpV3VacmSecurityToGroup(d.Get("model").(string), d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_snmp_v3_vacm_securitytogroup.go
+++ b/junos/resource_snmp_v3_vacm_securitytogroup.go
@@ -57,7 +57,7 @@ func resourceSnmpV3VacmSecurityToGroupCreate(ctx context.Context, d *schema.Reso
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -112,7 +112,7 @@ func resourceSnmpV3VacmSecurityToGroupCreate(ctx context.Context, d *schema.Reso
 func resourceSnmpV3VacmSecurityToGroupRead(ctx context.Context, d *schema.ResourceData, m interface{},
 ) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -154,7 +154,7 @@ func resourceSnmpV3VacmSecurityToGroupUpdate(ctx context.Context, d *schema.Reso
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -195,7 +195,7 @@ func resourceSnmpV3VacmSecurityToGroupDelete(ctx context.Context, d *schema.Reso
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -223,7 +223,7 @@ func resourceSnmpV3VacmSecurityToGroupDelete(ctx context.Context, d *schema.Reso
 func resourceSnmpV3VacmSecurityToGroupImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_snmp_view.go
+++ b/junos/resource_snmp_view.go
@@ -56,7 +56,7 @@ func resourceSnmpViewCreate(ctx context.Context, d *schema.ResourceData, m inter
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -105,7 +105,7 @@ func resourceSnmpViewCreate(ctx context.Context, d *schema.ResourceData, m inter
 
 func resourceSnmpViewRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -145,7 +145,7 @@ func resourceSnmpViewUpdate(ctx context.Context, d *schema.ResourceData, m inter
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -185,7 +185,7 @@ func resourceSnmpViewDelete(ctx context.Context, d *schema.ResourceData, m inter
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -213,7 +213,7 @@ func resourceSnmpViewDelete(ctx context.Context, d *schema.ResourceData, m inter
 func resourceSnmpViewImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_snmp_view.go
+++ b/junos/resource_snmp_view.go
@@ -17,10 +17,10 @@ type snmpViewOptions struct {
 
 func resourceSnmpView() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSnmpViewCreate,
-		ReadContext:   resourceSnmpViewRead,
-		UpdateContext: resourceSnmpViewUpdate,
-		DeleteContext: resourceSnmpViewDelete,
+		CreateWithoutTimeout: resourceSnmpViewCreate,
+		ReadWithoutTimeout:   resourceSnmpViewRead,
+		UpdateWithoutTimeout: resourceSnmpViewUpdate,
+		DeleteWithoutTimeout: resourceSnmpViewDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSnmpViewImport,
 		},
@@ -61,7 +61,9 @@ func resourceSnmpViewCreate(ctx context.Context, d *schema.ResourceData, m inter
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	snmpViewExists, err := checkSnmpViewExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -148,7 +150,9 @@ func resourceSnmpViewUpdate(ctx context.Context, d *schema.ResourceData, m inter
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSnmpView(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -186,7 +190,9 @@ func resourceSnmpViewDelete(ctx context.Context, d *schema.ResourceData, m inter
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSnmpView(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_static_route.go
+++ b/junos/resource_static_route.go
@@ -216,7 +216,7 @@ func resourceStaticRouteCreate(ctx context.Context, d *schema.ResourceData, m in
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -281,7 +281,7 @@ func resourceStaticRouteCreate(ctx context.Context, d *schema.ResourceData, m in
 
 func resourceStaticRouteRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -321,7 +321,7 @@ func resourceStaticRouteUpdate(ctx context.Context, d *schema.ResourceData, m in
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -362,7 +362,7 @@ func resourceStaticRouteDelete(ctx context.Context, d *schema.ResourceData, m in
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -390,7 +390,7 @@ func resourceStaticRouteDelete(ctx context.Context, d *schema.ResourceData, m in
 func resourceStaticRouteImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_static_route.go
+++ b/junos/resource_static_route.go
@@ -43,10 +43,10 @@ type staticRouteOptions struct {
 
 func resourceStaticRoute() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceStaticRouteCreate,
-		ReadContext:   resourceStaticRouteRead,
-		UpdateContext: resourceStaticRouteUpdate,
-		DeleteContext: resourceStaticRouteDelete,
+		CreateWithoutTimeout: resourceStaticRouteCreate,
+		ReadWithoutTimeout:   resourceStaticRouteRead,
+		UpdateWithoutTimeout: resourceStaticRouteUpdate,
+		DeleteWithoutTimeout: resourceStaticRouteDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceStaticRouteImport,
 		},
@@ -221,7 +221,9 @@ func resourceStaticRouteCreate(ctx context.Context, d *schema.ResourceData, m in
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if d.Get("routing_instance").(string) != defaultW {
 		instanceExists, err := checkRoutingInstanceExists(d.Get("routing_instance").(string), m, jnprSess)
@@ -324,7 +326,9 @@ func resourceStaticRouteUpdate(ctx context.Context, d *schema.ResourceData, m in
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delStaticRoute(d.Get("destination").(string), d.Get("routing_instance").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -363,7 +367,9 @@ func resourceStaticRouteDelete(ctx context.Context, d *schema.ResourceData, m in
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delStaticRoute(d.Get("destination").(string), d.Get("routing_instance").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_switch_options.go
+++ b/junos/resource_switch_options.go
@@ -15,10 +15,10 @@ type switchOptionsOptions struct {
 
 func resourceSwitchOptions() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSwitchOptionsCreate,
-		ReadContext:   resourceSwitchOptionsRead,
-		UpdateContext: resourceSwitchOptionsUpdate,
-		DeleteContext: resourceSwitchOptionsDelete,
+		CreateWithoutTimeout: resourceSwitchOptionsCreate,
+		ReadWithoutTimeout:   resourceSwitchOptionsRead,
+		UpdateWithoutTimeout: resourceSwitchOptionsUpdate,
+		DeleteWithoutTimeout: resourceSwitchOptionsDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSwitchOptionsImport,
 		},
@@ -59,7 +59,9 @@ func resourceSwitchOptionsCreate(ctx context.Context, d *schema.ResourceData, m 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := setSwitchOptions(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -121,7 +123,9 @@ func resourceSwitchOptionsUpdate(ctx context.Context, d *schema.ResourceData, m 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSwitchOptions(m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -160,7 +164,9 @@ func resourceSwitchOptionsDelete(ctx context.Context, d *schema.ResourceData, m 
 			return diag.FromErr(err)
 		}
 		defer sess.closeSession(jnprSess)
-		sess.configLock(jnprSess)
+		if err := sess.configLock(ctx, jnprSess); err != nil {
+			return diag.FromErr(err)
+		}
 		var diagWarns diag.Diagnostics
 		if err := delSwitchOptions(m, jnprSess); err != nil {
 			appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_switch_options.go
+++ b/junos/resource_switch_options.go
@@ -54,7 +54,7 @@ func resourceSwitchOptionsCreate(ctx context.Context, d *schema.ResourceData, m 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -82,7 +82,7 @@ func resourceSwitchOptionsCreate(ctx context.Context, d *schema.ResourceData, m 
 
 func resourceSwitchOptionsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -118,7 +118,7 @@ func resourceSwitchOptionsUpdate(ctx context.Context, d *schema.ResourceData, m 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -159,7 +159,7 @@ func resourceSwitchOptionsDelete(ctx context.Context, d *schema.ResourceData, m 
 
 			return nil
 		}
-		jnprSess, err := sess.startNewSession()
+		jnprSess, err := sess.startNewSession(ctx)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -188,7 +188,7 @@ func resourceSwitchOptionsDelete(ctx context.Context, d *schema.ResourceData, m 
 func resourceSwitchOptionsImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_system.go
+++ b/junos/resource_system.go
@@ -1859,7 +1859,7 @@ func readSystem(m interface{}, jnprSess *NetconfObject) (systemOptions, error) {
 					} else {
 						passWord, err := jdecode.Decode(strings.Trim(archiveSiteSplit[2], "\""))
 						if err != nil {
-							return confRead, fmt.Errorf("failed to decode archive-site password : %w", err)
+							return confRead, fmt.Errorf("failed to decode archive-site password: %w", err)
 						}
 						confRead.archivalConfiguration[0]["archive_site"] = append(
 							confRead.archivalConfiguration[0]["archive_site"].([]map[string]interface{}), map[string]interface{}{
@@ -2411,7 +2411,7 @@ func readSystemLicense(confRead *systemOptions, itemTrim string) error {
 			confRead.license[0]["autoupdate_password"], err = jdecode.Decode(strings.Trim(strings.TrimPrefix(
 				itemTrimPassword, "password "), "\""))
 			if err != nil {
-				return fmt.Errorf("failed to decode password : %w", err)
+				return fmt.Errorf("failed to decode password: %w", err)
 			}
 		}
 	case strings.HasPrefix(itemTrim, "license renew before-expiration "):

--- a/junos/resource_system.go
+++ b/junos/resource_system.go
@@ -937,7 +937,7 @@ func resourceSystemCreate(ctx context.Context, d *schema.ResourceData, m interfa
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -965,7 +965,7 @@ func resourceSystemCreate(ctx context.Context, d *schema.ResourceData, m interfa
 
 func resourceSystemRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -1000,7 +1000,7 @@ func resourceSystemUpdate(ctx context.Context, d *schema.ResourceData, m interfa
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -1038,7 +1038,7 @@ func resourceSystemDelete(ctx context.Context, d *schema.ResourceData, m interfa
 func resourceSystemImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_system.go
+++ b/junos/resource_system.go
@@ -46,10 +46,10 @@ type systemOptions struct {
 
 func resourceSystem() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSystemCreate,
-		ReadContext:   resourceSystemRead,
-		UpdateContext: resourceSystemUpdate,
-		DeleteContext: resourceSystemDelete,
+		CreateWithoutTimeout: resourceSystemCreate,
+		ReadWithoutTimeout:   resourceSystemRead,
+		UpdateWithoutTimeout: resourceSystemUpdate,
+		DeleteWithoutTimeout: resourceSystemDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSystemImport,
 		},
@@ -942,7 +942,9 @@ func resourceSystemCreate(ctx context.Context, d *schema.ResourceData, m interfa
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := setSystem(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -1003,7 +1005,9 @@ func resourceSystemUpdate(ctx context.Context, d *schema.ResourceData, m interfa
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSystem(m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_system_login_class.go
+++ b/junos/resource_system_login_class.go
@@ -194,7 +194,7 @@ func resourceSystemLoginClassCreate(ctx context.Context, d *schema.ResourceData,
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -243,7 +243,7 @@ func resourceSystemLoginClassCreate(ctx context.Context, d *schema.ResourceData,
 
 func resourceSystemLoginClassRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -283,7 +283,7 @@ func resourceSystemLoginClassUpdate(ctx context.Context, d *schema.ResourceData,
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -323,7 +323,7 @@ func resourceSystemLoginClassDelete(ctx context.Context, d *schema.ResourceData,
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -351,7 +351,7 @@ func resourceSystemLoginClassDelete(ctx context.Context, d *schema.ResourceData,
 func resourceSystemLoginClassImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_system_login_class.go
+++ b/junos/resource_system_login_class.go
@@ -42,10 +42,10 @@ type systemLoginClassOptions struct {
 
 func resourceSystemLoginClass() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSystemLoginClassCreate,
-		ReadContext:   resourceSystemLoginClassRead,
-		UpdateContext: resourceSystemLoginClassUpdate,
-		DeleteContext: resourceSystemLoginClassDelete,
+		CreateWithoutTimeout: resourceSystemLoginClassCreate,
+		ReadWithoutTimeout:   resourceSystemLoginClassRead,
+		UpdateWithoutTimeout: resourceSystemLoginClassUpdate,
+		DeleteWithoutTimeout: resourceSystemLoginClassDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSystemLoginClassImport,
 		},
@@ -199,7 +199,9 @@ func resourceSystemLoginClassCreate(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	systemLoginClassExists, err := checkSystemLoginClassExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -286,7 +288,9 @@ func resourceSystemLoginClassUpdate(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSystemLoginClass(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -324,7 +328,9 @@ func resourceSystemLoginClassDelete(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSystemLoginClass(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_system_login_user.go
+++ b/junos/resource_system_login_user.go
@@ -23,10 +23,10 @@ type systemLoginUserOptions struct {
 
 func resourceSystemLoginUser() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSystemLoginUserCreate,
-		ReadContext:   resourceSystemLoginUserRead,
-		UpdateContext: resourceSystemLoginUserUpdate,
-		DeleteContext: resourceSystemLoginUserDelete,
+		CreateWithoutTimeout: resourceSystemLoginUserCreate,
+		ReadWithoutTimeout:   resourceSystemLoginUserRead,
+		UpdateWithoutTimeout: resourceSystemLoginUserUpdate,
+		DeleteWithoutTimeout: resourceSystemLoginUserDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSystemLoginUserImport,
 		},
@@ -108,7 +108,9 @@ func resourceSystemLoginUserCreate(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	systemLoginUserExists, err := checkSystemLoginUserExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -196,7 +198,9 @@ func resourceSystemLoginUserUpdate(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSystemLoginUser(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -235,7 +239,9 @@ func resourceSystemLoginUserDelete(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSystemLoginUser(d.Get("name").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_system_login_user.go
+++ b/junos/resource_system_login_user.go
@@ -103,7 +103,7 @@ func resourceSystemLoginUserCreate(ctx context.Context, d *schema.ResourceData, 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -152,7 +152,7 @@ func resourceSystemLoginUserCreate(ctx context.Context, d *schema.ResourceData, 
 
 func resourceSystemLoginUserRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -193,7 +193,7 @@ func resourceSystemLoginUserUpdate(ctx context.Context, d *schema.ResourceData, 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -234,7 +234,7 @@ func resourceSystemLoginUserDelete(ctx context.Context, d *schema.ResourceData, 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -262,7 +262,7 @@ func resourceSystemLoginUserDelete(ctx context.Context, d *schema.ResourceData, 
 func resourceSystemLoginUserImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_system_ntp_server.go
+++ b/junos/resource_system_ntp_server.go
@@ -21,10 +21,10 @@ type ntpServerOptions struct {
 
 func resourceSystemNtpServer() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSystemNtpServerCreate,
-		ReadContext:   resourceSystemNtpServerRead,
-		UpdateContext: resourceSystemNtpServerUpdate,
-		DeleteContext: resourceSystemNtpServerDelete,
+		CreateWithoutTimeout: resourceSystemNtpServerCreate,
+		ReadWithoutTimeout:   resourceSystemNtpServerRead,
+		UpdateWithoutTimeout: resourceSystemNtpServerUpdate,
+		DeleteWithoutTimeout: resourceSystemNtpServerDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSystemNtpServerImport,
 		},
@@ -73,7 +73,9 @@ func resourceSystemNtpServerCreate(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	ntpServerExists, err := checkSystemNtpServerExists(d.Get("address").(string), m, jnprSess)
 	if err != nil {
@@ -161,7 +163,9 @@ func resourceSystemNtpServerUpdate(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSystemNtpServer(d.Get("address").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -200,7 +204,9 @@ func resourceSystemNtpServerDelete(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSystemNtpServer(d.Get("address").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_system_ntp_server.go
+++ b/junos/resource_system_ntp_server.go
@@ -68,7 +68,7 @@ func resourceSystemNtpServerCreate(ctx context.Context, d *schema.ResourceData, 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -118,7 +118,7 @@ func resourceSystemNtpServerCreate(ctx context.Context, d *schema.ResourceData, 
 
 func resourceSystemNtpServerRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -158,7 +158,7 @@ func resourceSystemNtpServerUpdate(ctx context.Context, d *schema.ResourceData, 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -199,7 +199,7 @@ func resourceSystemNtpServerDelete(ctx context.Context, d *schema.ResourceData, 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -227,7 +227,7 @@ func resourceSystemNtpServerDelete(ctx context.Context, d *schema.ResourceData, 
 func resourceSystemNtpServerImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_system_radius_server.go
+++ b/junos/resource_system_radius_server.go
@@ -31,10 +31,10 @@ type radiusServerOptions struct {
 
 func resourceSystemRadiusServer() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSystemRadiusServerCreate,
-		ReadContext:   resourceSystemRadiusServerRead,
-		UpdateContext: resourceSystemRadiusServerUpdate,
-		DeleteContext: resourceSystemRadiusServerDelete,
+		CreateWithoutTimeout: resourceSystemRadiusServerCreate,
+		ReadWithoutTimeout:   resourceSystemRadiusServerRead,
+		UpdateWithoutTimeout: resourceSystemRadiusServerUpdate,
+		DeleteWithoutTimeout: resourceSystemRadiusServerDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSystemRadiusServerImport,
 		},
@@ -137,7 +137,9 @@ func resourceSystemRadiusServerCreate(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	radiusServerExists, err := checkSystemRadiusServerExists(d.Get("address").(string), m, jnprSess)
 	if err != nil {
@@ -225,7 +227,9 @@ func resourceSystemRadiusServerUpdate(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSystemRadiusServer(d.Get("address").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -263,7 +267,9 @@ func resourceSystemRadiusServerDelete(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSystemRadiusServer(d.Get("address").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_system_radius_server.go
+++ b/junos/resource_system_radius_server.go
@@ -132,7 +132,7 @@ func resourceSystemRadiusServerCreate(ctx context.Context, d *schema.ResourceDat
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -182,7 +182,7 @@ func resourceSystemRadiusServerCreate(ctx context.Context, d *schema.ResourceDat
 
 func resourceSystemRadiusServerRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -222,7 +222,7 @@ func resourceSystemRadiusServerUpdate(ctx context.Context, d *schema.ResourceDat
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -262,7 +262,7 @@ func resourceSystemRadiusServerDelete(ctx context.Context, d *schema.ResourceDat
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -290,7 +290,7 @@ func resourceSystemRadiusServerDelete(ctx context.Context, d *schema.ResourceDat
 func resourceSystemRadiusServerImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_system_radius_server.go
+++ b/junos/resource_system_radius_server.go
@@ -455,7 +455,7 @@ func readSystemRadiusServer(address string, m interface{}, jnprSess *NetconfObje
 				confRead.preauthenticationSecret, err = jdecode.Decode(strings.Trim(strings.TrimPrefix(itemTrim,
 					"preauthentication-secret "), "\""))
 				if err != nil {
-					return confRead, fmt.Errorf("failed to decode preauthentication-secret : %w", err)
+					return confRead, fmt.Errorf("failed to decode preauthentication-secret: %w", err)
 				}
 			case strings.HasPrefix(itemTrim, "retry "):
 				var err error
@@ -470,7 +470,7 @@ func readSystemRadiusServer(address string, m interface{}, jnprSess *NetconfObje
 				confRead.secret, err = jdecode.Decode(strings.Trim(strings.TrimPrefix(itemTrim,
 					"secret "), "\""))
 				if err != nil {
-					return confRead, fmt.Errorf("failed to decode secret : %w", err)
+					return confRead, fmt.Errorf("failed to decode secret: %w", err)
 				}
 			case strings.HasPrefix(itemTrim, "source-address "):
 				confRead.sourceAddress = strings.TrimPrefix(itemTrim, "source-address ")

--- a/junos/resource_system_root_authentication.go
+++ b/junos/resource_system_root_authentication.go
@@ -19,10 +19,10 @@ type systemRootAuthOptions struct {
 
 func resourceSystemRootAuthentication() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSystemRootAuthenticationCreate,
-		ReadContext:   resourceSystemRootAuthenticationRead,
-		UpdateContext: resourceSystemRootAuthenticationUpdate,
-		DeleteContext: resourceSystemRootAuthenticationDelete,
+		CreateWithoutTimeout: resourceSystemRootAuthenticationCreate,
+		ReadWithoutTimeout:   resourceSystemRootAuthenticationRead,
+		UpdateWithoutTimeout: resourceSystemRootAuthenticationUpdate,
+		DeleteWithoutTimeout: resourceSystemRootAuthenticationDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSystemRootAuthenticationImport,
 		},
@@ -79,7 +79,9 @@ func resourceSystemRootAuthenticationCreate(ctx context.Context, d *schema.Resou
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	// To be able detect a plain text password not accepted by system
 	if d.Get("plain_text_password").(string) != "" {
@@ -150,7 +152,9 @@ func resourceSystemRootAuthenticationUpdate(ctx context.Context, d *schema.Resou
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSystemRootAuthentication(m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_system_root_authentication.go
+++ b/junos/resource_system_root_authentication.go
@@ -74,7 +74,7 @@ func resourceSystemRootAuthenticationCreate(ctx context.Context, d *schema.Resou
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -110,7 +110,7 @@ func resourceSystemRootAuthenticationCreate(ctx context.Context, d *schema.Resou
 
 func resourceSystemRootAuthenticationRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -147,7 +147,7 @@ func resourceSystemRootAuthenticationUpdate(ctx context.Context, d *schema.Resou
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -186,7 +186,7 @@ func resourceSystemRootAuthenticationDelete(ctx context.Context, d *schema.Resou
 func resourceSystemRootAuthenticationImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_system_services_dhcp_localserver_group.go
+++ b/junos/resource_system_services_dhcp_localserver_group.go
@@ -44,10 +44,10 @@ type systemServicesDhcpLocalServerGroupOptions struct {
 
 func resourceSystemServicesDhcpLocalServerGroup() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSystemServicesDhcpLocalServerGroupCreate,
-		ReadContext:   resourceSystemServicesDhcpLocalServerGroupRead,
-		UpdateContext: resourceSystemServicesDhcpLocalServerGroupUpdate,
-		DeleteContext: resourceSystemServicesDhcpLocalServerGroupDelete,
+		CreateWithoutTimeout: resourceSystemServicesDhcpLocalServerGroupCreate,
+		ReadWithoutTimeout:   resourceSystemServicesDhcpLocalServerGroupRead,
+		UpdateWithoutTimeout: resourceSystemServicesDhcpLocalServerGroupUpdate,
+		DeleteWithoutTimeout: resourceSystemServicesDhcpLocalServerGroupDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSystemServicesDhcpLocalServerGroupImport,
 		},
@@ -748,7 +748,9 @@ func resourceSystemServicesDhcpLocalServerGroupCreate(ctx context.Context, d *sc
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if d.Get("routing_instance").(string) != defaultW {
 		instanceExists, err := checkRoutingInstanceExists(d.Get("routing_instance").(string), m, jnprSess)
@@ -873,7 +875,9 @@ func resourceSystemServicesDhcpLocalServerGroupUpdate(ctx context.Context, d *sc
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSystemServicesDhcpLocalServerGroup(
 		d.Get("name").(string), d.Get("routing_instance").(string), d.Get("version").(string), m, jnprSess); err != nil {
@@ -914,7 +918,9 @@ func resourceSystemServicesDhcpLocalServerGroupDelete(ctx context.Context, d *sc
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSystemServicesDhcpLocalServerGroup(
 		d.Get("name").(string), d.Get("routing_instance").(string), d.Get("version").(string), m, jnprSess); err != nil {

--- a/junos/resource_system_services_dhcp_localserver_group.go
+++ b/junos/resource_system_services_dhcp_localserver_group.go
@@ -743,7 +743,7 @@ func resourceSystemServicesDhcpLocalServerGroupCreate(ctx context.Context, d *sc
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -826,7 +826,7 @@ func resourceSystemServicesDhcpLocalServerGroupCreate(ctx context.Context, d *sc
 func resourceSystemServicesDhcpLocalServerGroupRead(ctx context.Context, d *schema.ResourceData, m interface{},
 ) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -870,7 +870,7 @@ func resourceSystemServicesDhcpLocalServerGroupUpdate(ctx context.Context, d *sc
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -913,7 +913,7 @@ func resourceSystemServicesDhcpLocalServerGroupDelete(ctx context.Context, d *sc
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -942,7 +942,7 @@ func resourceSystemServicesDhcpLocalServerGroupDelete(ctx context.Context, d *sc
 func resourceSystemServicesDhcpLocalServerGroupImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_system_syslog_file.go
+++ b/junos/resource_system_syslog_file.go
@@ -40,10 +40,10 @@ type syslogFileOptions struct {
 
 func resourceSystemSyslogFile() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSystemSyslogFileCreate,
-		ReadContext:   resourceSystemSyslogFileRead,
-		UpdateContext: resourceSystemSyslogFileUpdate,
-		DeleteContext: resourceSystemSyslogFileDelete,
+		CreateWithoutTimeout: resourceSystemSyslogFileCreate,
+		ReadWithoutTimeout:   resourceSystemSyslogFileRead,
+		UpdateWithoutTimeout: resourceSystemSyslogFileUpdate,
+		DeleteWithoutTimeout: resourceSystemSyslogFileDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSystemSyslogFileImport,
 		},
@@ -247,7 +247,9 @@ func resourceSystemSyslogFileCreate(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	syslogFileExists, err := checkSystemSyslogFileExists(d.Get("filename").(string), m, jnprSess)
 	if err != nil {
@@ -335,7 +337,9 @@ func resourceSystemSyslogFileUpdate(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSystemSyslogFile(d.Get("filename").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -373,7 +377,9 @@ func resourceSystemSyslogFileDelete(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSystemSyslogFile(d.Get("filename").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_system_syslog_file.go
+++ b/junos/resource_system_syslog_file.go
@@ -696,7 +696,7 @@ func readSystemSyslogFile(filename string, m interface{}, jnprSess *NetconfObjec
 						sitesOptions["password"], err = jdecode.Decode(strings.Trim(strings.TrimPrefix(
 							itemTrimArchSites, "password "), "\""))
 						if err != nil {
-							return confRead, fmt.Errorf("failed to decode password : %w", err)
+							return confRead, fmt.Errorf("failed to decode password: %w", err)
 						}
 					case strings.HasPrefix(itemTrimArchSites, "routing-instance "):
 						sitesOptions["routing_instance"] = strings.TrimPrefix(itemTrimArchSites, "routing-instance ")

--- a/junos/resource_system_syslog_file.go
+++ b/junos/resource_system_syslog_file.go
@@ -242,7 +242,7 @@ func resourceSystemSyslogFileCreate(ctx context.Context, d *schema.ResourceData,
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -292,7 +292,7 @@ func resourceSystemSyslogFileCreate(ctx context.Context, d *schema.ResourceData,
 
 func resourceSystemSyslogFileRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -332,7 +332,7 @@ func resourceSystemSyslogFileUpdate(ctx context.Context, d *schema.ResourceData,
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -372,7 +372,7 @@ func resourceSystemSyslogFileDelete(ctx context.Context, d *schema.ResourceData,
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -400,7 +400,7 @@ func resourceSystemSyslogFileDelete(ctx context.Context, d *schema.ResourceData,
 func resourceSystemSyslogFileImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_system_syslog_host.go
+++ b/junos/resource_system_syslog_host.go
@@ -199,7 +199,7 @@ func resourceSystemSyslogHostCreate(ctx context.Context, d *schema.ResourceData,
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -248,7 +248,7 @@ func resourceSystemSyslogHostCreate(ctx context.Context, d *schema.ResourceData,
 
 func resourceSystemSyslogHostRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -288,7 +288,7 @@ func resourceSystemSyslogHostUpdate(ctx context.Context, d *schema.ResourceData,
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -328,7 +328,7 @@ func resourceSystemSyslogHostDelete(ctx context.Context, d *schema.ResourceData,
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -356,7 +356,7 @@ func resourceSystemSyslogHostDelete(ctx context.Context, d *schema.ResourceData,
 func resourceSystemSyslogHostImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_system_syslog_host.go
+++ b/junos/resource_system_syslog_host.go
@@ -42,10 +42,10 @@ type syslogHostOptions struct {
 
 func resourceSystemSyslogHost() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceSystemSyslogHostCreate,
-		ReadContext:   resourceSystemSyslogHostRead,
-		UpdateContext: resourceSystemSyslogHostUpdate,
-		DeleteContext: resourceSystemSyslogHostDelete,
+		CreateWithoutTimeout: resourceSystemSyslogHostCreate,
+		ReadWithoutTimeout:   resourceSystemSyslogHostRead,
+		UpdateWithoutTimeout: resourceSystemSyslogHostUpdate,
+		DeleteWithoutTimeout: resourceSystemSyslogHostDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceSystemSyslogHostImport,
 		},
@@ -204,7 +204,9 @@ func resourceSystemSyslogHostCreate(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	syslogHostExists, err := checkSystemSyslogHostExists(d.Get("host").(string), m, jnprSess)
 	if err != nil {
@@ -291,7 +293,9 @@ func resourceSystemSyslogHostUpdate(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSystemSyslogHost(d.Get("host").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -329,7 +333,9 @@ func resourceSystemSyslogHostDelete(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delSystemSyslogHost(d.Get("host").(string), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_vlan.go
+++ b/junos/resource_vlan.go
@@ -162,7 +162,7 @@ func resourceVlanCreate(ctx context.Context, d *schema.ResourceData, m interface
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -211,7 +211,7 @@ func resourceVlanCreate(ctx context.Context, d *schema.ResourceData, m interface
 
 func resourceVlanRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -255,7 +255,7 @@ func resourceVlanUpdate(ctx context.Context, d *schema.ResourceData, m interface
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -302,7 +302,7 @@ func resourceVlanDelete(ctx context.Context, d *schema.ResourceData, m interface
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -330,7 +330,7 @@ func resourceVlanDelete(ctx context.Context, d *schema.ResourceData, m interface
 func resourceVlanImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_vlan.go
+++ b/junos/resource_vlan.go
@@ -30,10 +30,10 @@ type vlanOptions struct {
 
 func resourceVlan() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceVlanCreate,
-		ReadContext:   resourceVlanRead,
-		UpdateContext: resourceVlanUpdate,
-		DeleteContext: resourceVlanDelete,
+		CreateWithoutTimeout: resourceVlanCreate,
+		ReadWithoutTimeout:   resourceVlanRead,
+		UpdateWithoutTimeout: resourceVlanUpdate,
+		DeleteWithoutTimeout: resourceVlanDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceVlanImport,
 		},
@@ -167,7 +167,9 @@ func resourceVlanCreate(ctx context.Context, d *schema.ResourceData, m interface
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	vlanExists, err := checkVlansExists(d.Get("name").(string), m, jnprSess)
 	if err != nil {
@@ -258,7 +260,9 @@ func resourceVlanUpdate(ctx context.Context, d *schema.ResourceData, m interface
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if d.HasChange("vxlan") {
 		oldVxlan, _ := d.GetChange("vxlan")
@@ -303,7 +307,9 @@ func resourceVlanDelete(ctx context.Context, d *schema.ResourceData, m interface
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delVlan(d.Get("name").(string), d.Get("vxlan").([]interface{}), m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_vstp.go
+++ b/junos/resource_vstp.go
@@ -24,10 +24,10 @@ type vstpOptions struct {
 
 func resourceVstp() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceVstpCreate,
-		ReadContext:   resourceVstpRead,
-		UpdateContext: resourceVstpUpdate,
-		DeleteContext: resourceVstpDelete,
+		CreateWithoutTimeout: resourceVstpCreate,
+		ReadWithoutTimeout:   resourceVstpRead,
+		UpdateWithoutTimeout: resourceVstpUpdate,
+		DeleteWithoutTimeout: resourceVstpDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceVstpImport,
 		},
@@ -98,7 +98,9 @@ func resourceVstpCreate(ctx context.Context, d *schema.ResourceData, m interface
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if d.Get("routing_instance").(string) != defaultW {
 		instanceExists, err := checkRoutingInstanceExists(d.Get("routing_instance").(string), m, jnprSess)
@@ -187,7 +189,9 @@ func resourceVstpUpdate(ctx context.Context, d *schema.ResourceData, m interface
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delVstp(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -225,7 +229,9 @@ func resourceVstpDelete(ctx context.Context, d *schema.ResourceData, m interface
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delVstp(d, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_vstp.go
+++ b/junos/resource_vstp.go
@@ -93,7 +93,7 @@ func resourceVstpCreate(ctx context.Context, d *schema.ResourceData, m interface
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -135,7 +135,7 @@ func resourceVstpCreate(ctx context.Context, d *schema.ResourceData, m interface
 
 func resourceVstpRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -184,7 +184,7 @@ func resourceVstpUpdate(ctx context.Context, d *schema.ResourceData, m interface
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -224,7 +224,7 @@ func resourceVstpDelete(ctx context.Context, d *schema.ResourceData, m interface
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -252,7 +252,7 @@ func resourceVstpDelete(ctx context.Context, d *schema.ResourceData, m interface
 func resourceVstpImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_vstp_interface.go
+++ b/junos/resource_vstp_interface.go
@@ -193,7 +193,7 @@ func resourceVstpInterfaceCreate(ctx context.Context, d *schema.ResourceData, m 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -351,7 +351,7 @@ func resourceVstpInterfaceCreate(ctx context.Context, d *schema.ResourceData, m 
 
 func resourceVstpInterfaceRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -397,7 +397,7 @@ func resourceVstpInterfaceUpdate(ctx context.Context, d *schema.ResourceData, m 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -443,7 +443,7 @@ func resourceVstpInterfaceDelete(ctx context.Context, d *schema.ResourceData, m 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -474,7 +474,7 @@ func resourceVstpInterfaceDelete(ctx context.Context, d *schema.ResourceData, m 
 func resourceVstpInterfaceImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_vstp_interface.go
+++ b/junos/resource_vstp_interface.go
@@ -29,10 +29,10 @@ type vstpInterfaceOptions struct {
 
 func resourceVstpInterface() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceVstpInterfaceCreate,
-		ReadContext:   resourceVstpInterfaceRead,
-		UpdateContext: resourceVstpInterfaceUpdate,
-		DeleteContext: resourceVstpInterfaceDelete,
+		CreateWithoutTimeout: resourceVstpInterfaceCreate,
+		ReadWithoutTimeout:   resourceVstpInterfaceRead,
+		UpdateWithoutTimeout: resourceVstpInterfaceUpdate,
+		DeleteWithoutTimeout: resourceVstpInterfaceDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceVstpInterfaceImport,
 		},
@@ -198,7 +198,9 @@ func resourceVstpInterfaceCreate(ctx context.Context, d *schema.ResourceData, m 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	vstpInterfaceVIdType, name, _, routingInstance := resourceVstpInterfaceReadID(resourceVstpInterfaceNewID(d))
 	vlan := d.Get("vlan").(string)
@@ -400,7 +402,9 @@ func resourceVstpInterfaceUpdate(ctx context.Context, d *schema.ResourceData, m 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delVstpInterface(
 		d.Get("name").(string), d.Get("routing_instance").(string),
@@ -444,7 +448,9 @@ func resourceVstpInterfaceDelete(ctx context.Context, d *schema.ResourceData, m 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delVstpInterface(
 		d.Get("name").(string), d.Get("routing_instance").(string),

--- a/junos/resource_vstp_vlan.go
+++ b/junos/resource_vstp_vlan.go
@@ -25,10 +25,10 @@ type vstpVlanOptions struct {
 
 func resourceVstpVlan() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceVstpVlanCreate,
-		ReadContext:   resourceVstpVlanRead,
-		UpdateContext: resourceVstpVlanUpdate,
-		DeleteContext: resourceVstpVlanDelete,
+		CreateWithoutTimeout: resourceVstpVlanCreate,
+		ReadWithoutTimeout:   resourceVstpVlanRead,
+		UpdateWithoutTimeout: resourceVstpVlanUpdate,
+		DeleteWithoutTimeout: resourceVstpVlanDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceVstpVlanImport,
 		},
@@ -100,7 +100,9 @@ func resourceVstpVlanCreate(ctx context.Context, d *schema.ResourceData, m inter
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if routingInstance != defaultW {
 		instanceExists, err := checkRoutingInstanceExists(routingInstance, m, jnprSess)
@@ -210,7 +212,9 @@ func resourceVstpVlanUpdate(ctx context.Context, d *schema.ResourceData, m inter
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delVstpVlan(d.Get("vlan_id").(string), d.Get("routing_instance").(string), false, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))
@@ -248,7 +252,9 @@ func resourceVstpVlanDelete(ctx context.Context, d *schema.ResourceData, m inter
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delVstpVlan(d.Get("vlan_id").(string), d.Get("routing_instance").(string), true, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_vstp_vlan.go
+++ b/junos/resource_vstp_vlan.go
@@ -95,7 +95,7 @@ func resourceVstpVlanCreate(ctx context.Context, d *schema.ResourceData, m inter
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -167,7 +167,7 @@ func resourceVstpVlanCreate(ctx context.Context, d *schema.ResourceData, m inter
 
 func resourceVstpVlanRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -207,7 +207,7 @@ func resourceVstpVlanUpdate(ctx context.Context, d *schema.ResourceData, m inter
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -247,7 +247,7 @@ func resourceVstpVlanDelete(ctx context.Context, d *schema.ResourceData, m inter
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -275,7 +275,7 @@ func resourceVstpVlanDelete(ctx context.Context, d *schema.ResourceData, m inter
 func resourceVstpVlanImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/resource_vstp_vlan_group.go
+++ b/junos/resource_vstp_vlan_group.go
@@ -26,10 +26,10 @@ type vstpVlanGroupOptions struct {
 
 func resourceVstpVlanGroup() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceVstpVlanGroupCreate,
-		ReadContext:   resourceVstpVlanGroupRead,
-		UpdateContext: resourceVstpVlanGroupUpdate,
-		DeleteContext: resourceVstpVlanGroupDelete,
+		CreateWithoutTimeout: resourceVstpVlanGroupCreate,
+		ReadWithoutTimeout:   resourceVstpVlanGroupRead,
+		UpdateWithoutTimeout: resourceVstpVlanGroupUpdate,
+		DeleteWithoutTimeout: resourceVstpVlanGroupDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceVstpVlanGroupImport,
 		},
@@ -105,7 +105,9 @@ func resourceVstpVlanGroupCreate(ctx context.Context, d *schema.ResourceData, m 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if routingInstance != defaultW {
 		instanceExists, err := checkRoutingInstanceExists(routingInstance, m, jnprSess)
@@ -218,7 +220,9 @@ func resourceVstpVlanGroupUpdate(ctx context.Context, d *schema.ResourceData, m 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delVstpVlanGroup(
 		d.Get("name").(string), d.Get("routing_instance").(string), false, m, jnprSess); err != nil {
@@ -257,7 +261,9 @@ func resourceVstpVlanGroupDelete(ctx context.Context, d *schema.ResourceData, m 
 		return diag.FromErr(err)
 	}
 	defer sess.closeSession(jnprSess)
-	sess.configLock(jnprSess)
+	if err := sess.configLock(ctx, jnprSess); err != nil {
+		return diag.FromErr(err)
+	}
 	var diagWarns diag.Diagnostics
 	if err := delVstpVlanGroup(d.Get("name").(string), d.Get("routing_instance").(string), true, m, jnprSess); err != nil {
 		appendDiagWarns(&diagWarns, sess.configClear(jnprSess))

--- a/junos/resource_vstp_vlan_group.go
+++ b/junos/resource_vstp_vlan_group.go
@@ -100,7 +100,7 @@ func resourceVstpVlanGroupCreate(ctx context.Context, d *schema.ResourceData, m 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -174,7 +174,7 @@ func resourceVstpVlanGroupCreate(ctx context.Context, d *schema.ResourceData, m 
 
 func resourceVstpVlanGroupRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -215,7 +215,7 @@ func resourceVstpVlanGroupUpdate(ctx context.Context, d *schema.ResourceData, m 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -256,7 +256,7 @@ func resourceVstpVlanGroupDelete(ctx context.Context, d *schema.ResourceData, m 
 
 		return nil
 	}
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -284,7 +284,7 @@ func resourceVstpVlanGroupDelete(ctx context.Context, d *schema.ResourceData, m 
 func resourceVstpVlanGroupImport(ctx context.Context, d *schema.ResourceData, m interface{},
 ) ([]*schema.ResourceData, error) {
 	sess := m.(*Session)
-	jnprSess, err := sess.startNewSession()
+	jnprSess, err := sess.startNewSession(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/session.go
+++ b/junos/session.go
@@ -19,6 +19,7 @@ type Session struct {
 	junosSleepLock         int
 	junosSleepShort        int
 	junosSleepSSHClosed    int
+	junosSSHTimeoutToEstab int
 	junosFilePermission    int64
 	junosIP                string
 	junosUserName          string
@@ -51,6 +52,7 @@ func (sess *Session) startNewSession() (*NetconfObject, error) {
 	if sess.junosPassword != "" {
 		auth.Password = sess.junosPassword
 	}
+	auth.Timeout = sess.junosSSHTimeoutToEstab
 	jnpr, err := netconfNewSession(sess.junosIP+":"+strconv.Itoa(sess.junosPort), &auth)
 	if err != nil {
 		return nil, err

--- a/junos/session.go
+++ b/junos/session.go
@@ -34,7 +34,7 @@ type Session struct {
 	junosSSHCiphers        []string
 }
 
-func (sess *Session) startNewSession() (*NetconfObject, error) {
+func (sess *Session) startNewSession(ctx context.Context) (*NetconfObject, error) {
 	var auth netconfAuthMethod
 	auth.Username = sess.junosUserName
 	auth.Ciphers = sess.junosSSHCiphers
@@ -54,7 +54,7 @@ func (sess *Session) startNewSession() (*NetconfObject, error) {
 		auth.Password = sess.junosPassword
 	}
 	auth.Timeout = sess.junosSSHTimeoutToEstab
-	jnpr, err := netconfNewSession(sess.junosIP+":"+strconv.Itoa(sess.junosPort), &auth)
+	jnpr, err := netconfNewSession(ctx, sess.junosIP+":"+strconv.Itoa(sess.junosPort), &auth)
 	if err != nil {
 		return nil, err
 	}

--- a/junos/session.go
+++ b/junos/session.go
@@ -127,18 +127,18 @@ func (sess *Session) appendFakeCreateSetFile(lines []string) error {
 	dirSetFile := path.Dir(sess.junosFakeCreateSetFile)
 	if _, err := os.Stat(dirSetFile); err != nil {
 		if err := os.MkdirAll(dirSetFile, os.FileMode(directoryPermission)); err != nil {
-			return fmt.Errorf("failed to create parent directory of `%s` : %w", sess.junosFakeCreateSetFile, err)
+			return fmt.Errorf("failed to create parent directory of '%s': %w", sess.junosFakeCreateSetFile, err)
 		}
 	}
 	f, err := os.OpenFile(sess.junosFakeCreateSetFile,
 		os.O_APPEND|os.O_CREATE|os.O_WRONLY, os.FileMode(sess.junosFilePermission))
 	if err != nil {
-		return fmt.Errorf("failed to openfile `%s` : %w", sess.junosFakeCreateSetFile, err)
+		return fmt.Errorf("failed to open file '%s': %w", sess.junosFakeCreateSetFile, err)
 	}
 	defer f.Close()
 	for _, v := range lines {
 		if _, err := f.WriteString(v + "\n"); err != nil {
-			return fmt.Errorf("failed to write in file `%s` : %w", sess.junosFakeCreateSetFile, err)
+			return fmt.Errorf("failed to write in file '%s': %w", sess.junosFakeCreateSetFile, err)
 		}
 	}
 


### PR DESCRIPTION
ENHANCEMENTS:

 * provider: add `ssh_timeout_to_establish` argument to configure a timeout for establishing TCP connections when initiating SSH connections
* provider: A gracefully shutting down of Terraform with `Ctrl-c` now stop threads waiting for candidate configuration lock (stop after a loop of `cmd_sleep_lock` seconds)  
  and cancel the TCP connection attempt to establish SSH session if it's not yet complete