### PR TITLE
Fix #392: ospf_area: add realm and other arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ENHANCEMENTS:
 
+* resource/`junos_ospf_area`: add `realm` argument to add a OSPFv3 realm area. (Fixes #392)
+
 BUG FIXES:
 
 ## 1.27.0 (May 06, 2022)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 
 ENHANCEMENTS:
 
-* resource/`junos_ospf_area`: add `realm` argument to add a OSPFv3 realm area. (Fixes #392)
+* resource/`junos_ospf_area`: add `realm` argument to add a OSPFv3 realm area. (Fixes #392),  
+  add new `area_range`, `context_identifier`, `inter_area_prefix_export`, `inter_area_prefix_import`, `network_summary_export`, `network_summary_import`, `no_context_identifier_advertisement`, `nssa`, `stub` and `virtual_link` arguments,  
+  add validation of `area_id`
 
 BUG FIXES:
 

--- a/docs/resources/ospf_area.md
+++ b/docs/resources/ospf_area.md
@@ -26,11 +26,15 @@ The following arguments are supported:
 
 - **area_id** (Required, String, Forces new resource)  
   The id of ospf area.
-- **routing_instance** (Optional, String)  
+- **routing_instance** (Optional, String, Forces new resource)  
   Routing instance for area.  
   Need to be `default` or name of routing instance.  
   Defaults to `default`.
-- **version** (Optional, String)  
+- **realm** (Optional, String, Forces new resource)  
+  OSPFv3 realm configuration.  
+  Need to be `ipv4-unicast`, `ipv4-multicast` or `ipv6-multicast`.  
+  `version` need to be `v3`.
+- **version** (Optional, String, Forces new resource)  
   Version of ospf.  
   Need to be `v2` or `v3`.  
   Defaults to `v2`.
@@ -185,13 +189,17 @@ The following arguments are supported:
 The following attributes are exported:
 
 - **id** (String)  
-  An identifier for the resource with format `<aread_id>_-_<version>_-_<routing_instance>`.
+  An identifier for the resource with format  
+  `<aread_id>_-_<version>_-_<routing_instance>`  
+  or `<aread_id>_-_<version>_-_<realm>_-_<routing_instance>` if realm is set.
 
 ## Import
 
-Junos ospf area can be imported using an id made up of
-`<aread_id>_-_<version>_-_<routing_instance>`, e.g.
+Junos ospf area can be imported using an id made up of  
+`<aread_id>_-_<version>_-_<routing_instance>` or  
+`<aread_id>_-_<version>_-_<realm>_-_<routing_instance>`, e.g.
 
 ```shell
 $ terraform import junos_ospf_area.demo_area 0.0.0.0_-_v2_-_default
+$ terraform import junos_ospf_area.demo_area2 0.0.0.0_-_v3_-_ipv4-unicast_-_default
 ```

--- a/docs/resources/ospf_area.md
+++ b/docs/resources/ospf_area.md
@@ -20,7 +20,7 @@ resource "junos_ospf_area" "demo_area" {
 
 ## Argument Reference
 
--> **Note** Some arguments are not compatible with version `v3` of ospf.
+-> **Note** Some arguments are only compatible with one version (`v2` or `v3`) of ospf.
 
 The following arguments are supported:
 
@@ -47,14 +47,14 @@ The following arguments are supported:
     Conflict with `authentication_md5`.
   - **authentication_md5** (Optional, Block List)  
     For each key_id, MD5 authentication key.  
-    See [below for nested schema](#authentication_md5-arguments).  
+    See [below for nested schema](#authentication_md5-arguments-for-interface).  
     Conflict with `authentication_simple_password`.
   - **bandwidth_based_metrics** (Optional, Block Set)  
     For each bandwidth, configure bandwidth based metrics.  
-    See [below for nested schema](#bandwidth_based_metrics-arguments).
+    See [below for nested schema](#bandwidth_based_metrics-arguments-for-interface).
   - **bfd_liveness_detection** (Optional, Block)  
     Bidirectional Forwarding Detection options.  
-    See [below for nested schema](#bfd_liveness_detection-arguments).
+    See [below for nested schema](#bfd_liveness_detection-arguments-for-interface).
   - **dead_interval** (Optional, Number)  
     Dead interval (seconds).
   - **demand_circuit** (Optional, Boolean)  
@@ -89,7 +89,7 @@ The following arguments are supported:
     Maximum OSPF packet size (128..65535).
   - **neighbor** (Optional, Block Set)  
     For each address, configure NBMA neighbor.  
-    See [below for nested schema](#neighbor-arguments).
+    See [below for nested schema](#neighbor-arguments-for-interface).
   - **no_advertise_adjacency_segment** (Optional, Boolean)  
     Do not advertise an adjacency segment for this interface.
   - **no_eligible_backup** (Optional, Boolean)  
@@ -122,10 +122,75 @@ The following arguments are supported:
     Traffic engineering metric (1..4294967295).
   - **transit_delay** (Optional, Number)  
     Transit delay (seconds) (1..65535).
+- **area_range** (Optional, Block Set)  
+  For each `range`, configure area range.  
+  See [below for nested schema](#area_range-arguments).
+- **context_identifier** (Optional, Set of String)  
+  Configure context identifier in support of edge protection.  
+  Conflict with `no_context_identifier_advertisement`.
+- **inter_area_prefix_export** (Optional, List of String)  
+  Export policy for Inter Area Prefix LSAs.
+- **inter_area_prefix_import** (Optional, List of String)  
+  Import policy for Inter Area Prefix LSAs.
+- **network_summary_export** (Optional, List of String)  
+  Export policy for Type 3 Summary LSAs.
+- **network_summary_import** (Optional, List of String)  
+  Import policy for Type 3 Summary LSAs.
+- **no_context_identifier_advertisement** (Optional, Boolean)  
+  Disable context identifier advertisments in this area.  
+  Conflict with `context_identifier`.
+- **nssa** (Optional, Block)  
+  Configure a not-so-stubby area.  
+  Conflict with `stub`.
+  - **area_range** (Optional, Block Set)  
+    For each `range`, configure area range.  
+    See [below for nested schema](#area_range-arguments).
+  - **default_lsa** (Optional, Block)  
+    Configure a default LSA.  
+    See [below for nested schema](#default_lsa-arguments-for-nssa).
+  - **no_summaries** (Optional, Boolean)  
+    Don't flood summary LSAs into this NSSA area.
+  - **summaries** (Optional, Boolean)  
+    Flood summary LSAs into this NSSA area.
+- **stub** (Optional, Block)  
+  Configure a stub area.  
+  Conflict with `nssa`.
+  - **default_metric** (Optional, Number)  
+    Metric for the default route in this stub area (1..16777215).
+  - **no_summaries** (Optional, Boolean)  
+    Don't flood summary LSAs into this stub area.
+  - **summaries** (Optional, Boolean)  
+    Flood summary LSAs into this stub area.
+- **virtual_link** (Optional, Block Set)  
+  For each combination of `neighbor_id` and `transit_area`, configure virtual link.
+  - **neighbor_id** (Required, String)  
+    Router ID of a virtual neighbor.  
+    Need to be a IPv4 address.
+  - **transit_area** (Required, String)  
+    Transit area in common with virtual neighbor.  
+    Need to be in IPv4 format.
+  - **dead_interval** (Optional, Number)  
+    Dead interval (seconds) (1..65535).
+  - **demand_circuit** (Optional, Boolean)  
+    Interface functions as a demand circuit.
+  - **disable** (Optional, Boolean)  
+    Disable this virtual link.
+  - **flood_reduction** (Optional, Boolean)  
+    Enable flood reduction.
+  - **hello_interval** (Optional, Number)  
+    Hello interval (seconds) (1..255).
+  - **ipsec_sa** (Optional, String)  
+    IPSec security association name.
+  - **mtu** (Optional, Number)  
+    Maximum OSPF packet size (128..65535).
+  - **retransmit_interval** (Optional, Number)  
+    Retransmission interval (seconds) (1..65535).
+  - **transit_delay** (Optional, Number)  
+    Transit delay (seconds) (1..65535).
 
 ---
 
-### authentication_md5 arguments
+### authentication_md5 arguments for interface
 
 - **key_id** (Required, Number)  
   Key ID for MD5 authentication (0..255).
@@ -136,7 +201,7 @@ The following arguments are supported:
 
 ---
 
-### bandwidth_based_metrics arguments
+### bandwidth_based_metrics arguments for interface
 
 - **bandwidth** (Required, String)  
   Bandwidth threshold.  
@@ -146,7 +211,7 @@ The following arguments are supported:
 
 ---
 
-### bfd_liveness_detection arguments
+### bfd_liveness_detection arguments for interface
 
 - **authentication_algorithm** (Optional, String)  
   Authentication algorithm name.
@@ -177,12 +242,36 @@ The following arguments are supported:
 
 ---
 
-### neighbor arguments
+### neighbor arguments for interface
 
 - **address** (Required, String)  
   Address of neighbor.
 - **eligible** (Optional, Boolean)  
   Eligible to be DR on an NBMA network.
+
+---
+
+### area_range arguments
+
+- **range** (Required, String)  
+  Range to summarize routes in this area.
+- **exact** (Optional, Boolean)  
+  Enforce exact match for advertisement of this area range.
+- **override_metric** (Optional, Number)  
+  Override the dynamic metric for this area-range (1..16777215).
+- **restrict** (Optional, Boolean)  
+  Restrict advertisement of this area range.
+
+---
+
+### default_lsa arguments for nssa
+
+- **default_metric** (Optional, Number)  
+  Metric for the default route in this area (1..16777215).
+- **metric_type** (Optional, Number)  
+  External metric type for the default type 7 LSA (1..2).
+- **type_7** (Optional, Boolean)  
+  Flood type 7 default LSA if no-summaries is configured.
 
 ## Attributes Reference
 

--- a/junos/resource_ospf_area.go
+++ b/junos/resource_ospf_area.go
@@ -15,11 +15,21 @@ import (
 )
 
 type ospfAreaOptions struct {
-	areaID          string
-	routingInstance string
-	realm           string
-	version         string
-	interFace       []map[string]interface{}
+	noContextIdentifierAdvertisement bool
+	areaID                           string
+	routingInstance                  string
+	realm                            string
+	version                          string
+	contextIdentifier                []string
+	interAreaPrefixExport            []string
+	interAreaPrefixImport            []string
+	networkSummaryExport             []string
+	networkSummaryImport             []string
+	areaRange                        []map[string]interface{}
+	interFace                        []map[string]interface{}
+	nssa                             []map[string]interface{}
+	stub                             []map[string]interface{}
+	virtualLink                      []map[string]interface{}
 }
 
 func resourceOspfArea() *schema.Resource {
@@ -36,6 +46,8 @@ func resourceOspfArea() *schema.Resource {
 				Type:     schema.TypeString,
 				ForceNew: true,
 				Required: true,
+				ValidateFunc: validation.StringMatch(
+					regexp.MustCompile(`^(\d|\.)+$`), "should be usually in the IP format"),
 			},
 			"routing_instance": {
 				Type:             schema.TypeString,
@@ -337,6 +349,248 @@ func resourceOspfArea() *schema.Resource {
 						"transit_delay": {
 							Type:         schema.TypeInt,
 							Optional:     true,
+							ValidateFunc: validation.IntBetween(1, 65535),
+						},
+					},
+				},
+			},
+			"area_range": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"range": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.IsCIDRNetwork(0, 128),
+						},
+						"exact": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+						"override_metric": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      0,
+							ValidateFunc: validation.IntBetween(1, 16777215),
+						},
+						"restrict": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+					},
+				},
+			},
+			"context_identifier": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					ValidateFunc: validation.StringMatch(
+						regexp.MustCompile(`^(\d{1,3}\.){3}\d{1,3}$`), "must be in the IP format"),
+				},
+				ConflictsWith: []string{"no_context_identifier_advertisement"},
+			},
+			"inter_area_prefix_export": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatDefault),
+				},
+			},
+			"inter_area_prefix_import": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatDefault),
+				},
+			},
+			"network_summary_export": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatDefault),
+				},
+			},
+			"network_summary_import": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type:             schema.TypeString,
+					ValidateDiagFunc: validateNameObjectJunos([]string{}, 64, formatDefault),
+				},
+			},
+			"no_context_identifier_advertisement": {
+				Type:          schema.TypeBool,
+				Optional:      true,
+				ConflictsWith: []string{"context_identifier"},
+			},
+			"nssa": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				MaxItems:      1,
+				ConflictsWith: []string{"stub"},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"area_range": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"range": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.IsCIDRNetwork(0, 128),
+									},
+									"exact": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Default:  false,
+									},
+									"override_metric": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Default:      0,
+										ValidateFunc: validation.IntBetween(1, 16777215),
+									},
+									"restrict": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Default:  false,
+									},
+								},
+							},
+						},
+						"default_lsa": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"default_metric": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(1, 16777215),
+									},
+									"metric_type": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										ValidateFunc: validation.IntBetween(1, 2),
+									},
+									"type_7": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+								},
+							},
+						},
+						"no_summaries": {
+							Type:          schema.TypeBool,
+							Optional:      true,
+							ConflictsWith: []string{"nssa.0.summaries"},
+						},
+						"summaries": {
+							Type:          schema.TypeBool,
+							Optional:      true,
+							ConflictsWith: []string{"nssa.0.no_summaries"},
+						},
+					},
+				},
+			},
+			"stub": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				MaxItems:      1,
+				ConflictsWith: []string{"nssa"},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"default_metric": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(1, 16777215),
+						},
+						"no_summaries": {
+							Type:          schema.TypeBool,
+							Optional:      true,
+							ConflictsWith: []string{"stub.0.summaries"},
+						},
+						"summaries": {
+							Type:          schema.TypeBool,
+							Optional:      true,
+							ConflictsWith: []string{"stub.0.no_summaries"},
+						},
+					},
+				},
+			},
+			"virtual_link": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"neighbor_id": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.IsIPv4Address,
+						},
+						"transit_area": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringMatch(
+								regexp.MustCompile(`^(\d{1,3}\.){3}\d{1,3}$`), "must be in the IP format"),
+						},
+						"dead_interval": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      0,
+							ValidateFunc: validation.IntBetween(1, 65535),
+						},
+						"demand_circuit": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+						"disable": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+						"flood_reduction": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+						"hello_interval": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      0,
+							ValidateFunc: validation.IntBetween(1, 255),
+						},
+						"ipsec_sa": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "",
+						},
+						"mtu": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      0,
+							ValidateFunc: validation.IntBetween(128, 65535),
+						},
+						"retransmit_interval": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      0,
+							ValidateFunc: validation.IntBetween(1, 65535),
+						},
+						"transit_delay": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Default:      0,
 							ValidateFunc: validation.IntBetween(1, 65535),
 						},
 					},
