### PR TITLE
[workflows] bump golangci-lint to v1.50

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -19,7 +19,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.2.0
         with:
-          version: v1.49
+          version: v1.50
           args: -c .golangci.yml -v
 
   markdown-lint:

--- a/junos/resource_policyoptions_test.go
+++ b/junos/resource_policyoptions_test.go
@@ -137,9 +137,9 @@ func TestAccJunosPolicyOptions_basic(t *testing.T) {
 						resource.TestCheckResourceAttr("junos_policyoptions_policy_statement.testacc_policyOptions",
 							"then.0.action", "accept"),
 						resource.TestCheckResourceAttr("junos_policyoptions_policy_statement.testacc_policyOptions",
-							"then.0.as_path_expand", "65000 65000"),
+							"then.0.as_path_expand", "65000 65000"), //nolint: dupword
 						resource.TestCheckResourceAttr("junos_policyoptions_policy_statement.testacc_policyOptions",
-							"then.0.as_path_prepend", "65000 65000"),
+							"then.0.as_path_prepend", "65000 65000"), //nolint: dupword
 						resource.TestCheckResourceAttr("junos_policyoptions_policy_statement.testacc_policyOptions",
 							"then.0.community.#", "3"),
 						resource.TestCheckResourceAttr("junos_policyoptions_policy_statement.testacc_policyOptions",
@@ -289,7 +289,7 @@ func TestAccJunosPolicyOptions_basic(t *testing.T) {
 						resource.TestCheckResourceAttr("junos_policyoptions_policy_statement.testacc_policyOptions",
 							"term.0.then.0.as_path_expand", "last-as count 1"),
 						resource.TestCheckResourceAttr("junos_policyoptions_policy_statement.testacc_policyOptions",
-							"term.0.then.0.as_path_prepend", "65000 65000"),
+							"term.0.then.0.as_path_prepend", "65000 65000"), //nolint: dupword
 						resource.TestCheckResourceAttr("junos_policyoptions_policy_statement.testacc_policyOptions",
 							"term.0.then.0.community.#", "3"),
 						resource.TestCheckResourceAttr("junos_policyoptions_policy_statement.testacc_policyOptions",


### PR DESCRIPTION
[workflows] bump golangci-lint to v1.50 and fix errors