### PR TITLE
deps: bump hashicorp/terraform-plugin-sdk to v2.13.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
-	github.com/hashicorp/terraform-plugin-sdk/v2 v2.11.0
+	github.com/hashicorp/terraform-plugin-sdk/v2 v2.13.0
 	github.com/jeremmfr/go-netconf v0.4.3
 	github.com/jeremmfr/go-utils v0.4.1
 	github.com/jeremmfr/junosdecode v1.1.0
@@ -57,4 +57,4 @@ require (
 	google.golang.org/protobuf v1.27.1 // indirect
 )
 
-replace github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/jeremmfr/terraform-plugin-sdk/v2 v2.11.1-0.20220316083425-f711567b3c5d
+replace github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/jeremmfr/terraform-plugin-sdk/v2 v2.13.1-0.20220411071827-346044975466

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,8 @@ github.com/jeremmfr/go-utils v0.4.1 h1:/Jhy9vmFW5uPNycVA/KqNxgifw1gEHFIn+Clik6gB
 github.com/jeremmfr/go-utils v0.4.1/go.mod h1:K0lGadiSvg9OKGJnW4Bs3t18/VApp/6x2+BV93Sts2M=
 github.com/jeremmfr/junosdecode v1.1.0 h1:Os8QeOzyL+BPuDZJMjyJgz4QPOgA8EChgKB2Ih5wwCc=
 github.com/jeremmfr/junosdecode v1.1.0/go.mod h1:nTY0XbZC2ePbZdV0wuUboSMtGrJxtpwWVYfHjrS2Oqw=
-github.com/jeremmfr/terraform-plugin-sdk/v2 v2.11.1-0.20220316083425-f711567b3c5d h1:omu2qkoxCW/HZ/SFo6dxj6O3o/QF8DCbiR7udP8Y+ao=
-github.com/jeremmfr/terraform-plugin-sdk/v2 v2.11.1-0.20220316083425-f711567b3c5d/go.mod h1:TPjMXvpPNWagHzYOmVPzzRRIBTuaLVukR+esL08tgzg=
+github.com/jeremmfr/terraform-plugin-sdk/v2 v2.13.1-0.20220411071827-346044975466 h1:xu1M3mxDkM56II9LOJsZ6hX1Ib0KXAjJ9D5wk3se4SA=
+github.com/jeremmfr/terraform-plugin-sdk/v2 v2.13.1-0.20220411071827-346044975466/go.mod h1:TPjMXvpPNWagHzYOmVPzzRRIBTuaLVukR+esL08tgzg=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
 github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=


### PR DESCRIPTION
- bump hashicorp/terraform-plugin-sdk to v2.13.0
with the go replace to minor fix to accept empty list of primitives on apply