### PR TITLE
Fix #383: interface_logical: add tunnel support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ENHANCEMENTS:
 
 * resource/`junos_interface_logical`: add `tunnel` block argument (Fixes #383)
+* data-source/`junos_interface_logical`: add `tunnel` block attribute (like resource)
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ENHANCEMENTS:
 
+* resource/`junos_interface_logical`: add `tunnel` block argument (Fixes #383)
+
 BUG FIXES:
 
 ## 1.26.0 (April 13, 2022)

--- a/docs/data-sources/interface_logical.md
+++ b/docs/data-sources/interface_logical.md
@@ -94,8 +94,36 @@ The following attributes are exported:
   The inbound services allowed.
 - **security_zone** (String)  
   Security zone where the interface is.
+- **tunnel** (Block)  
+  Tunnel parameters.  
+  See [below for nested schema](#tunnel-arguments).
 - **vlan_id** (Number)  
   802.1q VLAN ID for unit interface.
+
+---
+
+### tunnel arguments
+
+- **destination** (String)  
+  Tunnel destination.
+- **source** (String)  
+  Tunnel source.
+- **allow_fragmentation** (Boolean)  
+  Do not set DF bit on packets.
+- **do_not_fragment** (Boolean)  
+  Set DF bit on packets.
+- **flow_label** (Number)  
+  Flow label field of IP6-header (0..1048575).
+- **no_path_mtu_discovery** (Boolean)  
+  Don't enable path MTU discovery for tunnels.
+- **path_mtu_discovery** (Boolean)  
+  Enable path MTU discovery for tunnels.
+- **routing_instance_destination** (String)  
+  Routing instance to which tunnel ends belong.
+- **traffic_class** (Number)  
+  TOS/Traffic class field of IP-header (0..255).
+- **ttl** (Number)  
+  Time to live (1..255).
 
 ---
 

--- a/docs/resources/interface_logical.md
+++ b/docs/resources/interface_logical.md
@@ -96,6 +96,9 @@ The following arguments are supported:
 - **security_zone** (Optional, String)  
   Add this interface in security_zone.  
   Need to be created before.
+- **tunnel** (Optional, Block)  
+  Tunnel parameters.  
+  See [below for nested schema](#tunnel-arguments).
 - **vlan_id** (Optional, Computed, Number)  
   802.1q VLAN ID for unit interface.  
   If not set, computed with `name` of interface (ge-0/0/0.100 = 100)
@@ -103,6 +106,35 @@ The following arguments are supported:
 - **vlan_no_compute** (Optional, Boolean)  
   Disable the automatic compute of the `vlan_id` argument when not set.  
   Unnecessary if name has `.0` suffix or `st0.`, `irb.`, `vlan.` prefix because it's already disabled.
+
+---
+
+### tunnel arguments
+
+- **destination** (Required, String)  
+  Tunnel destination.
+- **source** (Required, String)  
+  Tunnel source.
+- **allow_fragmentation** (Optional, Boolean)  
+  Do not set DF bit on packets.  
+  Conflict with `do_not_fragment`.
+- **do_not_fragment** (Optional, Boolean)  
+  Set DF bit on packets.  
+  Conflict with `allow_fragmentation`.
+- **flow_label** (Optional, Number)  
+  Flow label field of IP6-header (0..1048575).
+- **no_path_mtu_discovery** (Optional, Boolean)  
+  Don't enable path MTU discovery for tunnels.  
+  Conflict with `path_mtu_discovery`.
+- **path_mtu_discovery** (Optional, Boolean)  
+  Enable path MTU discovery for tunnels.  
+  Conflict with `no_path_mtu_discovery`.
+- **routing_instance_destination** (Optional, String)  
+  Routing instance to which tunnel ends belong.
+- **traffic_class** (Optional, Number)  
+  TOS/Traffic class field of IP-header (0..255).
+- **ttl** (Optional, Number)  
+  Time to live (1..255).
 
 ---
 

--- a/junos/data_source_interface_logical.go
+++ b/junos/data_source_interface_logical.go
@@ -500,10 +500,57 @@ func dataSourceInterfaceLogical() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-
 			"security_zone": {
 				Type:     schema.TypeString,
 				Computed: true,
+			},
+			"tunnel": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"destination": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"source": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"allow_fragmentation": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"do_not_fragment": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"flow_label": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"no_path_mtu_discovery": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"path_mtu_discovery": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"routing_instance_destination": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"traffic_class": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"ttl": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
 			},
 			"vlan_id": {
 				Type:     schema.TypeInt,

--- a/junos/resource_interface_logical_test.go
+++ b/junos/resource_interface_logical_test.go
@@ -294,6 +294,15 @@ resource "junos_interface_logical" "testacc_interface_logical" {
     }
   }
 }
+resource "junos_interface_logical" "testacc_interface_logical2" {
+  name = "ip-0/0/0.0"
+  tunnel {
+    destination         = "192.0.2.10"
+    source              = "192.0.2.11"
+    allow_fragmentation = true
+    path_mtu_discovery  = true
+  }
+}
 `, interFace)
 }
 
@@ -385,6 +394,18 @@ resource "junos_interface_logical" "testacc_interface_logical" {
     address {
       cidr_ip = "fe80::1/64"
     }
+  }
+}
+resource "junos_interface_logical" "testacc_interface_logical2" {
+  name = "ip-0/0/0.0"
+  tunnel {
+    destination                  = "192.0.2.12"
+    source                       = "192.0.2.13"
+    do_not_fragment              = true
+    no_path_mtu_discovery        = true
+    routing_instance_destination = junos_routing_instance.testacc_interface_logical.name
+    traffic_class                = 202
+    ttl                          = 203
   }
 }
 `, interFace)


### PR DESCRIPTION
ENHANCEMENTS:

* resource/`junos_interface_logical`: add `tunnel` block argument (Fixes #383)
* data-source/`junos_interface_logical`: add `tunnel` block attribute (like resource)