### PR TITLE
security_policy: fix error reading config when there is permit suffix in application-services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ ENHANCEMENTS:
 BUG FIXES:
 
 * resource/`junos_security_global_policy`: fix error reading config when an element of `permit_application_services` have the suffix `permit`, `deny` or `reject` (Fixes #430)
+* resource/`junos_security_policy`: fix error reading config when an element of `permit_application_services` have the suffix `permit`, `deny` or `reject`
 
 ## 1.31.0 (October 12, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ ENHANCEMENTS:
 
 BUG FIXES:
 
+* resource/`junos_security_global_policy`: fix error reading config when an element of `permit_application_services` have the suffix `permit`, `deny` or `reject` (Fixes #430)
+
 ## 1.31.0 (October 12, 2022)
 
 FEATURES:

--- a/junos/resource_security_global_policy.go
+++ b/junos/resource_security_global_policy.go
@@ -485,9 +485,9 @@ func readSecurityGlobalPolicy(clt *Client, junSess *junosSession) (globalPolicyO
 						itemTrimPolicy, "match source-end-user-profile "), "\"")
 				case strings.HasPrefix(itemTrimPolicy, "then "):
 					switch {
-					case strings.HasSuffix(itemTrimPolicy, permitW),
-						strings.HasSuffix(itemTrimPolicy, "deny"),
-						strings.HasSuffix(itemTrimPolicy, "reject"):
+					case itemTrimPolicy == "then permit",
+						itemTrimPolicy == "then deny",
+						itemTrimPolicy == "then reject":
 						policy["then"] = strings.TrimPrefix(itemTrimPolicy, "then ")
 					case itemTrimPolicy == "then count":
 						policy["count"] = true

--- a/junos/resource_security_policy.go
+++ b/junos/resource_security_policy.go
@@ -556,9 +556,9 @@ func readSecurityPolicy(fromZone, toZone string, clt *Client, junSess *junosSess
 						itemTrimPolicy, "match source-end-user-profile "), "\"")
 				case strings.HasPrefix(itemTrimPolicy, "then "):
 					switch {
-					case strings.HasSuffix(itemTrimPolicy, permitW),
-						strings.HasSuffix(itemTrimPolicy, "deny"),
-						strings.HasSuffix(itemTrimPolicy, "reject"):
+					case itemTrimPolicy == "then permit",
+						itemTrimPolicy == "then deny",
+						itemTrimPolicy == "then reject":
 						policy["then"] = strings.TrimPrefix(itemTrimPolicy, "then ")
 					case itemTrimPolicy == "then count":
 						policy["count"] = true


### PR DESCRIPTION
BUG FIXES:

* resource/`junos_security_global_policy`: fix error reading config when an element of `permit_application_services` have the suffix `permit`, `deny` or `reject` (Fixes #430)
* resource/`junos_security_policy`: fix error reading config when an element of `permit_application_services` have the suffix `permit`, `deny` or `reject`