### PR TITLE
workflows: bump Templum/govulncheck-action to v0.0.6

### DIFF
--- a/.github/workflows/go_analysis.yml
+++ b/.github/workflows/go_analysis.yml
@@ -10,12 +10,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Running govulncheck
-        uses: Templum/govulncheck-action@v0.0.5
+        uses: Templum/govulncheck-action@v0.0.6
         with:
           go-version: 1.19
           vulncheck-version: latest
           package: ./...
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          fail-on-vuln: true
 
   CodeQL-Analyse:
     runs-on: ubuntu-latest


### PR DESCRIPTION
workflows: bump Templum/govulncheck-action to v0.0.6 
and enable new strict mode with fail-on-vuln:true