### PR TITLE
provider: fix default ssh_ciphers value not set correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ ENHANCEMENTS:
 
 BUG FIXES:
 
+* provider: fix default `ssh_ciphers` value not set correctly when not set in config
+
 ## 1.31.2 (November 16, 2022)
 
 BUG FIXES:

--- a/junos/netconf.go
+++ b/junos/netconf.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/jeremmfr/go-netconf/netconf"
 	"golang.org/x/crypto/ssh"
 )
@@ -255,13 +254,11 @@ func genSSHClientConfig(auth *sshAuthMethod) (*ssh.ClientConfig, error) {
 	return configs[0], nil
 }
 
-func defaultSSHCiphers() schema.SchemaDefaultFunc {
-	return func() (interface{}, error) {
-		return []interface{}{
-			"aes128-gcm@openssh.com", "chacha20-poly1305@openssh.com",
-			"aes128-ctr", "aes192-ctr", "aes256-ctr",
-			"aes128-cbc",
-		}, nil
+func defaultSSHCiphers() []string {
+	return []string{
+		"aes128-gcm@openssh.com", "chacha20-poly1305@openssh.com",
+		"aes128-ctr", "aes192-ctr", "aes256-ctr",
+		"aes128-cbc",
 	}
 }
 

--- a/junos/provider.go
+++ b/junos/provider.go
@@ -72,10 +72,9 @@ func Provider() *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("JUNOS_SLEEP_SSH_CLOSED", 0),
 			},
 			"ssh_ciphers": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				DefaultFunc: defaultSSHCiphers(),
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"ssh_timeout_to_establish": {
 				Type:        schema.TypeInt,
@@ -278,6 +277,9 @@ func configureProvider(ctx context.Context, d *schema.ResourceData) (interface{}
 	}
 	for _, v := range d.Get("ssh_ciphers").([]interface{}) {
 		c.junosSSHCiphers = append(c.junosSSHCiphers, v.(string))
+	}
+	if len(c.junosSSHCiphers) == 0 {
+		c.junosSSHCiphers = defaultSSHCiphers()
 	}
 
 	return c.newClient()


### PR DESCRIPTION
BUG FIXES:

* provider: fix default `ssh_ciphers` value not set correctly when not set in config