### PR TITLE
testacc: add pre-apply config plan checks for sensitive value

### DIFF
--- a/internal/providerfwk/resource_bgp_group_test.go
+++ b/internal/providerfwk/resource_bgp_group_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
 func TestAccJunosBgpGroup_basic(t *testing.T) {
@@ -119,6 +121,12 @@ func TestAccJunosBgpGroup_basic(t *testing.T) {
 				},
 				{
 					Config: testAccJunosBgpGroupConfigUpdate(),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectSensitiveValue("junos_bgp_group.testacc_bgpgroup",
+								tfjsonpath.New("authentication_key")),
+						},
+					},
 					Check: resource.ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr("junos_bgp_group.testacc_bgpgroup",
 							"routing_instance", "testacc_bgpgroup"),

--- a/internal/providerfwk/resource_bgp_neighbor_test.go
+++ b/internal/providerfwk/resource_bgp_neighbor_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
 func TestAccJunosBgpNeighbor_basic(t *testing.T) {
@@ -119,6 +121,12 @@ func TestAccJunosBgpNeighbor_basic(t *testing.T) {
 				},
 				{
 					Config: testAccJunosBgpNeighborConfigUpdate(),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectSensitiveValue("junos_bgp_neighbor.testacc_bgpneighbor",
+								tfjsonpath.New("authentication_key")),
+						},
+					},
 					Check: resource.ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr("junos_bgp_neighbor.testacc_bgpneighbor",
 							"routing_instance", "testacc_bgpneighbor"),

--- a/internal/providerfwk/resource_interface_logical_test.go
+++ b/internal/providerfwk/resource_interface_logical_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/jeremmfr/terraform-provider-junos/internal/junos"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
 // export TESTACC_INTERFACE=<inteface> for choose interface available else it's ge-0/0/3.
@@ -23,6 +25,16 @@ func TestAccJunosInterfaceLogical_basic(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config: testAccJunosInterfaceLogicalConfigCreate(testaccInterface),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectSensitiveValue("junos_interface_logical.testacc_interface_logical",
+								tfjsonpath.New("family_inet").
+									AtMapKey("address").AtSliceIndex(0).
+									AtMapKey("vrrp_group").AtSliceIndex(0).
+									AtMapKey("authentication_key"),
+							),
+						},
+					},
 					Check: resource.ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
 							"description", "testacc_interface_"+testaccInterface+".100"),

--- a/internal/providerfwk/resource_security_ike_ipsec_test.go
+++ b/internal/providerfwk/resource_security_ike_ipsec_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/jeremmfr/terraform-provider-junos/internal/junos"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
 // export TESTACC_INTERFACE=<inteface> for choose interface available else it's ge-0/0/3.
@@ -24,6 +26,12 @@ func TestAccJunosSecurityIkeIpsec_basic(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					Config: testAccJunosSecurityIkeIpsecConfigCreate(testaccIkeIpsec),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectSensitiveValue("junos_security_ike_policy.testacc_ikepol",
+								tfjsonpath.New("pre_shared_key_text")),
+						},
+					},
 					Check: resource.ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr("junos_security_ike_proposal.testacc_ikeprop",
 							"authentication_algorithm", "sha1"),
@@ -172,6 +180,12 @@ func TestAccJunosSecurityIkeIpsec_basic(t *testing.T) {
 				},
 				{
 					Config: testAccJunosSecurityIkeIpsecConfigUpdate2(testaccIkeIpsec),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectSensitiveValue("junos_security_ike_gateway.testacc_ikegateway",
+								tfjsonpath.New("aaa").AtMapKey("client_password")),
+						},
+					},
 					Check: resource.ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr("junos_security_ike_gateway.testacc_ikegateway",
 							"dead_peer_detection.send_mode", "probe-idle-tunnel"),
@@ -202,6 +216,14 @@ func TestAccJunosSecurityIkeIpsec_basic(t *testing.T) {
 				},
 				{
 					Config: testAccJunosSecurityIkeIpsecConfigUpdate4(testaccIkeIpsec),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectSensitiveValue("junos_security_ipsec_vpn.testacc_ipsecvpn",
+								tfjsonpath.New("manual").AtMapKey("authentication_key_text")),
+							plancheck.ExpectSensitiveValue("junos_security_ipsec_vpn.testacc_ipsecvpn",
+								tfjsonpath.New("manual").AtMapKey("encryption_key_text")),
+						},
+					},
 					Check: resource.ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr("junos_security_ike_gateway.testacc_ikegateway",
 							"dynamic_remote.inet", "192.168.0.4"),
@@ -209,6 +231,14 @@ func TestAccJunosSecurityIkeIpsec_basic(t *testing.T) {
 				},
 				{
 					Config: testAccJunosSecurityIkeIpsecConfigUpdate5(testaccIkeIpsec),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectSensitiveValue("junos_security_ipsec_vpn.testacc_ipsecvpn2",
+								tfjsonpath.New("manual").AtMapKey("authentication_key_hexa")),
+							plancheck.ExpectSensitiveValue("junos_security_ipsec_vpn.testacc_ipsecvpn2",
+								tfjsonpath.New("manual").AtMapKey("encryption_key_hexa")),
+						},
+					},
 					Check: resource.ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr("junos_security_ike_gateway.testacc_ikegateway",
 							"dynamic_remote.inet6", "2001:db8::1"),


### PR DESCRIPTION
testacc: add pre-apply config plan checks when expecting sensitive value for attributes