### PR TITLE
r/policyoptions_policy_statement: add some arguments inside `from` block argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ FEATURES:
 
 ENHANCEMENTS:
 
+* resource/`junos_policyoptions_policy_statement`: add `bgp_as_path_unique_count` block argument inside `from` block argument (Fixes #424)
+
 BUG FIXES:
 
 ## 1.30.1 (September 09, 2022)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ FEATURES:
 
 ENHANCEMENTS:
 
-* resource/`junos_policyoptions_policy_statement`: add `bgp_as_path_unique_count` block argument inside `from` block argument (Fixes #424)
+* resource/`junos_policyoptions_policy_statement`: add `bgp_as_path_calc_length`, `bgp_as_path_unique_count`, `bgp_community_count`, `bgp_srte_discriminator`, `color`, `evpn_esi`, `evpn_mac_route`, `evpn_tag`, `next_hop_type_merged`, `next_hop_weight`, `route_type`, `srte_color`, `state`, `tunnel_type` and `validation_database` arguments inside `from` block arguments (Fixes #424)
 
 BUG FIXES:
 

--- a/docs/resources/policyoptions_policy_statement.md
+++ b/docs/resources/policyoptions_policy_statement.md
@@ -76,6 +76,13 @@ The following arguments are supported:
 - **bgp_as_path** (Optional, Set of String)  
   Name of AS path regular expression.  
   See resource `junos_policyoptions_as_path`.
+- **bgp_as_path_calc_length** Optional, Block Set)  
+  For each count, number of BGP ASes excluding confederations.
+  - **count** (Required, Number)  
+    Number of ASes (0..1024).
+  - **match** (Required, String)  
+    Type of match: equal values, higher or equal values, lower or equal values.  
+    Need to `equal`, `orhigher` or `orlower`.
 - **bgp_as_path_group** (Optional, Set of String)  
   Name of AS path group.  
   See resource `junos_policyoptions_as_path_group`.
@@ -89,9 +96,27 @@ The following arguments are supported:
 - **bgp_community** (Optional, Set of String)  
   BGP community.  
   See resource `junos_policyoptions_community`.
+- **bgp_community_count** (Optional, Block Set)  
+  For each count, number of BGP communities.
+  - **count** (Required, Number)  
+    Number of communities (0..1024).
+  - **match** (Required, String)  
+    Type of match: equal values, higher or equal values, lower or equal values.  
+    Need to `equal`, `orhigher` or `orlower`.
 - **bgp_origin** (Optional, String)  
   BGP origin attribute.  
   Need to be `egp`, `igp` or `incomplete`.
+- **bgp_srte_discriminator** (Optional, Number)  
+  Srte discriminator.
+- **color** (Optional, Number)  
+  Color (preference) value.
+- **evpn_esi** (Optional, Set of String)  
+  ESI in EVPN Route.
+- **evpn_mac_route** (Optional, String)  
+  EVPN Mac Route type.  
+  Need to be `mac-ipv4`, `mac-ipv6` or `mac-only`.
+- **evpn_tag** (Optional, Set of Number)  
+  Tag in EVPN Route (0..4294967295).
 - **family** (Optional, String)  
   IP family.
 - **local_preference** (Optional, Number)  
@@ -106,6 +131,15 @@ The following arguments are supported:
   Neighboring router
 - **next_hop** (Optional, Set of String)  
   Next-hop router
+- **next_hop_type_merged** (Optional, Boolean)  
+  Merged next hop.
+- **next_hop_weight** (Optional, Block Set)  
+  For each combination of block arguments, weight of the gateway.
+  - **match** (Required, String)  
+    Type of match for weight.  
+    Need to be `equal`, `greater-than`, `greater-than-equal`, `less-than` or `less-than-equal`.
+  - **weight** (Required, Weight)  
+    Weight of the gateway (1..65535).
 - **ospf_area** (Optional, String)  
   OSPF area identifier
 - **policy** (Optional, List of String)  
@@ -126,6 +160,20 @@ The following arguments are supported:
     Need to be `address-mask`, `exact`, `longer`, `orlonger`, `prefix-length-range`, `through` or `upto`.
   - **option_value** (Optional, String)  
     For options that need an argument
+- **route_type** (Optional, String)  
+  Route type.  
+  Need to be `external` or `internal`.
+- **srte_color** (Optional, Number)  
+  Srte color.
+- **state** (Optional, String)  
+  Route state.  
+  Need to be `active` or `inactive`.
+- **tunnel_type** (Optional, Set of String)  
+  Tunnel type.  
+  Element need to be `gre`, `ipip` or `udp`.
+- **validation_database** (Optional, String)  
+  Name to identify a validation-state.  
+  Need to be `invalid`, `unknown` or `valid`.
 
 ---
 

--- a/docs/resources/policyoptions_policy_statement.md
+++ b/docs/resources/policyoptions_policy_statement.md
@@ -79,6 +79,13 @@ The following arguments are supported:
 - **bgp_as_path_group** (Optional, Set of String)  
   Name of AS path group.  
   See resource `junos_policyoptions_as_path_group`.
+- **bgp_as_path_unique_count** (Optional, Block Set)  
+  For each count, number of unique BGP ASes excluding confederations.
+  - **count** (Required, Number)  
+    Number of ASes (0..1024).
+  - **match** (Required, String)  
+    Type of match: equal values, higher or equal values, lower or equal values.  
+    Need to `equal`, `orhigher` or `orlower`.
 - **bgp_community** (Optional, Set of String)  
   BGP community.  
   See resource `junos_policyoptions_community`.

--- a/junos/func_common.go
+++ b/junos/func_common.go
@@ -280,9 +280,19 @@ func validateFilePermission() schema.SchemaValidateDiagFunc {
 }
 
 func sortSetOfString(list []interface{}) []string {
-	s := make([]string, 0)
-	for _, e := range list {
-		s = append(s, e.(string))
+	s := make([]string, len(list))
+	for k, e := range list {
+		s[k] = e.(string)
+	}
+	sort.Strings(s)
+
+	return s
+}
+
+func sortSetOfNumberToString(list []interface{}) []string {
+	s := make([]string, len(list))
+	for k, e := range list {
+		s[k] = strconv.Itoa(e.(int))
 	}
 	sort.Strings(s)
 

--- a/junos/resource_policyoptions_test.go
+++ b/junos/resource_policyoptions_test.go
@@ -750,17 +750,25 @@ resource "junos_policyoptions_policy_statement" "testacc_policyOptions" {
   from {
     aggregate_contributor = true
     bgp_as_path           = [junos_policyoptions_as_path.testacc_policyOptions.name]
-    bgp_community         = [junos_policyoptions_community.testacc_policyOptions.name]
-    bgp_origin            = "igp"
-    family                = "inet"
-    local_preference      = 100
-    routing_instance      = junos_routing_instance.testacc_policyOptions.name
-    interface             = ["st0.0"]
-    metric                = 5
-    neighbor              = ["192.0.2.4"]
-    next_hop              = ["192.0.2.4"]
-    ospf_area             = "0.0.0.0"
-    preference            = 100
+    bgp_as_path_unique_count {
+      count = 3
+      match = "equal"
+    }
+    bgp_as_path_unique_count {
+      count = 2
+      match = "orhigher"
+    }
+    bgp_community    = [junos_policyoptions_community.testacc_policyOptions.name]
+    bgp_origin       = "igp"
+    family           = "inet"
+    local_preference = 100
+    routing_instance = junos_routing_instance.testacc_policyOptions.name
+    interface        = ["st0.0"]
+    metric           = 5
+    neighbor         = ["192.0.2.4"]
+    next_hop         = ["192.0.2.4"]
+    ospf_area        = "0.0.0.0"
+    preference       = 100
     prefix_list = [junos_policyoptions_prefix_list.testacc_policyOptions.name,
       junos_policyoptions_prefix_list.testacc_policyOptions2.name,
     ]
@@ -805,20 +813,24 @@ resource "junos_policyoptions_policy_statement" "testacc_policyOptions" {
     from {
       aggregate_contributor = true
       bgp_as_path           = [junos_policyoptions_as_path.testacc_policyOptions.name]
-      bgp_community         = [junos_policyoptions_community.testacc_policyOptions.name]
-      bgp_origin            = "igp"
-      family                = "inet"
-      local_preference      = 100
-      routing_instance      = junos_routing_instance.testacc_policyOptions.name
-      interface             = ["st0.0"]
-      metric                = 5
-      neighbor              = ["192.0.2.4"]
-      next_hop              = ["192.0.2.4"]
-      ospf_area             = "0.0.0.0"
-      policy                = [junos_policyoptions_policy_statement.testacc_policyOptions2.name]
-      preference            = 100
-      prefix_list           = [junos_policyoptions_prefix_list.testacc_policyOptions.name]
-      protocol              = ["bgp"]
+      bgp_as_path_unique_count {
+        count = 4
+        match = "orlower"
+      }
+      bgp_community    = [junos_policyoptions_community.testacc_policyOptions.name]
+      bgp_origin       = "igp"
+      family           = "inet"
+      local_preference = 100
+      routing_instance = junos_routing_instance.testacc_policyOptions.name
+      interface        = ["st0.0"]
+      metric           = 5
+      neighbor         = ["192.0.2.4"]
+      next_hop         = ["192.0.2.4"]
+      ospf_area        = "0.0.0.0"
+      policy           = [junos_policyoptions_policy_statement.testacc_policyOptions2.name]
+      preference       = 100
+      prefix_list      = [junos_policyoptions_prefix_list.testacc_policyOptions.name]
+      protocol         = ["bgp"]
       route_filter {
         route  = "192.0.2.0/25"
         option = "exact"

--- a/junos/resource_policyoptions_test.go
+++ b/junos/resource_policyoptions_test.go
@@ -506,19 +506,28 @@ resource "junos_policyoptions_policy_statement" "testacc_policyOptions" {
   from {
     aggregate_contributor = true
     bgp_as_path           = [junos_policyoptions_as_path.testacc_policyOptions.name]
-    bgp_community         = [junos_policyoptions_community.testacc_policyOptions.name]
-    bgp_origin            = "igp"
-    family                = "inet"
-    local_preference      = 100
-    routing_instance      = junos_routing_instance.testacc_policyOptions.name
-    interface             = ["st0.0"]
-    metric                = 5
-    neighbor              = ["192.0.2.4"]
-    next_hop              = ["192.0.2.4"]
-    ospf_area             = "0.0.0.0"
-    preference            = 100
-    prefix_list           = [junos_policyoptions_prefix_list.testacc_policyOptions.name]
-    protocol              = ["bgp"]
+    bgp_as_path_calc_length {
+      count = 4
+      match = "orhigher"
+    }
+    bgp_community = [junos_policyoptions_community.testacc_policyOptions.name]
+    bgp_community_count {
+      count = 6
+      match = "orhigher"
+    }
+    bgp_origin       = "igp"
+    color            = 31
+    family           = "inet"
+    local_preference = 100
+    routing_instance = junos_routing_instance.testacc_policyOptions.name
+    interface        = ["st0.0"]
+    metric           = 5
+    neighbor         = ["192.0.2.4"]
+    next_hop         = ["192.0.2.4"]
+    ospf_area        = "0.0.0.0"
+    preference       = 100
+    prefix_list      = [junos_policyoptions_prefix_list.testacc_policyOptions.name]
+    protocol         = ["bgp"]
     route_filter {
       route  = "192.0.2.0/25"
       option = "exact"
@@ -750,6 +759,14 @@ resource "junos_policyoptions_policy_statement" "testacc_policyOptions" {
   from {
     aggregate_contributor = true
     bgp_as_path           = [junos_policyoptions_as_path.testacc_policyOptions.name]
+    bgp_as_path_calc_length {
+      count = 4
+      match = "orhigher"
+    }
+    bgp_as_path_calc_length {
+      count = 3
+      match = "equal"
+    }
     bgp_as_path_unique_count {
       count = 3
       match = "equal"
@@ -758,17 +775,39 @@ resource "junos_policyoptions_policy_statement" "testacc_policyOptions" {
       count = 2
       match = "orhigher"
     }
-    bgp_community    = [junos_policyoptions_community.testacc_policyOptions.name]
-    bgp_origin       = "igp"
-    family           = "inet"
-    local_preference = 100
-    routing_instance = junos_routing_instance.testacc_policyOptions.name
-    interface        = ["st0.0"]
-    metric           = 5
-    neighbor         = ["192.0.2.4"]
-    next_hop         = ["192.0.2.4"]
-    ospf_area        = "0.0.0.0"
-    preference       = 100
+    bgp_community = [junos_policyoptions_community.testacc_policyOptions.name]
+    bgp_community_count {
+      count = 6
+      match = "orhigher"
+    }
+    bgp_community_count {
+      count = 5
+      match = "equal"
+    }
+    bgp_origin             = "igp"
+    bgp_srte_discriminator = 30
+
+    evpn_esi             = ["00:11:11:11:11:11:11:11:11:33", "00:11:11:11:11:11:11:11:11:32"]
+    evpn_mac_route       = "mac-only"
+    evpn_tag             = [36, 35, 33]
+    family               = "evpn"
+    local_preference     = 100
+    routing_instance     = junos_routing_instance.testacc_policyOptions.name
+    interface            = ["st0.0"]
+    metric               = 5
+    neighbor             = ["192.0.2.4"]
+    next_hop             = ["192.0.2.4"]
+    next_hop_type_merged = true
+    next_hop_weight {
+      match  = "greater-than-equal"
+      weight = 500
+    }
+    next_hop_weight {
+      match  = "equal"
+      weight = 200
+    }
+    ospf_area  = "0.0.0.0"
+    preference = 100
     prefix_list = [junos_policyoptions_prefix_list.testacc_policyOptions.name,
       junos_policyoptions_prefix_list.testacc_policyOptions2.name,
     ]
@@ -777,6 +816,11 @@ resource "junos_policyoptions_policy_statement" "testacc_policyOptions" {
       route  = "192.0.2.0/25"
       option = "exact"
     }
+    route_type          = "internal"
+    srte_color          = 39
+    state               = "active"
+    tunnel_type         = ["ipip"]
+    validation_database = "valid"
   }
   to {
     bgp_as_path      = [junos_policyoptions_as_path.testacc_policyOptions.name]


### PR DESCRIPTION
ENHANCEMENTS:

* resource/`junos_policyoptions_policy_statement`: add `bgp_as_path_calc_length`, `bgp_as_path_unique_count`, `bgp_community_count`, `bgp_srte_discriminator`, `color`, `evpn_esi`, `evpn_mac_route`, `evpn_tag`, `next_hop_type_merged`, `next_hop_weight`, `route_type`, `srte_color`, `state`, `tunnel_type` and `validation_database` arguments inside `from` block arguments (Fixes #424)