### PR TITLE
Release v2.1.2

### DIFF
--- a/.changes/bugfix-2.1.1.md
+++ b/.changes/bugfix-2.1.1.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable-file MD013 MD041 -->
+BUG FIXES:
+
+* **resource/junos_security_ike_gateway** : fix `Value Conversion Error` when upgrading the provider before `v2.0.0` to `v2.0.0...v2.1.1` and there are this type of resource with `remote_identity` block set in state

--- a/.changes/bugfix-2.1.1.md
+++ b/.changes/bugfix-2.1.1.md
@@ -1,4 +1,0 @@
-<!-- markdownlint-disable-file MD013 MD041 -->
-BUG FIXES:
-
-* **resource/junos_security_ike_gateway** : fix `Value Conversion Error` when upgrading the provider before `v2.0.0` to `v2.0.0...v2.1.1` and there are this type of resource with `remote_identity` block set in state

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 <!-- markdownlint-disable-file MD013 MD041 -->
 # changelog
 
+## v2.1.2 (August 28, 2023)
+
+BUG FIXES:
+
+* **resource/junos_security_ike_gateway** : fix `Value Conversion Error` when upgrading the provider before `v2.0.0` to `v2.0.0...v2.1.1` and there are this type of resource with `remote_identity` block set in state (Fix [#533](https://github.com/jeremmfr/terraform-provider-junos/issues/533))
+
 ## v2.1.1 (August 21, 2023)
 
 BUG FIXES:

--- a/internal/providerfwk/upgradestate_security_ike_gateway.go
+++ b/internal/providerfwk/upgradestate_security_ike_gateway.go
@@ -172,8 +172,11 @@ func upgradeSecurityIkeGatewayV0toV1(
 			UserAtHostname            types.String                                                 `tfsdk:"user_at_hostname"`
 			DistinguishedName         []securityIkeGatewayBlockDynamicRemoteBlockDistinguishedName `tfsdk:"distinguished_name"`
 		} `tfsdk:"dynamic_remote"`
-		LocalIdentity  []securityIkeGatewayBlockLocalIdentity  `tfsdk:"local_identity"`
-		RemoteIdentity []securityIkeGatewayBlockRemoteIdentity `tfsdk:"remote_identity"`
+		LocalIdentity  []securityIkeGatewayBlockLocalIdentity `tfsdk:"local_identity"`
+		RemoteIdentity []struct {
+			Type  types.String `tfsdk:"type"`
+			Value types.String `tfsdk:"value"`
+		} `tfsdk:"remote_identity"`
 	}
 
 	var dataV0 modelV0
@@ -216,7 +219,10 @@ func upgradeSecurityIkeGatewayV0toV1(
 		dataV1.LocalIdentity = &dataV0.LocalIdentity[0]
 	}
 	if len(dataV0.RemoteIdentity) > 0 {
-		dataV1.RemoteIdentity = &dataV0.RemoteIdentity[0]
+		dataV1.RemoteIdentity = &securityIkeGatewayBlockRemoteIdentity{
+			Type:  dataV0.RemoteIdentity[0].Type,
+			Value: dataV0.RemoteIdentity[0].Value,
+		}
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, dataV1)...)


### PR DESCRIPTION
BUG FIXES:

* **resource/junos_security_ike_gateway** : fix `Value Conversion Error` when upgrading the provider before `v2.0.0` to `v2.0.0...v2.1.1` and there are this type of resource with `remote_identity` block set in state (Fix #533)