### PR TITLE
Refactor resource reading functions to make it more readable and maintainable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,13 @@ FEATURES:
 ENHANCEMENTS:
 
 * provider: add `ssh_retry_to_establish` argument to retry when establishing SSH connections
+* resource/`junos_security_address_book`: add `ipv4_only` and `ipv6_only` arguments inside `dns_name` block argument
+* refactor the code of most resource reading functions to make it more readable and maintainable
 
 BUG FIXES:
+
+* resource/`junos_security_address_book`: fix `description` not set correctly in `wildcard_address`, `dns_name`, `range_address` and `address_set` block arguments
+* resource/`junos_forwardingoptions_dhcprelay`, `junos_forwardingoptions_dhcprelay_group`, `junos_system_services_dhcp_localserver_group`: fix reading `value` argument with special chars
 
 ## 1.31.2 (November 16, 2022)
 

--- a/docs/resources/security_address_book.md
+++ b/docs/resources/security_address_book.md
@@ -79,6 +79,10 @@ The following arguments are supported:
     DNS name string value (`juniper.net`).
   - **description** (Optional, String)  
     Description of dns name address.
+  - **ipv4_only** (Optional, Boolean)  
+    IPv4 dns address.
+  - **ipv6_only** (Optional, Boolean)  
+    IPv6 dns address.
 - **range_address** (Optional, Block Set)  
    For each name of range address.
   - **name** (Required, String)  

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
 	github.com/jeremmfr/go-netconf v0.4.8
-	github.com/jeremmfr/go-utils v0.6.0
+	github.com/jeremmfr/go-utils v0.8.0
 	github.com/jeremmfr/junosdecode v1.1.0
 	golang.org/x/crypto v0.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,8 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOl
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jeremmfr/go-netconf v0.4.8 h1:vbLZtxT5RZfDPAfiAqQiP2bLtB8UaoW9J2I6ZXsO9Mw=
 github.com/jeremmfr/go-netconf v0.4.8/go.mod h1:TY0F7tEhtAICeWR2cOPdG+nXaZq7MUitfIiBLSVsqW0=
-github.com/jeremmfr/go-utils v0.6.0 h1:4YAwSlHj9BrKPy7KtGo5Rh5v4wH1lt1s6rJN5Jvv96E=
-github.com/jeremmfr/go-utils v0.6.0/go.mod h1:Lkn95iSzCRviFhn2/0XmqzWGmxI+kkoqKAZqip7VUmM=
+github.com/jeremmfr/go-utils v0.8.0 h1:erWRiUjS1nXhK1RXSRCmrxWchQ8nSvd0K/JR8v7V4hM=
+github.com/jeremmfr/go-utils v0.8.0/go.mod h1:Lkn95iSzCRviFhn2/0XmqzWGmxI+kkoqKAZqip7VUmM=
 github.com/jeremmfr/junosdecode v1.1.0 h1:Os8QeOzyL+BPuDZJMjyJgz4QPOgA8EChgKB2Ih5wwCc=
 github.com/jeremmfr/junosdecode v1.1.0/go.mod h1:nTY0XbZC2ePbZdV0wuUboSMtGrJxtpwWVYfHjrS2Oqw=
 github.com/jeremmfr/terraform-plugin-sdk/v2 v2.24.2-0.20221116074330-912f8cae0310 h1:Wb254o3dRKCZLyF/V83KOOS2xdGjW9vciBbBxOMUl/U=

--- a/junos/constants.go
+++ b/junos/constants.go
@@ -31,5 +31,6 @@ const (
 	ospfV2 = "ospf"
 	ospfV3 = "ospf3"
 
-	failedConvAtoiError = "failed to convert value from '%s' to integer: %w"
+	failedConvAtoiError           = "failed to convert value from '%s' to integer: %w"
+	cantReadValuesNotEnoughFields = "can't read values for %s in '%s': not enough fields"
 )

