### PR TITLE
r/bgp_*: add error in ValidateConfig with bfd_liveness_detection

### DIFF
--- a/internal/providerfwk/resource_bgp_group.go
+++ b/internal/providerfwk/resource_bgp_group.go
@@ -1021,6 +1021,15 @@ func (rsc *bgpGroup) ValidateConfig(
 			)
 		}
 	}
+	if config.BfdLivenessDetection != nil {
+		if config.BfdLivenessDetection.isEmpty() {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("bfd_liveness_detection").AtName("*"),
+				tfdiag.MissingConfigErrSummary,
+				"bfd_liveness_detection block is empty",
+			)
+		}
+	}
 	if config.BgpErrorTolerance != nil {
 		if !config.BgpErrorTolerance.MalformedRouteLimit.IsNull() &&
 			!config.BgpErrorTolerance.NoMalformedRouteLimit.IsNull() {

--- a/internal/providerfwk/resource_bgp_neighbor.go
+++ b/internal/providerfwk/resource_bgp_neighbor.go
@@ -1019,6 +1019,15 @@ func (rsc *bgpNeighbor) ValidateConfig(
 			)
 		}
 	}
+	if config.BfdLivenessDetection != nil {
+		if config.BfdLivenessDetection.isEmpty() {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("bfd_liveness_detection").AtName("*"),
+				tfdiag.MissingConfigErrSummary,
+				"bfd_liveness_detection block is empty",
+			)
+		}
+	}
 	if config.BgpErrorTolerance != nil {
 		if !config.BgpErrorTolerance.MalformedRouteLimit.IsNull() &&
 			!config.BgpErrorTolerance.NoMalformedRouteLimit.IsNull() {


### PR DESCRIPTION
**resource/bgp_***: add error in ValidateConfig when `bfd_liveness_detection` block is set but empty