### PR TITLE
bump github.com/hashicorp/terraform-plugin-sdk/v2 to v2.27.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.10.0
 	github.com/hashicorp/terraform-plugin-go v0.17.0
 	github.com/hashicorp/terraform-plugin-mux v0.11.1
-	github.com/hashicorp/terraform-plugin-sdk/v2 v2.26.1
+	github.com/hashicorp/terraform-plugin-sdk/v2 v2.27.0
 	github.com/hashicorp/terraform-plugin-testing v1.3.0
 	github.com/jeremmfr/go-netconf v0.4.12
 	github.com/jeremmfr/go-utils v0.9.0
@@ -63,4 +63,4 @@ require (
 	google.golang.org/protobuf v1.31.0 // indirect
 )
 
-replace github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/jeremmfr/terraform-plugin-sdk/v2 v2.26.2-0.20230323075736-fa464c32fe03
+replace github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/jeremmfr/terraform-plugin-sdk/v2 v2.27.1-0.20230630070723-25fea73ff21e

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,8 @@ github.com/jeremmfr/go-utils v0.9.0 h1:EMweJK12FKqRzYtISkwClVm1pnX/W7FDTqKnAm3f5
 github.com/jeremmfr/go-utils v0.9.0/go.mod h1:Lkn95iSzCRviFhn2/0XmqzWGmxI+kkoqKAZqip7VUmM=
 github.com/jeremmfr/junosdecode v1.1.1 h1:wOFfJIwLXP9s0eQzzAhuX7a7N1mc+AWgDLYAmR7VoWg=
 github.com/jeremmfr/junosdecode v1.1.1/go.mod h1:nTY0XbZC2ePbZdV0wuUboSMtGrJxtpwWVYfHjrS2Oqw=
-github.com/jeremmfr/terraform-plugin-sdk/v2 v2.26.2-0.20230323075736-fa464c32fe03 h1:w/dNAqGhPIPNh8TxNCUyAyzqq7b/oqVVd+Qs0vZzKgA=
-github.com/jeremmfr/terraform-plugin-sdk/v2 v2.26.2-0.20230323075736-fa464c32fe03/go.mod h1:xcOSYlRVdPLmDUoqPhO9fiO/YCN/l6MGYeTzGt5jgkQ=
+github.com/jeremmfr/terraform-plugin-sdk/v2 v2.27.1-0.20230630070723-25fea73ff21e h1:2pfGmLXTGkrY71GfmbHomxgoR5/TKDEAU0iaW+x3anc=
+github.com/jeremmfr/terraform-plugin-sdk/v2 v2.27.1-0.20230630070723-25fea73ff21e/go.mod h1:cUEP4ly/nxlHy5HzD6YRrHydtlheGvGRJDhiWqqVik4=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=


### PR DESCRIPTION
with the go replace to minor fix to accept empty list of primitives on apply

<details>
<summary>Release notes</summary>
<blockquote>
<p>NOTES:</p>

* helper/schema: Consumers directly referencing the `Resource` type `Schema` field should switch to the `SchemaMap` method to ensure new `SchemaFunc` field data is properly retrieved

<p>ENHANCEMENTS:</p>

* all: Improved SDK logging performance when messages would be skipped due to configured logging level
* helper/schema: Added `Resource` type `SchemaFunc` field and `SchemaMap` method, which can reduce resident memory usage with large schemas 
</blockquote>
</details>