--- a/junos/data_source_application_sets.go
+++ b/junos/data_source_application_sets.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	balt "github.com/jeremmfr/go-utils/basicalter"
 )
 
 func dataSourceApplicationSets() *schema.Resource {
@@ -106,16 +107,16 @@ func dataSourceApplicationSetsSearch(clt *Client, junSess *junosSession) (map[st
 				continue
 			}
 			itemTrim := strings.TrimPrefix(item, "set application-set ")
-			itemTrimSplit := strings.Split(itemTrim, " ")
-			if _, ok := results[itemTrimSplit[0]]; !ok {
-				results[itemTrimSplit[0]] = applicationSetOptions{name: itemTrimSplit[0]}
+			itemTrimFields := strings.Split(itemTrim, " ")
+			if _, ok := results[itemTrimFields[0]]; !ok {
+				results[itemTrimFields[0]] = applicationSetOptions{name: itemTrimFields[0]}
 			}
-			appSetOpts := results[itemTrimSplit[0]]
-			itemTrim = strings.TrimPrefix(itemTrim, itemTrimSplit[0]+" ")
-			if strings.HasPrefix(itemTrim, "application ") {
-				appSetOpts.applications = append(appSetOpts.applications, strings.TrimPrefix(itemTrim, "application "))
+			appSetOpts := results[itemTrimFields[0]]
+			balt.CutPrefixInString(&itemTrim, itemTrimFields[0]+" ")
+			if balt.CutPrefixInString(&itemTrim, "application ") {
+				appSetOpts.applications = append(appSetOpts.applications, itemTrim)
 			}
-			results[itemTrimSplit[0]] = appSetOpts
+			results[itemTrimFields[0]] = appSetOpts
 		}
 	}
 

--- a/junos/data_source_applications.go
+++ b/junos/data_source_applications.go
@@ -256,15 +256,15 @@ func dataSourceApplicationsSearch(clt *Client, junSess *junosSession) (map[strin
 				continue
 			}
 			itemTrim := strings.TrimPrefix(item, "set application ")
-			itemTrimSplit := strings.Split(itemTrim, " ")
-			if _, ok := results[itemTrimSplit[0]]; !ok {
-				results[itemTrimSplit[0]] = applicationOptions{name: itemTrimSplit[0]}
+			itemTrimFields := strings.Split(itemTrim, " ")
+			if _, ok := results[itemTrimFields[0]]; !ok {
+				results[itemTrimFields[0]] = applicationOptions{name: itemTrimFields[0]}
 			}
-			appOpts := results[itemTrimSplit[0]]
-			if err := appOpts.readLine(strings.TrimPrefix(itemTrim, itemTrimSplit[0]+" ")); err != nil {
+			appOpts := results[itemTrimFields[0]]
+			if err := appOpts.readLine(strings.TrimPrefix(itemTrim, itemTrimFields[0]+" ")); err != nil {
 				return results, err
 			}
-			results[itemTrimSplit[0]] = appOpts
+			results[itemTrimFields[0]] = appOpts
 		}
 	}
 

--- a/junos/data_source_interface.go
+++ b/junos/data_source_interface.go
@@ -409,17 +409,17 @@ func searchInterfaceID(configInterface, match string, clt *Client, junSess *juno
 		if !matched {
 			continue
 		}
-		itemTrimSplit := strings.Split(itemTrim, " ")
-		switch len(itemTrimSplit) {
+		itemTrimFields := strings.Split(itemTrim, " ")
+		switch len(itemTrimFields) {
 		case 0:
 			continue
 		case 1, 2:
-			intConfigList = append(intConfigList, itemTrimSplit[0])
+			intConfigList = append(intConfigList, itemTrimFields[0])
 		default:
-			if itemTrimSplit[1] == "unit" {
-				intConfigList = append(intConfigList, itemTrimSplit[0]+"."+itemTrimSplit[2])
+			if itemTrimFields[1] == "unit" {
+				intConfigList = append(intConfigList, itemTrimFields[0]+"."+itemTrimFields[2])
 			} else {
-				intConfigList = append(intConfigList, itemTrimSplit[0])
+				intConfigList = append(intConfigList, itemTrimFields[0])
 			}
 		}
 	}

--- a/junos/data_source_interface_logical.go
+++ b/junos/data_source_interface_logical.go
@@ -625,13 +625,13 @@ func searchInterfaceLogicalID(configInterface, match string, clt *Client, junSes
 		if !matched {
 			continue
 		}
-		itemTrimSplit := strings.Split(itemTrim, " ")
-		switch len(itemTrimSplit) {
+		itemTrimFields := strings.Split(itemTrim, " ")
+		switch len(itemTrimFields) {
 		case 0, 1, 2:
 			continue
 		default:
-			if itemTrimSplit[1] == "unit" && !bchk.InSlice("ethernet-switching", itemTrimSplit) {
-				intConfigList = append(intConfigList, itemTrimSplit[0]+"."+itemTrimSplit[2])
+			if itemTrimFields[1] == "unit" && !bchk.InSlice("ethernet-switching", itemTrimFields) {
+				intConfigList = append(intConfigList, itemTrimFields[0]+"."+itemTrimFields[2])
 			}
 		}
 	}

--- a/junos/data_source_interface_physical.go
+++ b/junos/data_source_interface_physical.go
@@ -401,11 +401,11 @@ func searchInterfacePhysicalID(configInterface, match string, clt *Client, junSe
 		if !matched {
 			continue
 		}
-		itemTrimSplit := strings.Split(itemTrim, " ")
-		if len(itemTrimSplit) == 0 {
+		itemTrimFields := strings.Split(itemTrim, " ")
+		if len(itemTrimFields) == 0 {
 			continue
 		}
-		intConfigList = append(intConfigList, itemTrimSplit[0])
+		intConfigList = append(intConfigList, itemTrimFields[0])
 	}
 	intConfigList = balt.UniqueInSlice(intConfigList)
 	if len(intConfigList) == 0 {

--- a/junos/func_common.go
+++ b/junos/func_common.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	balt "github.com/jeremmfr/go-utils/basicalter"
 	bchk "github.com/jeremmfr/go-utils/basiccheck"
 )
 
@@ -382,12 +383,12 @@ func listOfSyslogFacility() []string {
 }
 
 func replaceTildeToHomeDir(path *string) error {
-	if strings.HasPrefix(*path, "~") {
+	if balt.CutPrefixInString(path, "~") {
 		homeDir, err := os.UserHomeDir()
 		if err != nil {
 			return fmt.Errorf("failed to read user home directory: %w", err)
 		}
-		*path = homeDir + strings.TrimPrefix(*path, "~")
+		*path = homeDir + *path
 	}
 
 	return nil

--- a/junos/func_resource_bgp.go
+++ b/junos/func_resource_bgp.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	balt "github.com/jeremmfr/go-utils/basicalter"
 	bchk "github.com/jeremmfr/go-utils/basiccheck"
 	jdecode "github.com/jeremmfr/junosdecode"
 )
@@ -271,112 +272,105 @@ func setBgpOptsSimple(setPrefix string, d *schema.ResourceData, clt *Client, jun
 	return clt.configSet(configSet, junSess)
 }
 
-func readBgpOptsSimple(item string, confRead *bgpOptions) error {
+func (confRead *bgpOptions) readBgpOptsSimple(itemTrim string) (err error) {
 	switch {
-	case item == "accept-remote-nexthop":
+	case itemTrim == "accept-remote-nexthop":
 		confRead.acceptRemoteNexthop = true
-	case item == "advertise-external":
+	case itemTrim == "advertise-external":
 		confRead.advertiseExternal = true
-	case item == "advertise-external conditional":
+	case itemTrim == "advertise-external conditional":
 		confRead.advertiseExternalConditional = true
-	case item == "advertise-inactive":
+	case itemTrim == "advertise-inactive":
 		confRead.advertiseInactive = true
-	case item == "advertise-peer-as":
+	case itemTrim == "advertise-peer-as":
 		confRead.advertisePeerAs = true
-	case item == "as-override":
+	case itemTrim == "as-override":
 		confRead.asOverride = true
-	case strings.HasPrefix(item, "authentication-algorithm "):
-		confRead.authenticationAlgorithm = strings.TrimPrefix(item, "authentication-algorithm ")
-	case strings.HasPrefix(item, "authentication-key "):
-		var err error
-		confRead.authenticationKey, err = jdecode.Decode(strings.Trim(strings.TrimPrefix(item, "authentication-key "), "\""))
+	case balt.CutPrefixInString(&itemTrim, "authentication-algorithm "):
+		confRead.authenticationAlgorithm = itemTrim
+	case balt.CutPrefixInString(&itemTrim, "authentication-key "):
+		confRead.authenticationKey, err = jdecode.Decode(strings.Trim(itemTrim, "\""))
 		if err != nil {
 			return fmt.Errorf("failed to decode authentication-key: %w", err)
 		}
-	case strings.HasPrefix(item, "authentication-key-chain "):
-		confRead.authenticationKeyChain = strings.TrimPrefix(item, "authentication-key-chain ")
-	case strings.HasPrefix(item, "cluster "):
-		confRead.cluster = strings.TrimPrefix(item, "cluster ")
-	case item == "damping":
+	case balt.CutPrefixInString(&itemTrim, "authentication-key-chain "):
+		confRead.authenticationKeyChain = itemTrim
+	case balt.CutPrefixInString(&itemTrim, "cluster "):
+		confRead.cluster = itemTrim
+	case itemTrim == "damping":
 		confRead.damping = true
-	case strings.HasPrefix(item, "export "):
-		confRead.exportPolicy = append(confRead.exportPolicy, strings.TrimPrefix(item, "export "))
-	case strings.HasPrefix(item, "hold-time "):
-		var err error
-		confRead.holdTime, err = strconv.Atoi(strings.TrimPrefix(item, "hold-time "))
+	case balt.CutPrefixInString(&itemTrim, "export "):
+		confRead.exportPolicy = append(confRead.exportPolicy, itemTrim)
+	case balt.CutPrefixInString(&itemTrim, "hold-time "):
+		confRead.holdTime, err = strconv.Atoi(itemTrim)
 		if err != nil {
-			return fmt.Errorf(failedConvAtoiError, item, err)
+			return fmt.Errorf(failedConvAtoiError, itemTrim, err)
 		}
-	case strings.HasPrefix(item, "import "):
-		confRead.importPolicy = append(confRead.importPolicy, strings.TrimPrefix(item, "import "))
-	case item == "keep all":
+	case balt.CutPrefixInString(&itemTrim, "import "):
+		confRead.importPolicy = append(confRead.importPolicy, itemTrim)
+	case itemTrim == "keep all":
 		confRead.keepAll = true
-	case item == "keep none":
+	case itemTrim == "keep none":
 		confRead.keepNone = true
-	case strings.HasPrefix(item, "local-address "):
-		confRead.localAddress = strings.TrimPrefix(item, "local-address ")
-	case strings.HasPrefix(item, "local-as "):
+	case balt.CutPrefixInString(&itemTrim, "local-address "):
+		confRead.localAddress = itemTrim
+	case balt.CutPrefixInString(&itemTrim, "local-as "):
 		switch {
-		case strings.HasSuffix(item, " private"):
+		case itemTrim == "private":
 			confRead.localAsPrivate = true
-		case strings.HasSuffix(item, " alias"):
+		case itemTrim == "alias":
 			confRead.localAsAlias = true
-		case strings.HasSuffix(item, " no-prepend-global-as"):
+		case itemTrim == "no-prepend-global-as":
 			confRead.localAsNoPrependGlobalAs = true
-		case strings.HasPrefix(item, "local-as loops "):
-			var err error
-			confRead.localAsLoops, err = strconv.Atoi(strings.TrimPrefix(item, "local-as loops "))
+		case balt.CutPrefixInString(&itemTrim, "loops "):
+			confRead.localAsLoops, err = strconv.Atoi(itemTrim)
 			if err != nil {
-				return fmt.Errorf(failedConvAtoiError, item, err)
+				return fmt.Errorf(failedConvAtoiError, itemTrim, err)
 			}
 		default:
-			confRead.localAs = strings.TrimPrefix(item, "local-as ")
+			confRead.localAs = itemTrim
 		}
-	case strings.HasPrefix(item, "local-interface "):
-		confRead.localInterface = strings.TrimPrefix(item, "local-interface ")
-	case strings.HasPrefix(item, "local-preference "):
-		var err error
-		confRead.localPreference, err = strconv.Atoi(strings.TrimPrefix(item, "local-preference "))
+	case balt.CutPrefixInString(&itemTrim, "local-interface "):
+		confRead.localInterface = itemTrim
+	case balt.CutPrefixInString(&itemTrim, "local-preference "):
+		confRead.localPreference, err = strconv.Atoi(itemTrim)
 		if err != nil {
-			return fmt.Errorf(failedConvAtoiError, item, err)
+			return fmt.Errorf(failedConvAtoiError, itemTrim, err)
 		}
-	case item == "log-updown":
+	case itemTrim == "log-updown":
 		confRead.logUpdown = true
-	case strings.HasPrefix(item, "metric-out "):
-		if !strings.Contains(item, "igp") {
-			var err error
-			confRead.metricOut, err = strconv.Atoi(strings.TrimPrefix(item, "metric-out "))
-			if err != nil {
-				return fmt.Errorf(failedConvAtoiError, item, err)
+	case balt.CutPrefixInString(&itemTrim, "metric-out "):
+		switch {
+		case balt.CutPrefixInString(&itemTrim, "igp"):
+			confRead.metricOutIgp = true
+			switch {
+			case itemTrim == " delay-med-update":
+				confRead.metricOutIgpDelayMedUpdate = true
+			case balt.CutPrefixInString(&itemTrim, " "):
+				confRead.metricOutIgpOffset, err = strconv.Atoi(itemTrim)
+				if err != nil {
+					return fmt.Errorf(failedConvAtoiError, itemTrim, err)
+				}
 			}
-		} else {
-			if strings.HasPrefix(item, "metric-out igp") {
-				confRead.metricOutIgp = true
-				if item == "metric-out igp delay-med-update" {
-					confRead.metricOutIgpDelayMedUpdate = true
-				} else if strings.HasPrefix(item, "metric-out igp ") {
-					var err error
-					confRead.metricOutIgpOffset, err = strconv.Atoi(strings.TrimPrefix(item, "metric-out igp "))
-					if err != nil {
-						return fmt.Errorf(failedConvAtoiError, item, err)
-					}
+		case balt.CutPrefixInString(&itemTrim, "minimum-igp"):
+			confRead.metricOutMinimumIgp = true
+			if balt.CutPrefixInString(&itemTrim, " ") {
+				confRead.metricOutMinimumIgpOffset, err = strconv.Atoi(itemTrim)
+				if err != nil {
+					return fmt.Errorf(failedConvAtoiError, itemTrim, err)
 				}
-			} else {
-				confRead.metricOutMinimumIgp = true
-				if strings.HasPrefix(item, "metric-out minimum-igp ") {
-					var err error
-					confRead.metricOutMinimumIgpOffset, err = strconv.Atoi(strings.TrimPrefix(item, "metric-out minimum-igp "))
-					if err != nil {
-						return fmt.Errorf(failedConvAtoiError, item, err)
-					}
-				}
+			}
+		default:
+			confRead.metricOut, err = strconv.Atoi(itemTrim)
+			if err != nil {
+				return fmt.Errorf(failedConvAtoiError, itemTrim, err)
 			}
 		}
-	case item == "mtu-discovery":
+	case itemTrim == "mtu-discovery":
 		confRead.mtuDiscovery = true
-	case item == "multihop":
+	case itemTrim == "multihop":
 		confRead.multihop = true
-	case strings.HasPrefix(item, "multipath"):
+	case balt.CutPrefixInString(&itemTrim, "multipath"):
 		confRead.multipath = true
 		if len(confRead.bgpMultipath) == 0 {
 			confRead.bgpMultipath = append(confRead.bgpMultipath, map[string]interface{}{
@@ -386,35 +380,33 @@ func readBgpOptsSimple(item string, confRead *bgpOptions) error {
 			})
 		}
 		switch {
-		case item == "multipath allow-protection":
+		case itemTrim == " allow-protection":
 			confRead.bgpMultipath[0]["allow_protection"] = true
-		case item == "multipath disable":
+		case itemTrim == " disable":
 			confRead.bgpMultipath[0]["disable"] = true
-		case item == "multipath multiple-as":
+		case itemTrim == " multiple-as":
 			confRead.bgpMultipath[0]["multiple_as"] = true
 		}
-	case item == "no-advertise-peer-as":
+	case itemTrim == "no-advertise-peer-as":
 		confRead.noAdvertisePeerAs = true
-	case strings.HasPrefix(item, "out-delay "):
-		var err error
-		confRead.outDelay, err = strconv.Atoi(strings.TrimPrefix(item, "out-delay "))
+	case balt.CutPrefixInString(&itemTrim, "out-delay "):
+		confRead.outDelay, err = strconv.Atoi(itemTrim)
 		if err != nil {
-			return fmt.Errorf(failedConvAtoiError, item, err)
+			return fmt.Errorf(failedConvAtoiError, itemTrim, err)
 		}
-	case item == "passive":
+	case itemTrim == "passive":
 		confRead.passive = true
-	case strings.HasPrefix(item, "peer-as "):
-		confRead.peerAs = strings.TrimPrefix(item, "peer-as ")
-	case strings.HasPrefix(item, "preference "):
-		var err error
-		confRead.preference, err = strconv.Atoi(strings.TrimPrefix(item, "preference "))
+	case balt.CutPrefixInString(&itemTrim, "peer-as "):
+		confRead.peerAs = itemTrim
+	case balt.CutPrefixInString(&itemTrim, "preference "):
+		confRead.preference, err = strconv.Atoi(itemTrim)
 		if err != nil {
-			return fmt.Errorf(failedConvAtoiError, item, err)
+			return fmt.Errorf(failedConvAtoiError, itemTrim, err)
 		}
-	case item == "remove-private":
+	case itemTrim == "remove-private":
 		confRead.removePrivate = true
-	case strings.HasPrefix(item, "type "):
-		confRead.bgpType = strings.TrimPrefix(item, "type ")
+	case balt.CutPrefixInString(&itemTrim, "type "):
+		confRead.bgpType = itemTrim
 	}
 
 	return nil
@@ -483,63 +475,53 @@ func setBgpOptsBfd(setPrefix string, bfdLivenessDetection []interface{}, clt *Cl
 	return nil
 }
 
-func readBgpOptsBfd(item string, bfdRead map[string]interface{}) error {
-	itemTrim := strings.TrimPrefix(item, "bfd-liveness-detection ")
+func readBgpOptsBfd(itemTrim string, bfdRead map[string]interface{}) (err error) {
 	switch {
-	case strings.HasPrefix(itemTrim, "authentication algorithm "):
-		bfdRead["authentication_algorithm"] = strings.TrimPrefix(itemTrim, "authentication algorithm ")
-	case strings.HasPrefix(itemTrim, "authentication key-chain "):
-		bfdRead["authentication_key_chain"] = strings.TrimPrefix(itemTrim, "authentication key-chain ")
+	case balt.CutPrefixInString(&itemTrim, "authentication algorithm "):
+		bfdRead["authentication_algorithm"] = itemTrim
+	case balt.CutPrefixInString(&itemTrim, "authentication key-chain "):
+		bfdRead["authentication_key_chain"] = itemTrim
 	case itemTrim == "authentication loose-check":
 		bfdRead["authentication_loose_check"] = true
-	case strings.HasPrefix(itemTrim, "detection-time threshold "):
-		var err error
-		bfdRead["detection_time_threshold"], err = strconv.Atoi(strings.TrimPrefix(itemTrim, "detection-time threshold "))
+	case balt.CutPrefixInString(&itemTrim, "detection-time threshold "):
+		bfdRead["detection_time_threshold"], err = strconv.Atoi(itemTrim)
 		if err != nil {
 			return fmt.Errorf(failedConvAtoiError, itemTrim, err)
 		}
-	case strings.HasPrefix(itemTrim, "holddown-interval "):
-		var err error
-		bfdRead["holddown_interval"], err = strconv.Atoi(strings.TrimPrefix(itemTrim, "holddown-interval "))
+	case balt.CutPrefixInString(&itemTrim, "holddown-interval "):
+		bfdRead["holddown_interval"], err = strconv.Atoi(itemTrim)
 		if err != nil {
 			return fmt.Errorf(failedConvAtoiError, itemTrim, err)
 		}
-	case strings.HasPrefix(itemTrim, "minimum-interval "):
-		var err error
-		bfdRead["minimum_interval"], err = strconv.Atoi(strings.TrimPrefix(itemTrim, "minimum-interval "))
+	case balt.CutPrefixInString(&itemTrim, "minimum-interval "):
+		bfdRead["minimum_interval"], err = strconv.Atoi(itemTrim)
 		if err != nil {
 			return fmt.Errorf(failedConvAtoiError, itemTrim, err)
 		}
-	case strings.HasPrefix(itemTrim, "minimum-receive-interval "):
-		var err error
-		bfdRead["minimum_receive_interval"], err = strconv.Atoi(strings.TrimPrefix(itemTrim, "minimum-receive-interval "))
+	case balt.CutPrefixInString(&itemTrim, "minimum-receive-interval "):
+		bfdRead["minimum_receive_interval"], err = strconv.Atoi(itemTrim)
 		if err != nil {
 			return fmt.Errorf(failedConvAtoiError, itemTrim, err)
 		}
-	case strings.HasPrefix(itemTrim, "multiplier "):
-		var err error
-		bfdRead["multiplier"], err = strconv.Atoi(strings.TrimPrefix(itemTrim, "multiplier "))
+	case balt.CutPrefixInString(&itemTrim, "multiplier "):
+		bfdRead["multiplier"], err = strconv.Atoi(itemTrim)
 		if err != nil {
 			return fmt.Errorf(failedConvAtoiError, itemTrim, err)
 		}
-	case strings.HasPrefix(itemTrim, "session-mode "):
-		bfdRead["session_mode"] = strings.TrimPrefix(itemTrim, "session-mode ")
-	case strings.HasPrefix(itemTrim, "transmit-interval threshold "):
-		var err error
-		bfdRead["transmit_interval_threshold"], err = strconv.Atoi(
-			strings.TrimPrefix(itemTrim, "transmit-interval threshold "))
+	case balt.CutPrefixInString(&itemTrim, "session-mode "):
+		bfdRead["session_mode"] = itemTrim
+	case balt.CutPrefixInString(&itemTrim, "transmit-interval threshold "):
+		bfdRead["transmit_interval_threshold"], err = strconv.Atoi(itemTrim)
 		if err != nil {
 			return fmt.Errorf(failedConvAtoiError, itemTrim, err)
 		}
-	case strings.HasPrefix(itemTrim, "transmit-interval minimum-interval "):
-		var err error
-		bfdRead["transmit_interval_minimum_interval"], err = strconv.Atoi(
-			strings.TrimPrefix(itemTrim, "transmit-interval minimum-interval "))
+	case balt.CutPrefixInString(&itemTrim, "transmit-interval minimum-interval "):
+		bfdRead["transmit_interval_minimum_interval"], err = strconv.Atoi(itemTrim)
 		if err != nil {
 			return fmt.Errorf(failedConvAtoiError, itemTrim, err)
 		}
-	case strings.HasPrefix(itemTrim, "version "):
-		bfdRead["version"] = strings.TrimPrefix(itemTrim, "version ")
+	case balt.CutPrefixInString(&itemTrim, "version "):
+		bfdRead["version"] = itemTrim
 	}
 
 	return nil
@@ -624,27 +606,17 @@ func setBgpOptsFamilyPrefixLimit(setPrefix string, prefixLimit map[string]interf
 	return configSet, nil
 }
 
-func readBgpOptsFamily(item, familyType string, opts []map[string]interface{}) ([]map[string]interface{}, error) {
+func readBgpOptsFamily(itemTrim string, opts []map[string]interface{}) (_ []map[string]interface{}, err error) {
+	itemTrimFields := strings.Split(itemTrim, " ")
 	readOpts := map[string]interface{}{
-		"nlri_type":             "",
+		"nlri_type":             itemTrimFields[0],
 		"accepted_prefix_limit": make([]map[string]interface{}, 0),
 		"prefix_limit":          make([]map[string]interface{}, 0),
 	}
-	setPrefix := "family "
-	switch familyType {
-	case evpnW:
-		setPrefix += "evpn "
-	case inetW:
-		setPrefix += "inet "
-	case inet6W:
-		setPrefix += "inet6 "
-	}
-	trimSplit := strings.Split(strings.TrimPrefix(item, setPrefix), " ")
-	readOpts["nlri_type"] = trimSplit[0]
 	opts = copyAndRemoveItemMapList("nlri_type", readOpts, opts)
-	itemTrim := strings.TrimPrefix(item, setPrefix+readOpts["nlri_type"].(string)+" ")
+	balt.CutPrefixInString(&itemTrim, itemTrimFields[0]+" ")
 	switch {
-	case strings.HasPrefix(itemTrim, "accepted-prefix-limit "):
+	case balt.CutPrefixInString(&itemTrim, "accepted-prefix-limit "):
 		if len(readOpts["accepted_prefix_limit"].([]map[string]interface{})) == 0 {
 			readOpts["accepted_prefix_limit"] = append(readOpts["accepted_prefix_limit"].([]map[string]interface{}),
 				map[string]interface{}{
@@ -656,32 +628,28 @@ func readBgpOptsFamily(item, familyType string, opts []map[string]interface{}) (
 		}
 		readOptsPL := readOpts["accepted_prefix_limit"].([]map[string]interface{})[0]
 		switch {
-		case strings.HasPrefix(itemTrim, "accepted-prefix-limit maximum"):
-			var err error
-			readOptsPL["maximum"], err = strconv.Atoi(strings.TrimPrefix(itemTrim, "accepted-prefix-limit maximum "))
+		case balt.CutPrefixInString(&itemTrim, "maximum "):
+			readOptsPL["maximum"], err = strconv.Atoi(itemTrim)
 			if err != nil {
 				return append(opts, readOpts), fmt.Errorf(failedConvAtoiError, itemTrim, err)
 			}
 
-		case strings.HasPrefix(itemTrim, "accepted-prefix-limit teardown idle-timeout "):
-			var err error
-			if !strings.HasSuffix(itemTrim, " forever") {
-				readOptsPL["teardown_idle_timeout"], err = strconv.Atoi(
-					strings.TrimPrefix(itemTrim, "accepted-prefix-limit teardown idle-timeout "))
+		case balt.CutPrefixInString(&itemTrim, "teardown idle-timeout "):
+			if itemTrim == "forever" {
+				readOptsPL["teardown_idle_timeout_forever"] = true
+			} else {
+				readOptsPL["teardown_idle_timeout"], err = strconv.Atoi(itemTrim)
 				if err != nil {
 					return append(opts, readOpts), fmt.Errorf(failedConvAtoiError, itemTrim, err)
 				}
-			} else {
-				readOptsPL["teardown_idle_timeout_forever"] = true
 			}
-		case strings.HasPrefix(itemTrim, "accepted-prefix-limit teardown "):
-			var err error
-			readOptsPL["teardown"], err = strconv.Atoi(strings.TrimPrefix(itemTrim, "accepted-prefix-limit teardown "))
+		case balt.CutPrefixInString(&itemTrim, "teardown "):
+			readOptsPL["teardown"], err = strconv.Atoi(itemTrim)
 			if err != nil {
 				return append(opts, readOpts), fmt.Errorf(failedConvAtoiError, itemTrim, err)
 			}
 		}
-	case strings.HasPrefix(itemTrim, "prefix-limit "):
+	case balt.CutPrefixInString(&itemTrim, "prefix-limit "):
 		if len(readOpts["prefix_limit"].([]map[string]interface{})) == 0 {
 			readOpts["prefix_limit"] = append(readOpts["prefix_limit"].([]map[string]interface{}),
 				map[string]interface{}{
@@ -693,26 +661,22 @@ func readBgpOptsFamily(item, familyType string, opts []map[string]interface{}) (
 		}
 		readOptsPL := readOpts["prefix_limit"].([]map[string]interface{})[0]
 		switch {
-		case strings.HasPrefix(itemTrim, "prefix-limit maximum "):
-			var err error
-			readOptsPL["maximum"], err = strconv.Atoi(strings.TrimPrefix(itemTrim, "prefix-limit maximum "))
+		case balt.CutPrefixInString(&itemTrim, "maximum "):
+			readOptsPL["maximum"], err = strconv.Atoi(itemTrim)
 			if err != nil {
 				return append(opts, readOpts), fmt.Errorf(failedConvAtoiError, itemTrim, err)
 			}
-		case strings.HasPrefix(itemTrim, "prefix-limit teardown idle-timeout "):
-			var err error
-			if !strings.HasSuffix(itemTrim, " forever") {
-				readOptsPL["teardown_idle_timeout"], err = strconv.Atoi(
-					strings.TrimPrefix(itemTrim, "prefix-limit teardown idle-timeout "))
+		case balt.CutPrefixInString(&itemTrim, "teardown idle-timeout "):
+			if itemTrim == "forever" {
+				readOptsPL["teardown_idle_timeout_forever"] = true
+			} else {
+				readOptsPL["teardown_idle_timeout"], err = strconv.Atoi(itemTrim)
 				if err != nil {
 					return append(opts, readOpts), fmt.Errorf(failedConvAtoiError, itemTrim, err)
 				}
-			} else {
-				readOptsPL["teardown_idle_timeout_forever"] = true
 			}
-		case strings.HasPrefix(itemTrim, "prefix-limit teardown "):
-			var err error
-			readOptsPL["teardown"], err = strconv.Atoi(strings.TrimPrefix(itemTrim, "prefix-limit teardown "))
+		case balt.CutPrefixInString(&itemTrim, "teardown "):
+			readOptsPL["teardown"], err = strconv.Atoi(itemTrim)
 			if err != nil {
 				return append(opts, readOpts), fmt.Errorf(failedConvAtoiError, itemTrim, err)
 			}
@@ -752,20 +716,17 @@ func setBgpOptsGrafefulRestart(setPrefix string, gracefulRestarts []interface{},
 	return nil
 }
 
-func readBgpOptsGracefulRestart(item string, grRead map[string]interface{}) error {
-	itemTrim := strings.TrimPrefix(item, "graceful-restart ")
+func readBgpOptsGracefulRestart(itemTrim string, grRead map[string]interface{}) (err error) {
 	switch {
 	case itemTrim == disableW:
 		grRead["disable"] = true
-	case strings.HasPrefix(itemTrim, "restart-time "):
-		var err error
-		grRead["restart_time"], err = strconv.Atoi(strings.TrimPrefix(itemTrim, "restart-time "))
+	case balt.CutPrefixInString(&itemTrim, "restart-time "):
+		grRead["restart_time"], err = strconv.Atoi(itemTrim)
 		if err != nil {
 			return fmt.Errorf(failedConvAtoiError, itemTrim, err)
 		}
-	case strings.HasPrefix(itemTrim, "stale-routes-time "):
-		var err error
-		grRead["stale_route_time"], err = strconv.Atoi(strings.TrimPrefix(itemTrim, "stale-routes-time "))
+	case balt.CutPrefixInString(&itemTrim, "stale-routes-time "):
+		grRead["stale_route_time"], err = strconv.Atoi(itemTrim)
 		if err != nil {
 			return fmt.Errorf(failedConvAtoiError, itemTrim, err)
 		}

--- a/junos/func_resource_forwardingoptions_dhcprelay.go
+++ b/junos/func_resource_forwardingoptions_dhcprelay.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	balt "github.com/jeremmfr/go-utils/basicalter"
 )
 
 func schemaForwardingOptionsDhcpRelayAuthUsernameInclude() map[string]*schema.Schema {
@@ -1383,38 +1384,36 @@ func genForwardingOptionsDhcpRelayOption82() map[string]interface{} {
 	}
 }
 
-func readForwardingOptionsDhcpRelayAuthUsernameInclude(
-	itemTrim string, authUsernameInclude map[string]interface{},
-) {
+func readForwardingOptionsDhcpRelayAuthUsernameInclude(itemTrim string, authUsernameInclude map[string]interface{}) {
 	switch {
 	case itemTrim == "circuit-type":
 		authUsernameInclude["circuit_type"] = true
-	case strings.HasPrefix(itemTrim, "client-id"):
+	case balt.CutPrefixInString(&itemTrim, "client-id"):
 		authUsernameInclude["client_id"] = true
 		switch {
-		case itemTrim == "client-id exclude-headers":
+		case itemTrim == " exclude-headers":
 			authUsernameInclude["client_id_exclude_headers"] = true
-		case itemTrim == "client-id use-automatic-ascii-hex-encoding":
+		case itemTrim == " use-automatic-ascii-hex-encoding":
 			authUsernameInclude["client_id_use_automatic_ascii_hex_encoding"] = true
 		}
-	case strings.HasPrefix(itemTrim, "delimiter "):
-		authUsernameInclude["delimiter"] = strings.Trim(strings.TrimPrefix(itemTrim, "delimiter "), "\"")
-	case strings.HasPrefix(itemTrim, "domain-name "):
-		authUsernameInclude["domain_name"] = strings.Trim(strings.TrimPrefix(itemTrim, "domain-name "), "\"")
-	case strings.HasPrefix(itemTrim, "interface-description "):
-		authUsernameInclude["interface_description"] = strings.TrimPrefix(itemTrim, "interface-description ")
+	case balt.CutPrefixInString(&itemTrim, "delimiter "):
+		authUsernameInclude["delimiter"] = strings.Trim(itemTrim, "\"")
+	case balt.CutPrefixInString(&itemTrim, "domain-name "):
+		authUsernameInclude["domain_name"] = strings.Trim(itemTrim, "\"")
+	case balt.CutPrefixInString(&itemTrim, "interface-description "):
+		authUsernameInclude["interface_description"] = itemTrim
 	case itemTrim == "interface-name":
 		authUsernameInclude["interface_name"] = true
 	case itemTrim == "mac-address":
 		authUsernameInclude["mac_address"] = true
 	case itemTrim == "option-60":
 		authUsernameInclude["option_60"] = true
-	case strings.HasPrefix(itemTrim, "option-82"):
+	case balt.CutPrefixInString(&itemTrim, "option-82"):
 		authUsernameInclude["option_82"] = true
 		switch {
-		case itemTrim == "option-82 circuit-id":
+		case itemTrim == " circuit-id":
 			authUsernameInclude["option_82_circuit_id"] = true
-		case itemTrim == "option-82 remote-id":
+		case itemTrim == " remote-id":
 			authUsernameInclude["option_82_remote_id"] = true
 		}
 	case itemTrim == "relay-agent-interface-id":
@@ -1425,15 +1424,14 @@ func readForwardingOptionsDhcpRelayAuthUsernameInclude(
 		authUsernameInclude["relay_agent_subscriber_id"] = true
 	case itemTrim == "routing-instance-name":
 		authUsernameInclude["routing_instance_name"] = true
-	case strings.HasPrefix(itemTrim, "user-prefix "):
-		authUsernameInclude["user_prefix"] = strings.Trim(strings.TrimPrefix(itemTrim, "user-prefix "), "\"")
+	case balt.CutPrefixInString(&itemTrim, "user-prefix "):
+		authUsernameInclude["user_prefix"] = strings.Trim(itemTrim, "\"")
 	case itemTrim == "vlan-tags":
 		authUsernameInclude["vlan_tags"] = true
 	}
 }
 
-func readForwardingOptionsDhcpRelayOverridesV4(itemTrim string, overrides map[string]interface{}) error {
-	var err error
+func readForwardingOptionsDhcpRelayOverridesV4(itemTrim string, overrides map[string]interface{}) (err error) {
 	switch {
 	case itemTrim == "allow-no-end-option":
 		overrides["allow_no_end_option"] = true
@@ -1443,22 +1441,22 @@ func readForwardingOptionsDhcpRelayOverridesV4(itemTrim string, overrides map[st
 		overrides["always_write_giaddr"] = true
 	case itemTrim == "always-write-option-82":
 		overrides["always_write_option_82"] = true
-	case strings.HasPrefix(itemTrim, "asymmetric-lease-time "):
-		overrides["asymmetric_lease_time"], err = strconv.Atoi(strings.TrimPrefix(itemTrim, "asymmetric-lease-time "))
+	case balt.CutPrefixInString(&itemTrim, "asymmetric-lease-time "):
+		overrides["asymmetric_lease_time"], err = strconv.Atoi(itemTrim)
 	case itemTrim == "bootp-support":
 		overrides["bootp_support"] = true
-	case strings.HasPrefix(itemTrim, "client-discover-match "):
-		overrides["client_discover_match"] = strings.TrimPrefix(itemTrim, "client-discover-match ")
+	case balt.CutPrefixInString(&itemTrim, "client-discover-match "):
+		overrides["client_discover_match"] = itemTrim
 	case itemTrim == "delay-authentication":
 		overrides["delay_authentication"] = true
 	case itemTrim == "delete-binding-on-renegotiation":
 		overrides["delete_binding_on_renegotiation"] = true
 	case itemTrim == "disable-relay":
 		overrides["disable_relay"] = true
-	case strings.HasPrefix(itemTrim, "dual-stack "):
-		overrides["dual_stack"] = strings.Trim(strings.TrimPrefix(itemTrim, "dual-stack "), "\"")
-	case strings.HasPrefix(itemTrim, "interface-client-limit "):
-		overrides["interface_client_limit"], err = strconv.Atoi(strings.TrimPrefix(itemTrim, "interface-client-limit "))
+	case balt.CutPrefixInString(&itemTrim, "dual-stack "):
+		overrides["dual_stack"] = strings.Trim(itemTrim, "\"")
+	case balt.CutPrefixInString(&itemTrim, "interface-client-limit "):
+		overrides["interface_client_limit"], err = strconv.Atoi(itemTrim)
 	case itemTrim == "layer2-unicast-replies":
 		overrides["layer2_unicast_replies"] = true
 	case itemTrim == "no-allow-snooped-clients":
@@ -1469,16 +1467,16 @@ func readForwardingOptionsDhcpRelayOverridesV4(itemTrim string, overrides map[st
 		overrides["no_unicast_replies"] = true
 	case itemTrim == "proxy-mode":
 		overrides["proxy_mode"] = true
-	case strings.HasPrefix(itemTrim, "relay-source "):
-		overrides["relay_source"] = strings.TrimPrefix(itemTrim, "relay-source ")
+	case balt.CutPrefixInString(&itemTrim, "relay-source "):
+		overrides["relay_source"] = itemTrim
 	case itemTrim == "replace-ip-source-with giaddr":
 		overrides["replace_ip_source_with_giaddr"] = true
 	case itemTrim == "send-release-on-delete":
 		overrides["send_release_on_delete"] = true
 	case itemTrim == "trust-option-82":
 		overrides["trust_option_82"] = true
-	case strings.HasPrefix(itemTrim, "user-defined-option-82 "):
-		overrides["user_defined_option_82"] = strings.Trim(strings.TrimPrefix(itemTrim, "user-defined-option-82 "), "\"")
+	case balt.CutPrefixInString(&itemTrim, "user-defined-option-82 "):
+		overrides["user_defined_option_82"] = strings.Trim(itemTrim, "\"")
 	}
 	if err != nil {
 		return fmt.Errorf(failedConvAtoiError, itemTrim, err)
@@ -1487,34 +1485,32 @@ func readForwardingOptionsDhcpRelayOverridesV4(itemTrim string, overrides map[st
 	return nil
 }
 
-func readForwardingOptionsDhcpRelayOverridesV6(itemTrim string, overrides map[string]interface{}) error {
-	var err error
+func readForwardingOptionsDhcpRelayOverridesV6(itemTrim string, overrides map[string]interface{}) (err error) {
 	switch {
 	case itemTrim == "allow-snooped-clients":
 		overrides["allow_snooped_clients"] = true
 	case itemTrim == "always-process-option-request-option":
 		overrides["always_process_option_request_option"] = true
-	case strings.HasPrefix(itemTrim, "asymmetric-lease-time "):
-		overrides["asymmetric_lease_time"], err = strconv.Atoi(strings.TrimPrefix(itemTrim, "asymmetric-lease-time "))
-	case strings.HasPrefix(itemTrim, "asymmetric-prefix-lease-time "):
-		overrides["asymmetric_prefix_lease_time"], err = strconv.Atoi(strings.TrimPrefix(
-			itemTrim, "asymmetric-prefix-lease-time "))
+	case balt.CutPrefixInString(&itemTrim, "asymmetric-lease-time "):
+		overrides["asymmetric_lease_time"], err = strconv.Atoi(itemTrim)
+	case balt.CutPrefixInString(&itemTrim, "asymmetric-prefix-lease-time "):
+		overrides["asymmetric_prefix_lease_time"], err = strconv.Atoi(itemTrim)
 	case itemTrim == "client-negotiation-match incoming-interface":
 		overrides["client_negotiation_match_incoming_interface"] = true
 	case itemTrim == "delay-authentication":
 		overrides["delay_authentication"] = true
 	case itemTrim == "delete-binding-on-renegotiation":
 		overrides["delete_binding_on_renegotiation"] = true
-	case strings.HasPrefix(itemTrim, "dual-stack "):
-		overrides["dual_stack"] = strings.Trim(strings.TrimPrefix(itemTrim, "dual-stack "), "\"")
-	case strings.HasPrefix(itemTrim, "interface-client-limit "):
-		overrides["interface_client_limit"], err = strconv.Atoi(strings.TrimPrefix(itemTrim, "interface-client-limit "))
+	case balt.CutPrefixInString(&itemTrim, "dual-stack "):
+		overrides["dual_stack"] = strings.Trim(itemTrim, "\"")
+	case balt.CutPrefixInString(&itemTrim, "interface-client-limit "):
+		overrides["interface_client_limit"], err = strconv.Atoi(itemTrim)
 	case itemTrim == "no-allow-snooped-clients":
 		overrides["no_allow_snooped_clients"] = true
 	case itemTrim == "no-bind-on-request":
 		overrides["no_bind_on_request"] = true
-	case strings.HasPrefix(itemTrim, "relay-source "):
-		overrides["relay_source"] = strings.TrimPrefix(itemTrim, "relay-source ")
+	case balt.CutPrefixInString(&itemTrim, "relay-source "):
+		overrides["relay_source"] = itemTrim
 	case itemTrim == "send-release-on-delete":
 		overrides["send_release_on_delete"] = true
 	}
@@ -1542,8 +1538,8 @@ func readForwardingOptionsDhcpRelayAgentID(itemTrim string, agentID map[string]i
 		agentID["prefix_host_name"] = true
 	case itemTrim == "prefix routing-instance-name":
 		agentID["prefix_routing_instance_name"] = true
-	case strings.HasPrefix(itemTrim, "use-interface-description "):
-		agentID["use_interface_description"] = strings.TrimPrefix(itemTrim, "use-interface-description ")
+	case balt.CutPrefixInString(&itemTrim, "use-interface-description "):
+		agentID["use_interface_description"] = itemTrim
 	case itemTrim == "use-option-82":
 		agentID["use_option_82"] = true
 	case itemTrim == "use-option-82 strict":
@@ -1556,28 +1552,28 @@ func readForwardingOptionsDhcpRelayAgentID(itemTrim string, agentID map[string]i
 
 func readForwardingOptionsDhcpRelayOption(itemTrim string, relayOption map[string]interface{}) error {
 	switch {
-	case strings.HasPrefix(itemTrim, "option-15 default-action "):
-		itemTrimSplit := strings.Split(strings.TrimPrefix(itemTrim, "option-15 default-action "), " ")
+	case balt.CutPrefixInString(&itemTrim, "option-15 default-action "):
+		itemTrimFields := strings.Split(itemTrim, " ")
 		defAction := map[string]interface{}{
-			"action": itemTrimSplit[0],
+			"action": itemTrimFields[0],
 			"group":  "",
 		}
-		if len(itemTrimSplit) > 1 {
-			defAction["group"] = strings.Trim(strings.Join(itemTrimSplit[1:], " "), "\"")
+		if len(itemTrimFields) > 1 { // <action> <group>
+			defAction["group"] = strings.Trim(strings.Join(itemTrimFields[1:], " "), "\"")
 		}
 		relayOption["option_15_default_action"] = append(
 			relayOption["option_15_default_action"].([]map[string]interface{}),
 			defAction,
 		)
-	case strings.HasPrefix(itemTrim, "option-15 "):
-		itemTrimSplit := strings.Split(strings.TrimPrefix(itemTrim, "option-15 "), " ")
-		if len(itemTrimSplit) < 4 {
-			return fmt.Errorf("can't read values for option_15 in '%s'", itemTrim)
+	case balt.CutPrefixInString(&itemTrim, "option-15 "):
+		itemTrimFields := strings.Split(itemTrim, " ")
+		if len(itemTrimFields) < 4 { // <compare> <value_type> <value> <action> <group>?
+			return fmt.Errorf(cantReadValuesNotEnoughFields, "option-15", itemTrim)
 		}
-		value := itemTrimSplit[2]
+		value := itemTrimFields[2]
 		actionIndex := 3
-		if strings.Contains(itemTrimSplit[2], "\"") {
-			for k, v := range itemTrimSplit[3:] {
+		if strings.Contains(itemTrimFields[2], "\"") {
+			for k, v := range itemTrimFields[3:] {
 				value += " " + v
 				if strings.Contains(v, "\"") {
 					actionIndex = 3 + k + 1
@@ -1587,43 +1583,43 @@ func readForwardingOptionsDhcpRelayOption(itemTrim string, relayOption map[strin
 			}
 		}
 		value = strings.Trim(value, "\"")
-		action := itemTrimSplit[actionIndex]
+		action := itemTrimFields[actionIndex]
 		option15 := map[string]interface{}{
-			"compare":    itemTrimSplit[0],
-			"value_type": itemTrimSplit[1],
+			"compare":    itemTrimFields[0],
+			"value_type": itemTrimFields[1],
 			"value":      value,
 			"action":     action,
 			"group":      "",
 		}
-		if len(itemTrimSplit) > actionIndex {
-			option15["group"] = strings.Trim(strings.Join(itemTrimSplit[actionIndex+1:], " "), "\"")
+		if len(itemTrimFields) > actionIndex+1 {
+			option15["group"] = strings.Trim(strings.Join(itemTrimFields[actionIndex+1:], " "), "\"")
 		}
 		relayOption["option_15"] = append(
 			relayOption["option_15"].([]map[string]interface{}),
 			option15,
 		)
-	case strings.HasPrefix(itemTrim, "option-16 default-action "):
-		itemTrimSplit := strings.Split(strings.TrimPrefix(itemTrim, "option-16 default-action "), " ")
+	case balt.CutPrefixInString(&itemTrim, "option-16 default-action "):
+		itemTrimFields := strings.Split(itemTrim, " ")
 		defAction := map[string]interface{}{
-			"action": itemTrimSplit[0],
+			"action": itemTrimFields[0],
 			"group":  "",
 		}
-		if len(itemTrimSplit) > 1 {
-			defAction["group"] = strings.Trim(strings.Join(itemTrimSplit[1:], " "), "\"")
+		if len(itemTrimFields) > 1 { // <action> <group>
+			defAction["group"] = strings.Trim(strings.Join(itemTrimFields[1:], " "), "\"")
 		}
 		relayOption["option_16_default_action"] = append(
 			relayOption["option_16_default_action"].([]map[string]interface{}),
 			defAction,
 		)
-	case strings.HasPrefix(itemTrim, "option-16 "):
-		itemTrimSplit := strings.Split(strings.TrimPrefix(itemTrim, "option-16 "), " ")
-		if len(itemTrimSplit) < 4 {
-			return fmt.Errorf("can't read values for option_16 in '%s'", itemTrim)
+	case balt.CutPrefixInString(&itemTrim, "option-16 "):
+		itemTrimFields := strings.Split(itemTrim, " ")
+		if len(itemTrimFields) < 4 { // <compare> <value_type> <value> <action> <group>?
+			return fmt.Errorf(cantReadValuesNotEnoughFields, "option-16", itemTrim)
 		}
-		value := itemTrimSplit[2]
+		value := itemTrimFields[2]
 		actionIndex := 3
-		if strings.Contains(itemTrimSplit[2], "\"") {
-			for k, v := range itemTrimSplit[3:] {
+		if strings.Contains(itemTrimFields[2], "\"") {
+			for k, v := range itemTrimFields[3:] {
 				value += " " + v
 				if strings.Contains(v, "\"") {
 					actionIndex = 3 + k + 1
@@ -1633,43 +1629,43 @@ func readForwardingOptionsDhcpRelayOption(itemTrim string, relayOption map[strin
 			}
 		}
 		value = strings.Trim(value, "\"")
-		action := itemTrimSplit[actionIndex]
+		action := itemTrimFields[actionIndex]
 		option16 := map[string]interface{}{
-			"compare":    itemTrimSplit[0],
-			"value_type": itemTrimSplit[1],
+			"compare":    itemTrimFields[0],
+			"value_type": itemTrimFields[1],
 			"value":      value,
 			"action":     action,
 			"group":      "",
 		}
-		if len(itemTrimSplit) > actionIndex {
-			option16["group"] = strings.Trim(strings.Join(itemTrimSplit[actionIndex+1:], " "), "\"")
+		if len(itemTrimFields) > actionIndex+1 {
+			option16["group"] = strings.Trim(strings.Join(itemTrimFields[actionIndex+1:], " "), "\"")
 		}
 		relayOption["option_16"] = append(
 			relayOption["option_16"].([]map[string]interface{}),
 			option16,
 		)
-	case strings.HasPrefix(itemTrim, "option-60 default-action "):
-		itemTrimSplit := strings.Split(strings.TrimPrefix(itemTrim, "option-60 default-action "), " ")
+	case balt.CutPrefixInString(&itemTrim, "option-60 default-action "):
+		itemTrimFields := strings.Split(itemTrim, " ")
 		defAction := map[string]interface{}{
-			"action": itemTrimSplit[0],
+			"action": itemTrimFields[0],
 			"group":  "",
 		}
-		if len(itemTrimSplit) > 1 {
-			defAction["group"] = strings.Trim(strings.Join(itemTrimSplit[1:], " "), "\"")
+		if len(itemTrimFields) > 1 { // <action> <group>
+			defAction["group"] = strings.Trim(strings.Join(itemTrimFields[1:], " "), "\"")
 		}
 		relayOption["option_60_default_action"] = append(
 			relayOption["option_60_default_action"].([]map[string]interface{}),
 			defAction,
 		)
-	case strings.HasPrefix(itemTrim, "option-60 "):
-		itemTrimSplit := strings.Split(strings.TrimPrefix(itemTrim, "option-60 "), " ")
-		if len(itemTrimSplit) < 4 {
-			return fmt.Errorf("can't read values for option_60 in '%s'", itemTrim)
+	case balt.CutPrefixInString(&itemTrim, "option-60 "):
+		itemTrimFields := strings.Split(itemTrim, " ")
+		if len(itemTrimFields) < 4 { // <compare> <value_type> <value> <action> <group>?
+			return fmt.Errorf(cantReadValuesNotEnoughFields, "option-60", itemTrim)
 		}
-		value := itemTrimSplit[2]
+		value := itemTrimFields[2]
 		actionIndex := 3
-		if strings.Contains(itemTrimSplit[2], "\"") {
-			for k, v := range itemTrimSplit[3:] {
+		if strings.Contains(itemTrimFields[2], "\"") {
+			for k, v := range itemTrimFields[3:] {
 				value += " " + v
 				if strings.Contains(v, "\"") {
 					actionIndex = 3 + k + 1
@@ -1679,43 +1675,43 @@ func readForwardingOptionsDhcpRelayOption(itemTrim string, relayOption map[strin
 			}
 		}
 		value = strings.Trim(value, "\"")
-		action := itemTrimSplit[actionIndex]
+		action := itemTrimFields[actionIndex]
 		option60 := map[string]interface{}{
-			"compare":    itemTrimSplit[0],
-			"value_type": itemTrimSplit[1],
+			"compare":    itemTrimFields[0],
+			"value_type": itemTrimFields[1],
 			"value":      value,
 			"action":     action,
 			"group":      "",
 		}
-		if len(itemTrimSplit) > actionIndex {
-			option60["group"] = strings.Trim(strings.Join(itemTrimSplit[actionIndex+1:], " "), "\"")
+		if len(itemTrimFields) > actionIndex+1 {
+			option60["group"] = strings.Trim(strings.Join(itemTrimFields[actionIndex+1:], " "), "\"")
 		}
 		relayOption["option_60"] = append(
 			relayOption["option_60"].([]map[string]interface{}),
 			option60,
 		)
-	case strings.HasPrefix(itemTrim, "option-77 default-action "):
-		itemTrimSplit := strings.Split(strings.TrimPrefix(itemTrim, "option-77 default-action "), " ")
+	case balt.CutPrefixInString(&itemTrim, "option-77 default-action "):
+		itemTrimFields := strings.Split(itemTrim, " ")
 		defAction := map[string]interface{}{
-			"action": itemTrimSplit[0],
+			"action": itemTrimFields[0],
 			"group":  "",
 		}
-		if len(itemTrimSplit) > 1 {
-			defAction["group"] = strings.Trim(strings.Join(itemTrimSplit[1:], " "), "\"")
+		if len(itemTrimFields) > 1 { // <action> <group>
+			defAction["group"] = strings.Trim(strings.Join(itemTrimFields[1:], " "), "\"")
 		}
 		relayOption["option_77_default_action"] = append(
 			relayOption["option_77_default_action"].([]map[string]interface{}),
 			defAction,
 		)
-	case strings.HasPrefix(itemTrim, "option-77 "):
-		itemTrimSplit := strings.Split(strings.TrimPrefix(itemTrim, "option-77 "), " ")
-		if len(itemTrimSplit) < 4 {
-			return fmt.Errorf("can't read values for option_77 in '%s'", itemTrim)
+	case balt.CutPrefixInString(&itemTrim, "option-77 "):
+		itemTrimFields := strings.Split(itemTrim, " ")
+		if len(itemTrimFields) < 4 { // <compare> <value_type> <value> <action> <group>?
+			return fmt.Errorf(cantReadValuesNotEnoughFields, "option-77", itemTrim)
 		}
-		value := itemTrimSplit[2]
+		value := itemTrimFields[2]
 		actionIndex := 3
-		if strings.Contains(itemTrimSplit[2], "\"") {
-			for k, v := range itemTrimSplit[3:] {
+		if strings.Contains(itemTrimFields[2], "\"") {
+			for k, v := range itemTrimFields[3:] {
 				value += " " + v
 				if strings.Contains(v, "\"") {
 					actionIndex = 3 + k + 1
@@ -1725,26 +1721,23 @@ func readForwardingOptionsDhcpRelayOption(itemTrim string, relayOption map[strin
 			}
 		}
 		value = strings.Trim(value, "\"")
-		action := itemTrimSplit[actionIndex]
+		action := itemTrimFields[actionIndex]
 		option77 := map[string]interface{}{
-			"compare":    itemTrimSplit[0],
-			"value_type": itemTrimSplit[1],
+			"compare":    itemTrimFields[0],
+			"value_type": itemTrimFields[1],
 			"value":      value,
 			"action":     action,
 			"group":      "",
 		}
-		if len(itemTrimSplit) > actionIndex {
-			option77["group"] = strings.Trim(strings.Join(itemTrimSplit[actionIndex+1:], " "), "\"")
+		if len(itemTrimFields) > actionIndex+1 {
+			option77["group"] = strings.Trim(strings.Join(itemTrimFields[actionIndex+1:], " "), "\"")
 		}
 		relayOption["option_77"] = append(
 			relayOption["option_77"].([]map[string]interface{}),
 			option77,
 		)
-	case strings.HasPrefix(itemTrim, "option-order "):
-		relayOption["option_order"] = append(
-			relayOption["option_order"].([]string),
-			strings.TrimPrefix(itemTrim, "option-order "),
-		)
+	case balt.CutPrefixInString(&itemTrim, "option-order "):
+		relayOption["option_order"] = append(relayOption["option_order"].([]string), itemTrim)
 	}
 
 	return nil
@@ -1752,7 +1745,7 @@ func readForwardingOptionsDhcpRelayOption(itemTrim string, relayOption map[strin
 
 func readForwardingOptionsDhcpRelayOption82(itemTrim string, relayOption82 map[string]interface{}) {
 	switch {
-	case strings.HasPrefix(itemTrim, "circuit-id"):
+	case balt.CutPrefixInString(&itemTrim, "circuit-id"):
 		if len(relayOption82["circuit_id"].([]map[string]interface{})) == 0 {
 			relayOption82["circuit_id"] = append(relayOption82["circuit_id"].([]map[string]interface{}), map[string]interface{}{
 				"include_irb_and_l2":           false,
@@ -1766,27 +1759,26 @@ func readForwardingOptionsDhcpRelayOption82(itemTrim string, relayOption82 map[s
 				"vlan_id_only":                 false,
 			})
 		}
-		if strings.HasPrefix(itemTrim, "circuit-id ") {
+		if balt.CutPrefixInString(&itemTrim, " ") {
 			circuitID := relayOption82["circuit_id"].([]map[string]interface{})[0]
-			itemTrimCircuitID := strings.TrimPrefix(itemTrim, "circuit-id ")
 			switch {
-			case itemTrimCircuitID == "include-irb-and-l2":
+			case itemTrim == "include-irb-and-l2":
 				circuitID["include_irb_and_l2"] = true
-			case itemTrimCircuitID == "keep-incoming-circuit-id":
+			case itemTrim == "keep-incoming-circuit-id":
 				circuitID["keep_incoming_circuit_id"] = true
-			case itemTrimCircuitID == "no-vlan-interface-name":
+			case itemTrim == "no-vlan-interface-name":
 				circuitID["no_vlan_interface_name"] = true
-			case itemTrimCircuitID == "prefix host-name":
+			case itemTrim == "prefix host-name":
 				circuitID["prefix_host_name"] = true
-			case itemTrimCircuitID == "prefix routing-instance-name":
+			case itemTrim == "prefix routing-instance-name":
 				circuitID["prefix_routing_instance_name"] = true
-			case strings.HasPrefix(itemTrimCircuitID, "use-interface-description "):
-				circuitID["use_interface_description"] = strings.TrimPrefix(itemTrimCircuitID, "use-interface-description ")
-			case itemTrimCircuitID == "use-vlan-id":
+			case balt.CutPrefixInString(&itemTrim, "use-interface-description "):
+				circuitID["use_interface_description"] = itemTrim
+			case itemTrim == "use-vlan-id":
 				circuitID["use_vlan_id"] = true
-			case itemTrimCircuitID == "user-defined":
+			case itemTrim == "user-defined":
 				circuitID["user_defined"] = true
-			case itemTrimCircuitID == "vlan-id-only":
+			case itemTrim == "vlan-id-only":
 				circuitID["vlan_id_only"] = true
 			}
 		}
@@ -1794,7 +1786,7 @@ func readForwardingOptionsDhcpRelayOption82(itemTrim string, relayOption82 map[s
 		relayOption82["exclude_relay_agent_identifier"] = true
 	case itemTrim == "link-selection":
 		relayOption82["link_selection"] = true
-	case strings.HasPrefix(itemTrim, "remote-id"):
+	case balt.CutPrefixInString(&itemTrim, "remote-id"):
 		if len(relayOption82["remote_id"].([]map[string]interface{})) == 0 {
 			relayOption82["remote_id"] = append(relayOption82["remote_id"].([]map[string]interface{}), map[string]interface{}{
 				"hostname_only":                false,
@@ -1808,27 +1800,26 @@ func readForwardingOptionsDhcpRelayOption82(itemTrim string, relayOption82 map[s
 				"use_vlan_id":                  false,
 			})
 		}
-		if strings.HasPrefix(itemTrim, "remote-id ") {
+		if balt.CutPrefixInString(&itemTrim, " ") {
 			remoteID := relayOption82["remote_id"].([]map[string]interface{})[0]
-			itemTrimRemoteID := strings.TrimPrefix(itemTrim, "remote-id ")
 			switch {
-			case itemTrimRemoteID == "hostname-only":
+			case itemTrim == "hostname-only":
 				remoteID["hostname_only"] = true
-			case itemTrimRemoteID == "include-irb-and-l2":
+			case itemTrim == "include-irb-and-l2":
 				remoteID["include_irb_and_l2"] = true
-			case itemTrimRemoteID == "keep-incoming-remote-id":
+			case itemTrim == "keep-incoming-remote-id":
 				remoteID["keep_incoming_remote_id"] = true
-			case itemTrimRemoteID == "no-vlan-interface-name":
+			case itemTrim == "no-vlan-interface-name":
 				remoteID["no_vlan_interface_name"] = true
-			case itemTrimRemoteID == "prefix host-name":
+			case itemTrim == "prefix host-name":
 				remoteID["prefix_host_name"] = true
-			case itemTrimRemoteID == "prefix routing-instance-name":
+			case itemTrim == "prefix routing-instance-name":
 				remoteID["prefix_routing_instance_name"] = true
-			case strings.HasPrefix(itemTrimRemoteID, "use-interface-description "):
-				remoteID["use_interface_description"] = strings.TrimPrefix(itemTrimRemoteID, "use-interface-description ")
-			case strings.HasPrefix(itemTrimRemoteID, "use-string "):
-				remoteID["use_string"] = strings.Trim(strings.TrimPrefix(itemTrimRemoteID, "use-string "), "\"")
-			case itemTrimRemoteID == "use-vlan-id":
+			case balt.CutPrefixInString(&itemTrim, "use-interface-description "):
+				remoteID["use_interface_description"] = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "use-string "):
+				remoteID["use_string"] = strings.Trim(itemTrim, "\"")
+			case itemTrim == "use-vlan-id":
 				remoteID["use_vlan_id"] = true
 			}
 		}

--- a/junos/func_resource_forwardingoptions_dhcprelay.go
+++ b/junos/func_resource_forwardingoptions_dhcprelay.go
@@ -2,6 +2,7 @@ package junos
 
 import (
 	"fmt"
+	"html"
 	"strconv"
 	"strings"
 
@@ -1572,7 +1573,8 @@ func readForwardingOptionsDhcpRelayOption(itemTrim string, relayOption map[strin
 		}
 		value := itemTrimFields[2]
 		actionIndex := 3
-		if strings.Contains(itemTrimFields[2], "\"") {
+		if (strings.HasPrefix(itemTrimFields[2], "\"") && !strings.HasSuffix(itemTrimFields[2], "\"")) ||
+			itemTrimFields[2] == "\"" {
 			for k, v := range itemTrimFields[3:] {
 				value += " " + v
 				if strings.Contains(v, "\"") {
@@ -1582,7 +1584,7 @@ func readForwardingOptionsDhcpRelayOption(itemTrim string, relayOption map[strin
 				}
 			}
 		}
-		value = strings.Trim(value, "\"")
+		value = html.UnescapeString(strings.Trim(value, "\""))
 		action := itemTrimFields[actionIndex]
 		option15 := map[string]interface{}{
 			"compare":    itemTrimFields[0],
@@ -1618,7 +1620,8 @@ func readForwardingOptionsDhcpRelayOption(itemTrim string, relayOption map[strin
 		}
 		value := itemTrimFields[2]
 		actionIndex := 3
-		if strings.Contains(itemTrimFields[2], "\"") {
+		if (strings.HasPrefix(itemTrimFields[2], "\"") && !strings.HasSuffix(itemTrimFields[2], "\"")) ||
+			itemTrimFields[2] == "\"" {
 			for k, v := range itemTrimFields[3:] {
 				value += " " + v
 				if strings.Contains(v, "\"") {
@@ -1628,7 +1631,7 @@ func readForwardingOptionsDhcpRelayOption(itemTrim string, relayOption map[strin
 				}
 			}
 		}
-		value = strings.Trim(value, "\"")
+		value = html.UnescapeString(strings.Trim(value, "\""))
 		action := itemTrimFields[actionIndex]
 		option16 := map[string]interface{}{
 			"compare":    itemTrimFields[0],
@@ -1664,7 +1667,8 @@ func readForwardingOptionsDhcpRelayOption(itemTrim string, relayOption map[strin
 		}
 		value := itemTrimFields[2]
 		actionIndex := 3
-		if strings.Contains(itemTrimFields[2], "\"") {
+		if (strings.HasPrefix(itemTrimFields[2], "\"") && !strings.HasSuffix(itemTrimFields[2], "\"")) ||
+			itemTrimFields[2] == "\"" {
 			for k, v := range itemTrimFields[3:] {
 				value += " " + v
 				if strings.Contains(v, "\"") {
@@ -1674,7 +1678,7 @@ func readForwardingOptionsDhcpRelayOption(itemTrim string, relayOption map[strin
 				}
 			}
 		}
-		value = strings.Trim(value, "\"")
+		value = html.UnescapeString(strings.Trim(value, "\""))
 		action := itemTrimFields[actionIndex]
 		option60 := map[string]interface{}{
 			"compare":    itemTrimFields[0],
@@ -1710,7 +1714,8 @@ func readForwardingOptionsDhcpRelayOption(itemTrim string, relayOption map[strin
 		}
 		value := itemTrimFields[2]
 		actionIndex := 3
-		if strings.Contains(itemTrimFields[2], "\"") {
+		if (strings.HasPrefix(itemTrimFields[2], "\"") && !strings.HasSuffix(itemTrimFields[2], "\"")) ||
+			itemTrimFields[2] == "\"" {
 			for k, v := range itemTrimFields[3:] {
 				value += " " + v
 				if strings.Contains(v, "\"") {
@@ -1720,7 +1725,7 @@ func readForwardingOptionsDhcpRelayOption(itemTrim string, relayOption map[strin
 				}
 			}
 		}
-		value = strings.Trim(value, "\"")
+		value = html.UnescapeString(strings.Trim(value, "\""))
 		action := itemTrimFields[actionIndex]
 		option77 := map[string]interface{}{
 			"compare":    itemTrimFields[0],

--- a/junos/resource_aggregate_route.go
+++ b/junos/resource_aggregate_route.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	balt "github.com/jeremmfr/go-utils/basicalter"
 )
 
 type aggregateRouteOptions struct {
@@ -362,9 +363,8 @@ func resourceAggregateRouteImport(ctx context.Context, d *schema.ResourceData, m
 	return result, nil
 }
 
-func checkAggregateRouteExists(destination, instance string, clt *Client, junSess *junosSession) (bool, error) {
+func checkAggregateRouteExists(destination, instance string, clt *Client, junSess *junosSession) (_ bool, err error) {
 	var showConfig string
-	var err error
 	if instance == defaultW {
 		if !strings.Contains(destination, ":") {
 			showConfig, err = clt.command(cmdShowConfig+
@@ -470,11 +470,8 @@ func setAggregateRoute(d *schema.ResourceData, clt *Client, junSess *junosSessio
 }
 
 func readAggregateRoute(destination, instance string, clt *Client, junSess *junosSession,
-) (aggregateRouteOptions, error) {
-	var confRead aggregateRouteOptions
+) (confRead aggregateRouteOptions, err error) {
 	var showConfig string
-	var err error
-
 	if instance == defaultW {
 		if !strings.Contains(destination, ":") {
 			showConfig, err = clt.command(cmdShowConfig+
@@ -510,35 +507,38 @@ func readAggregateRoute(destination, instance string, clt *Client, junSess *juno
 			switch {
 			case itemTrim == "active":
 				confRead.active = true
-			case strings.HasPrefix(itemTrim, "as-path aggregator "):
-				itemTrimSplit := strings.Split(itemTrim, " ")
-				confRead.asPathAggregatorAsNumber = itemTrimSplit[2]
-				confRead.asPathAggregatorAddress = itemTrimSplit[3]
+			case balt.CutPrefixInString(&itemTrim, "as-path aggregator "):
+				itemTrimFields := strings.Split(itemTrim, " ")
+				if len(itemTrimFields) < 2 { // <as_number> <address>
+					return confRead, fmt.Errorf(cantReadValuesNotEnoughFields, "as-path aggregator", itemTrim)
+				}
+				confRead.asPathAggregatorAsNumber = itemTrimFields[0]
+				confRead.asPathAggregatorAddress = itemTrimFields[1]
 			case itemTrim == "as-path atomic-aggregate":
 				confRead.asPathAtomicAggregate = true
-			case strings.HasPrefix(itemTrim, "as-path origin "):
-				confRead.asPathOrigin = strings.TrimPrefix(itemTrim, "as-path origin ")
-			case strings.HasPrefix(itemTrim, "as-path path "):
-				confRead.asPathPath = strings.Trim(strings.TrimPrefix(itemTrim, "as-path path "), "\"")
+			case balt.CutPrefixInString(&itemTrim, "as-path origin "):
+				confRead.asPathOrigin = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "as-path path "):
+				confRead.asPathPath = strings.Trim(itemTrim, "\"")
 			case itemTrim == "brief":
 				confRead.brief = true
-			case strings.HasPrefix(itemTrim, "community "):
-				confRead.community = append(confRead.community, strings.TrimPrefix(itemTrim, "community "))
+			case balt.CutPrefixInString(&itemTrim, "community "):
+				confRead.community = append(confRead.community, itemTrim)
 			case itemTrim == discardW:
 				confRead.discard = true
 			case itemTrim == "full":
 				confRead.full = true
-			case strings.HasPrefix(itemTrim, "metric "):
-				confRead.metric, err = strconv.Atoi(strings.TrimPrefix(itemTrim, "metric "))
+			case balt.CutPrefixInString(&itemTrim, "metric "):
+				confRead.metric, err = strconv.Atoi(itemTrim)
 				if err != nil {
 					return confRead, fmt.Errorf(failedConvAtoiError, itemTrim, err)
 				}
 			case itemTrim == "passive":
 				confRead.passive = true
-			case strings.HasPrefix(itemTrim, "policy "):
-				confRead.policy = append(confRead.policy, strings.TrimPrefix(itemTrim, "policy "))
-			case strings.HasPrefix(itemTrim, "preference "):
-				confRead.preference, err = strconv.Atoi(strings.TrimPrefix(itemTrim, "preference "))
+			case balt.CutPrefixInString(&itemTrim, "policy "):
+				confRead.policy = append(confRead.policy, itemTrim)
+			case balt.CutPrefixInString(&itemTrim, "preference "):
+				confRead.preference, err = strconv.Atoi(itemTrim)
 				if err != nil {
 					return confRead, fmt.Errorf(failedConvAtoiError, itemTrim, err)
 				}

--- a/junos/resource_application_set.go
+++ b/junos/resource_application_set.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	balt "github.com/jeremmfr/go-utils/basicalter"
 )
 
 type applicationSetOptions struct {
@@ -256,9 +257,8 @@ func setApplicationSet(d *schema.ResourceData, clt *Client, junSess *junosSessio
 	return clt.configSet(configSet, junSess)
 }
 
-func readApplicationSet(applicationSet string, clt *Client, junSess *junosSession) (applicationSetOptions, error) {
-	var confRead applicationSetOptions
-
+func readApplicationSet(applicationSet string, clt *Client, junSess *junosSession,
+) (confRead applicationSetOptions, err error) {
 	showConfig, err := clt.command(cmdShowConfig+
 		"applications application-set "+applicationSet+pipeDisplaySetRelative, junSess)
 	if err != nil {
@@ -274,8 +274,8 @@ func readApplicationSet(applicationSet string, clt *Client, junSess *junosSessio
 				break
 			}
 			itemTrim := strings.TrimPrefix(item, setLS)
-			if strings.HasPrefix(itemTrim, "application ") {
-				confRead.applications = append(confRead.applications, strings.TrimPrefix(itemTrim, "application "))
+			if balt.CutPrefixInString(&itemTrim, "application ") {
+				confRead.applications = append(confRead.applications, itemTrim)
 			}
 		}
 	}

--- a/junos/resource_bgp_neighbor.go
+++ b/junos/resource_bgp_neighbor.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	balt "github.com/jeremmfr/go-utils/basicalter"
 )
 
 func resourceBgpNeighbor() *schema.Resource {
@@ -831,9 +832,8 @@ func resourceBgpNeighborImport(ctx context.Context, d *schema.ResourceData, m in
 	return result, nil
 }
 
-func checkBgpNeighborExists(ip, instance, group string, clt *Client, junSess *junosSession) (bool, error) {
+func checkBgpNeighborExists(ip, instance, group string, clt *Client, junSess *junosSession) (_ bool, err error) {
 	var showConfig string
-	var err error
 	if instance == defaultW {
 		showConfig, err = clt.command(cmdShowConfig+
 			"protocols bgp group "+group+" neighbor "+ip+pipeDisplaySet, junSess)
@@ -880,15 +880,12 @@ func setBgpNeighbor(d *schema.ResourceData, clt *Client, junSess *junosSession) 
 	return setBgpOptsGrafefulRestart(setPrefix, d.Get("graceful_restart").([]interface{}), clt, junSess)
 }
 
-func readBgpNeighbor(ip, instance, group string, clt *Client, junSess *junosSession) (bgpOptions, error) {
-	var confRead bgpOptions
-	var showConfig string
-	var err error
+func readBgpNeighbor(ip, instance, group string, clt *Client, junSess *junosSession) (confRead bgpOptions, err error) {
 	// default -1
 	confRead.localPreference = -1
 	confRead.metricOut = -1
 	confRead.preference = -1
-
+	var showConfig string
 	if instance == defaultW {
 		showConfig, err = clt.command(cmdShowConfig+
 			"protocols bgp group "+group+" neighbor "+ip+pipeDisplaySetRelative, junSess)
@@ -915,22 +912,22 @@ func readBgpNeighbor(ip, instance, group string, clt *Client, junSess *junosSess
 			}
 			itemTrim := strings.TrimPrefix(item, setLS)
 			switch {
-			case strings.HasPrefix(itemTrim, "family evpn "):
-				confRead.familyEvpn, err = readBgpOptsFamily(itemTrim, "evpn", confRead.familyEvpn)
+			case balt.CutPrefixInString(&itemTrim, "family evpn "):
+				confRead.familyEvpn, err = readBgpOptsFamily(itemTrim, confRead.familyEvpn)
 				if err != nil {
 					return confRead, err
 				}
-			case strings.HasPrefix(itemTrim, "family inet "):
-				confRead.familyInet, err = readBgpOptsFamily(itemTrim, inetW, confRead.familyInet)
+			case balt.CutPrefixInString(&itemTrim, "family inet "):
+				confRead.familyInet, err = readBgpOptsFamily(itemTrim, confRead.familyInet)
 				if err != nil {
 					return confRead, err
 				}
-			case strings.HasPrefix(itemTrim, "family inet6 "):
-				confRead.familyInet6, err = readBgpOptsFamily(itemTrim, inet6W, confRead.familyInet6)
+			case balt.CutPrefixInString(&itemTrim, "family inet6 "):
+				confRead.familyInet6, err = readBgpOptsFamily(itemTrim, confRead.familyInet6)
 				if err != nil {
 					return confRead, err
 				}
-			case strings.HasPrefix(itemTrim, "bfd-liveness-detection "):
+			case balt.CutPrefixInString(&itemTrim, "bfd-liveness-detection "):
 				if len(confRead.bfdLivenessDetection) == 0 {
 					confRead.bfdLivenessDetection = append(confRead.bfdLivenessDetection,
 						map[string]interface{}{
@@ -951,7 +948,7 @@ func readBgpNeighbor(ip, instance, group string, clt *Client, junSess *junosSess
 				if err := readBgpOptsBfd(itemTrim, confRead.bfdLivenessDetection[0]); err != nil {
 					return confRead, err
 				}
-			case strings.HasPrefix(itemTrim, "graceful-restart "):
+			case balt.CutPrefixInString(&itemTrim, "graceful-restart "):
 				if len(confRead.gracefulRestart) == 0 {
 					confRead.gracefulRestart = append(confRead.gracefulRestart, map[string]interface{}{
 						"disable":          false,
@@ -963,7 +960,7 @@ func readBgpNeighbor(ip, instance, group string, clt *Client, junSess *junosSess
 					return confRead, err
 				}
 			default:
-				err = readBgpOptsSimple(itemTrim, &confRead)
+				err = confRead.readBgpOptsSimple(itemTrim)
 				if err != nil {
 					return confRead, err
 				}

--- a/junos/resource_eventoptions_generate_event.go
+++ b/junos/resource_eventoptions_generate_event.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	balt "github.com/jeremmfr/go-utils/basicalter"
 )
 
 type eventoptionsGenerateEventOptions struct {
@@ -282,9 +283,7 @@ func setEventoptionsGenerateEvent(d *schema.ResourceData, clt *Client, junSess *
 }
 
 func readEventoptionsGenerateEvent(name string, clt *Client, junSess *junosSession,
-) (eventoptionsGenerateEventOptions, error) {
-	var confRead eventoptionsGenerateEventOptions
-
+) (confRead eventoptionsGenerateEventOptions, err error) {
 	showConfig, err := clt.command(cmdShowConfig+
 		"event-options generate-event \""+name+"\""+pipeDisplaySetRelative, junSess)
 	if err != nil {
@@ -301,14 +300,13 @@ func readEventoptionsGenerateEvent(name string, clt *Client, junSess *junosSessi
 			}
 			itemTrim := strings.TrimPrefix(item, setLS)
 			switch {
-			case strings.HasPrefix(itemTrim, "time-interval "):
-				var err error
-				confRead.timeInterval, err = strconv.Atoi(strings.TrimPrefix(itemTrim, "time-interval "))
+			case balt.CutPrefixInString(&itemTrim, "time-interval "):
+				confRead.timeInterval, err = strconv.Atoi(itemTrim)
 				if err != nil {
 					return confRead, fmt.Errorf(failedConvAtoiError, itemTrim, err)
 				}
-			case strings.HasPrefix(itemTrim, "time-of-day "):
-				confRead.timeOfDay = strings.Split(strings.Trim(strings.TrimPrefix(itemTrim, "time-of-day "), "\""), " ")[0]
+			case balt.CutPrefixInString(&itemTrim, "time-of-day "):
+				confRead.timeOfDay = strings.Split(strings.Trim(itemTrim, "\""), " ")[0]
 			case itemTrim == "no-drift":
 				confRead.noDrift = true
 			}

--- a/junos/resource_forwardingoptions_dhcprelay.go
+++ b/junos/resource_forwardingoptions_dhcprelay.go
@@ -3,6 +3,7 @@ package junos
 import (
 	"context"
 	"fmt"
+	"html"
 	"strconv"
 	"strings"
 
@@ -1506,7 +1507,7 @@ func readForwardingOptionsDhcpRelay( //nolint: gocognit, gocyclo
 				confRead.serverMatchDuid = append(confRead.serverMatchDuid, map[string]interface{}{
 					"compare":    itemTrimFields[0],
 					"value_type": itemTrimFields[1],
-					"value":      itemTrimFields[2],
+					"value":      html.UnescapeString(itemTrimFields[2]),
 					"action":     itemTrimFields[3],
 				})
 			case balt.CutPrefixInString(&itemTrim, "server-response-time "):

--- a/junos/resource_forwardingoptions_dhcprelay_group.go
+++ b/junos/resource_forwardingoptions_dhcprelay_group.go
@@ -3,6 +3,7 @@ package junos
 import (
 	"context"
 	"fmt"
+	"html"
 	"strconv"
 	"strings"
 
@@ -1558,7 +1559,7 @@ func readForwardingOptionsDhcpRelayGroup(name, instance, version string, clt *Cl
 				confRead.serverMatchDuid = append(confRead.serverMatchDuid, map[string]interface{}{
 					"compare":    itemTrimFields[0],
 					"value_type": itemTrimFields[1],
-					"value":      itemTrimFields[2],
+					"value":      html.UnescapeString(itemTrimFields[2]),
 					"action":     itemTrimFields[3],
 				})
 			case balt.CutPrefixInString(&itemTrim, "service-profile "):

--- a/junos/resource_forwardingoptions_dhcprelay_servergroup.go
+++ b/junos/resource_forwardingoptions_dhcprelay_servergroup.go
@@ -374,9 +374,7 @@ func setForwardingOptionsDhcpRelayServerGroup(d *schema.ResourceData, clt *Clien
 }
 
 func readForwardingOptionsDhcpRelayServerGroup(name, instance, version string, clt *Client, junSess *junosSession,
-) (fwdOptsDhcpRelSrvGrpOptions, error) {
-	var confRead fwdOptsDhcpRelSrvGrpOptions
-
+) (confRead fwdOptsDhcpRelSrvGrpOptions, err error) {
 	showCmd := cmdShowConfig
 	if instance != defaultW {
 		showCmd += routingInstancesWS + instance + " "
@@ -404,7 +402,7 @@ func readForwardingOptionsDhcpRelayServerGroup(name, instance, version string, c
 				break
 			}
 			if itemTrim != "" {
-				confRead.ipAddress = append(confRead.ipAddress, strings.TrimPrefix(itemTrim, " "))
+				confRead.ipAddress = append(confRead.ipAddress, itemTrim)
 			}
 		}
 	}

--- a/junos/resource_forwardingoptions_dhcprelay_test.go
+++ b/junos/resource_forwardingoptions_dhcprelay_test.go
@@ -260,7 +260,7 @@ resource "junos_forwardingoptions_dhcprelay" "testacc_dhcprelay_v6_default" {
     option_15 {
       compare    = "equals"
       value_type = "ascii"
-      value      = " equals ascii "
+      value      = "&equals-ascii "
       action     = "drop"
     }
     option_15 {

--- a/junos/resource_forwardingoptions_sampling_instance.go
+++ b/junos/resource_forwardingoptions_sampling_instance.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	balt "github.com/jeremmfr/go-utils/basicalter"
 	bchk "github.com/jeremmfr/go-utils/basiccheck"
 )
 
@@ -1070,9 +1071,7 @@ func setForwardingOptionsSamplingInstanceOutput(
 }
 
 func readForwardingOptionsSamplingInstance(name string, clt *Client, junSess *junosSession,
-) (samplingInstanceOptions, error) {
-	var confRead samplingInstanceOptions
-
+) (confRead samplingInstanceOptions, err error) {
 	showConfig, err := clt.command(cmdShowConfig+
 		"forwarding-options sampling instance \""+name+"\""+pipeDisplaySetRelative, junSess)
 	if err != nil {
@@ -1091,7 +1090,7 @@ func readForwardingOptionsSamplingInstance(name string, clt *Client, junSess *ju
 			switch {
 			case itemTrim == disableW:
 				confRead.disable = true
-			case strings.HasPrefix(itemTrim, "family inet input "):
+			case balt.CutPrefixInString(&itemTrim, "family inet input "):
 				if len(confRead.familyInetInput) == 0 {
 					confRead.familyInetInput = append(confRead.familyInetInput, map[string]interface{}{
 						"max_packets_per_second": -1,
@@ -1100,11 +1099,10 @@ func readForwardingOptionsSamplingInstance(name string, clt *Client, junSess *ju
 						"run_length":             -1,
 					})
 				}
-				if err := readForwardingOptionsSamplingInstanceInput(confRead.familyInetInput[0],
-					strings.TrimPrefix(itemTrim, "family inet input ")); err != nil {
+				if err := readForwardingOptionsSamplingInstanceInput(itemTrim, confRead.familyInetInput[0]); err != nil {
 					return confRead, err
 				}
-			case strings.HasPrefix(itemTrim, "family inet6 input "):
+			case balt.CutPrefixInString(&itemTrim, "family inet6 input "):
 				if len(confRead.familyInet6Input) == 0 {
 					confRead.familyInet6Input = append(confRead.familyInet6Input, map[string]interface{}{
 						"max_packets_per_second": -1,
@@ -1113,11 +1111,10 @@ func readForwardingOptionsSamplingInstance(name string, clt *Client, junSess *ju
 						"run_length":             -1,
 					})
 				}
-				if err := readForwardingOptionsSamplingInstanceInput(confRead.familyInet6Input[0],
-					strings.TrimPrefix(itemTrim, "family inet6 input ")); err != nil {
+				if err := readForwardingOptionsSamplingInstanceInput(itemTrim, confRead.familyInet6Input[0]); err != nil {
 					return confRead, err
 				}
-			case strings.HasPrefix(itemTrim, "family mpls input "):
+			case balt.CutPrefixInString(&itemTrim, "family mpls input "):
 				if len(confRead.familyMplsInput) == 0 {
 					confRead.familyMplsInput = append(confRead.familyMplsInput, map[string]interface{}{
 						"max_packets_per_second": -1,
@@ -1126,11 +1123,10 @@ func readForwardingOptionsSamplingInstance(name string, clt *Client, junSess *ju
 						"run_length":             -1,
 					})
 				}
-				if err := readForwardingOptionsSamplingInstanceInput(confRead.familyMplsInput[0],
-					strings.TrimPrefix(itemTrim, "family mpls input ")); err != nil {
+				if err := readForwardingOptionsSamplingInstanceInput(itemTrim, confRead.familyMplsInput[0]); err != nil {
 					return confRead, err
 				}
-			case strings.HasPrefix(itemTrim, "input "):
+			case balt.CutPrefixInString(&itemTrim, "input "):
 				if len(confRead.input) == 0 {
 					confRead.input = append(confRead.input, map[string]interface{}{
 						"max_packets_per_second": -1,
@@ -1139,11 +1135,10 @@ func readForwardingOptionsSamplingInstance(name string, clt *Client, junSess *ju
 						"run_length":             -1,
 					})
 				}
-				if err := readForwardingOptionsSamplingInstanceInput(confRead.input[0],
-					strings.TrimPrefix(itemTrim, "input ")); err != nil {
+				if err := readForwardingOptionsSamplingInstanceInput(itemTrim, confRead.input[0]); err != nil {
 					return confRead, err
 				}
-			case strings.HasPrefix(itemTrim, "family inet output "):
+			case balt.CutPrefixInString(&itemTrim, "family inet output "):
 				if len(confRead.familyInetOutput) == 0 {
 					confRead.familyInetOutput = append(confRead.familyInetOutput, map[string]interface{}{
 						"aggregate_export_interval":   0,
@@ -1156,11 +1151,10 @@ func readForwardingOptionsSamplingInstance(name string, clt *Client, junSess *ju
 						"interface":                   make([]map[string]interface{}, 0),
 					})
 				}
-				if err := readForwardingOptionsSamplingInstanceOutput(confRead.familyInetOutput[0],
-					strings.TrimPrefix(itemTrim, "family inet output "), inetW); err != nil {
+				if err := readForwardingOptionsSamplingInstanceOutput(itemTrim, confRead.familyInetOutput[0], inetW); err != nil {
 					return confRead, err
 				}
-			case strings.HasPrefix(itemTrim, "family inet6 output "):
+			case balt.CutPrefixInString(&itemTrim, "family inet6 output "):
 				if len(confRead.familyInet6Output) == 0 {
 					confRead.familyInet6Output = append(confRead.familyInet6Output, map[string]interface{}{
 						"aggregate_export_interval":   0,
@@ -1173,11 +1167,10 @@ func readForwardingOptionsSamplingInstance(name string, clt *Client, junSess *ju
 						"interface":                   make([]map[string]interface{}, 0),
 					})
 				}
-				if err := readForwardingOptionsSamplingInstanceOutput(confRead.familyInet6Output[0],
-					strings.TrimPrefix(itemTrim, "family inet6 output "), inet6W); err != nil {
+				if err := readForwardingOptionsSamplingInstanceOutput(itemTrim, confRead.familyInet6Output[0], inet6W); err != nil {
 					return confRead, err
 				}
-			case strings.HasPrefix(itemTrim, "family mpls output "):
+			case balt.CutPrefixInString(&itemTrim, "family mpls output "):
 				if len(confRead.familyMplsOutput) == 0 {
 					confRead.familyMplsOutput = append(confRead.familyMplsOutput, map[string]interface{}{
 						"aggregate_export_interval":   0,
@@ -1189,8 +1182,7 @@ func readForwardingOptionsSamplingInstance(name string, clt *Client, junSess *ju
 						"interface":                   make([]map[string]interface{}, 0),
 					})
 				}
-				if err := readForwardingOptionsSamplingInstanceOutput(confRead.familyMplsOutput[0],
-					strings.TrimPrefix(itemTrim, "family mpls output "), mplsW); err != nil {
+				if err := readForwardingOptionsSamplingInstanceOutput(itemTrim, confRead.familyMplsOutput[0], mplsW); err != nil {
 					return confRead, err
 				}
 			}
@@ -1200,29 +1192,25 @@ func readForwardingOptionsSamplingInstance(name string, clt *Client, junSess *ju
 	return confRead, nil
 }
 
-func readForwardingOptionsSamplingInstanceInput(inputRead map[string]interface{}, itemTrim string) error {
+func readForwardingOptionsSamplingInstanceInput(itemTrim string, inputRead map[string]interface{}) (err error) {
 	switch {
-	case strings.HasPrefix(itemTrim, "max-packets-per-second "):
-		var err error
-		inputRead["max_packets_per_second"], err = strconv.Atoi(strings.TrimPrefix(itemTrim, "max-packets-per-second "))
+	case balt.CutPrefixInString(&itemTrim, "max-packets-per-second "):
+		inputRead["max_packets_per_second"], err = strconv.Atoi(itemTrim)
 		if err != nil {
 			return fmt.Errorf(failedConvAtoiError, itemTrim, err)
 		}
-	case strings.HasPrefix(itemTrim, "maximum-packet-length "):
-		var err error
-		inputRead["maximum_packet_length"], err = strconv.Atoi(strings.TrimPrefix(itemTrim, "maximum-packet-length "))
+	case balt.CutPrefixInString(&itemTrim, "maximum-packet-length "):
+		inputRead["maximum_packet_length"], err = strconv.Atoi(itemTrim)
 		if err != nil {
 			return fmt.Errorf(failedConvAtoiError, itemTrim, err)
 		}
-	case strings.HasPrefix(itemTrim, "rate "):
-		var err error
-		inputRead["rate"], err = strconv.Atoi(strings.TrimPrefix(itemTrim, "rate "))
+	case balt.CutPrefixInString(&itemTrim, "rate "):
+		inputRead["rate"], err = strconv.Atoi(itemTrim)
 		if err != nil {
 			return fmt.Errorf(failedConvAtoiError, itemTrim, err)
 		}
-	case strings.HasPrefix(itemTrim, "run-length "):
-		var err error
-		inputRead["run_length"], err = strconv.Atoi(strings.TrimPrefix(itemTrim, "run-length "))
+	case balt.CutPrefixInString(&itemTrim, "run-length "):
+		inputRead["run_length"], err = strconv.Atoi(itemTrim)
 		if err != nil {
 			return fmt.Errorf(failedConvAtoiError, itemTrim, err)
 		}
@@ -1231,34 +1219,30 @@ func readForwardingOptionsSamplingInstanceInput(inputRead map[string]interface{}
 	return nil
 }
 
-func readForwardingOptionsSamplingInstanceOutput(outputRead map[string]interface{}, itemTrim, family string) error {
+func readForwardingOptionsSamplingInstanceOutput(itemTrim string, outputRead map[string]interface{}, family string,
+) (err error) {
 	switch {
-	case strings.HasPrefix(itemTrim, "aggregate-export-interval "):
-		var err error
-		outputRead["aggregate_export_interval"], err = strconv.Atoi(strings.TrimPrefix(
-			itemTrim, "aggregate-export-interval "))
+	case balt.CutPrefixInString(&itemTrim, "aggregate-export-interval "):
+		outputRead["aggregate_export_interval"], err = strconv.Atoi(itemTrim)
 		if err != nil {
 			return fmt.Errorf(failedConvAtoiError, itemTrim, err)
 		}
-	case strings.HasPrefix(itemTrim, "extension-service "):
-		outputRead["extension_service"] = append(outputRead["extension_service"].([]string),
-			strings.Trim(strings.TrimPrefix(itemTrim, "extension-service "), "\""))
-	case strings.HasPrefix(itemTrim, "flow-active-timeout "):
-		var err error
-		outputRead["flow_active_timeout"], err = strconv.Atoi(strings.TrimPrefix(itemTrim, "flow-active-timeout "))
+	case balt.CutPrefixInString(&itemTrim, "extension-service "):
+		outputRead["extension_service"] = append(outputRead["extension_service"].([]string), strings.Trim(itemTrim, "\""))
+	case balt.CutPrefixInString(&itemTrim, "flow-active-timeout "):
+		outputRead["flow_active_timeout"], err = strconv.Atoi(itemTrim)
 		if err != nil {
 			return fmt.Errorf(failedConvAtoiError, itemTrim, err)
 		}
-	case strings.HasPrefix(itemTrim, "flow-inactive-timeout "):
-		var err error
-		outputRead["flow_inactive_timeout"], err = strconv.Atoi(strings.TrimPrefix(itemTrim, "flow-inactive-timeout "))
+	case balt.CutPrefixInString(&itemTrim, "flow-inactive-timeout "):
+		outputRead["flow_inactive_timeout"], err = strconv.Atoi(itemTrim)
 		if err != nil {
 			return fmt.Errorf(failedConvAtoiError, itemTrim, err)
 		}
-	case strings.HasPrefix(itemTrim, "flow-server "):
-		flowServerLineCut := strings.Split(itemTrim, " ")
+	case balt.CutPrefixInString(&itemTrim, "flow-server "):
+		itemTrimFields := strings.Split(itemTrim, " ")
 		flowServer := map[string]interface{}{
-			"hostname":                              flowServerLineCut[1],
+			"hostname":                              itemTrimFields[0],
 			"port":                                  0,
 			"aggregation_autonomous_system":         false,
 			"aggregation_destination_prefix":        false,
@@ -1281,93 +1265,85 @@ func readForwardingOptionsSamplingInstanceOutput(outputRead map[string]interface
 		}
 		outputRead["flow_server"] = copyAndRemoveItemMapList(
 			"hostname", flowServer, outputRead["flow_server"].([]map[string]interface{}))
-		itemTrimFlowServer := strings.TrimPrefix(itemTrim, "flow-server "+flowServerLineCut[1]+" ")
+		balt.CutPrefixInString(&itemTrim, itemTrimFields[0]+" ")
 		switch {
-		case strings.HasPrefix(itemTrimFlowServer, "port "):
-			var err error
-			flowServer["port"], err = strconv.Atoi(strings.TrimPrefix(itemTrimFlowServer, "port "))
+		case balt.CutPrefixInString(&itemTrim, "port "):
+			flowServer["port"], err = strconv.Atoi(itemTrim)
 			if err != nil {
-				return fmt.Errorf(failedConvAtoiError, itemTrimFlowServer, err)
+				return fmt.Errorf(failedConvAtoiError, itemTrim, err)
 			}
-		case itemTrimFlowServer == "aggregation autonomous-system":
+		case itemTrim == "aggregation autonomous-system":
 			flowServer["aggregation_autonomous_system"] = true
-		case itemTrimFlowServer == "aggregation destination-prefix":
+		case itemTrim == "aggregation destination-prefix":
 			flowServer["aggregation_destination_prefix"] = true
-		case itemTrimFlowServer == "aggregation protocol-port":
+		case itemTrim == "aggregation protocol-port":
 			flowServer["aggregation_protocol_port"] = true
-		case strings.HasPrefix(itemTrimFlowServer, "aggregation source-destination-prefix"):
+		case balt.CutPrefixInString(&itemTrim, "aggregation source-destination-prefix"):
 			flowServer["aggregation_source_destination_prefix"] = true
-			if itemTrimFlowServer == "aggregation source-destination-prefix caida-compliant" {
+			if itemTrim == " caida-compliant" {
 				flowServer["aggregation_source_destination_prefix_caida_compliant"] = true
 			}
-		case itemTrimFlowServer == "aggregation source-prefix":
+		case itemTrim == "aggregation source-prefix":
 			flowServer["aggregation_source_prefix"] = true
-		case strings.HasPrefix(itemTrimFlowServer, "autonomous-system-type "):
-			flowServer["autonomous_system_type"] = strings.TrimPrefix(itemTrimFlowServer, "autonomous-system-type ")
-		case strings.HasPrefix(itemTrimFlowServer, "dscp "):
-			var err error
-			flowServer["dscp"], err = strconv.Atoi(strings.TrimPrefix(itemTrimFlowServer, "dscp "))
+		case balt.CutPrefixInString(&itemTrim, "autonomous-system-type "):
+			flowServer["autonomous_system_type"] = itemTrim
+		case balt.CutPrefixInString(&itemTrim, "dscp "):
+			flowServer["dscp"], err = strconv.Atoi(itemTrim)
 			if err != nil {
-				return fmt.Errorf(failedConvAtoiError, itemTrimFlowServer, err)
+				return fmt.Errorf(failedConvAtoiError, itemTrim, err)
 			}
-		case strings.HasPrefix(itemTrimFlowServer, "forwarding-class "):
-			flowServer["forwarding_class"] = strings.TrimPrefix(itemTrimFlowServer, "forwarding-class ")
-		case itemTrimFlowServer == "local-dump":
+		case balt.CutPrefixInString(&itemTrim, "forwarding-class "):
+			flowServer["forwarding_class"] = itemTrim
+		case itemTrim == "local-dump":
 			flowServer["local_dump"] = true
-		case itemTrimFlowServer == "no-local-dump":
+		case itemTrim == "no-local-dump":
 			flowServer["no_local_dump"] = true
-		case strings.HasPrefix(itemTrimFlowServer, "routing-instance "):
-			flowServer["routing_instance"] = strings.TrimPrefix(itemTrimFlowServer, "routing-instance ")
-		case strings.HasPrefix(itemTrimFlowServer, "source-address "):
-			flowServer["source_address"] = strings.TrimPrefix(itemTrimFlowServer, "source-address ")
-		case strings.HasPrefix(itemTrimFlowServer, "version "):
-			var err error
-			flowServer["version"], err = strconv.Atoi(strings.TrimPrefix(itemTrimFlowServer, "version "))
+		case balt.CutPrefixInString(&itemTrim, "routing-instance "):
+			flowServer["routing_instance"] = itemTrim
+		case balt.CutPrefixInString(&itemTrim, "source-address "):
+			flowServer["source_address"] = itemTrim
+		case balt.CutPrefixInString(&itemTrim, "version "):
+			flowServer["version"], err = strconv.Atoi(itemTrim)
 			if err != nil {
-				return fmt.Errorf(failedConvAtoiError, itemTrimFlowServer, err)
+				return fmt.Errorf(failedConvAtoiError, itemTrim, err)
 			}
-		case strings.HasPrefix(itemTrimFlowServer, "version-ipfix template "):
-			flowServer["version_ipfix_template"] = strings.Trim(strings.TrimPrefix(
-				itemTrimFlowServer, "version-ipfix template "), "\"")
-		case strings.HasPrefix(itemTrimFlowServer, "version9 template "):
-			flowServer["version9_template"] = strings.Trim(strings.TrimPrefix(itemTrimFlowServer, "version9 template "), "\"")
+		case balt.CutPrefixInString(&itemTrim, "version-ipfix template "):
+			flowServer["version_ipfix_template"] = strings.Trim(itemTrim, "\"")
+		case balt.CutPrefixInString(&itemTrim, "version9 template "):
+			flowServer["version9_template"] = strings.Trim(itemTrim, "\"")
 		}
 		outputRead["flow_server"] = append(outputRead["flow_server"].([]map[string]interface{}), flowServer)
-	case strings.HasPrefix(itemTrim, "inline-jflow flow-export-rate "):
-		var err error
-		outputRead["inline_jflow_export_rate"], err = strconv.Atoi(strings.TrimPrefix(
-			itemTrim, "inline-jflow flow-export-rate "))
+	case balt.CutPrefixInString(&itemTrim, "inline-jflow flow-export-rate "):
+		outputRead["inline_jflow_export_rate"], err = strconv.Atoi(itemTrim)
 		if err != nil {
 			return fmt.Errorf(failedConvAtoiError, itemTrim, err)
 		}
-	case strings.HasPrefix(itemTrim, "inline-jflow source-address "):
-		outputRead["inline_jflow_source_address"] = strings.TrimPrefix(itemTrim, "inline-jflow source-address ")
-	case strings.HasPrefix(itemTrim, "interface "):
-		interfaceLineCut := strings.Split(itemTrim, " ")
+	case balt.CutPrefixInString(&itemTrim, "inline-jflow source-address "):
+		outputRead["inline_jflow_source_address"] = itemTrim
+	case balt.CutPrefixInString(&itemTrim, "interface "):
+		itemTrimFields := strings.Split(itemTrim, " ")
 		iFace := map[string]interface{}{
-			"name":           interfaceLineCut[1],
+			"name":           itemTrimFields[0],
 			"engine_id":      -1,
 			"engine_type":    -1,
 			"source_address": "",
 		}
 		outputRead["interface"] = copyAndRemoveItemMapList(
 			"name", iFace, outputRead["interface"].([]map[string]interface{}))
-		itemTrimInterface := strings.TrimPrefix(itemTrim, "interface "+interfaceLineCut[1]+" ")
+		balt.CutPrefixInString(&itemTrim, itemTrimFields[0]+" ")
 		switch {
-		case strings.HasPrefix(itemTrimInterface, "engine-id "):
-			var err error
-			iFace["engine_id"], err = strconv.Atoi(strings.TrimPrefix(itemTrimInterface, "engine-id "))
+		case balt.CutPrefixInString(&itemTrim, "engine-id "):
+			iFace["engine_id"], err = strconv.Atoi(itemTrim)
 			if err != nil {
-				return fmt.Errorf(failedConvAtoiError, itemTrimInterface, err)
+				return fmt.Errorf(failedConvAtoiError, itemTrim, err)
 			}
-		case strings.HasPrefix(itemTrimInterface, "engine-type "):
-			var err error
-			iFace["engine_type"], err = strconv.Atoi(strings.TrimPrefix(itemTrimInterface, "engine-type "))
+		case balt.CutPrefixInString(&itemTrim, "engine-type "):
+			iFace["engine_type"], err = strconv.Atoi(itemTrim)
 			if err != nil {
-				return fmt.Errorf(failedConvAtoiError, itemTrimInterface, err)
+				return fmt.Errorf(failedConvAtoiError, itemTrim, err)
 			}
-		case strings.HasPrefix(itemTrimInterface, "source-address "):
-			iFace["source_address"] = strings.TrimPrefix(itemTrimInterface, "source-address ")
+		case balt.CutPrefixInString(&itemTrim, "source-address "):
+			iFace["source_address"] = itemTrim
 		}
 		outputRead["interface"] = append(outputRead["interface"].([]map[string]interface{}), iFace)
 	}

--- a/junos/resource_interface_st0_unit.go
+++ b/junos/resource_interface_st0_unit.go
@@ -170,8 +170,8 @@ func searchInterfaceSt0UnitToCreate(clt *Client, junSess *junosSession) (string,
 	st0int := make([]string, 0)
 	for _, line := range st0Line {
 		if strings.HasPrefix(line, "st0.") {
-			lineSplit := strings.Split(line, " ")
-			st0int = append(st0int, lineSplit[0])
+			lineFields := strings.Split(line, " ")
+			st0int = append(st0int, lineFields[0])
 		}
 	}
 	for i := 0; i <= 1073741823; i++ {

--- a/junos/resource_lldp_interface.go
+++ b/junos/resource_lldp_interface.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	balt "github.com/jeremmfr/go-utils/basicalter"
 )
 
 type lldpInterfaceOptions struct {
@@ -325,9 +326,7 @@ func setLldpInterface(d *schema.ResourceData, clt *Client, junSess *junosSession
 }
 
 func readLldpInterface(name string, clt *Client, junSess *junosSession,
-) (lldpInterfaceOptions, error) {
-	var confRead lldpInterfaceOptions
-
+) (confRead lldpInterfaceOptions, err error) {
 	showConfig, err := clt.command(
 		cmdShowConfig+"protocols lldp interface "+name+pipeDisplaySetRelative, junSess)
 	if err != nil {
@@ -348,7 +347,7 @@ func readLldpInterface(name string, clt *Client, junSess *junosSession,
 				confRead.disable = true
 			case itemTrim == "enable":
 				confRead.enable = true
-			case strings.HasPrefix(itemTrim, "power-negotiation"):
+			case balt.CutPrefixInString(&itemTrim, "power-negotiation"):
 				if len(confRead.powerNegotiation) == 0 {
 					confRead.powerNegotiation = append(confRead.powerNegotiation, map[string]interface{}{
 						"disable": false,
@@ -356,9 +355,9 @@ func readLldpInterface(name string, clt *Client, junSess *junosSession,
 					})
 				}
 				switch {
-				case itemTrim == "power-negotiation disable":
+				case itemTrim == " disable":
 					confRead.powerNegotiation[0]["disable"] = true
-				case itemTrim == "power-negotiation enable":
+				case itemTrim == " enable":
 					confRead.powerNegotiation[0]["enable"] = true
 				}
 			case itemTrim == "trap-notification disable":

--- a/junos/resource_policyoptions_as_path.go
+++ b/junos/resource_policyoptions_as_path.go
@@ -263,9 +263,7 @@ func setPolicyoptionsAsPath(d *schema.ResourceData, clt *Client, junSess *junosS
 	return clt.configSet(configSet, junSess)
 }
 
-func readPolicyoptionsAsPath(name string, clt *Client, junSess *junosSession) (asPathOptions, error) {
-	var confRead asPathOptions
-
+func readPolicyoptionsAsPath(name string, clt *Client, junSess *junosSession) (confRead asPathOptions, err error) {
 	showConfig, err := clt.command(cmdShowConfig+"policy-options as-path "+name+pipeDisplaySetRelative, junSess)
 	if err != nil {
 		return confRead, err

--- a/junos/resource_policyoptions_community.go
+++ b/junos/resource_policyoptions_community.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	balt "github.com/jeremmfr/go-utils/basicalter"
 )
 
 type communityOptions struct {
@@ -264,9 +265,8 @@ func setPolicyoptionsCommunity(d *schema.ResourceData, clt *Client, junSess *jun
 	return clt.configSet(configSet, junSess)
 }
 
-func readPolicyoptionsCommunity(name string, clt *Client, junSess *junosSession) (communityOptions, error) {
-	var confRead communityOptions
-
+func readPolicyoptionsCommunity(name string, clt *Client, junSess *junosSession,
+) (confRead communityOptions, err error) {
 	showConfig, err := clt.command(cmdShowConfig+
 		"policy-options community "+name+pipeDisplaySetRelative, junSess)
 	if err != nil {
@@ -283,8 +283,8 @@ func readPolicyoptionsCommunity(name string, clt *Client, junSess *junosSession)
 			}
 			itemTrim := strings.TrimPrefix(item, setLS)
 			switch {
-			case strings.HasPrefix(itemTrim, "members "):
-				confRead.members = append(confRead.members, strings.TrimPrefix(itemTrim, "members "))
+			case balt.CutPrefixInString(&itemTrim, "members "):
+				confRead.members = append(confRead.members, itemTrim)
 			case itemTrim == "invert-match":
 				confRead.invertMatch = true
 			}

--- a/junos/resource_policyoptions_test.go
+++ b/junos/resource_policyoptions_test.go
@@ -468,7 +468,27 @@ func TestAccJunosPolicyOptions_basic(t *testing.T) {
 					),
 				},
 				{
+					ResourceName:      "junos_policyoptions_as_path.testacc_policyOptions",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+				{
+					ResourceName:      "junos_policyoptions_as_path_group.testacc_policyOptions",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+				{
+					ResourceName:      "junos_policyoptions_community.testacc_policyOptions",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+				{
 					ResourceName:      "junos_policyoptions_policy_statement.testacc_policyOptions",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+				{
+					ResourceName:      "junos_policyoptions_prefix_list.testacc_policyOptions",
 					ImportState:       true,
 					ImportStateVerify: true,
 				},

--- a/junos/resource_rib_group.go
+++ b/junos/resource_rib_group.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	balt "github.com/jeremmfr/go-utils/basicalter"
 )
 
 type ribGroupOptions struct {
@@ -304,9 +305,7 @@ func setRibGroup(d *schema.ResourceData, clt *Client, junSess *junosSession) err
 	return clt.configSet(configSet, junSess)
 }
 
-func readRibGroup(group string, clt *Client, junSess *junosSession) (ribGroupOptions, error) {
-	var confRead ribGroupOptions
-
+func readRibGroup(group string, clt *Client, junSess *junosSession) (confRead ribGroupOptions, err error) {
 	showConfig, err := clt.command(cmdShowConfig+
 		"routing-options rib-groups "+group+pipeDisplaySetRelative, junSess)
 	if err != nil {
@@ -323,12 +322,12 @@ func readRibGroup(group string, clt *Client, junSess *junosSession) (ribGroupOpt
 			}
 			itemTrim := strings.TrimPrefix(item, setLS)
 			switch {
-			case strings.HasPrefix(itemTrim, "import-policy "):
-				confRead.importPolicy = append(confRead.importPolicy, strings.TrimPrefix(itemTrim, "import-policy "))
-			case strings.HasPrefix(itemTrim, "import-rib "):
-				confRead.importRib = append(confRead.importRib, strings.TrimPrefix(itemTrim, "import-rib "))
-			case strings.HasPrefix(itemTrim, "export-rib "):
-				confRead.exportRib = strings.TrimPrefix(itemTrim, "export-rib ")
+			case balt.CutPrefixInString(&itemTrim, "import-policy "):
+				confRead.importPolicy = append(confRead.importPolicy, itemTrim)
+			case balt.CutPrefixInString(&itemTrim, "import-rib "):
+				confRead.importRib = append(confRead.importRib, itemTrim)
+			case balt.CutPrefixInString(&itemTrim, "export-rib "):
+				confRead.exportRib = itemTrim
 			}
 		}
 	}

--- a/junos/resource_rip_group.go
+++ b/junos/resource_rip_group.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	balt "github.com/jeremmfr/go-utils/basicalter"
 )
 
 type ripGroupOptions struct {
@@ -460,9 +461,8 @@ func resourceRipGroupImport(ctx context.Context, d *schema.ResourceData, m inter
 }
 
 func checkRipGroupExists(name string, ripNg bool, routingInstance string, clt *Client, junSess *junosSession,
-) (bool, error) {
+) (_ bool, err error) {
 	var showConfig string
-	var err error
 	protoRipGroup := "protocols rip group \"" + name + "\""
 	if ripNg {
 		protoRipGroup = "protocols ripng group \"" + name + "\""
@@ -573,11 +573,10 @@ func setRipGroup(d *schema.ResourceData, clt *Client, junSess *junosSession) err
 }
 
 func readRipGroup(name string, ripNg bool, routingInstance string, clt *Client, junSess *junosSession,
-) (ripGroupOptions, error) {
-	var confRead ripGroupOptions
-	var showConfig string
-	var err error
+) (confRead ripGroupOptions, err error) {
+	// default -1
 	confRead.preference = -1
+	var showConfig string
 	protoRipGroup := "protocols rip group \"" + name + "\""
 	if ripNg {
 		protoRipGroup = "protocols ripng group \"" + name + "\""
@@ -605,7 +604,7 @@ func readRipGroup(name string, ripNg bool, routingInstance string, clt *Client, 
 			}
 			itemTrim := strings.TrimPrefix(item, setLS)
 			switch {
-			case strings.HasPrefix(itemTrim, "bfd-liveness-detection "):
+			case balt.CutPrefixInString(&itemTrim, "bfd-liveness-detection "):
 				if len(confRead.bfdLivenessDetection) == 0 {
 					confRead.bfdLivenessDetection = append(confRead.bfdLivenessDetection, map[string]interface{}{
 						"authentication_algorithm":           "",
@@ -621,40 +620,37 @@ func readRipGroup(name string, ripNg bool, routingInstance string, clt *Client, 
 						"version":                            "",
 					})
 				}
-				if err := readRipGroupBfd(
-					strings.TrimPrefix(itemTrim, "bfd-liveness-detection "),
-					confRead.bfdLivenessDetection[0],
-				); err != nil {
+				if err := readRipGroupBfd(itemTrim, confRead.bfdLivenessDetection[0]); err != nil {
 					return confRead, err
 				}
 			case itemTrim == "demand-circuit":
 				confRead.demandCircuit = true
-			case strings.HasPrefix(itemTrim, "export "):
-				confRead.exportPolicy = append(confRead.exportPolicy, strings.TrimPrefix(itemTrim, "export "))
-			case strings.HasPrefix(itemTrim, "import "):
-				confRead.importPolicy = append(confRead.importPolicy, strings.TrimPrefix(itemTrim, "import "))
-			case strings.HasPrefix(itemTrim, "max-retrans-time "):
-				confRead.maxRetransTime, err = strconv.Atoi(strings.TrimPrefix(itemTrim, "max-retrans-time "))
+			case balt.CutPrefixInString(&itemTrim, "export "):
+				confRead.exportPolicy = append(confRead.exportPolicy, itemTrim)
+			case balt.CutPrefixInString(&itemTrim, "import "):
+				confRead.importPolicy = append(confRead.importPolicy, itemTrim)
+			case balt.CutPrefixInString(&itemTrim, "max-retrans-time "):
+				confRead.maxRetransTime, err = strconv.Atoi(itemTrim)
 				if err != nil {
 					return confRead, fmt.Errorf(failedConvAtoiError, itemTrim, err)
 				}
-			case strings.HasPrefix(itemTrim, "metric-out "):
-				confRead.metricOut, err = strconv.Atoi(strings.TrimPrefix(itemTrim, "metric-out "))
+			case balt.CutPrefixInString(&itemTrim, "metric-out "):
+				confRead.metricOut, err = strconv.Atoi(itemTrim)
 				if err != nil {
 					return confRead, fmt.Errorf(failedConvAtoiError, itemTrim, err)
 				}
-			case strings.HasPrefix(itemTrim, "preference "):
-				confRead.preference, err = strconv.Atoi(strings.TrimPrefix(itemTrim, "preference "))
+			case balt.CutPrefixInString(&itemTrim, "preference "):
+				confRead.preference, err = strconv.Atoi(itemTrim)
 				if err != nil {
 					return confRead, fmt.Errorf(failedConvAtoiError, itemTrim, err)
 				}
-			case strings.HasPrefix(itemTrim, "route-timeout "):
-				confRead.routeTimeout, err = strconv.Atoi(strings.TrimPrefix(itemTrim, "route-timeout "))
+			case balt.CutPrefixInString(&itemTrim, "route-timeout "):
+				confRead.routeTimeout, err = strconv.Atoi(itemTrim)
 				if err != nil {
 					return confRead, fmt.Errorf(failedConvAtoiError, itemTrim, err)
 				}
-			case strings.HasPrefix(itemTrim, "update-interval "):
-				confRead.updateInterval, err = strconv.Atoi(strings.TrimPrefix(itemTrim, "update-interval "))
+			case balt.CutPrefixInString(&itemTrim, "update-interval "):
+				confRead.updateInterval, err = strconv.Atoi(itemTrim)
 				if err != nil {
 					return confRead, fmt.Errorf(failedConvAtoiError, itemTrim, err)
 				}
@@ -665,56 +661,48 @@ func readRipGroup(name string, ripNg bool, routingInstance string, clt *Client, 
 	return confRead, nil
 }
 
-func readRipGroupBfd(itemTrim string, bfd map[string]interface{}) error {
+func readRipGroupBfd(itemTrim string, bfd map[string]interface{}) (err error) {
 	switch {
-	case strings.HasPrefix(itemTrim, "authentication algorithm "):
-		bfd["authentication_algorithm"] = strings.TrimPrefix(itemTrim, "authentication algorithm ")
-	case strings.HasPrefix(itemTrim, "authentication key-chain "):
-		bfd["authentication_key_chain"] = strings.Trim(strings.TrimPrefix(itemTrim, "authentication key-chain "), "\"")
+	case balt.CutPrefixInString(&itemTrim, "authentication algorithm "):
+		bfd["authentication_algorithm"] = itemTrim
+	case balt.CutPrefixInString(&itemTrim, "authentication key-chain "):
+		bfd["authentication_key_chain"] = strings.Trim(itemTrim, "\"")
 	case itemTrim == "authentication loose-check":
 		bfd["authentication_loose_check"] = true
-	case strings.HasPrefix(itemTrim, "detection-time threshold "):
-		var err error
-		bfd["detection_time_threshold"], err = strconv.Atoi(strings.TrimPrefix(itemTrim, "detection-time threshold "))
+	case balt.CutPrefixInString(&itemTrim, "detection-time threshold "):
+		bfd["detection_time_threshold"], err = strconv.Atoi(itemTrim)
 		if err != nil {
 			return fmt.Errorf(failedConvAtoiError, itemTrim, err)
 		}
-	case strings.HasPrefix(itemTrim, "minimum-interval "):
-		var err error
-		bfd["minimum_interval"], err = strconv.Atoi(strings.TrimPrefix(itemTrim, "minimum-interval "))
+	case balt.CutPrefixInString(&itemTrim, "minimum-interval "):
+		bfd["minimum_interval"], err = strconv.Atoi(itemTrim)
 		if err != nil {
 			return fmt.Errorf(failedConvAtoiError, itemTrim, err)
 		}
-	case strings.HasPrefix(itemTrim, "minimum-receive-interval "):
-		var err error
-		bfd["minimum_receive_interval"], err = strconv.Atoi(strings.TrimPrefix(itemTrim, "minimum-receive-interval "))
+	case balt.CutPrefixInString(&itemTrim, "minimum-receive-interval "):
+		bfd["minimum_receive_interval"], err = strconv.Atoi(itemTrim)
 		if err != nil {
 			return fmt.Errorf(failedConvAtoiError, itemTrim, err)
 		}
-	case strings.HasPrefix(itemTrim, "multiplier "):
-		var err error
-		bfd["multiplier"], err = strconv.Atoi(strings.TrimPrefix(itemTrim, "multiplier "))
+	case balt.CutPrefixInString(&itemTrim, "multiplier "):
+		bfd["multiplier"], err = strconv.Atoi(itemTrim)
 		if err != nil {
 			return fmt.Errorf(failedConvAtoiError, itemTrim, err)
 		}
 	case itemTrim == "no-adaptation":
 		bfd["no_adaptation"] = true
-	case strings.HasPrefix(itemTrim, "transmit-interval minimum-interval "):
-		var err error
-		bfd["transmit_interval_minimum_interval"], err = strconv.Atoi(strings.TrimPrefix(
-			itemTrim, "transmit-interval minimum-interval "))
+	case balt.CutPrefixInString(&itemTrim, "transmit-interval minimum-interval "):
+		bfd["transmit_interval_minimum_interval"], err = strconv.Atoi(itemTrim)
 		if err != nil {
 			return fmt.Errorf(failedConvAtoiError, itemTrim, err)
 		}
-	case strings.HasPrefix(itemTrim, "transmit-interval threshold "):
-		var err error
-		bfd["transmit_interval_threshold"], err = strconv.Atoi(strings.TrimPrefix(
-			itemTrim, "transmit-interval threshold "))
+	case balt.CutPrefixInString(&itemTrim, "transmit-interval threshold "):
+		bfd["transmit_interval_threshold"], err = strconv.Atoi(itemTrim)
 		if err != nil {
 			return fmt.Errorf(failedConvAtoiError, itemTrim, err)
 		}
-	case strings.HasPrefix(itemTrim, "version "):
-		bfd["version"] = strings.TrimPrefix(itemTrim, "version ")
+	case balt.CutPrefixInString(&itemTrim, "version "):
+		bfd["version"] = itemTrim
 	}
 
 	return nil

--- a/junos/resource_routing_instance.go
+++ b/junos/resource_routing_instance.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	balt "github.com/jeremmfr/go-utils/basicalter"
 )
 
 type instanceOptions struct {
@@ -419,9 +420,7 @@ func setRoutingInstance(d *schema.ResourceData, clt *Client, junSess *junosSessi
 	return clt.configSet(configSet, junSess)
 }
 
-func readRoutingInstance(instance string, clt *Client, junSess *junosSession) (instanceOptions, error) {
-	var confRead instanceOptions
-
+func readRoutingInstance(instance string, clt *Client, junSess *junosSession) (confRead instanceOptions, err error) {
 	showConfig, err := clt.command(cmdShowConfig+routingInstancesWS+instance+pipeDisplaySetRelative, junSess)
 	if err != nil {
 		return confRead, err
@@ -437,39 +436,36 @@ func readRoutingInstance(instance string, clt *Client, junSess *junosSession) (i
 			}
 			itemTrim := strings.TrimPrefix(item, setLS)
 			switch {
-			case strings.HasPrefix(itemTrim, "description "):
-				confRead.description = strings.Trim(strings.TrimPrefix(itemTrim, "description "), "\"")
-			case strings.HasPrefix(itemTrim, "instance-type "):
-				confRead.instanceType = strings.TrimPrefix(itemTrim, "instance-type ")
-			case strings.HasPrefix(itemTrim, "route-distinguisher "):
-				confRead.routeDistinguisher = strings.TrimPrefix(itemTrim, "route-distinguisher ")
-			case strings.HasPrefix(itemTrim, "routing-options autonomous-system "):
-				confRead.as = strings.TrimPrefix(itemTrim, "routing-options autonomous-system ")
-			case strings.HasPrefix(itemTrim, "routing-options instance-export "):
-				confRead.instanceExport = append(confRead.instanceExport,
-					strings.TrimPrefix(itemTrim, "routing-options instance-export "))
-			case strings.HasPrefix(itemTrim, "routing-options instance-import "):
-				confRead.instanceImport = append(confRead.instanceImport,
-					strings.TrimPrefix(itemTrim, "routing-options instance-import "))
-			case strings.HasPrefix(itemTrim, "routing-options router-id "):
-				confRead.routerID = strings.TrimPrefix(itemTrim, "routing-options router-id ")
-			case strings.HasPrefix(itemTrim, "vrf-export "):
-				confRead.vrfExport = append(confRead.vrfExport, strings.Trim(strings.TrimPrefix(itemTrim, "vrf-export "), "\""))
-			case strings.HasPrefix(itemTrim, "vrf-import "):
-				confRead.vrfImport = append(confRead.vrfImport, strings.Trim(strings.TrimPrefix(itemTrim, "vrf-import "), "\""))
+			case balt.CutPrefixInString(&itemTrim, "description "):
+				confRead.description = strings.Trim(itemTrim, "\"")
+			case balt.CutPrefixInString(&itemTrim, "instance-type "):
+				confRead.instanceType = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "route-distinguisher "):
+				confRead.routeDistinguisher = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "routing-options autonomous-system "):
+				confRead.as = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "routing-options instance-export "):
+				confRead.instanceExport = append(confRead.instanceExport, itemTrim)
+			case balt.CutPrefixInString(&itemTrim, "routing-options instance-import "):
+				confRead.instanceImport = append(confRead.instanceImport, itemTrim)
+			case balt.CutPrefixInString(&itemTrim, "routing-options router-id "):
+				confRead.routerID = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "vrf-export "):
+				confRead.vrfExport = append(confRead.vrfExport, strings.Trim(itemTrim, "\""))
+			case balt.CutPrefixInString(&itemTrim, "vrf-import "):
+				confRead.vrfImport = append(confRead.vrfImport, strings.Trim(itemTrim, "\""))
 			case itemTrim == "vrf-target auto":
 				confRead.vrfTargetAuto = true
-			case strings.HasPrefix(itemTrim, "vrf-target export "):
-				confRead.vrfTargetExport = strings.TrimPrefix(itemTrim, "vrf-target export ")
-			case strings.HasPrefix(itemTrim, "vrf-target import "):
-				confRead.vrfTargetImport = strings.TrimPrefix(itemTrim, "vrf-target import ")
-			case strings.HasPrefix(itemTrim, "vrf-target "):
-				confRead.vrfTarget = strings.TrimPrefix(itemTrim, "vrf-target ")
-			case strings.HasPrefix(itemTrim, "vtep-source-interface "):
-				confRead.vtepSourceIf = strings.TrimPrefix(itemTrim, "vtep-source-interface ")
-			case strings.HasPrefix(itemTrim, "interface "):
-				confRead.interFace = append(confRead.interFace,
-					strings.Split(strings.TrimPrefix(itemTrim, "interface "), " ")[0])
+			case balt.CutPrefixInString(&itemTrim, "vrf-target export "):
+				confRead.vrfTargetExport = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "vrf-target import "):
+				confRead.vrfTargetImport = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "vrf-target "):
+				confRead.vrfTarget = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "vtep-source-interface "):
+				confRead.vtepSourceIf = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "interface "):
+				confRead.interFace = append(confRead.interFace, strings.Split(itemTrim, " ")[0])
 			}
 		}
 	}

--- a/junos/resource_security_address_book_test.go
+++ b/junos/resource_security_address_book_test.go
@@ -120,8 +120,9 @@ resource "junos_security_address_book" "testacc_securityGlobalAddressBook" {
     value       = "10.0.0.0/24"
   }
   wildcard_address {
-    name  = "testacc_wildcard"
-    value = "10.0.0.0/255.255.0.255"
+    name        = "testacc_wildcard"
+    description = "testacc_wildcard description"
+    value       = "10.0.0.0/255.255.0.255"
   }
   network_address {
     name        = "testacc_network2"
@@ -129,9 +130,10 @@ resource "junos_security_address_book" "testacc_securityGlobalAddressBook" {
     value       = "10.1.0.0/24"
   }
   range_address {
-    name = "testacc_range"
-    from = "10.1.1.1"
-    to   = "10.1.1.5"
+    name        = "testacc_range"
+    description = "testacc_range description"
+    from        = "10.1.1.1"
+    to          = "10.1.1.5"
   }
   dns_name {
     name  = "testacc_dns"
@@ -164,12 +166,20 @@ resource "junos_security_address_book" "testacc_securityGlobalAddressBook" {
     value       = "10.1.0.0/24"
   }
   dns_name {
-    name  = "testacc_dns"
-    value = "google.com"
+    name        = "testacc_dns"
+    description = "testacc_dns description"
+    value       = "google.com"
+    ipv4_only   = true
+  }
+  dns_name {
+    name      = "testacc_dns6"
+    value     = "google.com"
+    ipv6_only = true
   }
   address_set {
-    name    = "testacc_addressSet"
-    address = ["testacc_network", "testacc_dns"]
+    name        = "testacc_addressSet"
+    description = "testacc_addressSet description"
+    address     = ["testacc_network", "testacc_dns"]
   }
   address_set {
     name        = "testacc_addressSet2"

--- a/junos/resource_security_global_policy.go
+++ b/junos/resource_security_global_policy.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	balt "github.com/jeremmfr/go-utils/basicalter"
 	bchk "github.com/jeremmfr/go-utils/basiccheck"
 )
 
@@ -435,14 +436,11 @@ func setSecurityGlobalPolicy(d *schema.ResourceData, clt *Client, junSess *junos
 	return clt.configSet(configSet, junSess)
 }
 
-func readSecurityGlobalPolicy(clt *Client, junSess *junosSession) (globalPolicyOptions, error) {
-	var confRead globalPolicyOptions
-
+func readSecurityGlobalPolicy(clt *Client, junSess *junosSession) (confRead globalPolicyOptions, err error) {
 	showConfig, err := clt.command(cmdShowConfig+"security policies global"+pipeDisplaySetRelative, junSess)
 	if err != nil {
 		return confRead, err
 	}
-	policyList := make([]map[string]interface{}, 0)
 	if showConfig != emptyW {
 		for _, item := range strings.Split(showConfig, "\n") {
 			if strings.Contains(item, xmlStartTagConfigOut) {
@@ -452,50 +450,43 @@ func readSecurityGlobalPolicy(clt *Client, junSess *junosSession) (globalPolicyO
 				break
 			}
 			itemTrim := strings.TrimPrefix(item, setLS)
-			if strings.HasPrefix(itemTrim, "policy ") {
-				policyLineCut := strings.Split(itemTrim, " ")
-				policy := genMapGlobalPolicyWithName(policyLineCut[1])
-				policyList = copyAndRemoveItemMapList("name", policy, policyList)
-				itemTrimPolicy := strings.TrimPrefix(itemTrim, "policy "+policyLineCut[1]+" ")
+			if balt.CutPrefixInString(&itemTrim, "policy ") {
+				itemTrimFields := strings.Split(itemTrim, " ")
+				policy := genMapGlobalPolicyWithName(itemTrimFields[0])
+				confRead.policy = copyAndRemoveItemMapList("name", policy, confRead.policy)
+				balt.CutPrefixInString(&itemTrim, itemTrimFields[0]+" ")
 				switch {
-				case strings.HasPrefix(itemTrimPolicy, "match source-address "):
-					policy["match_source_address"] = append(policy["match_source_address"].([]string),
-						strings.TrimPrefix(itemTrimPolicy, "match source-address "))
-				case strings.HasPrefix(itemTrimPolicy, "match destination-address "):
-					policy["match_destination_address"] = append(policy["match_destination_address"].([]string),
-						strings.TrimPrefix(itemTrimPolicy, "match destination-address "))
-				case strings.HasPrefix(itemTrimPolicy, "match application "):
-					policy["match_application"] = append(policy["match_application"].([]string),
-						strings.TrimPrefix(itemTrimPolicy, "match application "))
-				case strings.HasPrefix(itemTrimPolicy, "match from-zone "):
-					policy["match_from_zone"] = append(policy["match_from_zone"].([]string),
-						strings.TrimPrefix(itemTrimPolicy, "match from-zone "))
-				case strings.HasPrefix(itemTrimPolicy, "match to-zone "):
-					policy["match_to_zone"] = append(policy["match_to_zone"].([]string),
-						strings.TrimPrefix(itemTrimPolicy, "match to-zone "))
-				case strings.HasPrefix(itemTrimPolicy, "match destination-address-excluded"):
+				case balt.CutPrefixInString(&itemTrim, "match source-address "):
+					policy["match_source_address"] = append(policy["match_source_address"].([]string), itemTrim)
+				case balt.CutPrefixInString(&itemTrim, "match destination-address "):
+					policy["match_destination_address"] = append(policy["match_destination_address"].([]string), itemTrim)
+				case balt.CutPrefixInString(&itemTrim, "match application "):
+					policy["match_application"] = append(policy["match_application"].([]string), itemTrim)
+				case balt.CutPrefixInString(&itemTrim, "match from-zone "):
+					policy["match_from_zone"] = append(policy["match_from_zone"].([]string), itemTrim)
+				case balt.CutPrefixInString(&itemTrim, "match to-zone "):
+					policy["match_to_zone"] = append(policy["match_to_zone"].([]string), itemTrim)
+				case itemTrim == "match destination-address-excluded":
 					policy["match_destination_address_excluded"] = true
-				case strings.HasPrefix(itemTrimPolicy, "match dynamic-application "):
-					policy["match_dynamic_application"] = append(policy["match_dynamic_application"].([]string),
-						strings.TrimPrefix(itemTrimPolicy, "match dynamic-application "))
-				case strings.HasPrefix(itemTrimPolicy, "match source-address-excluded"):
+				case balt.CutPrefixInString(&itemTrim, "match dynamic-application "):
+					policy["match_dynamic_application"] = append(policy["match_dynamic_application"].([]string), itemTrim)
+				case itemTrim == "match source-address-excluded":
 					policy["match_source_address_excluded"] = true
-				case strings.HasPrefix(itemTrimPolicy, "match source-end-user-profile "):
-					policy["match_source_end_user_profile"] = strings.Trim(strings.TrimPrefix(
-						itemTrimPolicy, "match source-end-user-profile "), "\"")
-				case strings.HasPrefix(itemTrimPolicy, "then "):
+				case balt.CutPrefixInString(&itemTrim, "match source-end-user-profile "):
+					policy["match_source_end_user_profile"] = strings.Trim(itemTrim, "\"")
+				case balt.CutPrefixInString(&itemTrim, "then "):
 					switch {
-					case itemTrimPolicy == "then permit",
-						itemTrimPolicy == "then deny",
-						itemTrimPolicy == "then reject":
-						policy["then"] = strings.TrimPrefix(itemTrimPolicy, "then ")
-					case itemTrimPolicy == "then count":
+					case itemTrim == "permit",
+						itemTrim == "deny",
+						itemTrim == "reject":
+						policy["then"] = itemTrim
+					case itemTrim == "count":
 						policy["count"] = true
-					case itemTrimPolicy == "then log session-init":
+					case itemTrim == "log session-init":
 						policy["log_init"] = true
-					case itemTrimPolicy == "then log session-close":
+					case itemTrim == "log session-close":
 						policy["log_close"] = true
-					case strings.HasPrefix(itemTrimPolicy, "then permit application-services"):
+					case balt.CutPrefixInString(&itemTrim, "permit application-services "):
 						policy["then"] = permitW
 						if len(policy["permit_application_services"].([]map[string]interface{})) == 0 {
 							policy["permit_application_services"] = append(
@@ -516,15 +507,14 @@ func readSecurityGlobalPolicy(clt *Client, junSess *junosSession) (globalPolicyO
 									"utm_policy":                           "",
 								})
 						}
-						readGlobalPolicyPermitApplicationServices(itemTrimPolicy,
+						readGlobalPolicyPermitApplicationServices(itemTrim,
 							policy["permit_application_services"].([]map[string]interface{})[0])
 					}
 				}
-				policyList = append(policyList, policy)
+				confRead.policy = append(confRead.policy, policy)
 			}
 		}
 	}
-	confRead.policy = policyList
 
 	return confRead, nil
 }
@@ -562,40 +552,33 @@ func genMapGlobalPolicyWithName(name string) map[string]interface{} {
 	}
 }
 
-func readGlobalPolicyPermitApplicationServices(itemTrimPolicy string, applicationServices map[string]interface{}) {
-	itemTrimPolicyPermitAppSvc := strings.TrimPrefix(itemTrimPolicy, "then permit application-services ")
+func readGlobalPolicyPermitApplicationServices(itemTrim string, applicationServices map[string]interface{}) {
 	switch {
-	case strings.HasPrefix(itemTrimPolicyPermitAppSvc, "advanced-anti-malware-policy "):
-		applicationServices["advanced_anti_malware_policy"] = strings.Trim(strings.TrimPrefix(itemTrimPolicyPermitAppSvc,
-			"advanced-anti-malware-policy "), "\"")
-	case strings.HasPrefix(itemTrimPolicyPermitAppSvc, "application-firewall rule-set "):
-		applicationServices["application_firewall_rule_set"] = strings.Trim(strings.TrimPrefix(itemTrimPolicyPermitAppSvc,
-			"application-firewall rule-set "), "\"")
-	case strings.HasPrefix(itemTrimPolicyPermitAppSvc, "application-traffic-control rule-set "):
-		applicationServices["application_traffic_control_rule_set"] = strings.Trim(
-			strings.TrimPrefix(itemTrimPolicyPermitAppSvc, "application-traffic-control rule-set "), "\"")
-	case strings.HasPrefix(itemTrimPolicyPermitAppSvc, "gprs-gtp-profile "):
-		applicationServices["gprs_gtp_profile"] = strings.Trim(strings.TrimPrefix(itemTrimPolicyPermitAppSvc,
-			"gprs-gtp-profile "), "\"")
-	case strings.HasPrefix(itemTrimPolicyPermitAppSvc, "gprs-sctp-profile "):
-		applicationServices["gprs_sctp_profile"] = strings.Trim(strings.TrimPrefix(itemTrimPolicyPermitAppSvc,
-			"gprs-sctp-profile "), "\"")
-	case itemTrimPolicyPermitAppSvc == "idp":
+	case balt.CutPrefixInString(&itemTrim, "advanced-anti-malware-policy "):
+		applicationServices["advanced_anti_malware_policy"] = strings.Trim(itemTrim, "\"")
+	case balt.CutPrefixInString(&itemTrim, "application-firewall rule-set "):
+		applicationServices["application_firewall_rule_set"] = strings.Trim(itemTrim, "\"")
+	case balt.CutPrefixInString(&itemTrim, "application-traffic-control rule-set "):
+		applicationServices["application_traffic_control_rule_set"] = strings.Trim(itemTrim, "\"")
+	case balt.CutPrefixInString(&itemTrim, "gprs-gtp-profile "):
+		applicationServices["gprs_gtp_profile"] = strings.Trim(itemTrim, "\"")
+	case balt.CutPrefixInString(&itemTrim, "gprs-sctp-profile "):
+		applicationServices["gprs_sctp_profile"] = strings.Trim(itemTrim, "\"")
+	case itemTrim == "idp":
 		applicationServices["idp"] = true
-	case strings.HasPrefix(itemTrimPolicyPermitAppSvc, "idp-policy "):
-		applicationServices["idp_policy"] = strings.Trim(strings.TrimPrefix(itemTrimPolicyPermitAppSvc, "idp-policy "), "\"")
-	case itemTrimPolicyPermitAppSvc == "redirect-wx":
+	case balt.CutPrefixInString(&itemTrim, "idp-policy "):
+		applicationServices["idp_policy"] = strings.Trim(itemTrim, "\"")
+	case itemTrim == "redirect-wx":
 		applicationServices["redirect_wx"] = true
-	case itemTrimPolicyPermitAppSvc == "reverse-redirect-wx":
+	case itemTrim == "reverse-redirect-wx":
 		applicationServices["reverse_redirect_wx"] = true
-	case strings.HasPrefix(itemTrimPolicyPermitAppSvc, "security-intelligence-policy "):
-		applicationServices["security_intelligence_policy"] = strings.Trim(strings.TrimPrefix(itemTrimPolicyPermitAppSvc,
-			"security-intelligence-policy "), "\"")
-	case strings.HasPrefix(itemTrimPolicyPermitAppSvc, "ssl-proxy"):
-		if strings.HasPrefix(itemTrimPolicyPermitAppSvc, "ssl-proxy profile-name ") {
+	case balt.CutPrefixInString(&itemTrim, "security-intelligence-policy "):
+		applicationServices["security_intelligence_policy"] = strings.Trim(itemTrim, "\"")
+	case balt.CutPrefixInString(&itemTrim, "ssl-proxy"):
+		if balt.CutPrefixInString(&itemTrim, " profile-name ") {
 			applicationServices["ssl_proxy"] = append(applicationServices["ssl_proxy"].([]map[string]interface{}),
 				map[string]interface{}{
-					"profile_name": strings.Trim(strings.TrimPrefix(itemTrimPolicyPermitAppSvc, "ssl-proxy profile-name "), "\""),
+					"profile_name": strings.Trim(itemTrim, "\""),
 				})
 		} else {
 			applicationServices["ssl_proxy"] = append(applicationServices["ssl_proxy"].([]map[string]interface{}),
@@ -603,11 +586,11 @@ func readGlobalPolicyPermitApplicationServices(itemTrimPolicy string, applicatio
 					"profile_name": "",
 				})
 		}
-	case strings.HasPrefix(itemTrimPolicyPermitAppSvc, "uac-policy"):
-		if strings.HasPrefix(itemTrimPolicyPermitAppSvc, "uac-policy captive-portal ") {
+	case balt.CutPrefixInString(&itemTrim, "uac-policy"):
+		if balt.CutPrefixInString(&itemTrim, " captive-portal ") {
 			applicationServices["uac_policy"] = append(applicationServices["uac_policy"].([]map[string]interface{}),
 				map[string]interface{}{
-					"captive_portal": strings.Trim(strings.TrimPrefix(itemTrimPolicyPermitAppSvc, "uac-policy captive-portal "), "\""),
+					"captive_portal": strings.Trim(itemTrim, "\""),
 				})
 		} else {
 			applicationServices["uac_policy"] = append(applicationServices["uac_policy"].([]map[string]interface{}),
@@ -615,8 +598,8 @@ func readGlobalPolicyPermitApplicationServices(itemTrimPolicy string, applicatio
 					"captive_portal": "",
 				})
 		}
-	case strings.HasPrefix(itemTrimPolicyPermitAppSvc, "utm-policy "):
-		applicationServices["utm_policy"] = strings.Trim(strings.TrimPrefix(itemTrimPolicyPermitAppSvc, "utm-policy "), "\"")
+	case balt.CutPrefixInString(&itemTrim, "utm-policy "):
+		applicationServices["utm_policy"] = strings.Trim(itemTrim, "\"")
 	}
 }
 

--- a/junos/resource_security_idp_custom_attack_group.go
+++ b/junos/resource_security_idp_custom_attack_group.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	balt "github.com/jeremmfr/go-utils/basicalter"
 )
 
 type idpCustomAttackGroupOptions struct {
@@ -266,9 +267,7 @@ func setSecurityIdpCustomAttackGroup(d *schema.ResourceData, clt *Client, junSes
 }
 
 func readSecurityIdpCustomAttackGroup(customAttackGroup string, clt *Client, junSess *junosSession,
-) (idpCustomAttackGroupOptions, error) {
-	var confRead idpCustomAttackGroupOptions
-
+) (confRead idpCustomAttackGroupOptions, err error) {
 	showConfig, err := clt.command(cmdShowConfig+
 		"security idp custom-attack-group \""+customAttackGroup+"\""+pipeDisplaySetRelative, junSess)
 	if err != nil {
@@ -284,8 +283,8 @@ func readSecurityIdpCustomAttackGroup(customAttackGroup string, clt *Client, jun
 				break
 			}
 			itemTrim := strings.TrimPrefix(item, setLS)
-			if strings.HasPrefix(itemTrim, "group-members ") {
-				confRead.member = append(confRead.member, strings.Trim(strings.TrimPrefix(itemTrim, "group-members "), "\""))
+			if balt.CutPrefixInString(&itemTrim, "group-members ") {
+				confRead.member = append(confRead.member, strings.Trim(itemTrim, "\""))
 			}
 		}
 	}

--- a/junos/resource_security_ike_proposal.go
+++ b/junos/resource_security_ike_proposal.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	balt "github.com/jeremmfr/go-utils/basicalter"
 )
 
 type ikeProposalOptions struct {
@@ -291,9 +292,7 @@ func setIkeProposal(d *schema.ResourceData, clt *Client, junSess *junosSession) 
 	return clt.configSet(configSet, junSess)
 }
 
-func readIkeProposal(ikeProposal string, clt *Client, junSess *junosSession) (ikeProposalOptions, error) {
-	var confRead ikeProposalOptions
-
+func readIkeProposal(ikeProposal string, clt *Client, junSess *junosSession) (confRead ikeProposalOptions, err error) {
 	showConfig, err := clt.command(cmdShowConfig+
 		"security ike proposal "+ikeProposal+pipeDisplaySetRelative, junSess)
 	if err != nil {
@@ -310,16 +309,16 @@ func readIkeProposal(ikeProposal string, clt *Client, junSess *junosSession) (ik
 			}
 			itemTrim := strings.TrimPrefix(item, setLS)
 			switch {
-			case strings.HasPrefix(itemTrim, "authentication-algorithm "):
-				confRead.authenticationAlgorithm = strings.TrimPrefix(itemTrim, "authentication-algorithm ")
-			case strings.HasPrefix(itemTrim, "authentication-method "):
-				confRead.authenticationMethod = strings.TrimPrefix(itemTrim, "authentication-method ")
-			case strings.HasPrefix(itemTrim, "dh-group "):
-				confRead.dhGroup = strings.TrimPrefix(itemTrim, "dh-group ")
-			case strings.HasPrefix(itemTrim, "encryption-algorithm"):
-				confRead.encryptionAlgorithm = strings.TrimPrefix(itemTrim, "encryption-algorithm ")
-			case strings.HasPrefix(itemTrim, "lifetime-seconds"):
-				confRead.lifetimeSeconds, err = strconv.Atoi(strings.TrimPrefix(itemTrim, "lifetime-seconds "))
+			case balt.CutPrefixInString(&itemTrim, "authentication-algorithm "):
+				confRead.authenticationAlgorithm = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "authentication-method "):
+				confRead.authenticationMethod = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "dh-group "):
+				confRead.dhGroup = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "encryption-algorithm "):
+				confRead.encryptionAlgorithm = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "lifetime-seconds "):
+				confRead.lifetimeSeconds, err = strconv.Atoi(itemTrim)
 				if err != nil {
 					return confRead, fmt.Errorf(failedConvAtoiError, itemTrim, err)
 				}

--- a/junos/resource_security_ipsec_policy.go
+++ b/junos/resource_security_ipsec_policy.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	balt "github.com/jeremmfr/go-utils/basicalter"
 )
 
 type ipsecPolicyOptions struct {
@@ -277,9 +278,7 @@ func setIpsecPolicy(d *schema.ResourceData, clt *Client, junSess *junosSession) 
 	return clt.configSet(configSet, junSess)
 }
 
-func readIpsecPolicy(ipsecPolicy string, clt *Client, junSess *junosSession) (ipsecPolicyOptions, error) {
-	var confRead ipsecPolicyOptions
-
+func readIpsecPolicy(ipsecPolicy string, clt *Client, junSess *junosSession) (confRead ipsecPolicyOptions, err error) {
 	showConfig, err := clt.command(cmdShowConfig+
 		"security ipsec policy "+ipsecPolicy+pipeDisplaySetRelative, junSess)
 	if err != nil {
@@ -296,12 +295,12 @@ func readIpsecPolicy(ipsecPolicy string, clt *Client, junSess *junosSession) (ip
 			}
 			itemTrim := strings.TrimPrefix(item, setLS)
 			switch {
-			case strings.HasPrefix(itemTrim, "perfect-forward-secrecy keys "):
-				confRead.pfsKeys = strings.TrimPrefix(itemTrim, "perfect-forward-secrecy keys ")
-			case strings.HasPrefix(itemTrim, "proposals "):
-				confRead.proposals = append(confRead.proposals, strings.TrimPrefix(itemTrim, "proposals "))
-			case strings.HasPrefix(itemTrim, "proposal-set "):
-				confRead.proposalSet = strings.TrimPrefix(itemTrim, "proposal-set ")
+			case balt.CutPrefixInString(&itemTrim, "perfect-forward-secrecy keys "):
+				confRead.pfsKeys = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "proposals "):
+				confRead.proposals = append(confRead.proposals, itemTrim)
+			case balt.CutPrefixInString(&itemTrim, "proposal-set "):
+				confRead.proposalSet = itemTrim
 			}
 		}
 	}

--- a/junos/resource_security_ipsec_proposal.go
+++ b/junos/resource_security_ipsec_proposal.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	balt "github.com/jeremmfr/go-utils/basicalter"
 )
 
 type ipsecProposalOptions struct {
@@ -293,9 +294,8 @@ func setIpsecProposal(d *schema.ResourceData, clt *Client, junSess *junosSession
 	return clt.configSet(configSet, junSess)
 }
 
-func readIpsecProposal(ipsecProposal string, clt *Client, junSess *junosSession) (ipsecProposalOptions, error) {
-	var confRead ipsecProposalOptions
-
+func readIpsecProposal(ipsecProposal string, clt *Client, junSess *junosSession,
+) (confRead ipsecProposalOptions, err error) {
 	showConfig, err := clt.command(cmdShowConfig+
 		"security ipsec proposal "+ipsecProposal+pipeDisplaySetRelative, junSess)
 	if err != nil {
@@ -312,22 +312,22 @@ func readIpsecProposal(ipsecProposal string, clt *Client, junSess *junosSession)
 			}
 			itemTrim := strings.TrimPrefix(item, setLS)
 			switch {
-			case strings.HasPrefix(itemTrim, "authentication-algorithm "):
-				confRead.authenticatioAlgorithm = strings.TrimPrefix(itemTrim, "authentication-algorithm ")
-			case strings.HasPrefix(itemTrim, "encryption-algorithm "):
-				confRead.encryptionAlgorithm = strings.TrimPrefix(itemTrim, "encryption-algorithm ")
-			case strings.HasPrefix(itemTrim, "lifetime-kilobytes "):
-				confRead.lifetimeKilobytes, err = strconv.Atoi(strings.TrimPrefix(itemTrim, "lifetime-kilobytes "))
+			case balt.CutPrefixInString(&itemTrim, "authentication-algorithm "):
+				confRead.authenticatioAlgorithm = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "encryption-algorithm "):
+				confRead.encryptionAlgorithm = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "lifetime-kilobytes "):
+				confRead.lifetimeKilobytes, err = strconv.Atoi(itemTrim)
 				if err != nil {
 					return confRead, fmt.Errorf(failedConvAtoiError, itemTrim, err)
 				}
-			case strings.HasPrefix(itemTrim, "lifetime-seconds "):
-				confRead.lifetimeSeconds, err = strconv.Atoi(strings.TrimPrefix(itemTrim, "lifetime-seconds "))
+			case balt.CutPrefixInString(&itemTrim, "lifetime-seconds "):
+				confRead.lifetimeSeconds, err = strconv.Atoi(itemTrim)
 				if err != nil {
 					return confRead, fmt.Errorf(failedConvAtoiError, itemTrim, err)
 				}
-			case strings.HasPrefix(itemTrim, "protocol "):
-				confRead.protocol = strings.TrimPrefix(itemTrim, "protocol ")
+			case balt.CutPrefixInString(&itemTrim, "protocol "):
+				confRead.protocol = itemTrim
 			}
 		}
 	}

--- a/junos/resource_security_nat_destination_pool.go
+++ b/junos/resource_security_nat_destination_pool.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	balt "github.com/jeremmfr/go-utils/basicalter"
 )
 
 type natDestinationPoolOptions struct {
@@ -302,9 +303,7 @@ func setSecurityNatDestinationPool(d *schema.ResourceData, clt *Client, junSess 
 }
 
 func readSecurityNatDestinationPool(name string, clt *Client, junSess *junosSession,
-) (natDestinationPoolOptions, error) {
-	var confRead natDestinationPoolOptions
-
+) (confRead natDestinationPoolOptions, err error) {
 	showConfig, err := clt.command(cmdShowConfig+
 		"security nat destination pool "+name+pipeDisplaySetRelative, junSess)
 	if err != nil {
@@ -321,19 +320,19 @@ func readSecurityNatDestinationPool(name string, clt *Client, junSess *junosSess
 			}
 			itemTrim := strings.TrimPrefix(item, setLS)
 			switch {
-			case strings.HasPrefix(itemTrim, "address port"):
-				confRead.addressPort, err = strconv.Atoi(strings.TrimPrefix(itemTrim, "address port "))
+			case balt.CutPrefixInString(&itemTrim, "address port "):
+				confRead.addressPort, err = strconv.Atoi(itemTrim)
 				if err != nil {
 					return confRead, fmt.Errorf(failedConvAtoiError, itemTrim, err)
 				}
-			case strings.HasPrefix(itemTrim, "address to"):
-				confRead.addressTo = strings.TrimPrefix(itemTrim, "address to ")
-			case strings.HasPrefix(itemTrim, "address "):
-				confRead.address = strings.TrimPrefix(itemTrim, "address ")
-			case strings.HasPrefix(itemTrim, "description "):
-				confRead.description = strings.Trim(strings.TrimPrefix(itemTrim, "description "), "\"")
-			case strings.HasPrefix(itemTrim, "routing-instance "):
-				confRead.routingInstance = strings.TrimPrefix(itemTrim, "routing-instance ")
+			case balt.CutPrefixInString(&itemTrim, "address to "):
+				confRead.addressTo = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "address "):
+				confRead.address = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "description "):
+				confRead.description = strings.Trim(itemTrim, "\"")
+			case balt.CutPrefixInString(&itemTrim, "routing-instance "):
+				confRead.routingInstance = itemTrim
 			}
 		}
 	}

--- a/junos/resource_security_policy_tunnel_pair_policy.go
+++ b/junos/resource_security_policy_tunnel_pair_policy.go
@@ -308,9 +308,7 @@ func setSecurityPolicyTunnelPairPolicy(d *schema.ResourceData, clt *Client, junS
 }
 
 func readSecurityPolicyTunnelPairPolicy(zoneA, policyAtoB, zoneB, policyBtoA string, clt *Client, junSess *junosSession,
-) (policyPairPolicyOptions, error) {
-	var confRead policyPairPolicyOptions
-
+) (confRead policyPairPolicyOptions, err error) {
 	showConfig, err := clt.command(cmdShowConfig+
 		"security policies from-zone "+zoneA+" to-zone "+zoneB+" policy "+policyAtoB+
 		" then permit tunnel pair-policy"+pipeDisplaySet, junSess)

--- a/junos/resource_security_screen_whitelist.go
+++ b/junos/resource_security_screen_whitelist.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	balt "github.com/jeremmfr/go-utils/basicalter"
 )
 
 type screenWhiteListOptions struct {
@@ -267,9 +268,8 @@ func setSecurityScreenWhiteList(d *schema.ResourceData, clt *Client, junSess *ju
 	return clt.configSet(configSet, junSess)
 }
 
-func readSecurityScreenWhiteList(name string, clt *Client, junSess *junosSession) (screenWhiteListOptions, error) {
-	var confRead screenWhiteListOptions
-
+func readSecurityScreenWhiteList(name string, clt *Client, junSess *junosSession,
+) (confRead screenWhiteListOptions, err error) {
 	showConfig, err := clt.command(cmdShowConfig+
 		"security screen white-list "+name+pipeDisplaySetRelative, junSess)
 	if err != nil {
@@ -285,8 +285,8 @@ func readSecurityScreenWhiteList(name string, clt *Client, junSess *junosSession
 				break
 			}
 			itemTrim := strings.TrimPrefix(item, setLS)
-			if strings.HasPrefix(itemTrim, "address ") {
-				confRead.address = append(confRead.address, strings.TrimPrefix(itemTrim, "address "))
+			if balt.CutPrefixInString(&itemTrim, "address ") {
+				confRead.address = append(confRead.address, itemTrim)
 			}
 		}
 	}

--- a/junos/resource_security_utm_custom_url_category.go
+++ b/junos/resource_security_utm_custom_url_category.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	balt "github.com/jeremmfr/go-utils/basicalter"
 )
 
 type utmCustomURLCategoryOptions struct {
@@ -266,9 +267,7 @@ func setUtmCustomURLCategory(d *schema.ResourceData, clt *Client, junSess *junos
 }
 
 func readUtmCustomURLCategory(urlCategory string, clt *Client, junSess *junosSession,
-) (utmCustomURLCategoryOptions, error) {
-	var confRead utmCustomURLCategoryOptions
-
+) (confRead utmCustomURLCategoryOptions, err error) {
 	showConfig, err := clt.command(cmdShowConfig+
 		"security utm custom-objects custom-url-category "+urlCategory+pipeDisplaySetRelative, junSess)
 	if err != nil {
@@ -284,8 +283,8 @@ func readUtmCustomURLCategory(urlCategory string, clt *Client, junSess *junosSes
 				break
 			}
 			itemTrim := strings.TrimPrefix(item, setLS)
-			if strings.HasPrefix(itemTrim, "value ") {
-				confRead.value = append(confRead.value, strings.TrimPrefix(itemTrim, "value "))
+			if balt.CutPrefixInString(&itemTrim, "value ") {
+				confRead.value = append(confRead.value, itemTrim)
 			}
 		}
 	}

--- a/junos/resource_security_utm_custom_url_pattern.go
+++ b/junos/resource_security_utm_custom_url_pattern.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	balt "github.com/jeremmfr/go-utils/basicalter"
 )
 
 type utmCustomURLPatternOptions struct {
@@ -264,9 +265,7 @@ func setUtmCustomURLPattern(d *schema.ResourceData, clt *Client, junSess *junosS
 }
 
 func readUtmCustomURLPattern(urlPattern string, clt *Client, junSess *junosSession,
-) (utmCustomURLPatternOptions, error) {
-	var confRead utmCustomURLPatternOptions
-
+) (confRead utmCustomURLPatternOptions, err error) {
 	showConfig, err := clt.command(cmdShowConfig+
 		"security utm custom-objects url-pattern "+urlPattern+pipeDisplaySetRelative, junSess)
 	if err != nil {
@@ -282,8 +281,8 @@ func readUtmCustomURLPattern(urlPattern string, clt *Client, junSess *junosSessi
 				break
 			}
 			itemTrim := strings.TrimPrefix(item, setLS)
-			if strings.HasPrefix(itemTrim, "value ") {
-				confRead.value = append(confRead.value, strings.Trim(strings.TrimPrefix(itemTrim, "value "), "\""))
+			if balt.CutPrefixInString(&itemTrim, "value ") {
+				confRead.value = append(confRead.value, strings.Trim(itemTrim, "\""))
 			}
 		}
 	}

--- a/junos/resource_security_zone_book_address_set.go
+++ b/junos/resource_security_zone_book_address_set.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	balt "github.com/jeremmfr/go-utils/basicalter"
 )
 
 type zoneBookAddressSetOptions struct {
@@ -330,9 +331,7 @@ func setSecurityZoneBookAddressSet(d *schema.ResourceData, clt *Client, junSess 
 }
 
 func readSecurityZoneBookAddressSet(zone, addressSet string, clt *Client, junSess *junosSession,
-) (zoneBookAddressSetOptions, error) {
-	var confRead zoneBookAddressSetOptions
-
+) (confRead zoneBookAddressSetOptions, err error) {
 	showConfig, err := clt.command(cmdShowConfig+
 		"security zones security-zone "+zone+" address-book address-set "+addressSet+pipeDisplaySetRelative, junSess)
 	if err != nil {
@@ -350,12 +349,12 @@ func readSecurityZoneBookAddressSet(zone, addressSet string, clt *Client, junSes
 			}
 			itemTrim := strings.TrimPrefix(item, setLS)
 			switch {
-			case strings.HasPrefix(itemTrim, "description "):
-				confRead.description = strings.Trim(strings.TrimPrefix(itemTrim, "description "), "\"")
-			case strings.HasPrefix(itemTrim, "address "):
-				confRead.address = append(confRead.address, strings.TrimPrefix(itemTrim, "address "))
-			case strings.HasPrefix(itemTrim, "address-set "):
-				confRead.addressSet = append(confRead.addressSet, strings.TrimPrefix(itemTrim, "address-set "))
+			case balt.CutPrefixInString(&itemTrim, "description "):
+				confRead.description = strings.Trim(itemTrim, "\"")
+			case balt.CutPrefixInString(&itemTrim, "address "):
+				confRead.address = append(confRead.address, itemTrim)
+			case balt.CutPrefixInString(&itemTrim, "address-set "):
+				confRead.addressSet = append(confRead.addressSet, itemTrim)
 			}
 		}
 	}

--- a/junos/resource_security_zone_test.go
+++ b/junos/resource_security_zone_test.go
@@ -170,8 +170,10 @@ resource "junos_security_zone" "testacc_securityZone" {
   inbound_services  = ["ssh"]
 }
 resource "junos_interface_logical" "testacc_securityZone" {
-  name          = "%s.0"
-  security_zone = junos_security_zone.testacc_securityZone.name
+  name                       = "%s.0"
+  security_zone              = junos_security_zone.testacc_securityZone.name
+  security_inbound_protocols = ["bgp"]
+  security_inbound_services  = ["ssh"]
 }
 `, interFace)
 }
@@ -182,8 +184,10 @@ resource "junos_security_zone" "testacc_securityZone" {
   name = "testacc_securityZone"
 }
 resource "junos_interface_logical" "testacc_securityZone" {
-  name          = "%s.0"
-  security_zone = junos_security_zone.testacc_securityZone.name
+  name                       = "%s.0"
+  security_zone              = junos_security_zone.testacc_securityZone.name
+  security_inbound_protocols = ["bgp"]
+  security_inbound_services  = ["ssh"]
 }
 `, interFace)
 }

--- a/junos/resource_services_advanced_anti_malware_policy.go
+++ b/junos/resource_services_advanced_anti_malware_policy.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	balt "github.com/jeremmfr/go-utils/basicalter"
 )
 
 type svcAdvancedAntiMalwarePolicyOptions struct {
@@ -415,9 +416,7 @@ func setServicesAdvancedAntiMalwarePolicy(d *schema.ResourceData, clt *Client, j
 }
 
 func readServicesAdvancedAntiMalwarePolicy(policy string, clt *Client, junSess *junosSession,
-) (svcAdvancedAntiMalwarePolicyOptions, error) {
-	var confRead svcAdvancedAntiMalwarePolicyOptions
-
+) (confRead svcAdvancedAntiMalwarePolicyOptions, err error) {
 	showConfig, err := clt.command(cmdShowConfig+
 		"services advanced-anti-malware policy \""+policy+"\""+pipeDisplaySetRelative, junSess)
 	if err != nil {
@@ -438,35 +437,34 @@ func readServicesAdvancedAntiMalwarePolicy(policy string, clt *Client, junSess *
 				confRead.blacklistNotificationLog = true
 			case itemTrim == "default-notification log":
 				confRead.defaultNotificationLog = true
-			case strings.HasPrefix(itemTrim, "fallback-options action "):
-				confRead.fallbackOptionsAction = strings.TrimPrefix(itemTrim, "fallback-options action ")
+			case balt.CutPrefixInString(&itemTrim, "fallback-options action "):
+				confRead.fallbackOptionsAction = itemTrim
 			case itemTrim == "fallback-options notification log":
 				confRead.fallbackOptionsNotificationLog = true
-			case strings.HasPrefix(itemTrim, "http action "):
-				confRead.httpAction = strings.TrimPrefix(itemTrim, "http action ")
-			case strings.HasPrefix(itemTrim, "http client-notify file "):
-				confRead.httpClientNotifyFile = strings.Trim(strings.TrimPrefix(itemTrim, "http client-notify file "), "\"")
-			case strings.HasPrefix(itemTrim, "http client-notify message "):
-				confRead.httpClientNotifyMessage = strings.Trim(strings.TrimPrefix(itemTrim, "http client-notify message "), "\"")
-			case strings.HasPrefix(itemTrim, "http client-notify redirect-url "):
-				confRead.httpClientNotifyRedirectURL = strings.Trim(strings.TrimPrefix(
-					itemTrim, "http client-notify redirect-url "), "\"")
-			case strings.HasPrefix(itemTrim, "http file-verdict-unknown "):
-				confRead.httpFileVerdictUnknown = strings.TrimPrefix(itemTrim, "http file-verdict-unknown ")
-			case strings.HasPrefix(itemTrim, "http inspection-profile "):
-				confRead.httpInspectionProfile = strings.Trim(strings.TrimPrefix(itemTrim, "http inspection-profile "), "\"")
+			case balt.CutPrefixInString(&itemTrim, "http action "):
+				confRead.httpAction = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "http client-notify file "):
+				confRead.httpClientNotifyFile = strings.Trim(itemTrim, "\"")
+			case balt.CutPrefixInString(&itemTrim, "http client-notify message "):
+				confRead.httpClientNotifyMessage = strings.Trim(itemTrim, "\"")
+			case balt.CutPrefixInString(&itemTrim, "http client-notify redirect-url "):
+				confRead.httpClientNotifyRedirectURL = strings.Trim(itemTrim, "\"")
+			case balt.CutPrefixInString(&itemTrim, "http file-verdict-unknown "):
+				confRead.httpFileVerdictUnknown = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "http inspection-profile "):
+				confRead.httpInspectionProfile = strings.Trim(itemTrim, "\"")
 			case itemTrim == "http notification log":
 				confRead.httpNotificationLog = true
-			case strings.HasPrefix(itemTrim, "imap inspection-profile "):
-				confRead.imapInspectionProfile = strings.Trim(strings.TrimPrefix(itemTrim, "imap inspection-profile "), "\"")
+			case balt.CutPrefixInString(&itemTrim, "imap inspection-profile "):
+				confRead.imapInspectionProfile = strings.Trim(itemTrim, "\"")
 			case itemTrim == "imap notification log":
 				confRead.imapNotificationLog = true
-			case strings.HasPrefix(itemTrim, "smtp inspection-profile "):
-				confRead.smtpInspectionProfile = strings.Trim(strings.TrimPrefix(itemTrim, "smtp inspection-profile "), "\"")
+			case balt.CutPrefixInString(&itemTrim, "smtp inspection-profile "):
+				confRead.smtpInspectionProfile = strings.Trim(itemTrim, "\"")
 			case itemTrim == "smtp notification log":
 				confRead.smtpNotificationLog = true
-			case strings.HasPrefix(itemTrim, "verdict-threshold "):
-				confRead.verdictThreshold = strings.TrimPrefix(itemTrim, "verdict-threshold ")
+			case balt.CutPrefixInString(&itemTrim, "verdict-threshold "):
+				confRead.verdictThreshold = itemTrim
 			case itemTrim == "whitelist-notification log":
 				confRead.whitelistNotificationLog = true
 			}

--- a/junos/resource_snmp_clientlist.go
+++ b/junos/resource_snmp_clientlist.go
@@ -254,9 +254,7 @@ func setSnmpClientlist(d *schema.ResourceData, clt *Client, junSess *junosSessio
 	return clt.configSet(configSet, junSess)
 }
 
-func readSnmpClientlist(name string, clt *Client, junSess *junosSession) (snmpClientlistOptions, error) {
-	var confRead snmpClientlistOptions
-
+func readSnmpClientlist(name string, clt *Client, junSess *junosSession) (confRead snmpClientlistOptions, err error) {
 	showConfig, err := clt.command(cmdShowConfig+"snmp client-list \""+name+"\""+pipeDisplaySetRelative, junSess)
 	if err != nil {
 		return confRead, err

--- a/junos/resource_snmp_v3_usm_user.go
+++ b/junos/resource_snmp_v3_usm_user.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	balt "github.com/jeremmfr/go-utils/basicalter"
 	jdecode "github.com/jeremmfr/junosdecode"
 )
 
@@ -456,9 +457,7 @@ func setSnmpV3UsmUser(d *schema.ResourceData, clt *Client, junSess *junosSession
 }
 
 func readSnmpV3UsmUser(confSrc snmpV3UsmUserOptions, clt *Client, junSess *junosSession,
-) (snmpV3UsmUserOptions, error) {
-	var confRead snmpV3UsmUserOptions
-
+) (confRead snmpV3UsmUserOptions, err error) {
 	showCommand := cmdShowConfig + "snmp v3 usm local-engine user \"" + confSrc.name + "\"" + pipeDisplaySetRelative
 	if confSrc.engineType != "local" {
 		showCommand = cmdShowConfig + "snmp v3 usm remote-engine \"" + confSrc.engineID +
@@ -481,64 +480,54 @@ func readSnmpV3UsmUser(confSrc snmpV3UsmUserOptions, clt *Client, junSess *junos
 			}
 			itemTrim := strings.TrimPrefix(item, setLS)
 			switch {
-			case strings.HasPrefix(itemTrim, "authentication-md5 authentication-key "):
+			case balt.CutPrefixInString(&itemTrim, "authentication-md5 authentication-key "):
 				confRead.authenticationType = "authentication-md5"
 				if confSrc.authenticationPassword != "" && confSrc.authenticationType == confRead.authenticationType {
 					confRead.authenticationPassword = confSrc.authenticationPassword
 				} else {
-					var err error
-					confRead.authenticationKey, err = jdecode.Decode(strings.Trim(strings.TrimPrefix(
-						itemTrim, "authentication-md5 authentication-key "), "\""))
+					confRead.authenticationKey, err = jdecode.Decode(strings.Trim(itemTrim, "\""))
 					if err != nil {
 						return confRead, fmt.Errorf("failed to decode authentication-key: %w", err)
 					}
 				}
 			case itemTrim == "authentication-none":
 				confRead.authenticationType = itemTrim
-			case strings.HasPrefix(itemTrim, "authentication-sha authentication-key "):
+			case balt.CutPrefixInString(&itemTrim, "authentication-sha authentication-key "):
 				confRead.authenticationType = "authentication-sha"
 				if confSrc.authenticationPassword != "" && confSrc.authenticationType == confRead.authenticationType {
 					confRead.authenticationPassword = confSrc.authenticationPassword
 				} else {
-					var err error
-					confRead.authenticationKey, err = jdecode.Decode(strings.Trim(strings.TrimPrefix(
-						itemTrim, "authentication-sha authentication-key "), "\""))
+					confRead.authenticationKey, err = jdecode.Decode(strings.Trim(itemTrim, "\""))
 					if err != nil {
 						return confRead, fmt.Errorf("failed to decode authentication-key: %w", err)
 					}
 				}
-			case strings.HasPrefix(itemTrim, "privacy-3des privacy-key "):
+			case balt.CutPrefixInString(&itemTrim, "privacy-3des privacy-key "):
 				confRead.privacyType = "privacy-3des"
 				if confSrc.privacyPassword != "" && confSrc.privacyType == confRead.privacyType {
 					confRead.privacyPassword = confSrc.privacyPassword
 				} else {
-					var err error
-					confRead.privacyKey, err = jdecode.Decode(strings.Trim(strings.TrimPrefix(
-						itemTrim, "privacy-3des privacy-key "), "\""))
+					confRead.privacyKey, err = jdecode.Decode(strings.Trim(itemTrim, "\""))
 					if err != nil {
 						return confRead, fmt.Errorf("failed to decode privacy-key: %w", err)
 					}
 				}
-			case strings.HasPrefix(itemTrim, "privacy-aes128 privacy-key "):
+			case balt.CutPrefixInString(&itemTrim, "privacy-aes128 privacy-key "):
 				confRead.privacyType = "privacy-aes128"
 				if confSrc.privacyPassword != "" && confSrc.privacyType == confRead.privacyType {
 					confRead.privacyPassword = confSrc.privacyPassword
 				} else {
-					var err error
-					confRead.privacyKey, err = jdecode.Decode(strings.Trim(strings.TrimPrefix(
-						itemTrim, "privacy-aes128 privacy-key "), "\""))
+					confRead.privacyKey, err = jdecode.Decode(strings.Trim(itemTrim, "\""))
 					if err != nil {
 						return confRead, fmt.Errorf("failed to decode privacy-key: %w", err)
 					}
 				}
-			case strings.HasPrefix(itemTrim, "privacy-des privacy-key "):
+			case balt.CutPrefixInString(&itemTrim, "privacy-des privacy-key "):
 				confRead.privacyType = "privacy-des"
 				if confSrc.privacyPassword != "" && confSrc.privacyType == confRead.privacyType {
 					confRead.privacyPassword = confSrc.privacyPassword
 				} else {
-					var err error
-					confRead.privacyKey, err = jdecode.Decode(strings.Trim(strings.TrimPrefix(
-						itemTrim, "privacy-des privacy-key "), "\""))
+					confRead.privacyKey, err = jdecode.Decode(strings.Trim(itemTrim, "\""))
 					if err != nil {
 						return confRead, fmt.Errorf("failed to decode privacy-key: %w", err)
 					}

--- a/junos/resource_snmp_v3_vacm_securitytogroup.go
+++ b/junos/resource_snmp_v3_vacm_securitytogroup.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	balt "github.com/jeremmfr/go-utils/basicalter"
 	bchk "github.com/jeremmfr/go-utils/basiccheck"
 )
 
@@ -291,9 +292,7 @@ func setSnmpV3VacmSecurityToGroup(d *schema.ResourceData, clt *Client, junSess *
 }
 
 func readSnmpV3VacmSecurityToGroup(model, name string, clt *Client, junSess *junosSession,
-) (snmpV3VacmSecurityToGroupOptions, error) {
-	var confRead snmpV3VacmSecurityToGroupOptions
-
+) (confRead snmpV3VacmSecurityToGroupOptions, err error) {
 	showConfig, err := clt.command(cmdShowConfig+"snmp v3 vacm security-to-group "+
 		"security-model "+model+" security-name \""+name+"\""+pipeDisplaySetRelative, junSess)
 	if err != nil {
@@ -309,8 +308,9 @@ func readSnmpV3VacmSecurityToGroup(model, name string, clt *Client, junSess *jun
 			if strings.Contains(item, xmlEndTagConfigOut) {
 				break
 			}
-			if strings.HasPrefix(item, setLS+"group ") {
-				confRead.group = strings.Trim(strings.TrimPrefix(item, setLS+"group "), "\"")
+			itemTrim := strings.TrimPrefix(item, setLS)
+			if balt.CutPrefixInString(&itemTrim, "group ") {
+				confRead.group = strings.Trim(itemTrim, "\"")
 			}
 		}
 	}

--- a/junos/resource_switch_options.go
+++ b/junos/resource_switch_options.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	balt "github.com/jeremmfr/go-utils/basicalter"
 )
 
 type switchOptionsOptions struct {
@@ -229,9 +230,7 @@ func delSwitchOptions(clt *Client, junSess *junosSession) error {
 	return clt.configSet(configSet, junSess)
 }
 
-func readSwitchOptions(clt *Client, junSess *junosSession) (switchOptionsOptions, error) {
-	var confRead switchOptionsOptions
-
+func readSwitchOptions(clt *Client, junSess *junosSession) (confRead switchOptionsOptions, err error) {
 	showConfig, err := clt.command(cmdShowConfig+"switch-options"+pipeDisplaySetRelative, junSess)
 	if err != nil {
 		return confRead, err
@@ -245,8 +244,8 @@ func readSwitchOptions(clt *Client, junSess *junosSession) (switchOptionsOptions
 				break
 			}
 			itemTrim := strings.TrimPrefix(item, setLS)
-			if strings.HasPrefix(itemTrim, "vtep-source-interface ") {
-				confRead.vtepSourceIf = strings.TrimPrefix(itemTrim, "vtep-source-interface ")
+			if balt.CutPrefixInString(&itemTrim, "vtep-source-interface ") {
+				confRead.vtepSourceIf = itemTrim
 			}
 		}
 	}

--- a/junos/resource_system_services_dhcp_localserver_group.go
+++ b/junos/resource_system_services_dhcp_localserver_group.go
@@ -3,6 +3,7 @@ package junos
 import (
 	"context"
 	"fmt"
+	"html"
 	"strconv"
 	"strings"
 
@@ -1984,7 +1985,7 @@ func readSystemServicesDhcpLocalServerGroupOverridesV4(itemTrim string, override
 				"option":     itemTrimFields[0],
 				"compare":    itemTrimFields[1],
 				"value_type": itemTrimFields[2],
-				"value":      strings.Trim(strings.Join(itemTrimFields[3:], " "), "\""),
+				"value":      html.UnescapeString(strings.Trim(strings.Join(itemTrimFields[3:], " "), "\"")),
 			})
 	case balt.CutPrefixInString(&itemTrim, "delay-offer delay-time "):
 		overrides["delay_offer_delay_time"], err = strconv.Atoi(itemTrim)
@@ -2036,7 +2037,7 @@ func readSystemServicesDhcpLocalServerGroupOverridesV6(itemTrim string, override
 				"option":     itemTrimFields[0],
 				"compare":    itemTrimFields[1],
 				"value_type": itemTrimFields[2],
-				"value":      strings.Trim(strings.Join(itemTrimFields[3:], " "), "\""),
+				"value":      html.UnescapeString(strings.Trim(strings.Join(itemTrimFields[3:], " "), "\"")),
 			})
 	case balt.CutPrefixInString(&itemTrim, "delay-advertise delay-time "):
 		overrides["delay_advertise_delay_time"], err = strconv.Atoi(itemTrim)

--- a/junos/resource_system_syslog_file.go
+++ b/junos/resource_system_syslog_file.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	balt "github.com/jeremmfr/go-utils/basicalter"
 	bchk "github.com/jeremmfr/go-utils/basiccheck"
 	jdecode "github.com/jeremmfr/junosdecode"
 )
@@ -564,9 +565,7 @@ func setSystemSyslogFile(d *schema.ResourceData, clt *Client, junSess *junosSess
 	return clt.configSet(configSet, junSess)
 }
 
-func readSystemSyslogFile(filename string, clt *Client, junSess *junosSession) (syslogFileOptions, error) {
-	var confRead syslogFileOptions
-
+func readSystemSyslogFile(filename string, clt *Client, junSess *junosSession) (confRead syslogFileOptions, err error) {
 	showConfig, err := clt.command(cmdShowConfig+"system syslog file "+filename+pipeDisplaySetRelative, junSess)
 	if err != nil {
 		return confRead, err
@@ -586,51 +585,50 @@ func readSystemSyslogFile(filename string, clt *Client, junSess *junosSession) (
 				confRead.allowDuplicates = true
 			case itemTrim == "explicit-priority":
 				confRead.explicitPriority = true
-			case strings.HasPrefix(itemTrim, "match "):
-				confRead.match = strings.Trim(strings.TrimPrefix(itemTrim, "match "), "\"")
-			case strings.HasPrefix(itemTrim, "match-strings "):
-				confRead.matchStrings = append(confRead.matchStrings,
-					strings.Trim(strings.TrimPrefix(itemTrim, "match-strings "), "\""))
-			case strings.HasPrefix(itemTrim, "structured-data"):
+			case balt.CutPrefixInString(&itemTrim, "match "):
+				confRead.match = strings.Trim(itemTrim, "\"")
+			case balt.CutPrefixInString(&itemTrim, "match-strings "):
+				confRead.matchStrings = append(confRead.matchStrings, strings.Trim(itemTrim, "\""))
+			case balt.CutPrefixInString(&itemTrim, "structured-data"):
 				if len(confRead.structuredData) == 0 {
 					confRead.structuredData = append(confRead.structuredData, map[string]interface{}{
 						"brief": false,
 					})
 				}
-				if itemTrim == "structured-data brief" {
+				if itemTrim == " brief" {
 					confRead.structuredData[0]["brief"] = true
 				}
-			case strings.HasPrefix(itemTrim, "any "):
-				confRead.anySeverity = strings.TrimPrefix(itemTrim, "any ")
-			case strings.HasPrefix(itemTrim, "authorization "):
-				confRead.authorizationSeverity = strings.TrimPrefix(itemTrim, "authorization ")
-			case strings.HasPrefix(itemTrim, "change-log "):
-				confRead.changelogSeverity = strings.TrimPrefix(itemTrim, "change-log ")
-			case strings.HasPrefix(itemTrim, "conflict-log "):
-				confRead.conflictlogSeverity = strings.TrimPrefix(itemTrim, "conflict-log ")
-			case strings.HasPrefix(itemTrim, "daemon "):
-				confRead.daemonSeverity = strings.TrimPrefix(itemTrim, "daemon ")
-			case strings.HasPrefix(itemTrim, "dfc "):
-				confRead.dfcSeverity = strings.TrimPrefix(itemTrim, "dfc ")
-			case strings.HasPrefix(itemTrim, "external "):
-				confRead.externalSeverity = strings.TrimPrefix(itemTrim, "external ")
-			case strings.HasPrefix(itemTrim, "firewall "):
-				confRead.firewallSeverity = strings.TrimPrefix(itemTrim, "firewall ")
-			case strings.HasPrefix(itemTrim, "ftp "):
-				confRead.ftpSeverity = strings.TrimPrefix(itemTrim, "ftp ")
-			case strings.HasPrefix(itemTrim, "interactive-commands "):
-				confRead.interactivecommandsSeverity = strings.TrimPrefix(itemTrim, "interactive-commands ")
-			case strings.HasPrefix(itemTrim, "kernel "):
-				confRead.kernelSeverity = strings.TrimPrefix(itemTrim, "kernel ")
-			case strings.HasPrefix(itemTrim, "ntp "):
-				confRead.ntpSeverity = strings.TrimPrefix(itemTrim, "ntp ")
-			case strings.HasPrefix(itemTrim, "pfe "):
-				confRead.pfeSeverity = strings.TrimPrefix(itemTrim, "pfe ")
-			case strings.HasPrefix(itemTrim, "security "):
-				confRead.securitySeverity = strings.TrimPrefix(itemTrim, "security ")
-			case strings.HasPrefix(itemTrim, "user "):
-				confRead.userSeverity = strings.TrimPrefix(itemTrim, "user ")
-			case strings.HasPrefix(itemTrim, "archive"):
+			case balt.CutPrefixInString(&itemTrim, "any "):
+				confRead.anySeverity = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "authorization "):
+				confRead.authorizationSeverity = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "change-log "):
+				confRead.changelogSeverity = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "conflict-log "):
+				confRead.conflictlogSeverity = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "daemon "):
+				confRead.daemonSeverity = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "dfc "):
+				confRead.dfcSeverity = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "external "):
+				confRead.externalSeverity = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "firewall "):
+				confRead.firewallSeverity = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "ftp "):
+				confRead.ftpSeverity = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "interactive-commands "):
+				confRead.interactivecommandsSeverity = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "kernel "):
+				confRead.kernelSeverity = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "ntp "):
+				confRead.ntpSeverity = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "pfe "):
+				confRead.pfeSeverity = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "security "):
+				confRead.securitySeverity = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "user "):
+				confRead.userSeverity = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "archive"):
 				if len(confRead.archive) == 0 {
 					confRead.archive = append(confRead.archive, map[string]interface{}{
 						"sites":             make([]map[string]interface{}, 0),
@@ -645,57 +643,49 @@ func readSystemSyslogFile(filename string, clt *Client, junSess *junosSession) (
 					})
 				}
 				switch {
-				case itemTrim == "archive binary-data":
+				case itemTrim == " binary-data":
 					confRead.archive[0]["binary_data"] = true
-				case itemTrim == "archive no-binary-data":
+				case itemTrim == " no-binary-data":
 					confRead.archive[0]["no_binary_data"] = true
-				case itemTrim == "archive world-readable":
+				case itemTrim == " world-readable":
 					confRead.archive[0]["world_readable"] = true
-				case itemTrim == "archive no-world-readable":
+				case itemTrim == " no-world-readable":
 					confRead.archive[0]["no_world_readable"] = true
-				case strings.HasPrefix(itemTrim, "archive files "):
-					var err error
-					confRead.archive[0]["files"], err = strconv.Atoi(strings.TrimPrefix(itemTrim, "archive files "))
+				case balt.CutPrefixInString(&itemTrim, " files "):
+					confRead.archive[0]["files"], err = strconv.Atoi(itemTrim)
 					if err != nil {
 						return confRead, fmt.Errorf(failedConvAtoiError, itemTrim, err)
 					}
-				case strings.HasPrefix(itemTrim, "archive size "):
-					var err error
-					confRead.archive[0]["size"], err = strconv.Atoi(strings.TrimPrefix(itemTrim, "archive size "))
+				case balt.CutPrefixInString(&itemTrim, " size "):
+					confRead.archive[0]["size"], err = strconv.Atoi(itemTrim)
 					if err != nil {
 						return confRead, fmt.Errorf(failedConvAtoiError, itemTrim, err)
 					}
-				case strings.HasPrefix(itemTrim, "archive transfer-interval "):
-					var err error
-					confRead.archive[0]["transfer_interval"], err = strconv.Atoi(strings.TrimPrefix(
-						itemTrim, "archive transfer-interval "))
+				case balt.CutPrefixInString(&itemTrim, " transfer-interval "):
+					confRead.archive[0]["transfer_interval"], err = strconv.Atoi(itemTrim)
 					if err != nil {
 						return confRead, fmt.Errorf(failedConvAtoiError, itemTrim, err)
 					}
-				case strings.HasPrefix(itemTrim, "archive start-time "):
-					confRead.archive[0]["start_time"] = strings.Split(strings.Trim(strings.TrimPrefix(
-						itemTrim, "archive start-time "), "\""), " ")[0]
-				case strings.HasPrefix(itemTrim, "archive archive-sites "):
-					itemTrimArchSitesSplit := strings.Split(
-						strings.TrimPrefix(itemTrim, "archive archive-sites "), " ")
-					itemTrimArchSites := strings.TrimPrefix(itemTrim, "archive archive-sites "+itemTrimArchSitesSplit[0]+" ")
+				case balt.CutPrefixInString(&itemTrim, " start-time "):
+					confRead.archive[0]["start_time"] = strings.Split(strings.Trim(itemTrim, "\""), " ")[0]
+				case balt.CutPrefixInString(&itemTrim, " archive-sites "):
+					itemTrimFields := strings.Split(itemTrim, " ")
 					sitesOptions := map[string]interface{}{
-						"url":              itemTrimArchSitesSplit[0],
+						"url":              itemTrimFields[0],
 						"password":         "",
 						"routing_instance": "",
 					}
 					confRead.archive[0]["sites"] = copyAndRemoveItemMapList("url", sitesOptions,
 						confRead.archive[0]["sites"].([]map[string]interface{}))
+					balt.CutPrefixInString(&itemTrim, itemTrimFields[0]+" ")
 					switch {
-					case strings.HasPrefix(itemTrimArchSites, "password "):
-						var err error
-						sitesOptions["password"], err = jdecode.Decode(strings.Trim(strings.TrimPrefix(
-							itemTrimArchSites, "password "), "\""))
+					case balt.CutPrefixInString(&itemTrim, "password "):
+						sitesOptions["password"], err = jdecode.Decode(strings.Trim(itemTrim, "\""))
 						if err != nil {
 							return confRead, fmt.Errorf("failed to decode password: %w", err)
 						}
-					case strings.HasPrefix(itemTrimArchSites, "routing-instance "):
-						sitesOptions["routing_instance"] = strings.TrimPrefix(itemTrimArchSites, "routing-instance ")
+					case balt.CutPrefixInString(&itemTrim, "routing-instance "):
+						sitesOptions["routing_instance"] = itemTrim
 					}
 					confRead.archive[0]["sites"] = append(confRead.archive[0]["sites"].([]map[string]interface{}), sitesOptions)
 				}

--- a/junos/resource_system_syslog_host.go
+++ b/junos/resource_system_syslog_host.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	balt "github.com/jeremmfr/go-utils/basicalter"
 )
 
 type syslogHostOptions struct {
@@ -482,9 +483,7 @@ func setSystemSyslogHost(d *schema.ResourceData, clt *Client, junSess *junosSess
 	return clt.configSet(configSet, junSess)
 }
 
-func readSystemSyslogHost(host string, clt *Client, junSess *junosSession) (syslogHostOptions, error) {
-	var confRead syslogHostOptions
-
+func readSystemSyslogHost(host string, clt *Client, junSess *junosSession) (confRead syslogHostOptions, err error) {
 	showConfig, err := clt.command(cmdShowConfig+"system syslog host "+host+pipeDisplaySetRelative, junSess)
 	if err != nil {
 		return confRead, err
@@ -506,62 +505,60 @@ func readSystemSyslogHost(host string, clt *Client, junSess *junosSession) (sysl
 				confRead.excludeHostname = true
 			case itemTrim == "explicit-priority":
 				confRead.explicitPriority = true
-			case strings.HasPrefix(itemTrim, "facility-override "):
-				confRead.facilityOverride = strings.TrimPrefix(itemTrim, "facility-override ")
-			case strings.HasPrefix(itemTrim, "log-prefix "):
-				confRead.logPrefix = strings.TrimPrefix(itemTrim, "log-prefix ")
-			case strings.HasPrefix(itemTrim, "match "):
-				confRead.match = strings.Trim(strings.TrimPrefix(itemTrim, "match "), "\"")
-			case strings.HasPrefix(itemTrim, "match-strings "):
-				confRead.matchStrings = append(confRead.matchStrings,
-					strings.Trim(strings.TrimPrefix(itemTrim, "match-strings "), "\""))
-			case strings.HasPrefix(itemTrim, "port "):
-				var err error
-				confRead.port, err = strconv.Atoi(strings.TrimPrefix(itemTrim, "port "))
+			case balt.CutPrefixInString(&itemTrim, "facility-override "):
+				confRead.facilityOverride = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "log-prefix "):
+				confRead.logPrefix = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "match "):
+				confRead.match = strings.Trim(itemTrim, "\"")
+			case balt.CutPrefixInString(&itemTrim, "match-strings "):
+				confRead.matchStrings = append(confRead.matchStrings, strings.Trim(itemTrim, "\""))
+			case balt.CutPrefixInString(&itemTrim, "port "):
+				confRead.port, err = strconv.Atoi(itemTrim)
 				if err != nil {
 					return confRead, fmt.Errorf(failedConvAtoiError, itemTrim, err)
 				}
-			case strings.HasPrefix(itemTrim, "source-address "):
-				confRead.sourceAddress = strings.TrimPrefix(itemTrim, "source-address ")
-			case strings.HasPrefix(itemTrim, "structured-data"):
+			case balt.CutPrefixInString(&itemTrim, "source-address "):
+				confRead.sourceAddress = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "structured-data"):
 				if len(confRead.structuredData) == 0 {
 					confRead.structuredData = append(confRead.structuredData, map[string]interface{}{
 						"brief": false,
 					})
 				}
-				if itemTrim == "structured-data brief" {
+				if itemTrim == " brief" {
 					confRead.structuredData[0]["brief"] = true
 				}
-			case strings.HasPrefix(itemTrim, "any "):
-				confRead.anySeverity = strings.TrimPrefix(itemTrim, "any ")
-			case strings.HasPrefix(itemTrim, "authorization "):
-				confRead.authorizationSeverity = strings.TrimPrefix(itemTrim, "authorization ")
-			case strings.HasPrefix(itemTrim, "change-log "):
-				confRead.changelogSeverity = strings.TrimPrefix(itemTrim, "change-log ")
-			case strings.HasPrefix(itemTrim, "conflict-log "):
-				confRead.conflictlogSeverity = strings.TrimPrefix(itemTrim, "conflict-log ")
-			case strings.HasPrefix(itemTrim, "daemon "):
-				confRead.daemonSeverity = strings.TrimPrefix(itemTrim, "daemon ")
-			case strings.HasPrefix(itemTrim, "dfc "):
-				confRead.dfcSeverity = strings.TrimPrefix(itemTrim, "dfc ")
-			case strings.HasPrefix(itemTrim, "external "):
-				confRead.externalSeverity = strings.TrimPrefix(itemTrim, "external ")
-			case strings.HasPrefix(itemTrim, "firewall "):
-				confRead.firewallSeverity = strings.TrimPrefix(itemTrim, "firewall ")
-			case strings.HasPrefix(itemTrim, "ftp "):
-				confRead.ftpSeverity = strings.TrimPrefix(itemTrim, "ftp ")
-			case strings.HasPrefix(itemTrim, "interactive-commands "):
-				confRead.interactivecommandsSeverity = strings.TrimPrefix(itemTrim, "interactive-commands ")
-			case strings.HasPrefix(itemTrim, "kernel "):
-				confRead.kernelSeverity = strings.TrimPrefix(itemTrim, "kernel ")
-			case strings.HasPrefix(itemTrim, "ntp "):
-				confRead.ntpSeverity = strings.TrimPrefix(itemTrim, "ntp ")
-			case strings.HasPrefix(itemTrim, "pfe "):
-				confRead.pfeSeverity = strings.TrimPrefix(itemTrim, "pfe ")
-			case strings.HasPrefix(itemTrim, "security "):
-				confRead.securitySeverity = strings.TrimPrefix(itemTrim, "security ")
-			case strings.HasPrefix(itemTrim, "user "):
-				confRead.userSeverity = strings.TrimPrefix(itemTrim, "user ")
+			case balt.CutPrefixInString(&itemTrim, "any "):
+				confRead.anySeverity = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "authorization "):
+				confRead.authorizationSeverity = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "change-log "):
+				confRead.changelogSeverity = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "conflict-log "):
+				confRead.conflictlogSeverity = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "daemon "):
+				confRead.daemonSeverity = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "dfc "):
+				confRead.dfcSeverity = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "external "):
+				confRead.externalSeverity = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "firewall "):
+				confRead.firewallSeverity = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "ftp "):
+				confRead.ftpSeverity = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "interactive-commands "):
+				confRead.interactivecommandsSeverity = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "kernel "):
+				confRead.kernelSeverity = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "ntp "):
+				confRead.ntpSeverity = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "pfe "):
+				confRead.pfeSeverity = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "security "):
+				confRead.securitySeverity = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "user "):
+				confRead.userSeverity = itemTrim
 			}
 		}
 	}

--- a/junos/resource_vstp_vlan_group.go
+++ b/junos/resource_vstp_vlan_group.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	balt "github.com/jeremmfr/go-utils/basicalter"
 )
 
 type vstpVlanGroupOptions struct {
@@ -335,9 +336,8 @@ func resourceVstpVlanGroupImport(ctx context.Context, d *schema.ResourceData, m 
 }
 
 func checkVstpVlanGroupExists(name, routingInstance string, clt *Client, junSess *junosSession,
-) (bool, error) {
+) (_ bool, err error) {
 	var showConfig string
-	var err error
 	if routingInstance == defaultW {
 		showConfig, err = clt.command(cmdShowConfig+
 			"protocols vstp vlan-group group "+name+pipeDisplaySet, junSess)
@@ -390,10 +390,8 @@ func setVstpVlanGroup(d *schema.ResourceData, clt *Client, junSess *junosSession
 }
 
 func readVstpVlanGroup(name, routingInstance string, clt *Client, junSess *junosSession,
-) (vstpVlanGroupOptions, error) {
-	var confRead vstpVlanGroupOptions
+) (confRead vstpVlanGroupOptions, err error) {
 	var showConfig string
-	var err error
 	if routingInstance == defaultW {
 		showConfig, err = clt.command(cmdShowConfig+
 			"protocols vstp vlan-group group "+name+pipeDisplaySetRelative, junSess)
@@ -416,32 +414,29 @@ func readVstpVlanGroup(name, routingInstance string, clt *Client, junSess *junos
 			}
 			itemTrim := strings.TrimPrefix(item, setLS)
 			switch {
-			case strings.HasPrefix(itemTrim, "vlan "):
-				confRead.vlan = append(confRead.vlan, strings.TrimPrefix(itemTrim, "vlan "))
-			case strings.HasPrefix(itemTrim, "backup-bridge-priority "):
-				confRead.backupBridgePriority = strings.TrimPrefix(itemTrim, "backup-bridge-priority ")
-			case strings.HasPrefix(itemTrim, "bridge-priority "):
-				confRead.bridgePriority = strings.TrimPrefix(itemTrim, "bridge-priority ")
-			case strings.HasPrefix(itemTrim, "forward-delay "):
-				var err error
-				confRead.forwardDelay, err = strconv.Atoi(strings.TrimPrefix(itemTrim, "forward-delay "))
+			case balt.CutPrefixInString(&itemTrim, "vlan "):
+				confRead.vlan = append(confRead.vlan, itemTrim)
+			case balt.CutPrefixInString(&itemTrim, "backup-bridge-priority "):
+				confRead.backupBridgePriority = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "bridge-priority "):
+				confRead.bridgePriority = itemTrim
+			case balt.CutPrefixInString(&itemTrim, "forward-delay "):
+				confRead.forwardDelay, err = strconv.Atoi(itemTrim)
 				if err != nil {
 					return confRead, fmt.Errorf(failedConvAtoiError, itemTrim, err)
 				}
-			case strings.HasPrefix(itemTrim, "hello-time "):
-				var err error
-				confRead.helloTime, err = strconv.Atoi(strings.TrimPrefix(itemTrim, "hello-time "))
+			case balt.CutPrefixInString(&itemTrim, "hello-time "):
+				confRead.helloTime, err = strconv.Atoi(itemTrim)
 				if err != nil {
 					return confRead, fmt.Errorf(failedConvAtoiError, itemTrim, err)
 				}
-			case strings.HasPrefix(itemTrim, "max-age "):
-				var err error
-				confRead.maxAge, err = strconv.Atoi(strings.TrimPrefix(itemTrim, "max-age "))
+			case balt.CutPrefixInString(&itemTrim, "max-age "):
+				confRead.maxAge, err = strconv.Atoi(itemTrim)
 				if err != nil {
 					return confRead, fmt.Errorf(failedConvAtoiError, itemTrim, err)
 				}
-			case strings.HasPrefix(itemTrim, "system-identifier "):
-				confRead.systemIdentifier = strings.TrimPrefix(itemTrim, "system-identifier ")
+			case balt.CutPrefixInString(&itemTrim, "system-identifier "):
+				confRead.systemIdentifier = itemTrim
 			}
 		}
 	}


### PR DESCRIPTION
ENHANCEMENTS:

* resource/`junos_security_address_book`: add `ipv4_only` and `ipv6_only` arguments inside `dns_name` block argument
* refactor the code of most resource reading functions to make it more readable and maintainable

BUG FIXES:

* resource/`junos_security_address_book`: fix `description` not set correctly in `wildcard_address`, `dns_name`, `range_address` and `address_set` block arguments
* resource/`junos_forwardingoptions_dhcprelay`, `junos_forwardingoptions_dhcprelay_group`, `junos_system_services_dhcp_localserver_group`: fix reading `value` argument with special chars