### PR TITLE
r/security_static_nat: remove the need to set `routing_instance` argument with `type` = `inet`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ ENHANCEMENTS:
 BUG FIXES:
 
 * resource/`junos_security_nat_static`: remove the need to set `routing_instance` argument with `type` = `inet` inside `then` block of `rule` block (`then static-nat inet` without `routing-instance` is correct to do NAT64) (Fixes #420)
+* resource/`junos_security_nat_static_rule`: remove the need to set `routing_instance` argument with `type` = `inet` inside `then` block (`then static-nat inet` without `routing-instance` is correct to do NAT64)
 
 ## 1.30.0 (September 07, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ ENHANCEMENTS:
 
 BUG FIXES:
 
+* resource/`junos_security_nat_static`: remove the need to set `routing_instance` argument with `type` = `inet` inside `then` block of `rule` block (`then static-nat inet` without `routing-instance` is correct to do NAT64) (Fixes #420)
+
 ## 1.30.0 (September 07, 2022)
 
 FEATURES:

--- a/junos/resource_security_nat_static_rule_test.go
+++ b/junos/resource_security_nat_static_rule_test.go
@@ -60,6 +60,9 @@ func TestAccJunosSecurityNatStaticRule_basic(t *testing.T) {
 					ImportState:       true,
 					ImportStateVerify: true,
 				},
+				{
+					Config: testAccJunosSecurityNatStaticRuleConfigCreate2(),
+				},
 			},
 		})
 	}
@@ -83,6 +86,14 @@ resource "junos_security_nat_static_rule" "testacc_securityNATSttRule" {
     type             = "prefix"
     routing_instance = junos_routing_instance.testacc_securityNATSttRule.name
     prefix           = "192.0.2.128/25"
+  }
+}
+resource "junos_security_nat_static_rule" "testacc_securityNATSttRuleInet" {
+  name                = "testacc_securityNATSttRuleInet"
+  rule_set            = junos_security_nat_static.testacc_securityNATSttRule.name
+  destination_address = "64:ff9b::/96"
+  then {
+    type = "inet"
   }
 }
 
@@ -175,6 +186,34 @@ resource "junos_security_address_book" "testacc_securityNATSttRule" {
     name  = "testacc_securityNATSttRule-src"
     value = "192.0.2.224/27"
   }
+}
+`
+}
+
+func testAccJunosSecurityNatStaticRuleConfigCreate2() string {
+	return `
+resource "junos_security_nat_static" "testacc_securityNATSttRuleInet" {
+  name = "testacc_securityNATSttRuleInet"
+  from {
+    type  = "zone"
+    value = [junos_security_zone.testacc_securityNATSttRuleInet.name]
+  }
+  configure_rules_singly = true
+}
+resource "junos_security_nat_static_rule" "testacc_securityNATSttRuleInet" {
+  name                = "testacc_securityNATSttRuleInet"
+  rule_set            = junos_security_nat_static.testacc_securityNATSttRuleInet.name
+  destination_address = "64:ff9b::/96"
+  then {
+    type             = "inet"
+    routing_instance = junos_routing_instance.testacc_securityNATSttRuleInet.name
+  }
+}
+resource "junos_security_zone" "testacc_securityNATSttRuleInet" {
+  name = "testacc_securityNATSttRuleInet"
+}
+resource "junos_routing_instance" "testacc_securityNATSttRuleInet" {
+  name = "testacc_securityNATSttRuleInet"
 }
 `
 }

--- a/junos/resource_security_nat_static_test.go
+++ b/junos/resource_security_nat_static_test.go
@@ -25,7 +25,7 @@ func TestAccJunosSecurityNatStatic_basic(t *testing.T) {
 						resource.TestCheckResourceAttr("junos_security_nat_static.testacc_securityNATStt",
 							"from.0.value.0", "testacc_securityNATStt"),
 						resource.TestCheckResourceAttr("junos_security_nat_static.testacc_securityNATStt",
-							"rule.#", "1"),
+							"rule.#", "2"),
 						resource.TestCheckResourceAttr("junos_security_nat_static.testacc_securityNATStt",
 							"rule.0.name", "testacc_securityNATSttRule"),
 						resource.TestCheckResourceAttr("junos_security_nat_static.testacc_securityNATStt",
@@ -67,6 +67,9 @@ func TestAccJunosSecurityNatStatic_basic(t *testing.T) {
 					ImportState:   true,
 					ImportStateId: "testacc_securityNATStt_singly_-_no_rules",
 				},
+				{
+					Config: testAccJunosSecurityNatStaticConfigUpdate2(),
+				},
 			},
 		})
 	}
@@ -88,6 +91,13 @@ resource "junos_security_nat_static" "testacc_securityNATStt" {
       type             = "prefix"
       routing_instance = junos_routing_instance.testacc_securityNATStt.name
       prefix           = "192.0.2.128/25"
+    }
+  }
+  rule {
+    name                = "testacc_securityNATSttRule2"
+    destination_address = "64:ff9b::/96"
+    then {
+      type = "inet"
     }
   }
 }
@@ -183,6 +193,48 @@ resource "junos_security_nat_static" "testacc_securityNATStt_singly" {
     value = [junos_routing_instance.testacc_securityNATStt.name]
   }
   configure_rules_singly = true
+}
+`
+}
+
+func testAccJunosSecurityNatStaticConfigUpdate2() string {
+	return `
+resource "junos_security_nat_static" "testacc_securityNATStt" {
+  name = "testacc_securityNATStt"
+  from {
+    type  = "zone"
+    value = [junos_security_zone.testacc_securityNATStt.name]
+  }
+  rule {
+    name                = "testacc_securityNATSttRule"
+    destination_address = "64:ff9b::/96"
+    then {
+      type             = "inet"
+      routing_instance = junos_routing_instance.testacc_securityNATStt.name
+    }
+  }
+}
+
+resource "junos_security_zone" "testacc_securityNATStt" {
+  name = "testacc_securityNATStt"
+}
+resource "junos_routing_instance" "testacc_securityNATStt" {
+  name = "testacc_securityNATStt"
+}
+
+resource "junos_security_address_book" "testacc_securityNATStt" {
+  network_address {
+    name  = "testacc_securityNATSttRule2"
+    value = "192.0.2.128/27"
+  }
+  network_address {
+    name  = "testacc_securityNATStt-prefix"
+    value = "192.0.2.160/27"
+  }
+  network_address {
+    name  = "testacc_securityNATStt-src"
+    value = "192.0.2.224/27"
+  }
 }
 `
 }


### PR DESCRIPTION
BUG FIXES:

* resource/`junos_security_nat_static`: remove the need to set `routing_instance` argument with `type` = `inet` inside `then` block of `rule` block (`then static-nat inet` without `routing-instance` is correct to do NAT64) (Fixes #420)
* resource/`junos_security_nat_static_rule`: remove the need to set `routing_instance` argument with `type` = `inet` inside `then` block (`then static-nat inet` without `routing-instance` is correct to do NAT64)