### PR TITLE
r/security_nat_source_pool: fix crash with a single port in port_range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ ENHANCEMENTS:
 
 BUG FIXES:
 
+* resource/`junos_security_nat_source_pool`: fix crash and set correctly with a single port in `port_range`, add format precision in docs (Fixes #382)
+
 ## 1.26.0 (April 13, 2022)
 
 ENHANCEMENTS:

--- a/docs/resources/security_nat_source_pool.md
+++ b/docs/resources/security_nat_source_pool.md
@@ -40,7 +40,8 @@ The following arguments are supported:
 - **port_overloading_factor** (Optional, Number)  
   Port overloading factor for each IP.
 - **port_range** (Optional, String)  
-  Range of port for source nat.
+  Range of port for source nat.  
+  Format need to match `\d+(-\d+)?` with minimum low port 1024 and maximum high port 65535.
 - **routing_instance** (Optional, String)  
   Name of routing instance for switch with nat.
 

--- a/junos/resource_security_nat_source_test.go
+++ b/junos/resource_security_nat_source_test.go
@@ -135,6 +135,13 @@ resource "junos_security_nat_source_pool" "testacc_securitySNATPool" {
   pool_utilization_alarm_raise_threshold = 80
   pool_utilization_alarm_clear_threshold = 60
 }
+resource "junos_security_nat_source_pool" "testacc_securitySNATPool2" {
+  name             = "testacc_securitySNATPool2"
+  description      = "testacc securitySNATPool2"
+  address          = ["192.0.2.2/32"]
+  routing_instance = junos_routing_instance.testacc_securitySNAT.name
+  port_range       = "1300"
+}
 
 resource "junos_security_zone" "testacc_securitySNAT" {
   name = "testacc_securitySNAT"
@@ -205,6 +212,13 @@ resource "junos_security_nat_source_pool" "testacc_securitySNATPool" {
   routing_instance        = junos_routing_instance.testacc_securitySNAT.name
   address_pooling         = "no-paired"
   port_overloading_factor = 3
+}
+resource "junos_security_nat_source_pool" "testacc_securitySNATPool2" {
+  name             = "testacc_securitySNATPool2"
+  description      = "testacc securitySNATPool2"
+  address          = ["192.0.2.2/32"]
+  routing_instance = junos_routing_instance.testacc_securitySNAT.name
+  port_range       = "1300-62000"
 }
 
 resource "junos_security_zone" "testacc_securitySNAT" {


### PR DESCRIPTION
BUG FIXES:

* resource/`junos_security_nat_source_pool`: fix crash and set correctly with a single port in `port_range`, add format precision in docs (Fixes #382)