@@ -674,212 +928,380 @@ func setOspfArea(d *schema.ResourceData, m interface{}, jnprSess *NetconfObject)
 		}
 		interfaceNameList = append(interfaceNameList, ospfInterface["name"].(string))
 		setPrefixInterface := setPrefix + "interface " + ospfInterface["name"].(string) + " "
-		configSet = append(configSet, setPrefixInterface)
-		if v := ospfInterface["authentication_simple_password"].(string); v != "" {
-			if len(ospfInterface["authentication_md5"].([]interface{})) != 0 {
-				return fmt.Errorf("conflict between 'authentication_simple_password' and 'authentication_md5'"+
-					" in interface '%s'", ospfInterface["name"].(string))
-			}
-			configSet = append(configSet, setPrefixInterface+"authentication simple-password \""+v+"\"")
+		configSetInterface, err := setOspfAreaInterface(setPrefixInterface, ospfInterface)
+		if err != nil {
+			return err
 		}
-		authenticationMD5List := make([]int, 0)
-		for _, mAuthMD5 := range ospfInterface["authentication_md5"].([]interface{}) {
-			authMD5 := mAuthMD5.(map[string]interface{})
-			if bchk.IntInSlice(authMD5["key_id"].(int), authenticationMD5List) {
-				return fmt.Errorf("multiple blocks authentication_md5 with the same key_id %d in interface with name %s",
-					authMD5["key_id"].(int), ospfInterface["name"].(string))
-			}
-			authenticationMD5List = append(authenticationMD5List, authMD5["key_id"].(int))
-			configSet = append(configSet, setPrefixInterface+"authentication md5 "+
-				strconv.Itoa(authMD5["key_id"].(int))+" key \""+authMD5["key"].(string)+"\"")
-			if v := authMD5["start_time"].(string); v != "" {
-				configSet = append(configSet, setPrefixInterface+"authentication md5 "+
-					strconv.Itoa(authMD5["key_id"].(int))+" start-time "+v)
-			}
+		configSet = append(configSet, configSetInterface...)
+	}
+	areaRangeList := make([]string, 0)
+	for _, areaRangeBlock := range d.Get("area_range").(*schema.Set).List() {
+		areaRange := areaRangeBlock.(map[string]interface{})
+		if bchk.StringInSlice(areaRange["range"].(string), areaRangeList) {
+			return fmt.Errorf("multiple blocks area_range with the same range %s", areaRange["range"].(string))
 		}
-		bandwidthBasedMetricsList := make([]string, 0)
-		for _, mBandBaseMet := range ospfInterface["bandwidth_based_metrics"].(*schema.Set).List() {
-			bandwidthBaseMetrics := mBandBaseMet.(map[string]interface{})
-			if bchk.StringInSlice(bandwidthBaseMetrics["bandwidth"].(string), bandwidthBasedMetricsList) {
-				return fmt.Errorf("multiple blocks bandwidth_based_metrics with the same bandwidth %s in interface with name %s",
-					bandwidthBaseMetrics["bandwidth"].(string), ospfInterface["name"].(string))
-			}
-			bandwidthBasedMetricsList = append(bandwidthBasedMetricsList, bandwidthBaseMetrics["bandwidth"].(string))
-			configSet = append(configSet, setPrefixInterface+"bandwidth-based-metrics bandwidth "+
-				bandwidthBaseMetrics["bandwidth"].(string)+" metric "+strconv.Itoa(bandwidthBaseMetrics["metric"].(int)))
+		areaRangeList = append(areaRangeList, areaRange["range"].(string))
+		configSet = append(configSet, setPrefix+"area-range "+areaRange["range"].(string))
+		if areaRange["exact"].(bool) {
+			configSet = append(configSet,
+				setPrefix+"area-range "+areaRange["range"].(string)+" exact",
+			)
 		}
-		for _, mBFDLivDet := range ospfInterface["bfd_liveness_detection"].([]interface{}) {
-			if mBFDLivDet == nil {
-				return fmt.Errorf("bfd_liveness_detection block is empty in interface %s", ospfInterface["name"].(string))
-			}
-			setPrefixBfd := setPrefixInterface + "bfd-liveness-detection "
-			bfdLiveDetect := mBFDLivDet.(map[string]interface{})
-			if v := bfdLiveDetect["authentication_algorithm"].(string); v != "" {
-				configSet = append(configSet, setPrefixBfd+"authentication algorithm "+v)
-			}
-			if v := bfdLiveDetect["authentication_key_chain"].(string); v != "" {
-				configSet = append(configSet, setPrefixBfd+"authentication key-chain \""+v+"\"")
-			}
-			if bfdLiveDetect["authentication_loose_check"].(bool) {
-				configSet = append(configSet, setPrefixBfd+"authentication loose-check")
-			}
-			if v := bfdLiveDetect["detection_time_threshold"].(int); v != 0 {
-				configSet = append(configSet, setPrefixBfd+"detection-time threshold "+strconv.Itoa(v))
-			}
-			if bfdLiveDetect["full_neighbors_only"].(bool) {
-				configSet = append(configSet, setPrefixBfd+"full-neighbors-only")
-			}
-			if v := bfdLiveDetect["holddown_interval"].(int); v != 0 {
-				configSet = append(configSet, setPrefixBfd+"holddown-interval "+strconv.Itoa(v))
-			}
-			if v := bfdLiveDetect["minimum_interval"].(int); v != 0 {
-				configSet = append(configSet, setPrefixBfd+"minimum-interval "+strconv.Itoa(v))
-			}
-			if v := bfdLiveDetect["minimum_receive_interval"].(int); v != 0 {
-				configSet = append(configSet, setPrefixBfd+"minimum-receive-interval "+strconv.Itoa(v))
-			}
-			if v := bfdLiveDetect["multiplier"].(int); v != 0 {
-				configSet = append(configSet, setPrefixBfd+"multiplier "+strconv.Itoa(v))
-			}
-			if bfdLiveDetect["no_adaptation"].(bool) {
-				configSet = append(configSet, setPrefixBfd+"no-adaptation")
-			}
-			if v := bfdLiveDetect["transmit_interval_minimum_interval"].(int); v != 0 {
-				configSet = append(configSet, setPrefixBfd+
-					"transmit-interval minimum-interval "+strconv.Itoa(v))
-			}
-			if v := bfdLiveDetect["transmit_interval_threshold"].(int); v != 0 {
-				configSet = append(configSet, setPrefixBfd+
-					"transmit-interval threshold "+strconv.Itoa(v))
-			}
-			if v := bfdLiveDetect["version"].(string); v != "" {
-				configSet = append(configSet, setPrefixBfd+"version "+v)
-			}
-			if len(configSet) == 0 || !strings.HasPrefix(configSet[len(configSet)-1], setPrefixBfd) {
-				return fmt.Errorf("bfd_liveness_detection block is empty in interface %s", ospfInterface["name"].(string))
-			}
+		if v := areaRange["override_metric"].(int); v != 0 {
+			configSet = append(configSet,
+				setPrefix+"area-range "+areaRange["range"].(string)+" override-metric "+strconv.Itoa(v),
+			)
 		}
-		if v := ospfInterface["dead_interval"].(int); v != 0 {
-			configSet = append(configSet, setPrefixInterface+"dead-interval "+strconv.Itoa(v))
+		if areaRange["restrict"].(bool) {
+			configSet = append(configSet,
+				setPrefix+"area-range "+areaRange["range"].(string)+" restrict",
+			)
 		}
-		if ospfInterface["demand_circuit"].(bool) {
-			configSet = append(configSet, setPrefixInterface+"demand-circuit")
-		}
-		if ospfInterface["disable"].(bool) {
-			configSet = append(configSet, setPrefixInterface+"disable")
-		}
-		if ospfInterface["dynamic_neighbors"].(bool) {
-			configSet = append(configSet, setPrefixInterface+"dynamic-neighbors")
-		}
-		if ospfInterface["flood_reduction"].(bool) {
-			configSet = append(configSet, setPrefixInterface+"flood-reduction")
-		}
-		if v := ospfInterface["hello_interval"].(int); v != 0 {
-			configSet = append(configSet, setPrefixInterface+"hello-interval "+strconv.Itoa(v))
-		}
-		if v := ospfInterface["interface_type"].(string); v != "" {
-			configSet = append(configSet, setPrefixInterface+"interface-type "+v)
-		}
-		if v := ospfInterface["ipsec_sa"].(string); v != "" {
-			configSet = append(configSet, setPrefixInterface+"ipsec-sa \""+v+"\"")
-		}
-		if t := ospfInterface["ipv4_adjacency_segment_protected_type"].(string); t != "" {
-			if v := ospfInterface["ipv4_adjacency_segment_protected_value"].(string); v != "" {
-				configSet = append(configSet, setPrefixInterface+"ipv4-adjacency-segment protected "+t+" "+v)
-			} else {
-				configSet = append(configSet, setPrefixInterface+"ipv4-adjacency-segment protected "+t)
+	}
+	for _, contextIdentifier := range sortSetOfString(d.Get("context_identifier").(*schema.Set).List()) {
+		configSet = append(configSet, setPrefix+"context-identifier "+contextIdentifier)
+	}
+	for _, interAreaPrefExport := range d.Get("inter_area_prefix_export").([]interface{}) {
+		configSet = append(configSet, setPrefix+"inter-area-prefix-export "+interAreaPrefExport.(string))
+	}
+	for _, interAreaPrefImport := range d.Get("inter_area_prefix_import").([]interface{}) {
+		configSet = append(configSet, setPrefix+"inter-area-prefix-import "+interAreaPrefImport.(string))
+	}
+	for _, networkSummaryExport := range d.Get("network_summary_export").([]interface{}) {
+		configSet = append(configSet, setPrefix+"network-summary-export "+networkSummaryExport.(string))
+	}
+	for _, networkSummaryImport := range d.Get("network_summary_import").([]interface{}) {
+		configSet = append(configSet, setPrefix+"network-summary-import "+networkSummaryImport.(string))
+	}
+	if d.Get("no_context_identifier_advertisement").(bool) {
+		configSet = append(configSet, setPrefix+"no-context-identifier-advertisement")
+	}
+	for _, nssaBlock := range d.Get("nssa").([]interface{}) {
+		setPrefixNssa := setPrefix + "nssa "
+		configSet = append(configSet, setPrefixNssa)
+		if nssaBlock != nil {
+			nssa := nssaBlock.(map[string]interface{})
+			nssaAreaRangeList := make([]string, 0)
+			for _, areaRangeBlock := range nssa["area_range"].(*schema.Set).List() {
+				areaRange := areaRangeBlock.(map[string]interface{})
+				if bchk.StringInSlice(areaRange["range"].(string), nssaAreaRangeList) {
+					return fmt.Errorf("multiple blocks area_range with the same range %s in nssa block", areaRange["range"].(string))
+				}
+				nssaAreaRangeList = append(nssaAreaRangeList, areaRange["range"].(string))
+				configSet = append(configSet, setPrefixNssa+"area-range "+areaRange["range"].(string))
+				if areaRange["exact"].(bool) {
+					configSet = append(configSet,
+						setPrefixNssa+"area-range "+areaRange["range"].(string)+" exact",
+					)
+				}
+				if v := areaRange["override_metric"].(int); v != 0 {
+					configSet = append(configSet,
+						setPrefixNssa+"area-range "+areaRange["range"].(string)+" override-metric "+strconv.Itoa(v),
+					)
+				}
+				if areaRange["restrict"].(bool) {
+					configSet = append(configSet,
+						setPrefixNssa+"area-range "+areaRange["range"].(string)+" restrict",
+					)
+				}
 			}
-		} else if ospfInterface["ipv4_adjacency_segment_protected_value"].(string) != "" {
-			return fmt.Errorf("ipv4_adjacency_segment_protected_type need to be set with " +
-				"ipv4_adjacency_segment_protected_value")
-		}
-		if t := ospfInterface["ipv4_adjacency_segment_unprotected_type"].(string); t != "" {
-			if v := ospfInterface["ipv4_adjacency_segment_unprotected_value"].(string); v != "" {
-				configSet = append(configSet, setPrefixInterface+"ipv4-adjacency-segment unprotected "+t+" "+v)
-			} else {
-				configSet = append(configSet, setPrefixInterface+"ipv4-adjacency-segment unprotected "+t)
+			for _, defaultLsaBlock := range nssa["default_lsa"].([]interface{}) {
+				configSet = append(configSet, setPrefixNssa+"default-lsa")
+				if defaultLsaBlock != nil {
+					defaultLsa := defaultLsaBlock.(map[string]interface{})
+					if v := defaultLsa["default_metric"].(int); v != 0 {
+						configSet = append(configSet, setPrefixNssa+"default-lsa default-metric "+strconv.Itoa(v))
+					}
+					if v := defaultLsa["metric_type"].(int); v != 0 {
+						configSet = append(configSet, setPrefixNssa+"default-lsa metric-type "+strconv.Itoa(v))
+					}
+					if defaultLsa["type_7"].(bool) {
+						configSet = append(configSet, setPrefixNssa+"default-lsa type-7")
+					}
+				}
 			}
-		} else if ospfInterface["ipv4_adjacency_segment_unprotected_value"].(string) != "" {
-			return fmt.Errorf("ipv4_adjacency_segment_unprotected_type need to be set with " +
-				"ipv4_adjacency_segment_unprotected_value")
-		}
-		if ospfInterface["link_protection"].(bool) {
-			configSet = append(configSet, setPrefixInterface+"link-protection")
-		}
-		if v := ospfInterface["metric"].(int); v != 0 {
-			configSet = append(configSet, setPrefixInterface+"metric "+strconv.Itoa(v))
-		}
-		if v := ospfInterface["mtu"].(int); v != 0 {
-			configSet = append(configSet, setPrefixInterface+"mtu "+strconv.Itoa(v))
-		}
-		neighborList := make([]string, 0)
-		for _, mNeighbor := range ospfInterface["neighbor"].(*schema.Set).List() {
-			neighbor := mNeighbor.(map[string]interface{})
-			if bchk.StringInSlice(neighbor["address"].(string), neighborList) {
-				return fmt.Errorf("multiple blocks neighbor with the same address %s in interface with name %s",
-					neighbor["address"].(string), ospfInterface["name"].(string))
+			if nssa["no_summaries"].(bool) {
+				configSet = append(configSet, setPrefixNssa+"no-summaries")
 			}
-			neighborList = append(neighborList, neighbor["address"].(string))
-			configSet = append(configSet, setPrefixInterface+"neighbor "+neighbor["address"].(string))
-			if neighbor["eligible"].(bool) {
-				configSet = append(configSet, setPrefixInterface+"neighbor "+neighbor["address"].(string)+" eligible")
+			if nssa["summaries"].(bool) {
+				configSet = append(configSet, setPrefixNssa+"summaries")
 			}
 		}
-		if ospfInterface["no_advertise_adjacency_segment"].(bool) {
-			configSet = append(configSet, setPrefixInterface+"no-advertise-adjacency-segment")
-		}
-		if ospfInterface["no_eligible_backup"].(bool) {
-			configSet = append(configSet, setPrefixInterface+"no-eligible-backup")
-		}
-		if ospfInterface["no_eligible_remote_backup"].(bool) {
-			configSet = append(configSet, setPrefixInterface+"no-eligible-remote-backup")
-		}
-		if ospfInterface["no_interface_state_traps"].(bool) {
-			configSet = append(configSet, setPrefixInterface+"no-interface-state-traps")
-		}
-		if ospfInterface["no_neighbor_down_notification"].(bool) {
-			configSet = append(configSet, setPrefixInterface+"no-neighbor-down-notification")
-		}
-		if ospfInterface["node_link_protection"].(bool) {
-			configSet = append(configSet, setPrefixInterface+"node-link-protection")
-		}
-		if ospfInterface["passive"].(bool) {
-			configSet = append(configSet, setPrefixInterface+"passive")
-			if v := ospfInterface["passive_traffic_engineering_remote_node_id"].(string); v != "" {
-				configSet = append(configSet, setPrefixInterface+"passive traffic-engineering remote-node-id "+v)
+	}
+	for _, stubBlock := range d.Get("stub").([]interface{}) {
+		configSet = append(configSet, setPrefix+"stub")
+		if stubBlock != nil {
+			stub := stubBlock.(map[string]interface{})
+			if v := stub["default_metric"].(int); v != 0 {
+				configSet = append(configSet, setPrefix+"stub default-metric "+strconv.Itoa(v))
 			}
-			if v := ospfInterface["passive_traffic_engineering_remote_node_router_id"].(string); v != "" {
-				configSet = append(configSet, setPrefixInterface+"passive traffic-engineering remote-node-router-id "+v)
+			if stub["no_summaries"].(bool) {
+				configSet = append(configSet, setPrefix+"stub no-summaries")
 			}
-		} else if ospfInterface["passive_traffic_engineering_remote_node_id"].(string) != "" ||
-			ospfInterface["passive_traffic_engineering_remote_node_router_id"].(string) != "" {
-			return fmt.Errorf("passive need to be true with " +
-				"passive_traffic_engineering_remote_node_id and passive_traffic_engineering_remote_node_router_id")
+			if stub["summaries"].(bool) {
+				configSet = append(configSet, setPrefix+"stub summaries")
+			}
 		}
-		if v := ospfInterface["poll_interval"].(int); v != 0 {
-			configSet = append(configSet, setPrefixInterface+"poll-interval "+strconv.Itoa(v))
+	}
+	virtualLinkList := make([]string, 0)
+	for _, virtualLinkBlock := range d.Get("virtual_link").(*schema.Set).List() {
+		virtualLink := virtualLinkBlock.(map[string]interface{})
+		if bchk.StringInSlice(
+			virtualLink["neighbor_id"].(string)+idSeparator+virtualLink["transit_area"].(string),
+			virtualLinkList,
+		) {
+			return fmt.Errorf(
+				"multiple blocks virtual_link with the same neighbor_id '%s' and transit_area '%s'",
+				virtualLink["neighbor_id"].(string), virtualLink["transit_area"].(string))
 		}
-		if v := ospfInterface["priority"].(int); v != -1 {
-			configSet = append(configSet, setPrefixInterface+"priority "+strconv.Itoa(v))
+		virtualLinkList = append(
+			virtualLinkList, virtualLink["neighbor_id"].(string)+idSeparator+virtualLink["transit_area"].(string),
+		)
+		setPrefixVirtualLink := setPrefix + "virtual-link " +
+			"neighbor-id " + virtualLink["neighbor_id"].(string) +
+			" transit-area " + virtualLink["transit_area"].(string) + " "
+		configSet = append(configSet, setPrefixVirtualLink)
+		if v := virtualLink["dead_interval"].(int); v != 0 {
+			configSet = append(configSet, setPrefixVirtualLink+"dead-interval "+strconv.Itoa(v))
 		}
-		if v := ospfInterface["retransmit_interval"].(int); v != 0 {
-			configSet = append(configSet, setPrefixInterface+"retransmit-interval "+strconv.Itoa(v))
+		if virtualLink["demand_circuit"].(bool) {
+			configSet = append(configSet, setPrefixVirtualLink+"demand-circuit")
 		}
-		if ospfInterface["secondary"].(bool) {
-			configSet = append(configSet, setPrefixInterface+"secondary")
+		if virtualLink["disable"].(bool) {
+			configSet = append(configSet, setPrefixVirtualLink+"disable")
 		}
-		if ospfInterface["strict_bfd"].(bool) {
-			configSet = append(configSet, setPrefixInterface+"strict-bfd")
+		if virtualLink["flood_reduction"].(bool) {
+			configSet = append(configSet, setPrefixVirtualLink+"flood-reduction")
 		}
-		if v := ospfInterface["te_metric"].(int); v != 0 {
-			configSet = append(configSet, setPrefixInterface+"te-metric "+strconv.Itoa(v))
+		if v := virtualLink["hello_interval"].(int); v != 0 {
+			configSet = append(configSet, setPrefixVirtualLink+"hello-interval "+strconv.Itoa(v))
 		}
-		if v := ospfInterface["transit_delay"].(int); v != 0 {
-			configSet = append(configSet, setPrefixInterface+"transit-delay "+strconv.Itoa(v))
+		if v := virtualLink["ipsec_sa"].(string); v != "" {
+			configSet = append(configSet, setPrefixVirtualLink+"ipsec-sa \""+v+"\"")
+		}
+		if v := virtualLink["mtu"].(int); v != 0 {
+			configSet = append(configSet, setPrefixVirtualLink+"mtu "+strconv.Itoa(v))
+		}
+		if v := virtualLink["retransmit_interval"].(int); v != 0 {
+			configSet = append(configSet, setPrefixVirtualLink+"retransmit-interval "+strconv.Itoa(v))
+		}
+		if v := virtualLink["transit_delay"].(int); v != 0 {
+			configSet = append(configSet, setPrefixVirtualLink+"transit-delay "+strconv.Itoa(v))
 		}
 	}
 
 	return sess.configSet(configSet, jnprSess)
+}
+
+func setOspfAreaInterface(setPrefix string, ospfInterface map[string]interface{}) ([]string, error) {
+	configSet := make([]string, 0)
+
+	configSet = append(configSet, setPrefix)
+	if v := ospfInterface["authentication_simple_password"].(string); v != "" {
+		if len(ospfInterface["authentication_md5"].([]interface{})) != 0 {
+			return configSet, fmt.Errorf("conflict between 'authentication_simple_password' and 'authentication_md5'"+
+				" in interface '%s'", ospfInterface["name"].(string))
+		}
+		configSet = append(configSet, setPrefix+"authentication simple-password \""+v+"\"")
+	}
+	authenticationMD5List := make([]int, 0)
+	for _, mAuthMD5 := range ospfInterface["authentication_md5"].([]interface{}) {
+		authMD5 := mAuthMD5.(map[string]interface{})
+		if bchk.IntInSlice(authMD5["key_id"].(int), authenticationMD5List) {
+			return configSet, fmt.Errorf("multiple blocks authentication_md5 with the same key_id %d in interface with name %s",
+				authMD5["key_id"].(int), ospfInterface["name"].(string))
+		}
+		authenticationMD5List = append(authenticationMD5List, authMD5["key_id"].(int))
+		configSet = append(configSet, setPrefix+"authentication md5 "+
+			strconv.Itoa(authMD5["key_id"].(int))+" key \""+authMD5["key"].(string)+"\"")
+		if v := authMD5["start_time"].(string); v != "" {
+			configSet = append(configSet, setPrefix+"authentication md5 "+
+				strconv.Itoa(authMD5["key_id"].(int))+" start-time "+v)
+		}
+	}
+	bandwidthBasedMetricsList := make([]string, 0)
+	for _, mBandBaseMet := range ospfInterface["bandwidth_based_metrics"].(*schema.Set).List() {
+		bandwidthBaseMetrics := mBandBaseMet.(map[string]interface{})
+		if bchk.StringInSlice(bandwidthBaseMetrics["bandwidth"].(string), bandwidthBasedMetricsList) {
+			return configSet, fmt.Errorf("multiple blocks bandwidth_based_metrics "+
+				"with the same bandwidth %s in interface with name %s",
+				bandwidthBaseMetrics["bandwidth"].(string), ospfInterface["name"].(string))
+		}
+		bandwidthBasedMetricsList = append(bandwidthBasedMetricsList, bandwidthBaseMetrics["bandwidth"].(string))
+		configSet = append(configSet, setPrefix+"bandwidth-based-metrics bandwidth "+
+			bandwidthBaseMetrics["bandwidth"].(string)+" metric "+strconv.Itoa(bandwidthBaseMetrics["metric"].(int)))
+	}
+	for _, mBFDLivDet := range ospfInterface["bfd_liveness_detection"].([]interface{}) {
+		if mBFDLivDet == nil {
+			return configSet, fmt.Errorf("bfd_liveness_detection block is empty in interface %s", ospfInterface["name"].(string))
+		}
+		setPrefixBfd := setPrefix + "bfd-liveness-detection "
+		bfdLiveDetect := mBFDLivDet.(map[string]interface{})
+		if v := bfdLiveDetect["authentication_algorithm"].(string); v != "" {
+			configSet = append(configSet, setPrefixBfd+"authentication algorithm "+v)
+		}
+		if v := bfdLiveDetect["authentication_key_chain"].(string); v != "" {
+			configSet = append(configSet, setPrefixBfd+"authentication key-chain \""+v+"\"")
+		}
+		if bfdLiveDetect["authentication_loose_check"].(bool) {
+			configSet = append(configSet, setPrefixBfd+"authentication loose-check")
+		}
+		if v := bfdLiveDetect["detection_time_threshold"].(int); v != 0 {
+			configSet = append(configSet, setPrefixBfd+"detection-time threshold "+strconv.Itoa(v))
+		}
+		if bfdLiveDetect["full_neighbors_only"].(bool) {
+			configSet = append(configSet, setPrefixBfd+"full-neighbors-only")
+		}
+		if v := bfdLiveDetect["holddown_interval"].(int); v != 0 {
+			configSet = append(configSet, setPrefixBfd+"holddown-interval "+strconv.Itoa(v))
+		}
+		if v := bfdLiveDetect["minimum_interval"].(int); v != 0 {
+			configSet = append(configSet, setPrefixBfd+"minimum-interval "+strconv.Itoa(v))
+		}
+		if v := bfdLiveDetect["minimum_receive_interval"].(int); v != 0 {
+			configSet = append(configSet, setPrefixBfd+"minimum-receive-interval "+strconv.Itoa(v))
+		}
+		if v := bfdLiveDetect["multiplier"].(int); v != 0 {
+			configSet = append(configSet, setPrefixBfd+"multiplier "+strconv.Itoa(v))
+		}
+		if bfdLiveDetect["no_adaptation"].(bool) {
+			configSet = append(configSet, setPrefixBfd+"no-adaptation")
+		}
+		if v := bfdLiveDetect["transmit_interval_minimum_interval"].(int); v != 0 {
+			configSet = append(configSet, setPrefixBfd+
+				"transmit-interval minimum-interval "+strconv.Itoa(v))
+		}
+		if v := bfdLiveDetect["transmit_interval_threshold"].(int); v != 0 {
+			configSet = append(configSet, setPrefixBfd+
+				"transmit-interval threshold "+strconv.Itoa(v))
+		}
+		if v := bfdLiveDetect["version"].(string); v != "" {
+			configSet = append(configSet, setPrefixBfd+"version "+v)
+		}
+		if len(configSet) == 0 || !strings.HasPrefix(configSet[len(configSet)-1], setPrefixBfd) {
+			return configSet, fmt.Errorf("bfd_liveness_detection block is empty in interface %s", ospfInterface["name"].(string))
+		}
+	}
+	if v := ospfInterface["dead_interval"].(int); v != 0 {
+		configSet = append(configSet, setPrefix+"dead-interval "+strconv.Itoa(v))
+	}
+	if ospfInterface["demand_circuit"].(bool) {
+		configSet = append(configSet, setPrefix+"demand-circuit")
+	}
+	if ospfInterface["disable"].(bool) {
+		configSet = append(configSet, setPrefix+"disable")
+	}
+	if ospfInterface["dynamic_neighbors"].(bool) {
+		configSet = append(configSet, setPrefix+"dynamic-neighbors")
+	}
+	if ospfInterface["flood_reduction"].(bool) {
+		configSet = append(configSet, setPrefix+"flood-reduction")
+	}
+	if v := ospfInterface["hello_interval"].(int); v != 0 {
+		configSet = append(configSet, setPrefix+"hello-interval "+strconv.Itoa(v))
+	}
+	if v := ospfInterface["interface_type"].(string); v != "" {
+		configSet = append(configSet, setPrefix+"interface-type "+v)
+	}
+	if v := ospfInterface["ipsec_sa"].(string); v != "" {
+		configSet = append(configSet, setPrefix+"ipsec-sa \""+v+"\"")
+	}
+	if t := ospfInterface["ipv4_adjacency_segment_protected_type"].(string); t != "" {
+		if v := ospfInterface["ipv4_adjacency_segment_protected_value"].(string); v != "" {
+			configSet = append(configSet, setPrefix+"ipv4-adjacency-segment protected "+t+" "+v)
+		} else {
+			configSet = append(configSet, setPrefix+"ipv4-adjacency-segment protected "+t)
+		}
+	} else if ospfInterface["ipv4_adjacency_segment_protected_value"].(string) != "" {
+		return configSet, fmt.Errorf("ipv4_adjacency_segment_protected_type need to be set with " +
+			"ipv4_adjacency_segment_protected_value")
+	}
+	if t := ospfInterface["ipv4_adjacency_segment_unprotected_type"].(string); t != "" {
+		if v := ospfInterface["ipv4_adjacency_segment_unprotected_value"].(string); v != "" {
+			configSet = append(configSet, setPrefix+"ipv4-adjacency-segment unprotected "+t+" "+v)
+		} else {
+			configSet = append(configSet, setPrefix+"ipv4-adjacency-segment unprotected "+t)
+		}
+	} else if ospfInterface["ipv4_adjacency_segment_unprotected_value"].(string) != "" {
+		return configSet, fmt.Errorf("ipv4_adjacency_segment_unprotected_type need to be set with " +
+			"ipv4_adjacency_segment_unprotected_value")
+	}
+	if ospfInterface["link_protection"].(bool) {
+		configSet = append(configSet, setPrefix+"link-protection")
+	}
+	if v := ospfInterface["metric"].(int); v != 0 {
+		configSet = append(configSet, setPrefix+"metric "+strconv.Itoa(v))
+	}
+	if v := ospfInterface["mtu"].(int); v != 0 {
+		configSet = append(configSet, setPrefix+"mtu "+strconv.Itoa(v))
+	}
+	neighborList := make([]string, 0)
+	for _, mNeighbor := range ospfInterface["neighbor"].(*schema.Set).List() {
+		neighbor := mNeighbor.(map[string]interface{})
+		if bchk.StringInSlice(neighbor["address"].(string), neighborList) {
+			return configSet, fmt.Errorf("multiple blocks neighbor with the same address %s in interface with name %s",
+				neighbor["address"].(string), ospfInterface["name"].(string))
+		}
+		neighborList = append(neighborList, neighbor["address"].(string))
+		configSet = append(configSet, setPrefix+"neighbor "+neighbor["address"].(string))
+		if neighbor["eligible"].(bool) {
+			configSet = append(configSet, setPrefix+"neighbor "+neighbor["address"].(string)+" eligible")
+		}
+	}
+	if ospfInterface["no_advertise_adjacency_segment"].(bool) {
+		configSet = append(configSet, setPrefix+"no-advertise-adjacency-segment")
+	}
+	if ospfInterface["no_eligible_backup"].(bool) {
+		configSet = append(configSet, setPrefix+"no-eligible-backup")
+	}
+	if ospfInterface["no_eligible_remote_backup"].(bool) {
+		configSet = append(configSet, setPrefix+"no-eligible-remote-backup")
+	}
+	if ospfInterface["no_interface_state_traps"].(bool) {
+		configSet = append(configSet, setPrefix+"no-interface-state-traps")
+	}
+	if ospfInterface["no_neighbor_down_notification"].(bool) {
+		configSet = append(configSet, setPrefix+"no-neighbor-down-notification")
+	}
+	if ospfInterface["node_link_protection"].(bool) {
+		configSet = append(configSet, setPrefix+"node-link-protection")
+	}
+	if ospfInterface["passive"].(bool) {
+		configSet = append(configSet, setPrefix+"passive")
+		if v := ospfInterface["passive_traffic_engineering_remote_node_id"].(string); v != "" {
+			configSet = append(configSet, setPrefix+"passive traffic-engineering remote-node-id "+v)
+		}
+		if v := ospfInterface["passive_traffic_engineering_remote_node_router_id"].(string); v != "" {
+			configSet = append(configSet, setPrefix+"passive traffic-engineering remote-node-router-id "+v)
+		}
+	} else if ospfInterface["passive_traffic_engineering_remote_node_id"].(string) != "" ||
+		ospfInterface["passive_traffic_engineering_remote_node_router_id"].(string) != "" {
+		return configSet, fmt.Errorf("passive need to be true with " +
+			"passive_traffic_engineering_remote_node_id and passive_traffic_engineering_remote_node_router_id")
+	}
+	if v := ospfInterface["poll_interval"].(int); v != 0 {
+		configSet = append(configSet, setPrefix+"poll-interval "+strconv.Itoa(v))
+	}
+	if v := ospfInterface["priority"].(int); v != -1 {
+		configSet = append(configSet, setPrefix+"priority "+strconv.Itoa(v))
+	}
+	if v := ospfInterface["retransmit_interval"].(int); v != 0 {
+		configSet = append(configSet, setPrefix+"retransmit-interval "+strconv.Itoa(v))
+	}
+	if ospfInterface["secondary"].(bool) {
+		configSet = append(configSet, setPrefix+"secondary")
+	}
+	if ospfInterface["strict_bfd"].(bool) {
+		configSet = append(configSet, setPrefix+"strict-bfd")
+	}
+	if v := ospfInterface["te_metric"].(int); v != 0 {
+		configSet = append(configSet, setPrefix+"te-metric "+strconv.Itoa(v))
+	}
+	if v := ospfInterface["transit_delay"].(int); v != 0 {
+		configSet = append(configSet, setPrefix+"transit-delay "+strconv.Itoa(v))
+	}
+
+	return configSet, nil
 }
 
 func readOspfArea(idArea, version, realm, routingInstance string, m interface{}, jnprSess *NetconfObject,
@@ -934,7 +1356,8 @@ func readOspfArea(idArea, version, realm, routingInstance string, m interface{},
 				break
 			}
 			itemTrim := strings.TrimPrefix(item, setLS)
-			if strings.HasPrefix(itemTrim, "interface ") {
+			switch {
+			case strings.HasPrefix(itemTrim, "interface "):
 				itemInterfaceList := strings.Split(strings.TrimPrefix(itemTrim, "interface "), " ")
 				interfaceOptions := map[string]interface{}{
 					"name":                                       itemInterfaceList[0],
@@ -977,211 +1400,396 @@ func readOspfArea(idArea, version, realm, routingInstance string, m interface{},
 				}
 				itemTrimInterface := strings.TrimPrefix(itemTrim, "interface "+itemInterfaceList[0]+" ")
 				confRead.interFace = copyAndRemoveItemMapList("name", interfaceOptions, confRead.interFace)
-				switch {
-				case strings.HasPrefix(itemTrimInterface, "authentication simple-password "):
-					var err error
-					interfaceOptions["authentication_simple_password"], err = jdecode.Decode(strings.Trim(strings.TrimPrefix(
-						itemTrimInterface, "authentication simple-password "), "\""))
-					if err != nil {
-						return confRead, fmt.Errorf("failed to decode authentication simple-password: %w", err)
-					}
-				case strings.HasPrefix(itemTrimInterface, "authentication md5 "):
-					itemTrimInterfaceSplit := strings.Split(strings.TrimPrefix(itemTrimInterface, "authentication md5 "), " ")
-					keyID, err := strconv.Atoi(itemTrimInterfaceSplit[0])
-					if err != nil {
-						return confRead, fmt.Errorf(failedConvAtoiError, itemTrimInterfaceSplit[0], err)
-					}
-					authMD5 := map[string]interface{}{
-						"key_id":     keyID,
-						"key":        "",
-						"start_time": "",
-					}
-					interfaceOptions["authentication_md5"] = copyAndRemoveItemMapList("key_id", authMD5,
-						interfaceOptions["authentication_md5"].([]map[string]interface{}))
-					itemTrimAuthMD5 := strings.TrimPrefix(itemTrimInterface, "authentication md5 "+itemTrimInterfaceSplit[0]+" ")
-					switch {
-					case strings.HasPrefix(itemTrimAuthMD5, "key "):
-						var err error
-						authMD5["key"], err = jdecode.Decode(strings.Trim(strings.TrimPrefix(
-							itemTrimAuthMD5, "key "), "\""))
-						if err != nil {
-							return confRead, fmt.Errorf("failed to decode authentication md5 key: %w", err)
-						}
-					case strings.HasPrefix(itemTrimAuthMD5, "start-time "):
-						authMD5["start_time"] = strings.Split(strings.Trim(strings.TrimPrefix(
-							itemTrimAuthMD5, "start-time "), "\""), " ")[0]
-					}
-					interfaceOptions["authentication_md5"] = append(
-						interfaceOptions["authentication_md5"].([]map[string]interface{}), authMD5)
-				case strings.HasPrefix(itemTrimInterface, "bandwidth-based-metrics bandwidth "):
-					itemTrimInterfaceSplit := strings.Split(strings.TrimPrefix(
-						itemTrimInterface, "bandwidth-based-metrics bandwidth "), " ")
-					if len(itemTrimInterfaceSplit) < 3 {
-						return confRead, fmt.Errorf("can't read values for bandwidth_based_metrics in %s", itemTrimInterface)
-					}
-					metric, err := strconv.Atoi(itemTrimInterfaceSplit[2])
-					if err != nil {
-						return confRead, fmt.Errorf(failedConvAtoiError, itemTrimInterfaceSplit[2], err)
-					}
-					interfaceOptions["bandwidth_based_metrics"] = append(
-						interfaceOptions["bandwidth_based_metrics"].([]map[string]interface{}), map[string]interface{}{
-							"bandwidth": itemTrimInterfaceSplit[0],
-							"metric":    metric,
-						})
-				case strings.HasPrefix(itemTrimInterface, "bfd-liveness-detection "):
-					if len(interfaceOptions["bfd_liveness_detection"].([]map[string]interface{})) == 0 {
-						interfaceOptions["bfd_liveness_detection"] = append(
-							interfaceOptions["bfd_liveness_detection"].([]map[string]interface{}), map[string]interface{}{
-								"authentication_algorithm":           "",
-								"authentication_key_chain":           "",
-								"authentication_loose_check":         false,
-								"detection_time_threshold":           0,
-								"full_neighbors_only":                false,
-								"holddown_interval":                  0,
-								"minimum_interval":                   0,
-								"minimum_receive_interval":           0,
-								"multiplier":                         0,
-								"no_adaptation":                      false,
-								"transmit_interval_minimum_interval": 0,
-								"transmit_interval_threshold":        0,
-								"version":                            "",
-							})
-					}
-					if err := readOspfAreaInterfaceBfd(strings.TrimPrefix(itemTrimInterface, "bfd-liveness-detection "),
-						interfaceOptions["bfd_liveness_detection"].([]map[string]interface{})[0]); err != nil {
-						return confRead, err
-					}
-				case strings.HasPrefix(itemTrimInterface, "dead-interval "):
-					interfaceOptions["dead_interval"], err = strconv.Atoi(
-						strings.TrimPrefix(itemTrimInterface, "dead-interval "))
-					if err != nil {
-						return confRead, fmt.Errorf(failedConvAtoiError, itemTrimInterface, err)
-					}
-				case itemTrimInterface == "demand-circuit":
-					interfaceOptions["demand_circuit"] = true
-				case itemTrimInterface == disableW:
-					interfaceOptions["disable"] = true
-				case itemTrimInterface == "dynamic-neighbors":
-					interfaceOptions["dynamic_neighbors"] = true
-				case itemTrimInterface == "flood-reduction":
-					interfaceOptions["flood_reduction"] = true
-				case strings.HasPrefix(itemTrimInterface, "hello-interval "):
-					interfaceOptions["hello_interval"], err = strconv.Atoi(
-						strings.TrimPrefix(itemTrimInterface, "hello-interval "))
-					if err != nil {
-						return confRead, fmt.Errorf(failedConvAtoiError, itemTrimInterface, err)
-					}
-				case strings.HasPrefix(itemTrimInterface, "interface-type "):
-					interfaceOptions["interface_type"] = strings.TrimPrefix(itemTrimInterface, "interface-type ")
-				case strings.HasPrefix(itemTrimInterface, "ipsec-sa "):
-					interfaceOptions["ipsec_sa"] = strings.Trim(strings.TrimPrefix(itemTrimInterface, "ipsec-sa "), "\"")
-				case strings.HasPrefix(itemTrimInterface, "ipv4-adjacency-segment protected "):
-					itemTrimInterfaceSplit := strings.Split(strings.TrimPrefix(
-						itemTrimInterface, "ipv4-adjacency-segment protected "), " ")
-					interfaceOptions["ipv4_adjacency_segment_protected_type"] = itemTrimInterfaceSplit[0]
-					if len(itemTrimInterfaceSplit) > 1 {
-						interfaceOptions["ipv4_adjacency_segment_protected_value"] = itemTrimInterfaceSplit[1]
-					}
-				case strings.HasPrefix(itemTrimInterface, "ipv4-adjacency-segment unprotected "):
-					itemTrimInterfaceSplit := strings.Split(strings.TrimPrefix(
-						itemTrimInterface, "ipv4-adjacency-segment unprotected "), " ")
-					interfaceOptions["ipv4_adjacency_segment_unprotected_type"] = itemTrimInterfaceSplit[0]
-					if len(itemTrimInterfaceSplit) > 1 {
-						interfaceOptions["ipv4_adjacency_segment_unprotected_value"] = itemTrimInterfaceSplit[1]
-					}
-				case itemTrimInterface == "link-protection":
-					interfaceOptions["link_protection"] = true
-				case strings.HasPrefix(itemTrimInterface, "metric "):
-					interfaceOptions["metric"], err = strconv.Atoi(
-						strings.TrimPrefix(itemTrimInterface, "metric "))
-					if err != nil {
-						return confRead, fmt.Errorf(failedConvAtoiError, itemTrimInterface, err)
-					}
-				case strings.HasPrefix(itemTrimInterface, "mtu "):
-					interfaceOptions["mtu"], err = strconv.Atoi(
-						strings.TrimPrefix(itemTrimInterface, "mtu "))
-					if err != nil {
-						return confRead, fmt.Errorf(failedConvAtoiError, itemTrimInterface, err)
-					}
-				case strings.HasPrefix(itemTrimInterface, "neighbor "):
-					itemTrimInterfaceSplit := strings.Split(strings.TrimPrefix(itemTrimInterface, "neighbor "), " ")
-					address := itemTrimInterfaceSplit[0]
-					if len(itemTrimInterfaceSplit) > 1 && itemTrimInterfaceSplit[1] == "eligible" {
-						interfaceOptions["neighbor"] = append(
-							interfaceOptions["neighbor"].([]map[string]interface{}), map[string]interface{}{
-								"address":  address,
-								"eligible": true,
-							})
-					} else {
-						interfaceOptions["neighbor"] = append(
-							interfaceOptions["neighbor"].([]map[string]interface{}), map[string]interface{}{
-								"address":  address,
-								"eligible": false,
-							})
-					}
-				case itemTrimInterface == "no-advertise-adjacency-segment":
-					interfaceOptions["no_advertise_adjacency_segment"] = true
-				case itemTrimInterface == "no-eligible-backup":
-					interfaceOptions["no_eligible_backup"] = true
-				case itemTrimInterface == "no-eligible-remote-backup":
-					interfaceOptions["no_eligible_remote_backup"] = true
-				case itemTrimInterface == "no-interface-state-traps":
-					interfaceOptions["no_interface_state_traps"] = true
-				case itemTrimInterface == "no-neighbor-down-notification":
-					interfaceOptions["no_neighbor_down_notification"] = true
-				case itemTrimInterface == "node-link-protection":
-					interfaceOptions["node_link_protection"] = true
-				case strings.HasPrefix(itemTrimInterface, "passive"):
-					interfaceOptions["passive"] = true
-					switch {
-					case strings.HasPrefix(itemTrimInterface, "passive traffic-engineering remote-node-id "):
-						interfaceOptions["passive_traffic_engineering_remote_node_id"] = strings.TrimPrefix(
-							itemTrimInterface, "passive traffic-engineering remote-node-id ")
-					case strings.HasPrefix(itemTrimInterface, "passive traffic-engineering remote-node-router-id "):
-						interfaceOptions["passive_traffic_engineering_remote_node_router_id"] = strings.TrimPrefix(
-							itemTrimInterface, "passive traffic-engineering remote-node-router-id ")
-					}
-				case strings.HasPrefix(itemTrimInterface, "poll-interval "):
-					interfaceOptions["poll_interval"], err = strconv.Atoi(
-						strings.TrimPrefix(itemTrimInterface, "poll-interval "))
-					if err != nil {
-						return confRead, fmt.Errorf(failedConvAtoiError, itemTrimInterface, err)
-					}
-				case strings.HasPrefix(itemTrimInterface, "priority "):
-					interfaceOptions["priority"], err = strconv.Atoi(
-						strings.TrimPrefix(itemTrimInterface, "priority "))
-					if err != nil {
-						return confRead, fmt.Errorf(failedConvAtoiError, itemTrimInterface, err)
-					}
-				case strings.HasPrefix(itemTrimInterface, "retransmit-interval "):
-					interfaceOptions["retransmit_interval"], err = strconv.Atoi(
-						strings.TrimPrefix(itemTrimInterface, "retransmit-interval "))
-					if err != nil {
-						return confRead, fmt.Errorf(failedConvAtoiError, itemTrimInterface, err)
-					}
-				case itemTrimInterface == "secondary":
-					interfaceOptions["secondary"] = true
-				case itemTrimInterface == "strict-bfd":
-					interfaceOptions["strict_bfd"] = true
-				case strings.HasPrefix(itemTrimInterface, "te-metric "):
-					interfaceOptions["te_metric"], err = strconv.Atoi(
-						strings.TrimPrefix(itemTrimInterface, "te-metric "))
-					if err != nil {
-						return confRead, fmt.Errorf(failedConvAtoiError, itemTrimInterface, err)
-					}
-				case strings.HasPrefix(itemTrimInterface, "transit-delay "):
-					interfaceOptions["transit_delay"], err = strconv.Atoi(
-						strings.TrimPrefix(itemTrimInterface, "transit-delay "))
-					if err != nil {
-						return confRead, fmt.Errorf(failedConvAtoiError, itemTrimInterface, err)
-					}
+				if err := readOspfAreaInterface(itemTrimInterface, interfaceOptions); err != nil {
+					return confRead, err
 				}
 				confRead.interFace = append(confRead.interFace, interfaceOptions)
+			case strings.HasPrefix(itemTrim, "area-range "):
+				itemTrimSplit := strings.Split(strings.TrimPrefix(itemTrim, "area-range "), " ")
+				areaRange := map[string]interface{}{
+					"range":           itemTrimSplit[0],
+					"exact":           false,
+					"override_metric": 0,
+					"restrict":        false,
+				}
+				confRead.areaRange = copyAndRemoveItemMapList("range", areaRange, confRead.areaRange)
+				itemTrimAreaRange := strings.TrimPrefix(itemTrim, "area-range "+itemTrimSplit[0]+" ")
+				switch {
+				case itemTrimAreaRange == "exact":
+					areaRange["exact"] = true
+				case strings.HasPrefix(itemTrimAreaRange, "override-metric "):
+					var err error
+					areaRange["override_metric"], err = strconv.Atoi(strings.TrimPrefix(itemTrimAreaRange, "override-metric "))
+					if err != nil {
+						return confRead, fmt.Errorf(failedConvAtoiError, itemTrim, err)
+					}
+				case itemTrimAreaRange == "restrict":
+					areaRange["restrict"] = true
+				}
+				confRead.areaRange = append(confRead.areaRange, areaRange)
+			case strings.HasPrefix(itemTrim, "context-identifier "):
+				confRead.contextIdentifier = append(confRead.contextIdentifier, strings.TrimPrefix(itemTrim, "context-identifier "))
+			case strings.HasPrefix(itemTrim, "inter-area-prefix-export "):
+				confRead.interAreaPrefixExport = append(
+					confRead.interAreaPrefixExport, strings.TrimPrefix(itemTrim, "inter-area-prefix-export "))
+			case strings.HasPrefix(itemTrim, "inter-area-prefix-import "):
+				confRead.interAreaPrefixImport = append(
+					confRead.interAreaPrefixImport, strings.TrimPrefix(itemTrim, "inter-area-prefix-import "))
+			case strings.HasPrefix(itemTrim, "network-summary-export "):
+				confRead.networkSummaryExport = append(
+					confRead.networkSummaryExport, strings.TrimPrefix(itemTrim, "network-summary-export "))
+			case strings.HasPrefix(itemTrim, "network-summary-import "):
+				confRead.networkSummaryImport = append(
+					confRead.networkSummaryImport, strings.TrimPrefix(itemTrim, "network-summary-import "))
+			case itemTrim == "no-context-identifier-advertisement":
+				confRead.noContextIdentifierAdvertisement = true
+			case strings.HasPrefix(itemTrim, "nssa"):
+				if len(confRead.nssa) == 0 {
+					confRead.nssa = append(confRead.nssa, map[string]interface{}{
+						"area_range":   make([]map[string]interface{}, 0),
+						"default_lsa":  make([]map[string]interface{}, 0),
+						"no_summaries": false,
+						"summaries":    false,
+					})
+				}
+				switch {
+				case strings.HasPrefix(itemTrim, "nssa area-range "):
+					itemTrimSplit := strings.Split(strings.TrimPrefix(itemTrim, "nssa area-range "), " ")
+					areaRange := map[string]interface{}{
+						"range":           itemTrimSplit[0],
+						"exact":           false,
+						"override_metric": 0,
+						"restrict":        false,
+					}
+					confRead.nssa[0]["area_range"] = copyAndRemoveItemMapList(
+						"range",
+						areaRange,
+						confRead.nssa[0]["area_range"].([]map[string]interface{}),
+					)
+					itemTrimAreaRange := strings.TrimPrefix(itemTrim, "nssa area-range "+itemTrimSplit[0]+" ")
+					switch {
+					case itemTrimAreaRange == "exact":
+						areaRange["exact"] = true
+					case strings.HasPrefix(itemTrimAreaRange, "override-metric "):
+						var err error
+						areaRange["override_metric"], err = strconv.Atoi(strings.TrimPrefix(itemTrimAreaRange, "override-metric "))
+						if err != nil {
+							return confRead, fmt.Errorf(failedConvAtoiError, itemTrim, err)
+						}
+					case itemTrimAreaRange == "restrict":
+						areaRange["restrict"] = true
+					}
+					confRead.nssa[0]["area_range"] = append(confRead.nssa[0]["area_range"].([]map[string]interface{}), areaRange)
+				case strings.HasPrefix(itemTrim, "nssa default-lsa"):
+					if len(confRead.nssa[0]["default_lsa"].([]map[string]interface{})) == 0 {
+						confRead.nssa[0]["default_lsa"] = append(
+							confRead.nssa[0]["default_lsa"].([]map[string]interface{}),
+							map[string]interface{}{
+								"default_metric": 0,
+								"metric_type":    0,
+								"type_7":         false,
+							})
+					}
+					defaultLsa := confRead.nssa[0]["default_lsa"].([]map[string]interface{})[0]
+					switch {
+					case strings.HasPrefix(itemTrim, "nssa default-lsa default-metric "):
+						var err error
+						defaultLsa["default_metric"], err = strconv.Atoi(strings.TrimPrefix(itemTrim, "nssa default-lsa default-metric "))
+						if err != nil {
+							return confRead, fmt.Errorf(failedConvAtoiError, itemTrim, err)
+						}
+					case strings.HasPrefix(itemTrim, "nssa default-lsa metric-type "):
+						var err error
+						defaultLsa["metric_type"], err = strconv.Atoi(strings.TrimPrefix(itemTrim, "nssa default-lsa metric-type "))
+						if err != nil {
+							return confRead, fmt.Errorf(failedConvAtoiError, itemTrim, err)
+						}
+					case itemTrim == "nssa default-lsa type-7":
+						defaultLsa["type_7"] = true
+					}
+				case itemTrim == "nssa no-summaries":
+					confRead.nssa[0]["no_summaries"] = true
+				case itemTrim == "nssa summaries":
+					confRead.nssa[0]["summaries"] = true
+				}
+			case strings.HasPrefix(itemTrim, "stub"):
+				if len(confRead.stub) == 0 {
+					confRead.stub = append(confRead.stub, map[string]interface{}{
+						"default_metric": 0,
+						"no_summaries":   false,
+						"summaries":      false,
+					})
+				}
+				switch {
+				case strings.HasPrefix(itemTrim, "stub default-metric "):
+					var err error
+					confRead.stub[0]["default_metric"], err = strconv.Atoi(strings.TrimPrefix(itemTrim, "stub default-metric "))
+					if err != nil {
+						return confRead, fmt.Errorf(failedConvAtoiError, itemTrim, err)
+					}
+				case itemTrim == "stub no-summaries":
+					confRead.stub[0]["no_summaries"] = true
+				case itemTrim == "stub summaries":
+					confRead.stub[0]["summaries"] = true
+				}
+			case strings.HasPrefix(itemTrim, "virtual-link "):
+				itemTrimSplit := strings.Split(strings.TrimPrefix(itemTrim, "virtual-link "), " ")
+				if len(itemTrimSplit) < 4 {
+					return confRead, fmt.Errorf("can't find neighbor_id and transit_area in %s", itemTrim)
+				}
+				virtualLink := map[string]interface{}{
+					"neighbor_id":         itemTrimSplit[1],
+					"transit_area":        itemTrimSplit[3],
+					"dead_interval":       0,
+					"demand_circuit":      false,
+					"disable":             false,
+					"flood_reduction":     false,
+					"hello_interval":      0,
+					"ipsec_sa":            "",
+					"mtu":                 0,
+					"retransmit_interval": 0,
+					"transit_delay":       0,
+				}
+				confRead.virtualLink = copyAndRemoveItemMapList2("neighbor_id", "transit_area", virtualLink, confRead.virtualLink)
+				itemTrimVirtualLink := strings.TrimPrefix(itemTrim,
+					"virtual-link neighbor-id "+itemTrimSplit[1]+" transit-area "+itemTrimSplit[3]+" ")
+				var err error
+				switch {
+				case strings.HasPrefix(itemTrimVirtualLink, "dead-interval "):
+					virtualLink["dead_interval"], err = strconv.Atoi(strings.TrimPrefix(itemTrimVirtualLink, "dead-interval "))
+				case itemTrimVirtualLink == "demand-circuit":
+					virtualLink["demand_circuit"] = true
+				case itemTrimVirtualLink == "disable":
+					virtualLink["disable"] = true
+				case itemTrimVirtualLink == "flood-reduction":
+					virtualLink["flood_reduction"] = true
+				case strings.HasPrefix(itemTrimVirtualLink, "hello-interval "):
+					virtualLink["hello_interval"], err = strconv.Atoi(strings.TrimPrefix(itemTrimVirtualLink, "hello-interval "))
+				case strings.HasPrefix(itemTrimVirtualLink, "ipsec-sa "):
+					virtualLink["ipsec_sa"] = strings.Trim(strings.TrimPrefix(itemTrimVirtualLink, "ipsec-sa "), "\"")
+				case strings.HasPrefix(itemTrimVirtualLink, "mtu "):
+					virtualLink["mtu"], err = strconv.Atoi(strings.TrimPrefix(itemTrimVirtualLink, "mtu "))
+				case strings.HasPrefix(itemTrimVirtualLink, "retransmit-interval "):
+					virtualLink["retransmit_interval"], err = strconv.Atoi(strings.TrimPrefix(
+						itemTrimVirtualLink, "retransmit-interval ",
+					))
+				case strings.HasPrefix(itemTrimVirtualLink, "transit-delay "):
+					virtualLink["transit_delay"], err = strconv.Atoi(strings.TrimPrefix(itemTrimVirtualLink, "transit-delay "))
+				}
+				if err != nil {
+					return confRead, fmt.Errorf(failedConvAtoiError, itemTrim, err)
+				}
+				confRead.virtualLink = append(confRead.virtualLink, virtualLink)
 			}
 		}
 	}
 
 	return confRead, nil
+}
+
+func readOspfAreaInterface(itemTrim string, interfaceOptions map[string]interface{}) error {
+	var err error
+	switch {
+	case strings.HasPrefix(itemTrim, "authentication simple-password "):
+		var err error
+		interfaceOptions["authentication_simple_password"], err = jdecode.Decode(strings.Trim(strings.TrimPrefix(
+			itemTrim, "authentication simple-password "), "\""))
+		if err != nil {
+			return fmt.Errorf("failed to decode authentication simple-password: %w", err)
+		}
+	case strings.HasPrefix(itemTrim, "authentication md5 "):
+		itemTrimSplit := strings.Split(strings.TrimPrefix(itemTrim, "authentication md5 "), " ")
+		keyID, err := strconv.Atoi(itemTrimSplit[0])
+		if err != nil {
+			return fmt.Errorf(failedConvAtoiError, itemTrimSplit[0], err)
+		}
+		authMD5 := map[string]interface{}{
+			"key_id":     keyID,
+			"key":        "",
+			"start_time": "",
+		}
+		interfaceOptions["authentication_md5"] = copyAndRemoveItemMapList("key_id", authMD5,
+			interfaceOptions["authentication_md5"].([]map[string]interface{}))
+		itemTrimAuthMD5 := strings.TrimPrefix(itemTrim, "authentication md5 "+itemTrimSplit[0]+" ")
+		switch {
+		case strings.HasPrefix(itemTrimAuthMD5, "key "):
+			var err error
+			authMD5["key"], err = jdecode.Decode(strings.Trim(strings.TrimPrefix(
+				itemTrimAuthMD5, "key "), "\""))
+			if err != nil {
+				return fmt.Errorf("failed to decode authentication md5 key: %w", err)
+			}
+		case strings.HasPrefix(itemTrimAuthMD5, "start-time "):
+			authMD5["start_time"] = strings.Split(strings.Trim(strings.TrimPrefix(
+				itemTrimAuthMD5, "start-time "), "\""), " ")[0]
+		}
+		interfaceOptions["authentication_md5"] = append(
+			interfaceOptions["authentication_md5"].([]map[string]interface{}), authMD5)
+	case strings.HasPrefix(itemTrim, "bandwidth-based-metrics bandwidth "):
+		itemTrimSplit := strings.Split(strings.TrimPrefix(
+			itemTrim, "bandwidth-based-metrics bandwidth "), " ")
+		if len(itemTrimSplit) < 3 {
+			return fmt.Errorf("can't read values for bandwidth_based_metrics in %s", itemTrim)
+		}
+		metric, err := strconv.Atoi(itemTrimSplit[2])
+		if err != nil {
+			return fmt.Errorf(failedConvAtoiError, itemTrimSplit[2], err)
+		}
+		interfaceOptions["bandwidth_based_metrics"] = append(
+			interfaceOptions["bandwidth_based_metrics"].([]map[string]interface{}), map[string]interface{}{
+				"bandwidth": itemTrimSplit[0],
+				"metric":    metric,
+			})
+	case strings.HasPrefix(itemTrim, "bfd-liveness-detection "):
+		if len(interfaceOptions["bfd_liveness_detection"].([]map[string]interface{})) == 0 {
+			interfaceOptions["bfd_liveness_detection"] = append(
+				interfaceOptions["bfd_liveness_detection"].([]map[string]interface{}), map[string]interface{}{
+					"authentication_algorithm":           "",
+					"authentication_key_chain":           "",
+					"authentication_loose_check":         false,
+					"detection_time_threshold":           0,
+					"full_neighbors_only":                false,
+					"holddown_interval":                  0,
+					"minimum_interval":                   0,
+					"minimum_receive_interval":           0,
+					"multiplier":                         0,
+					"no_adaptation":                      false,
+					"transmit_interval_minimum_interval": 0,
+					"transmit_interval_threshold":        0,
+					"version":                            "",
+				})
+		}
+		if err := readOspfAreaInterfaceBfd(strings.TrimPrefix(itemTrim, "bfd-liveness-detection "),
+			interfaceOptions["bfd_liveness_detection"].([]map[string]interface{})[0]); err != nil {
+			return err
+		}
+	case strings.HasPrefix(itemTrim, "dead-interval "):
+		interfaceOptions["dead_interval"], err = strconv.Atoi(
+			strings.TrimPrefix(itemTrim, "dead-interval "))
+		if err != nil {
+			return fmt.Errorf(failedConvAtoiError, itemTrim, err)
+		}
+	case itemTrim == "demand-circuit":
+		interfaceOptions["demand_circuit"] = true
+	case itemTrim == disableW:
+		interfaceOptions["disable"] = true
+	case itemTrim == "dynamic-neighbors":
+		interfaceOptions["dynamic_neighbors"] = true
+	case itemTrim == "flood-reduction":
+		interfaceOptions["flood_reduction"] = true
+	case strings.HasPrefix(itemTrim, "hello-interval "):
+		interfaceOptions["hello_interval"], err = strconv.Atoi(
+			strings.TrimPrefix(itemTrim, "hello-interval "))
+		if err != nil {
+			return fmt.Errorf(failedConvAtoiError, itemTrim, err)
+		}
+	case strings.HasPrefix(itemTrim, "interface-type "):
+		interfaceOptions["interface_type"] = strings.TrimPrefix(itemTrim, "interface-type ")
+	case strings.HasPrefix(itemTrim, "ipsec-sa "):
+		interfaceOptions["ipsec_sa"] = strings.Trim(strings.TrimPrefix(itemTrim, "ipsec-sa "), "\"")
+	case strings.HasPrefix(itemTrim, "ipv4-adjacency-segment protected "):
+		itemTrimSplit := strings.Split(strings.TrimPrefix(
+			itemTrim, "ipv4-adjacency-segment protected "), " ")
+		interfaceOptions["ipv4_adjacency_segment_protected_type"] = itemTrimSplit[0]
+		if len(itemTrimSplit) > 1 {
+			interfaceOptions["ipv4_adjacency_segment_protected_value"] = itemTrimSplit[1]
+		}
+	case strings.HasPrefix(itemTrim, "ipv4-adjacency-segment unprotected "):
+		itemTrimSplit := strings.Split(strings.TrimPrefix(
+			itemTrim, "ipv4-adjacency-segment unprotected "), " ")
+		interfaceOptions["ipv4_adjacency_segment_unprotected_type"] = itemTrimSplit[0]
+		if len(itemTrimSplit) > 1 {
+			interfaceOptions["ipv4_adjacency_segment_unprotected_value"] = itemTrimSplit[1]
+		}
+	case itemTrim == "link-protection":
+		interfaceOptions["link_protection"] = true
+	case strings.HasPrefix(itemTrim, "metric "):
+		interfaceOptions["metric"], err = strconv.Atoi(
+			strings.TrimPrefix(itemTrim, "metric "))
+		if err != nil {
+			return fmt.Errorf(failedConvAtoiError, itemTrim, err)
+		}
+	case strings.HasPrefix(itemTrim, "mtu "):
+		interfaceOptions["mtu"], err = strconv.Atoi(
+			strings.TrimPrefix(itemTrim, "mtu "))
+		if err != nil {
+			return fmt.Errorf(failedConvAtoiError, itemTrim, err)
+		}
+	case strings.HasPrefix(itemTrim, "neighbor "):
+		itemTrimSplit := strings.Split(strings.TrimPrefix(itemTrim, "neighbor "), " ")
+		address := itemTrimSplit[0]
+		if len(itemTrimSplit) > 1 && itemTrimSplit[1] == "eligible" {
+			interfaceOptions["neighbor"] = append(
+				interfaceOptions["neighbor"].([]map[string]interface{}), map[string]interface{}{
+					"address":  address,
+					"eligible": true,
+				})
+		} else {
+			interfaceOptions["neighbor"] = append(
+				interfaceOptions["neighbor"].([]map[string]interface{}), map[string]interface{}{
+					"address":  address,
+					"eligible": false,
+				})
+		}
+	case itemTrim == "no-advertise-adjacency-segment":
+		interfaceOptions["no_advertise_adjacency_segment"] = true
+	case itemTrim == "no-eligible-backup":
+		interfaceOptions["no_eligible_backup"] = true
+	case itemTrim == "no-eligible-remote-backup":
+		interfaceOptions["no_eligible_remote_backup"] = true
+	case itemTrim == "no-interface-state-traps":
+		interfaceOptions["no_interface_state_traps"] = true
+	case itemTrim == "no-neighbor-down-notification":
+		interfaceOptions["no_neighbor_down_notification"] = true
+	case itemTrim == "node-link-protection":
+		interfaceOptions["node_link_protection"] = true
+	case strings.HasPrefix(itemTrim, "passive"):
+		interfaceOptions["passive"] = true
+		switch {
+		case strings.HasPrefix(itemTrim, "passive traffic-engineering remote-node-id "):
+			interfaceOptions["passive_traffic_engineering_remote_node_id"] = strings.TrimPrefix(
+				itemTrim, "passive traffic-engineering remote-node-id ")
+		case strings.HasPrefix(itemTrim, "passive traffic-engineering remote-node-router-id "):
+			interfaceOptions["passive_traffic_engineering_remote_node_router_id"] = strings.TrimPrefix(
+				itemTrim, "passive traffic-engineering remote-node-router-id ")
+		}
+	case strings.HasPrefix(itemTrim, "poll-interval "):
+		interfaceOptions["poll_interval"], err = strconv.Atoi(
+			strings.TrimPrefix(itemTrim, "poll-interval "))
+		if err != nil {
+			return fmt.Errorf(failedConvAtoiError, itemTrim, err)
+		}
+	case strings.HasPrefix(itemTrim, "priority "):
+		interfaceOptions["priority"], err = strconv.Atoi(
+			strings.TrimPrefix(itemTrim, "priority "))
+		if err != nil {
+			return fmt.Errorf(failedConvAtoiError, itemTrim, err)
+		}
+	case strings.HasPrefix(itemTrim, "retransmit-interval "):
+		interfaceOptions["retransmit_interval"], err = strconv.Atoi(
+			strings.TrimPrefix(itemTrim, "retransmit-interval "))
+		if err != nil {
+			return fmt.Errorf(failedConvAtoiError, itemTrim, err)
+		}
+	case itemTrim == "secondary":
+		interfaceOptions["secondary"] = true
+	case itemTrim == "strict-bfd":
+		interfaceOptions["strict_bfd"] = true
+	case strings.HasPrefix(itemTrim, "te-metric "):
+		interfaceOptions["te_metric"], err = strconv.Atoi(
+			strings.TrimPrefix(itemTrim, "te-metric "))
+		if err != nil {
+			return fmt.Errorf(failedConvAtoiError, itemTrim, err)
+		}
+	case strings.HasPrefix(itemTrim, "transit-delay "):
+		interfaceOptions["transit_delay"], err = strconv.Atoi(
+			strings.TrimPrefix(itemTrim, "transit-delay "))
+		if err != nil {
+			return fmt.Errorf(failedConvAtoiError, itemTrim, err)
+		}
+	}
+
+	return nil
 }
 
 func readOspfAreaInterfaceBfd(itemTrim string, bfd map[string]interface{}) error {
@@ -1284,9 +1892,6 @@ func fillOspfAreaData(d *schema.ResourceData, ospfAreaOptions ospfAreaOptions) {
 	if tfErr := d.Set("area_id", ospfAreaOptions.areaID); tfErr != nil {
 		panic(tfErr)
 	}
-	if tfErr := d.Set("interface", ospfAreaOptions.interFace); tfErr != nil {
-		panic(tfErr)
-	}
 	if tfErr := d.Set("routing_instance", ospfAreaOptions.routingInstance); tfErr != nil {
 		panic(tfErr)
 	}
@@ -1294,6 +1899,42 @@ func fillOspfAreaData(d *schema.ResourceData, ospfAreaOptions ospfAreaOptions) {
 		panic(tfErr)
 	}
 	if tfErr := d.Set("version", ospfAreaOptions.version); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("interface", ospfAreaOptions.interFace); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("area_range", ospfAreaOptions.areaRange); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("context_identifier", ospfAreaOptions.contextIdentifier); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("inter_area_prefix_export", ospfAreaOptions.interAreaPrefixExport); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("inter_area_prefix_import", ospfAreaOptions.interAreaPrefixImport); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("network_summary_export", ospfAreaOptions.networkSummaryExport); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("network_summary_import", ospfAreaOptions.networkSummaryImport); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set(
+		"no_context_identifier_advertisement",
+		ospfAreaOptions.noContextIdentifierAdvertisement,
+	); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("nssa", ospfAreaOptions.nssa); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("stub", ospfAreaOptions.stub); tfErr != nil {
+		panic(tfErr)
+	}
+	if tfErr := d.Set("virtual_link", ospfAreaOptions.virtualLink); tfErr != nil {
 		panic(tfErr)
 	}
 }

--- a/junos/resource_ospf_area_test.go
+++ b/junos/resource_ospf_area_test.go
@@ -73,6 +73,21 @@ func TestAccJunosOspfArea_basic(t *testing.T) {
 					ImportState:       true,
 					ImportStateVerify: true,
 				},
+				{
+					ResourceName:      "junos_ospf_area.testacc_ospfarea2",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+				{
+					ResourceName:      "junos_ospf_area.testacc_ospfareav3ipv4",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+				{
+					ResourceName:      "junos_ospf_area.testacc_ospfarea2v3realm",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
 			},
 		})
 	}
@@ -90,6 +105,19 @@ resource "junos_ospf_area" "testacc_ospfarea" {
     retransmit_interval = 12
     hello_interval      = 11
     dead_interval       = 10
+  }
+  interface {
+    name      = junos_interface_logical.testacc_ospfarea.name
+    secondary = true
+  }
+}
+resource "junos_ospf_area" "testacc_ospfareav3ipv4" {
+  area_id = "0.0.0.0"
+  version = "v3"
+  realm   = "ipv4-unicast"
+  interface {
+    name    = "all"
+    disable = true
   }
   interface {
     name      = junos_interface_logical.testacc_ospfarea.name
@@ -143,6 +171,21 @@ resource "junos_ospf_area" "testacc_ospfarea" {
     neighbor {
       address  = "192.0.2.5"
       eligible = "true"
+    }
+  }
+}
+resource "junos_ospf_area" "testacc_ospfareav3ipv4" {
+  area_id = "0.0.0.0"
+  version = "v3"
+  realm   = "ipv4-unicast"
+  interface {
+    name     = junos_interface_logical.testacc_ospfarea.name
+    priority = 0
+    bfd_liveness_detection {
+      full_neighbors_only                = true
+      minimum_receive_interval           = 27
+      transmit_interval_minimum_interval = 50
+      transmit_interval_threshold        = 51
     }
   }
 }
@@ -204,6 +247,25 @@ resource "junos_ospf_area" "testacc_ospfarea2" {
       transmit_interval_minimum_interval = 18
       transmit_interval_threshold        = 19
       version                            = "automatic"
+    }
+  }
+}
+resource "junos_ospf_area" "testacc_ospfarea2v3realm" {
+  area_id          = "0.0.0.0"
+  version          = "v3"
+  realm            = "ipv4-multicast"
+  routing_instance = junos_routing_instance.testacc_ospfarea.name
+  interface {
+    name    = "all"
+    passive = true
+  }
+  interface {
+    name = junos_interface_logical.testacc_ospfarea2.name
+    bfd_liveness_detection {
+      version                            = "automatic"
+      minimum_receive_interval           = 270
+      transmit_interval_minimum_interval = 500
+      transmit_interval_threshold        = 510
     }
   }
 }


### PR DESCRIPTION
ENHANCEMENTS:

* resource/`junos_ospf_area`: add `realm` argument to add a OSPFv3 realm area. (Fixes #392),  
  add new `area_range`, `context_identifier`, `inter_area_prefix_export`, `inter_area_prefix_import`, `network_summary_export`, `network_summary_import`, `no_context_identifier_advertisement`, `nssa`, `stub` and `virtual_link` arguments,  
  add validation of `area_id`