### PR TITLE
r/forwardingoptions_sampling_instance: fix #536

### DIFF
--- a/.changes/issue-536.md
+++ b/.changes/issue-536.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable-file MD013 MD041 -->
+BUG FIXES:
+
+* **resource/junos_forwardingoptions_sampling_instance**: avoid resources replacement when upgrading the provider before `v2.0.0` and without refreshing resource states (`-refresh=false`) (Fix [#536](https://github.com/jeremmfr/terraform-provider-junos/issues/536))

--- a/internal/providerfwk/upgradestate_forwardingoptions_sampling_instance.go
+++ b/internal/providerfwk/upgradestate_forwardingoptions_sampling_instance.go
@@ -3,6 +3,8 @@ package providerfwk
 import (
 	"context"
 
+	"github.com/jeremmfr/terraform-provider-junos/internal/junos"
+
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -176,6 +178,7 @@ func upgradeForwardingoptionsSamplingInstanceStateV0toV1(
 	var dataV1 forwardingoptionsSamplingInstanceData
 	dataV1.ID = dataV0.ID
 	dataV1.Name = dataV0.Name
+	dataV1.RoutingInstance = types.StringValue(junos.DefaultW)
 	dataV1.Disable = dataV0.Disable
 	if len(dataV0.FamilyInetInput) > 0 {
 		dataV1.FamilyInetInput = &dataV0.FamilyInetInput[0]


### PR DESCRIPTION
BUG FIXES:

* **resource/junos_forwardingoptions_sampling_instance**: avoid resources replacement when upgrading the provider before `v2.0.0` and without refreshing resource states (`-refresh=false`) (Fix #536)