### PR TITLE
providerfwk/upgradestate: avoid using latest struct

### DIFF
--- a/internal/providerfwk/resource_security_nat_source.go
+++ b/internal/providerfwk/resource_security_nat_source.go
@@ -357,7 +357,7 @@ type securityNatSourceBlockRule struct {
 type securityNatSourceBlockRuleConfig struct {
 	Name  types.String                                `tfsdk:"name"`
 	Match *securityNatSourceBlockRuleBlockMatchConfig `tfsdk:"match"`
-	Then  *securityNatDestinationBlockRuleBlockThen   `tfsdk:"then"`
+	Then  *securityNatSourceBlockRuleBlockThen        `tfsdk:"then"`
 }
 
 type securityNatSourceBlockRuleBlockMatch struct {

--- a/internal/providerfwk/upgradestate_bgp_group.go
+++ b/internal/providerfwk/upgradestate_bgp_group.go
@@ -299,52 +299,69 @@ func upgradeBgpGroupStateV0toV1(
 	ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse,
 ) {
 	type modelV0 struct {
-		AcceptRemoteNexthop          types.Bool                     `tfsdk:"accept_remote_nexthop"`
-		AdvertiseExternal            types.Bool                     `tfsdk:"advertise_external"`
-		AdvertiseExternalConditional types.Bool                     `tfsdk:"advertise_external_conditional"`
-		AdvertiseInactive            types.Bool                     `tfsdk:"advertise_inactive"`
-		AdvertisePeerAS              types.Bool                     `tfsdk:"advertise_peer_as"`
-		NoAdvertisePeerAS            types.Bool                     `tfsdk:"no_advertise_peer_as"`
-		ASOverride                   types.Bool                     `tfsdk:"as_override"`
-		Damping                      types.Bool                     `tfsdk:"damping"`
-		KeepAll                      types.Bool                     `tfsdk:"keep_all"`
-		KeepNone                     types.Bool                     `tfsdk:"keep_none"`
-		LocalASAlias                 types.Bool                     `tfsdk:"local_as_alias"`
-		LocalASNoPrependGlobalAS     types.Bool                     `tfsdk:"local_as_no_prepend_global_as"`
-		LocalASPrivate               types.Bool                     `tfsdk:"local_as_private"`
-		LogUpdown                    types.Bool                     `tfsdk:"log_updown"`
-		MetricOutIgp                 types.Bool                     `tfsdk:"metric_out_igp"`
-		MetricOutIgpDelayMedUpdate   types.Bool                     `tfsdk:"metric_out_igp_delay_med_update"`
-		MetricOutMinimumIgp          types.Bool                     `tfsdk:"metric_out_minimum_igp"`
-		MtuDiscovery                 types.Bool                     `tfsdk:"mtu_discovery"`
-		Multihop                     types.Bool                     `tfsdk:"multihop"`
-		Passive                      types.Bool                     `tfsdk:"passive"`
-		RemovePrivate                types.Bool                     `tfsdk:"remove_private"`
-		AuthenticationAlgorithm      types.String                   `tfsdk:"authentication_algorithm"`
-		AuthenticationKey            types.String                   `tfsdk:"authentication_key"`
-		AuthenticationKeyChain       types.String                   `tfsdk:"authentication_key_chain"`
-		Cluster                      types.String                   `tfsdk:"cluster"`
-		Export                       []types.String                 `tfsdk:"export"`
-		HoldTime                     types.Int64                    `tfsdk:"hold_time"`
-		ID                           types.String                   `tfsdk:"id"`
-		Import                       []types.String                 `tfsdk:"import"`
-		LocalAddress                 types.String                   `tfsdk:"local_address"`
-		LocalAS                      types.String                   `tfsdk:"local_as"`
-		LocalASLoops                 types.Int64                    `tfsdk:"local_as_loops"`
-		LocalInterface               types.String                   `tfsdk:"local_interface"`
-		LocalPreference              types.Int64                    `tfsdk:"local_preference"`
-		MetricOut                    types.Int64                    `tfsdk:"metric_out"`
-		MetricOutIgpOffset           types.Int64                    `tfsdk:"metric_out_igp_offset"`
-		MetricOutMinimumIgpOffset    types.Int64                    `tfsdk:"metric_out_minimum_igp_offset"`
-		Name                         types.String                   `tfsdk:"name"`
-		OutDelay                     types.Int64                    `tfsdk:"out_delay"`
-		PeerAS                       types.String                   `tfsdk:"peer_as"`
-		Preference                   types.Int64                    `tfsdk:"preference"`
-		RoutingInstance              types.String                   `tfsdk:"routing_instance"`
-		Type                         types.String                   `tfsdk:"type"`
-		BfdLivenessDetection         []bgpBlockBfdLivenessDetection `tfsdk:"bfd_liveness_detection"`
-		BgpMultipath                 []bgpBlockBgpMultipath         `tfsdk:"bgp_multipath"`
-		FamilyEvpn                   []struct {
+		AcceptRemoteNexthop          types.Bool     `tfsdk:"accept_remote_nexthop"`
+		AdvertiseExternal            types.Bool     `tfsdk:"advertise_external"`
+		AdvertiseExternalConditional types.Bool     `tfsdk:"advertise_external_conditional"`
+		AdvertiseInactive            types.Bool     `tfsdk:"advertise_inactive"`
+		AdvertisePeerAS              types.Bool     `tfsdk:"advertise_peer_as"`
+		NoAdvertisePeerAS            types.Bool     `tfsdk:"no_advertise_peer_as"`
+		ASOverride                   types.Bool     `tfsdk:"as_override"`
+		Damping                      types.Bool     `tfsdk:"damping"`
+		KeepAll                      types.Bool     `tfsdk:"keep_all"`
+		KeepNone                     types.Bool     `tfsdk:"keep_none"`
+		LocalASAlias                 types.Bool     `tfsdk:"local_as_alias"`
+		LocalASNoPrependGlobalAS     types.Bool     `tfsdk:"local_as_no_prepend_global_as"`
+		LocalASPrivate               types.Bool     `tfsdk:"local_as_private"`
+		LogUpdown                    types.Bool     `tfsdk:"log_updown"`
+		MetricOutIgp                 types.Bool     `tfsdk:"metric_out_igp"`
+		MetricOutIgpDelayMedUpdate   types.Bool     `tfsdk:"metric_out_igp_delay_med_update"`
+		MetricOutMinimumIgp          types.Bool     `tfsdk:"metric_out_minimum_igp"`
+		MtuDiscovery                 types.Bool     `tfsdk:"mtu_discovery"`
+		Multihop                     types.Bool     `tfsdk:"multihop"`
+		Passive                      types.Bool     `tfsdk:"passive"`
+		RemovePrivate                types.Bool     `tfsdk:"remove_private"`
+		AuthenticationAlgorithm      types.String   `tfsdk:"authentication_algorithm"`
+		AuthenticationKey            types.String   `tfsdk:"authentication_key"`
+		AuthenticationKeyChain       types.String   `tfsdk:"authentication_key_chain"`
+		Cluster                      types.String   `tfsdk:"cluster"`
+		Export                       []types.String `tfsdk:"export"`
+		HoldTime                     types.Int64    `tfsdk:"hold_time"`
+		ID                           types.String   `tfsdk:"id"`
+		Import                       []types.String `tfsdk:"import"`
+		LocalAddress                 types.String   `tfsdk:"local_address"`
+		LocalAS                      types.String   `tfsdk:"local_as"`
+		LocalASLoops                 types.Int64    `tfsdk:"local_as_loops"`
+		LocalInterface               types.String   `tfsdk:"local_interface"`
+		LocalPreference              types.Int64    `tfsdk:"local_preference"`
+		MetricOut                    types.Int64    `tfsdk:"metric_out"`
+		MetricOutIgpOffset           types.Int64    `tfsdk:"metric_out_igp_offset"`
+		MetricOutMinimumIgpOffset    types.Int64    `tfsdk:"metric_out_minimum_igp_offset"`
+		Name                         types.String   `tfsdk:"name"`
+		OutDelay                     types.Int64    `tfsdk:"out_delay"`
+		PeerAS                       types.String   `tfsdk:"peer_as"`
+		Preference                   types.Int64    `tfsdk:"preference"`
+		RoutingInstance              types.String   `tfsdk:"routing_instance"`
+		Type                         types.String   `tfsdk:"type"`
+		BfdLivenessDetection         []struct {
+			AuthenticationLooseCheck        types.Bool   `tfsdk:"authentication_loose_check"`
+			AuthenticationAlgorithm         types.String `tfsdk:"authentication_algorithm"`
+			AuthenticationKeyChain          types.String `tfsdk:"authentication_key_chain"`
+			DetectionTimeThreshold          types.Int64  `tfsdk:"detection_time_threshold"`
+			HolddownInterval                types.Int64  `tfsdk:"holddown_interval"`
+			MinimumInterval                 types.Int64  `tfsdk:"minimum_interval"`
+			MinimumReceiveInterval          types.Int64  `tfsdk:"minimum_receive_interval"`
+			Multiplier                      types.Int64  `tfsdk:"multiplier"`
+			SessionMode                     types.String `tfsdk:"session_mode"`
+			TransmitIntervalMinimumInterval types.Int64  `tfsdk:"transmit_interval_minimum_interval"`
+			TransmitIntervalThreshold       types.Int64  `tfsdk:"transmit_interval_threshold"`
+			Version                         types.String `tfsdk:"version"`
+		} `tfsdk:"bfd_liveness_detection"`
+		BgpMultipath []struct {
+			AllowProtection types.Bool `tfsdk:"allow_protection"`
+			Disable         types.Bool `tfsdk:"disable"`
+			MultipleAS      types.Bool `tfsdk:"multiple_as"`
+		} `tfsdk:"bgp_multipath"`
+		FamilyEvpn []struct {
 			NlriType            types.String                     `tfsdk:"nlri_type"`
 			AcceptedPrefixLimit []bgpBlockFamilyBlockPrefixLimit `tfsdk:"accepted_prefix_limit"`
 			PrefixLimit         []bgpBlockFamilyBlockPrefixLimit `tfsdk:"prefix_limit"`
@@ -359,7 +376,11 @@ func upgradeBgpGroupStateV0toV1(
 			AcceptedPrefixLimit []bgpBlockFamilyBlockPrefixLimit `tfsdk:"accepted_prefix_limit"`
 			PrefixLimit         []bgpBlockFamilyBlockPrefixLimit `tfsdk:"prefix_limit"`
 		} `tfsdk:"family_inet6"`
-		GracefulRestart []bgpBlockGracefulRestart `tfsdk:"graceful_restart"`
+		GracefulRestart []struct {
+			Disable        types.Bool  `tfsdk:"disable"`
+			RestartTime    types.Int64 `tfsdk:"restart_time"`
+			StaleRouteTime types.Int64 `tfsdk:"stale_route_time"`
+		} `tfsdk:"graceful_restart"`
 	}
 
 	var dataV0 modelV0
@@ -413,10 +434,27 @@ func upgradeBgpGroupStateV0toV1(
 	dataV1.Preference = dataV0.Preference
 	dataV1.RemovePrivate = dataV0.RemovePrivate
 	if len(dataV0.BfdLivenessDetection) > 0 {
-		dataV1.BfdLivenessDetection = &dataV0.BfdLivenessDetection[0]
+		dataV1.BfdLivenessDetection = &bgpBlockBfdLivenessDetection{
+			AuthenticationLooseCheck:        dataV0.BfdLivenessDetection[0].AuthenticationLooseCheck,
+			AuthenticationAlgorithm:         dataV0.BfdLivenessDetection[0].AuthenticationAlgorithm,
+			AuthenticationKeyChain:          dataV0.BfdLivenessDetection[0].AuthenticationKeyChain,
+			DetectionTimeThreshold:          dataV0.BfdLivenessDetection[0].DetectionTimeThreshold,
+			HolddownInterval:                dataV0.BfdLivenessDetection[0].HolddownInterval,
+			MinimumInterval:                 dataV0.BfdLivenessDetection[0].MinimumInterval,
+			MinimumReceiveInterval:          dataV0.BfdLivenessDetection[0].MinimumReceiveInterval,
+			Multiplier:                      dataV0.BfdLivenessDetection[0].Multiplier,
+			SessionMode:                     dataV0.BfdLivenessDetection[0].SessionMode,
+			TransmitIntervalMinimumInterval: dataV0.BfdLivenessDetection[0].TransmitIntervalMinimumInterval,
+			TransmitIntervalThreshold:       dataV0.BfdLivenessDetection[0].TransmitIntervalThreshold,
+			Version:                         dataV0.BfdLivenessDetection[0].Version,
+		}
 	}
 	if len(dataV0.BgpMultipath) > 0 {
-		dataV1.BgpMultipath = &dataV0.BgpMultipath[0]
+		dataV1.BgpMultipath = &bgpBlockBgpMultipath{
+			AllowProtection: dataV0.BgpMultipath[0].AllowProtection,
+			Disable:         dataV0.BgpMultipath[0].Disable,
+			MultipleAS:      dataV0.BgpMultipath[0].MultipleAS,
+		}
 	}
 	for _, blockV0 := range dataV0.FamilyEvpn {
 		blockV1 := bgpBlockFamily{
@@ -455,7 +493,11 @@ func upgradeBgpGroupStateV0toV1(
 		dataV1.FamilyInet6 = append(dataV1.FamilyInet6, blockV1)
 	}
 	if len(dataV0.GracefulRestart) > 0 {
-		dataV1.GracefulRestart = &dataV0.GracefulRestart[0]
+		dataV1.GracefulRestart = &bgpBlockGracefulRestart{
+			Disable:        dataV0.GracefulRestart[0].Disable,
+			RestartTime:    dataV0.GracefulRestart[0].RestartTime,
+			StaleRouteTime: dataV0.GracefulRestart[0].StaleRouteTime,
+		}
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, dataV1)...)

--- a/internal/providerfwk/upgradestate_bgp_neighbor.go
+++ b/internal/providerfwk/upgradestate_bgp_neighbor.go
@@ -298,52 +298,69 @@ func upgradeBgpNeighborStateV0toV1(
 	ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse,
 ) {
 	type modelV0 struct {
-		AcceptRemoteNexthop          types.Bool                     `tfsdk:"accept_remote_nexthop"`
-		AdvertiseExternal            types.Bool                     `tfsdk:"advertise_external"`
-		AdvertiseExternalConditional types.Bool                     `tfsdk:"advertise_external_conditional"`
-		AdvertiseInactive            types.Bool                     `tfsdk:"advertise_inactive"`
-		AdvertisePeerAS              types.Bool                     `tfsdk:"advertise_peer_as"`
-		NoAdvertisePeerAS            types.Bool                     `tfsdk:"no_advertise_peer_as"`
-		ASOverride                   types.Bool                     `tfsdk:"as_override"`
-		Damping                      types.Bool                     `tfsdk:"damping"`
-		KeepAll                      types.Bool                     `tfsdk:"keep_all"`
-		KeepNone                     types.Bool                     `tfsdk:"keep_none"`
-		LocalASAlias                 types.Bool                     `tfsdk:"local_as_alias"`
-		LocalASNoPrependGlobalAS     types.Bool                     `tfsdk:"local_as_no_prepend_global_as"`
-		LocalASPrivate               types.Bool                     `tfsdk:"local_as_private"`
-		LogUpdown                    types.Bool                     `tfsdk:"log_updown"`
-		MetricOutIgp                 types.Bool                     `tfsdk:"metric_out_igp"`
-		MetricOutIgpDelayMedUpdate   types.Bool                     `tfsdk:"metric_out_igp_delay_med_update"`
-		MetricOutMinimumIgp          types.Bool                     `tfsdk:"metric_out_minimum_igp"`
-		MtuDiscovery                 types.Bool                     `tfsdk:"mtu_discovery"`
-		Multihop                     types.Bool                     `tfsdk:"multihop"`
-		Passive                      types.Bool                     `tfsdk:"passive"`
-		RemovePrivate                types.Bool                     `tfsdk:"remove_private"`
-		AuthenticationAlgorithm      types.String                   `tfsdk:"authentication_algorithm"`
-		AuthenticationKey            types.String                   `tfsdk:"authentication_key"`
-		AuthenticationKeyChain       types.String                   `tfsdk:"authentication_key_chain"`
-		Cluster                      types.String                   `tfsdk:"cluster"`
-		Export                       []types.String                 `tfsdk:"export"`
-		Group                        types.String                   `tfsdk:"group"`
-		HoldTime                     types.Int64                    `tfsdk:"hold_time"`
-		ID                           types.String                   `tfsdk:"id"`
-		Import                       []types.String                 `tfsdk:"import"`
-		IP                           types.String                   `tfsdk:"ip"`
-		LocalAddress                 types.String                   `tfsdk:"local_address"`
-		LocalAS                      types.String                   `tfsdk:"local_as"`
-		LocalASLoops                 types.Int64                    `tfsdk:"local_as_loops"`
-		LocalInterface               types.String                   `tfsdk:"local_interface"`
-		LocalPreference              types.Int64                    `tfsdk:"local_preference"`
-		MetricOut                    types.Int64                    `tfsdk:"metric_out"`
-		MetricOutIgpOffset           types.Int64                    `tfsdk:"metric_out_igp_offset"`
-		MetricOutMinimumIgpOffset    types.Int64                    `tfsdk:"metric_out_minimum_igp_offset"`
-		OutDelay                     types.Int64                    `tfsdk:"out_delay"`
-		PeerAS                       types.String                   `tfsdk:"peer_as"`
-		Preference                   types.Int64                    `tfsdk:"preference"`
-		RoutingInstance              types.String                   `tfsdk:"routing_instance"`
-		BfdLivenessDetection         []bgpBlockBfdLivenessDetection `tfsdk:"bfd_liveness_detection"`
-		BgpMultipath                 []bgpBlockBgpMultipath         `tfsdk:"bgp_multipath"`
-		FamilyEvpn                   []struct {
+		AcceptRemoteNexthop          types.Bool     `tfsdk:"accept_remote_nexthop"`
+		AdvertiseExternal            types.Bool     `tfsdk:"advertise_external"`
+		AdvertiseExternalConditional types.Bool     `tfsdk:"advertise_external_conditional"`
+		AdvertiseInactive            types.Bool     `tfsdk:"advertise_inactive"`
+		AdvertisePeerAS              types.Bool     `tfsdk:"advertise_peer_as"`
+		NoAdvertisePeerAS            types.Bool     `tfsdk:"no_advertise_peer_as"`
+		ASOverride                   types.Bool     `tfsdk:"as_override"`
+		Damping                      types.Bool     `tfsdk:"damping"`
+		KeepAll                      types.Bool     `tfsdk:"keep_all"`
+		KeepNone                     types.Bool     `tfsdk:"keep_none"`
+		LocalASAlias                 types.Bool     `tfsdk:"local_as_alias"`
+		LocalASNoPrependGlobalAS     types.Bool     `tfsdk:"local_as_no_prepend_global_as"`
+		LocalASPrivate               types.Bool     `tfsdk:"local_as_private"`
+		LogUpdown                    types.Bool     `tfsdk:"log_updown"`
+		MetricOutIgp                 types.Bool     `tfsdk:"metric_out_igp"`
+		MetricOutIgpDelayMedUpdate   types.Bool     `tfsdk:"metric_out_igp_delay_med_update"`
+		MetricOutMinimumIgp          types.Bool     `tfsdk:"metric_out_minimum_igp"`
+		MtuDiscovery                 types.Bool     `tfsdk:"mtu_discovery"`
+		Multihop                     types.Bool     `tfsdk:"multihop"`
+		Passive                      types.Bool     `tfsdk:"passive"`
+		RemovePrivate                types.Bool     `tfsdk:"remove_private"`
+		AuthenticationAlgorithm      types.String   `tfsdk:"authentication_algorithm"`
+		AuthenticationKey            types.String   `tfsdk:"authentication_key"`
+		AuthenticationKeyChain       types.String   `tfsdk:"authentication_key_chain"`
+		Cluster                      types.String   `tfsdk:"cluster"`
+		Export                       []types.String `tfsdk:"export"`
+		Group                        types.String   `tfsdk:"group"`
+		HoldTime                     types.Int64    `tfsdk:"hold_time"`
+		ID                           types.String   `tfsdk:"id"`
+		Import                       []types.String `tfsdk:"import"`
+		IP                           types.String   `tfsdk:"ip"`
+		LocalAddress                 types.String   `tfsdk:"local_address"`
+		LocalAS                      types.String   `tfsdk:"local_as"`
+		LocalASLoops                 types.Int64    `tfsdk:"local_as_loops"`
+		LocalInterface               types.String   `tfsdk:"local_interface"`
+		LocalPreference              types.Int64    `tfsdk:"local_preference"`
+		MetricOut                    types.Int64    `tfsdk:"metric_out"`
+		MetricOutIgpOffset           types.Int64    `tfsdk:"metric_out_igp_offset"`
+		MetricOutMinimumIgpOffset    types.Int64    `tfsdk:"metric_out_minimum_igp_offset"`
+		OutDelay                     types.Int64    `tfsdk:"out_delay"`
+		PeerAS                       types.String   `tfsdk:"peer_as"`
+		Preference                   types.Int64    `tfsdk:"preference"`
+		RoutingInstance              types.String   `tfsdk:"routing_instance"`
+		BfdLivenessDetection         []struct {
+			AuthenticationLooseCheck        types.Bool   `tfsdk:"authentication_loose_check"`
+			AuthenticationAlgorithm         types.String `tfsdk:"authentication_algorithm"`
+			AuthenticationKeyChain          types.String `tfsdk:"authentication_key_chain"`
+			DetectionTimeThreshold          types.Int64  `tfsdk:"detection_time_threshold"`
+			HolddownInterval                types.Int64  `tfsdk:"holddown_interval"`
+			MinimumInterval                 types.Int64  `tfsdk:"minimum_interval"`
+			MinimumReceiveInterval          types.Int64  `tfsdk:"minimum_receive_interval"`
+			Multiplier                      types.Int64  `tfsdk:"multiplier"`
+			SessionMode                     types.String `tfsdk:"session_mode"`
+			TransmitIntervalMinimumInterval types.Int64  `tfsdk:"transmit_interval_minimum_interval"`
+			TransmitIntervalThreshold       types.Int64  `tfsdk:"transmit_interval_threshold"`
+			Version                         types.String `tfsdk:"version"`
+		} `tfsdk:"bfd_liveness_detection"`
+		BgpMultipath []struct {
+			AllowProtection types.Bool `tfsdk:"allow_protection"`
+			Disable         types.Bool `tfsdk:"disable"`
+			MultipleAS      types.Bool `tfsdk:"multiple_as"`
+		} `tfsdk:"bgp_multipath"`
+		FamilyEvpn []struct {
 			NlriType            types.String                     `tfsdk:"nlri_type"`
 			AcceptedPrefixLimit []bgpBlockFamilyBlockPrefixLimit `tfsdk:"accepted_prefix_limit"`
 			PrefixLimit         []bgpBlockFamilyBlockPrefixLimit `tfsdk:"prefix_limit"`
@@ -358,7 +375,11 @@ func upgradeBgpNeighborStateV0toV1(
 			AcceptedPrefixLimit []bgpBlockFamilyBlockPrefixLimit `tfsdk:"accepted_prefix_limit"`
 			PrefixLimit         []bgpBlockFamilyBlockPrefixLimit `tfsdk:"prefix_limit"`
 		} `tfsdk:"family_inet6"`
-		GracefulRestart []bgpBlockGracefulRestart `tfsdk:"graceful_restart"`
+		GracefulRestart []struct {
+			Disable        types.Bool  `tfsdk:"disable"`
+			RestartTime    types.Int64 `tfsdk:"restart_time"`
+			StaleRouteTime types.Int64 `tfsdk:"stale_route_time"`
+		} `tfsdk:"graceful_restart"`
 	}
 
 	var dataV0 modelV0
@@ -412,10 +433,27 @@ func upgradeBgpNeighborStateV0toV1(
 	dataV1.Preference = dataV0.Preference
 	dataV1.RemovePrivate = dataV0.RemovePrivate
 	if len(dataV0.BfdLivenessDetection) > 0 {
-		dataV1.BfdLivenessDetection = &dataV0.BfdLivenessDetection[0]
+		dataV1.BfdLivenessDetection = &bgpBlockBfdLivenessDetection{
+			AuthenticationLooseCheck:        dataV0.BfdLivenessDetection[0].AuthenticationLooseCheck,
+			AuthenticationAlgorithm:         dataV0.BfdLivenessDetection[0].AuthenticationAlgorithm,
+			AuthenticationKeyChain:          dataV0.BfdLivenessDetection[0].AuthenticationKeyChain,
+			DetectionTimeThreshold:          dataV0.BfdLivenessDetection[0].DetectionTimeThreshold,
+			HolddownInterval:                dataV0.BfdLivenessDetection[0].HolddownInterval,
+			MinimumInterval:                 dataV0.BfdLivenessDetection[0].MinimumInterval,
+			MinimumReceiveInterval:          dataV0.BfdLivenessDetection[0].MinimumReceiveInterval,
+			Multiplier:                      dataV0.BfdLivenessDetection[0].Multiplier,
+			SessionMode:                     dataV0.BfdLivenessDetection[0].SessionMode,
+			TransmitIntervalMinimumInterval: dataV0.BfdLivenessDetection[0].TransmitIntervalMinimumInterval,
+			TransmitIntervalThreshold:       dataV0.BfdLivenessDetection[0].TransmitIntervalThreshold,
+			Version:                         dataV0.BfdLivenessDetection[0].Version,
+		}
 	}
 	if len(dataV0.BgpMultipath) > 0 {
-		dataV1.BgpMultipath = &dataV0.BgpMultipath[0]
+		dataV1.BgpMultipath = &bgpBlockBgpMultipath{
+			AllowProtection: dataV0.BgpMultipath[0].AllowProtection,
+			Disable:         dataV0.BgpMultipath[0].Disable,
+			MultipleAS:      dataV0.BgpMultipath[0].MultipleAS,
+		}
 	}
 	for _, blockV0 := range dataV0.FamilyEvpn {
 		blockV1 := bgpBlockFamily{
@@ -454,7 +492,11 @@ func upgradeBgpNeighborStateV0toV1(
 		dataV1.FamilyInet6 = append(dataV1.FamilyInet6, blockV1)
 	}
 	if len(dataV0.GracefulRestart) > 0 {
-		dataV1.GracefulRestart = &dataV0.GracefulRestart[0]
+		dataV1.GracefulRestart = &bgpBlockGracefulRestart{
+			Disable:        dataV0.GracefulRestart[0].Disable,
+			RestartTime:    dataV0.GracefulRestart[0].RestartTime,
+			StaleRouteTime: dataV0.GracefulRestart[0].StaleRouteTime,
+		}
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, dataV1)...)

--- a/internal/providerfwk/upgradestate_forwardingoptions_sampling_instance.go
+++ b/internal/providerfwk/upgradestate_forwardingoptions_sampling_instance.go
@@ -26,12 +26,45 @@ func (rsc *forwardingoptionsSamplingInstance) UpgradeState(_ context.Context) ma
 				Blocks: map[string]schema.Block{
 					"family_inet_input": schema.ListNestedBlock{
 						NestedObject: schema.NestedBlockObject{
-							Attributes: rsc.schemaInputAttributes(),
+							Attributes: map[string]schema.Attribute{
+								"max_packets_per_second": schema.Int64Attribute{
+									Optional: true,
+								},
+								"maximum_packet_length": schema.Int64Attribute{
+									Optional: true,
+								},
+								"rate": schema.Int64Attribute{
+									Optional: true,
+								},
+								"run_length": schema.Int64Attribute{
+									Optional: true,
+								},
+							},
 						},
 					},
 					"family_inet_output": schema.ListNestedBlock{
 						NestedObject: schema.NestedBlockObject{
-							Attributes: rsc.schemaFamilyInetOutputAttributes(),
+							Attributes: map[string]schema.Attribute{
+								"aggregate_export_interval": schema.Int64Attribute{
+									Optional: true,
+								},
+								"extension_service": schema.ListAttribute{
+									ElementType: types.StringType,
+									Optional:    true,
+								},
+								"flow_active_timeout": schema.Int64Attribute{
+									Optional: true,
+								},
+								"flow_inactive_timeout": schema.Int64Attribute{
+									Optional: true,
+								},
+								"inline_jflow_export_rate": schema.Int64Attribute{
+									Optional: true,
+								},
+								"inline_jflow_source_address": schema.StringAttribute{
+									Optional: true,
+								},
+							},
 							Blocks: map[string]schema.Block{
 								"flow_server": schema.ListNestedBlock{
 									NestedObject: schema.NestedBlockObject{
@@ -103,18 +136,127 @@ func (rsc *forwardingoptionsSamplingInstance) UpgradeState(_ context.Context) ma
 					},
 					"family_inet6_input": schema.ListNestedBlock{
 						NestedObject: schema.NestedBlockObject{
-							Attributes: rsc.schemaInputAttributes(),
+							Attributes: map[string]schema.Attribute{
+								"max_packets_per_second": schema.Int64Attribute{
+									Optional: true,
+								},
+								"maximum_packet_length": schema.Int64Attribute{
+									Optional: true,
+								},
+								"rate": schema.Int64Attribute{
+									Optional: true,
+								},
+								"run_length": schema.Int64Attribute{
+									Optional: true,
+								},
+							},
 						},
 					},
 					"family_inet6_output": schema.ListNestedBlock{
 						NestedObject: schema.NestedBlockObject{
-							Attributes: rsc.schemaFamilyInetOutputAttributes(),
-							Blocks:     rsc.schemaOutputBlock(),
+							Attributes: map[string]schema.Attribute{
+								"aggregate_export_interval": schema.Int64Attribute{
+									Optional: true,
+								},
+								"extension_service": schema.ListAttribute{
+									ElementType: types.StringType,
+									Optional:    true,
+								},
+								"flow_active_timeout": schema.Int64Attribute{
+									Optional: true,
+								},
+								"flow_inactive_timeout": schema.Int64Attribute{
+									Optional: true,
+								},
+								"inline_jflow_export_rate": schema.Int64Attribute{
+									Optional: true,
+								},
+								"inline_jflow_source_address": schema.StringAttribute{
+									Optional: true,
+								},
+							},
+							Blocks: map[string]schema.Block{
+								"flow_server": schema.SetNestedBlock{
+									NestedObject: schema.NestedBlockObject{
+										Attributes: map[string]schema.Attribute{
+											"hostname": schema.StringAttribute{
+												Required: true,
+											},
+											"port": schema.Int64Attribute{
+												Required: true,
+											},
+											"aggregation_autonomous_system": schema.BoolAttribute{
+												Optional: true,
+											},
+											"aggregation_destination_prefix": schema.BoolAttribute{
+												Optional: true,
+											},
+											"aggregation_protocol_port": schema.BoolAttribute{
+												Optional: true,
+											},
+											"aggregation_source_destination_prefix": schema.BoolAttribute{
+												Optional: true,
+											},
+											"aggregation_source_destination_prefix_caida_compliant": schema.BoolAttribute{
+												Optional: true,
+											},
+											"aggregation_source_prefix": schema.BoolAttribute{
+												Optional: true,
+											},
+											"autonomous_system_type": schema.StringAttribute{
+												Optional: true,
+											},
+											"dscp": schema.Int64Attribute{
+												Optional: true,
+											},
+											"forwarding_class": schema.StringAttribute{
+												Optional: true,
+											},
+											"local_dump": schema.BoolAttribute{
+												Optional: true,
+											},
+											"no_local_dump": schema.BoolAttribute{
+												Optional: true,
+											},
+											"routing_instance": schema.StringAttribute{
+												Optional: true,
+											},
+											"source_address": schema.StringAttribute{
+												Optional: true,
+											},
+											"version9_template": schema.StringAttribute{
+												Optional: true,
+											},
+											"version_ipfix_template": schema.StringAttribute{
+												Optional: true,
+											},
+										},
+									},
+								},
+								"interface": schema.ListNestedBlock{
+									NestedObject: schema.NestedBlockObject{
+										Attributes: rsc.schemaOutputInterfaceAttributes(),
+									},
+								},
+							},
 						},
 					},
 					"family_mpls_input": schema.ListNestedBlock{
 						NestedObject: schema.NestedBlockObject{
-							Attributes: rsc.schemaInputAttributes(),
+							Attributes: map[string]schema.Attribute{
+								"max_packets_per_second": schema.Int64Attribute{
+									Optional: true,
+								},
+								"maximum_packet_length": schema.Int64Attribute{
+									Optional: true,
+								},
+								"rate": schema.Int64Attribute{
+									Optional: true,
+								},
+								"run_length": schema.Int64Attribute{
+									Optional: true,
+								},
+							},
 						},
 					},
 					"family_mpls_output": schema.ListNestedBlock{
@@ -136,12 +278,88 @@ func (rsc *forwardingoptionsSamplingInstance) UpgradeState(_ context.Context) ma
 									Optional: true,
 								},
 							},
-							Blocks: rsc.schemaOutputBlock(),
+							Blocks: map[string]schema.Block{
+								"flow_server": schema.SetNestedBlock{
+									NestedObject: schema.NestedBlockObject{
+										Attributes: map[string]schema.Attribute{
+											"hostname": schema.StringAttribute{
+												Required: true,
+											},
+											"port": schema.Int64Attribute{
+												Required: true,
+											},
+											"aggregation_autonomous_system": schema.BoolAttribute{
+												Optional: true,
+											},
+											"aggregation_destination_prefix": schema.BoolAttribute{
+												Optional: true,
+											},
+											"aggregation_protocol_port": schema.BoolAttribute{
+												Optional: true,
+											},
+											"aggregation_source_destination_prefix": schema.BoolAttribute{
+												Optional: true,
+											},
+											"aggregation_source_destination_prefix_caida_compliant": schema.BoolAttribute{
+												Optional: true,
+											},
+											"aggregation_source_prefix": schema.BoolAttribute{
+												Optional: true,
+											},
+											"autonomous_system_type": schema.StringAttribute{
+												Optional: true,
+											},
+											"dscp": schema.Int64Attribute{
+												Optional: true,
+											},
+											"forwarding_class": schema.StringAttribute{
+												Optional: true,
+											},
+											"local_dump": schema.BoolAttribute{
+												Optional: true,
+											},
+											"no_local_dump": schema.BoolAttribute{
+												Optional: true,
+											},
+											"routing_instance": schema.StringAttribute{
+												Optional: true,
+											},
+											"source_address": schema.StringAttribute{
+												Optional: true,
+											},
+											"version9_template": schema.StringAttribute{
+												Optional: true,
+											},
+											"version_ipfix_template": schema.StringAttribute{
+												Optional: true,
+											},
+										},
+									},
+								},
+								"interface": schema.ListNestedBlock{
+									NestedObject: schema.NestedBlockObject{
+										Attributes: rsc.schemaOutputInterfaceAttributes(),
+									},
+								},
+							},
 						},
 					},
 					"input": schema.ListNestedBlock{
 						NestedObject: schema.NestedBlockObject{
-							Attributes: rsc.schemaInputAttributes(),
+							Attributes: map[string]schema.Attribute{
+								"max_packets_per_second": schema.Int64Attribute{
+									Optional: true,
+								},
+								"maximum_packet_length": schema.Int64Attribute{
+									Optional: true,
+								},
+								"rate": schema.Int64Attribute{
+									Optional: true,
+								},
+								"run_length": schema.Int64Attribute{
+									Optional: true,
+								},
+							},
 						},
 					},
 				},
@@ -154,17 +372,119 @@ func (rsc *forwardingoptionsSamplingInstance) UpgradeState(_ context.Context) ma
 func upgradeForwardingoptionsSamplingInstanceStateV0toV1(
 	ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse,
 ) {
+	//nolint:lll
 	type modelV0 struct {
-		Disable           types.Bool                                                `tfsdk:"disable"`
-		ID                types.String                                              `tfsdk:"id"`
-		Name              types.String                                              `tfsdk:"name"`
-		FamilyInetInput   []forwardingoptionsSamplingInstanceBlockInput             `tfsdk:"family_inet_input"`
-		FamilyInetOutput  []forwardingoptionsSamplingInstanceBlockFamilyInetOutput  `tfsdk:"family_inet_output"`
-		FamilyInet6Input  []forwardingoptionsSamplingInstanceBlockInput             `tfsdk:"family_inet6_input"`
-		FamilyInet6Output []forwardingoptionsSamplingInstanceBlockFamilyInet6Output `tfsdk:"family_inet6_output"`
-		FamilyMplsInput   []forwardingoptionsSamplingInstanceBlockInput             `tfsdk:"family_mpls_input"`
-		FamilyMplsOutput  []forwardingoptionsSamplingInstanceBlockFamilyMplsOutput  `tfsdk:"family_mpls_output"`
-		Input             []forwardingoptionsSamplingInstanceBlockInput             `tfsdk:"input"`
+		Disable         types.Bool   `tfsdk:"disable"`
+		ID              types.String `tfsdk:"id"`
+		Name            types.String `tfsdk:"name"`
+		FamilyInetInput []struct {
+			MaxPacketsPerSecond types.Int64 `tfsdk:"max_packets_per_second"`
+			MaximumPacketLength types.Int64 `tfsdk:"maximum_packet_length"`
+			Rate                types.Int64 `tfsdk:"rate"`
+			RunLength           types.Int64 `tfsdk:"run_length"`
+		} `tfsdk:"family_inet_input"`
+		FamilyInetOutput []struct {
+			AggregateExportInterval  types.Int64    `tfsdk:"aggregate_export_interval"`
+			ExtensionService         []types.String `tfsdk:"extension_service"`
+			FlowActiveTimeout        types.Int64    `tfsdk:"flow_active_timeout"`
+			FlowInactiveTimeout      types.Int64    `tfsdk:"flow_inactive_timeout"`
+			InlineJflowExportRate    types.Int64    `tfsdk:"inline_jflow_export_rate"`
+			InlineJflowSourceAddress types.String   `tfsdk:"inline_jflow_source_address"`
+			FlowServer               []struct {
+				AggregationAutonomousSystem                      types.Bool   `tfsdk:"aggregation_autonomous_system"`
+				AggregationDestinationPrefix                     types.Bool   `tfsdk:"aggregation_destination_prefix"`
+				AggregationProtocolPort                          types.Bool   `tfsdk:"aggregation_protocol_port"`
+				AggregationSourceDestinationPrefix               types.Bool   `tfsdk:"aggregation_source_destination_prefix"`
+				AggregationSourceDestinationPrefixCaidaCompliant types.Bool   `tfsdk:"aggregation_source_destination_prefix_caida_compliant"`
+				AggregationSourcePrefix                          types.Bool   `tfsdk:"aggregation_source_prefix"`
+				LocalDump                                        types.Bool   `tfsdk:"local_dump"`
+				NoLocalDump                                      types.Bool   `tfsdk:"no_local_dump"`
+				Hostname                                         types.String `tfsdk:"hostname"`
+				Port                                             types.Int64  `tfsdk:"port"`
+				AutonomousSystemType                             types.String `tfsdk:"autonomous_system_type"`
+				Dscp                                             types.Int64  `tfsdk:"dscp"`
+				ForwardingClass                                  types.String `tfsdk:"forwarding_class"`
+				RoutingInstance                                  types.String `tfsdk:"routing_instance"`
+				SourceAddress                                    types.String `tfsdk:"source_address"`
+				Version                                          types.Int64  `tfsdk:"version"`
+				Version9Template                                 types.String `tfsdk:"version9_template"`
+				VersionIPFixTemplate                             types.String `tfsdk:"version_ipfix_template"`
+			} `tfsdk:"flow_server"`
+			Interface []forwardingoptionsSamplingInstanceBlockOutputBlockInterface `tfsdk:"interface"`
+		} `tfsdk:"family_inet_output"`
+		FamilyInet6Input []struct {
+			MaxPacketsPerSecond types.Int64 `tfsdk:"max_packets_per_second"`
+			MaximumPacketLength types.Int64 `tfsdk:"maximum_packet_length"`
+			Rate                types.Int64 `tfsdk:"rate"`
+			RunLength           types.Int64 `tfsdk:"run_length"`
+		} `tfsdk:"family_inet6_input"`
+		FamilyInet6Output []struct {
+			AggregateExportInterval  types.Int64    `tfsdk:"aggregate_export_interval"`
+			ExtensionService         []types.String `tfsdk:"extension_service"`
+			FlowActiveTimeout        types.Int64    `tfsdk:"flow_active_timeout"`
+			FlowInactiveTimeout      types.Int64    `tfsdk:"flow_inactive_timeout"`
+			InlineJflowExportRate    types.Int64    `tfsdk:"inline_jflow_export_rate"`
+			InlineJflowSourceAddress types.String   `tfsdk:"inline_jflow_source_address"`
+			FlowServer               []struct {
+				AggregationAutonomousSystem                      types.Bool   `tfsdk:"aggregation_autonomous_system"`
+				AggregationDestinationPrefix                     types.Bool   `tfsdk:"aggregation_destination_prefix"`
+				AggregationProtocolPort                          types.Bool   `tfsdk:"aggregation_protocol_port"`
+				AggregationSourceDestinationPrefix               types.Bool   `tfsdk:"aggregation_source_destination_prefix"`
+				AggregationSourceDestinationPrefixCaidaCompliant types.Bool   `tfsdk:"aggregation_source_destination_prefix_caida_compliant"`
+				AggregationSourcePrefix                          types.Bool   `tfsdk:"aggregation_source_prefix"`
+				LocalDump                                        types.Bool   `tfsdk:"local_dump"`
+				NoLocalDump                                      types.Bool   `tfsdk:"no_local_dump"`
+				Hostname                                         types.String `tfsdk:"hostname"`
+				Port                                             types.Int64  `tfsdk:"port"`
+				AutonomousSystemType                             types.String `tfsdk:"autonomous_system_type"`
+				Dscp                                             types.Int64  `tfsdk:"dscp"`
+				ForwardingClass                                  types.String `tfsdk:"forwarding_class"`
+				RoutingInstance                                  types.String `tfsdk:"routing_instance"`
+				SourceAddress                                    types.String `tfsdk:"source_address"`
+				Version9Template                                 types.String `tfsdk:"version9_template"`
+				VersionIPFixTemplate                             types.String `tfsdk:"version_ipfix_template"`
+			} `tfsdk:"flow_server"`
+			Interface []forwardingoptionsSamplingInstanceBlockOutputBlockInterface `tfsdk:"interface"`
+		} `tfsdk:"family_inet6_output"`
+		FamilyMplsInput []struct {
+			MaxPacketsPerSecond types.Int64 `tfsdk:"max_packets_per_second"`
+			MaximumPacketLength types.Int64 `tfsdk:"maximum_packet_length"`
+			Rate                types.Int64 `tfsdk:"rate"`
+			RunLength           types.Int64 `tfsdk:"run_length"`
+		} `tfsdk:"family_mpls_input"`
+		FamilyMplsOutput []struct {
+			AggregateExportInterval  types.Int64  `tfsdk:"aggregate_export_interval"`
+			FlowActiveTimeout        types.Int64  `tfsdk:"flow_active_timeout"`
+			FlowInactiveTimeout      types.Int64  `tfsdk:"flow_inactive_timeout"`
+			InlineJflowExportRate    types.Int64  `tfsdk:"inline_jflow_export_rate"`
+			InlineJflowSourceAddress types.String `tfsdk:"inline_jflow_source_address"`
+			FlowServer               []struct {
+				AggregationAutonomousSystem                      types.Bool   `tfsdk:"aggregation_autonomous_system"`
+				AggregationDestinationPrefix                     types.Bool   `tfsdk:"aggregation_destination_prefix"`
+				AggregationProtocolPort                          types.Bool   `tfsdk:"aggregation_protocol_port"`
+				AggregationSourceDestinationPrefix               types.Bool   `tfsdk:"aggregation_source_destination_prefix"`
+				AggregationSourceDestinationPrefixCaidaCompliant types.Bool   `tfsdk:"aggregation_source_destination_prefix_caida_compliant"`
+				AggregationSourcePrefix                          types.Bool   `tfsdk:"aggregation_source_prefix"`
+				LocalDump                                        types.Bool   `tfsdk:"local_dump"`
+				NoLocalDump                                      types.Bool   `tfsdk:"no_local_dump"`
+				Hostname                                         types.String `tfsdk:"hostname"`
+				Port                                             types.Int64  `tfsdk:"port"`
+				AutonomousSystemType                             types.String `tfsdk:"autonomous_system_type"`
+				Dscp                                             types.Int64  `tfsdk:"dscp"`
+				ForwardingClass                                  types.String `tfsdk:"forwarding_class"`
+				RoutingInstance                                  types.String `tfsdk:"routing_instance"`
+				SourceAddress                                    types.String `tfsdk:"source_address"`
+				Version9Template                                 types.String `tfsdk:"version9_template"`
+				VersionIPFixTemplate                             types.String `tfsdk:"version_ipfix_template"`
+			} `tfsdk:"flow_server"`
+			Interface []forwardingoptionsSamplingInstanceBlockOutputBlockInterface `tfsdk:"interface"`
+		} `tfsdk:"family_mpls_output"`
+		Input []struct {
+			MaxPacketsPerSecond types.Int64 `tfsdk:"max_packets_per_second"`
+			MaximumPacketLength types.Int64 `tfsdk:"maximum_packet_length"`
+			Rate                types.Int64 `tfsdk:"rate"`
+			RunLength           types.Int64 `tfsdk:"run_length"`
+		} `tfsdk:"input"`
 	}
 
 	var dataV0 modelV0
@@ -178,25 +498,138 @@ func upgradeForwardingoptionsSamplingInstanceStateV0toV1(
 	dataV1.Name = dataV0.Name
 	dataV1.Disable = dataV0.Disable
 	if len(dataV0.FamilyInetInput) > 0 {
-		dataV1.FamilyInetInput = &dataV0.FamilyInetInput[0]
+		dataV1.FamilyInetInput = &forwardingoptionsSamplingInstanceBlockInput{
+			MaxPacketsPerSecond: dataV0.FamilyInetInput[0].MaxPacketsPerSecond,
+			MaximumPacketLength: dataV0.FamilyInetInput[0].MaximumPacketLength,
+			Rate:                dataV0.FamilyInetInput[0].Rate,
+			RunLength:           dataV0.FamilyInetInput[0].RunLength,
+		}
 	}
 	if len(dataV0.FamilyInetOutput) > 0 {
-		dataV1.FamilyInetOutput = &dataV0.FamilyInetOutput[0]
+		dataV1.FamilyInetOutput = &forwardingoptionsSamplingInstanceBlockFamilyInetOutput{
+			AggregateExportInterval:  dataV0.FamilyInetOutput[0].AggregateExportInterval,
+			ExtensionService:         dataV0.FamilyInetOutput[0].ExtensionService,
+			FlowActiveTimeout:        dataV0.FamilyInetOutput[0].FlowActiveTimeout,
+			FlowInactiveTimeout:      dataV0.FamilyInetOutput[0].FlowInactiveTimeout,
+			InlineJflowExportRate:    dataV0.FamilyInetOutput[0].InlineJflowExportRate,
+			InlineJflowSourceAddress: dataV0.FamilyInetOutput[0].InlineJflowSourceAddress,
+			Interface:                dataV0.FamilyInetOutput[0].Interface,
+		}
+		for _, blockV0 := range dataV0.FamilyInetOutput[0].FlowServer {
+			dataV1.FamilyInetOutput.FlowServer = append(dataV1.FamilyInetOutput.FlowServer,
+				forwardingoptionsSamplingInstanceBlockFamilyInetOutputBlockFlowServer{
+					AggregationAutonomousSystem:                      blockV0.AggregationAutonomousSystem,
+					AggregationDestinationPrefix:                     blockV0.AggregationDestinationPrefix,
+					AggregationProtocolPort:                          blockV0.AggregationProtocolPort,
+					AggregationSourceDestinationPrefix:               blockV0.AggregationSourceDestinationPrefix,
+					AggregationSourceDestinationPrefixCaidaCompliant: blockV0.AggregationSourceDestinationPrefixCaidaCompliant,
+					AggregationSourcePrefix:                          blockV0.AggregationSourcePrefix,
+					LocalDump:                                        blockV0.LocalDump,
+					NoLocalDump:                                      blockV0.NoLocalDump,
+					Hostname:                                         blockV0.Hostname,
+					Port:                                             blockV0.Port,
+					AutonomousSystemType:                             blockV0.AutonomousSystemType,
+					Dscp:                                             blockV0.Dscp,
+					ForwardingClass:                                  blockV0.ForwardingClass,
+					RoutingInstance:                                  blockV0.RoutingInstance,
+					SourceAddress:                                    blockV0.SourceAddress,
+					Version:                                          blockV0.Version,
+					Version9Template:                                 blockV0.Version9Template,
+					VersionIPFixTemplate:                             blockV0.VersionIPFixTemplate,
+				},
+			)
+		}
 	}
 	if len(dataV0.FamilyInet6Input) > 0 {
-		dataV1.FamilyInet6Input = &dataV0.FamilyInet6Input[0]
+		dataV1.FamilyInet6Input = &forwardingoptionsSamplingInstanceBlockInput{
+			MaxPacketsPerSecond: dataV0.FamilyInet6Input[0].MaxPacketsPerSecond,
+			MaximumPacketLength: dataV0.FamilyInet6Input[0].MaximumPacketLength,
+			Rate:                dataV0.FamilyInet6Input[0].Rate,
+			RunLength:           dataV0.FamilyInet6Input[0].RunLength,
+		}
 	}
 	if len(dataV0.FamilyInet6Output) > 0 {
-		dataV1.FamilyInet6Output = &dataV0.FamilyInet6Output[0]
+		dataV1.FamilyInet6Output = &forwardingoptionsSamplingInstanceBlockFamilyInet6Output{
+			AggregateExportInterval:  dataV0.FamilyInet6Output[0].AggregateExportInterval,
+			ExtensionService:         dataV0.FamilyInet6Output[0].ExtensionService,
+			FlowActiveTimeout:        dataV0.FamilyInet6Output[0].FlowActiveTimeout,
+			FlowInactiveTimeout:      dataV0.FamilyInet6Output[0].FlowInactiveTimeout,
+			InlineJflowExportRate:    dataV0.FamilyInet6Output[0].InlineJflowExportRate,
+			InlineJflowSourceAddress: dataV0.FamilyInet6Output[0].InlineJflowSourceAddress,
+			Interface:                dataV0.FamilyInet6Output[0].Interface,
+		}
+		for _, blockV0 := range dataV0.FamilyInet6Output[0].FlowServer {
+			dataV1.FamilyInet6Output.FlowServer = append(dataV1.FamilyInet6Output.FlowServer,
+				forwardingoptionsSamplingInstanceBlockOutputBlockFlowServer{
+					AggregationAutonomousSystem:                      blockV0.AggregationAutonomousSystem,
+					AggregationDestinationPrefix:                     blockV0.AggregationDestinationPrefix,
+					AggregationProtocolPort:                          blockV0.AggregationProtocolPort,
+					AggregationSourceDestinationPrefix:               blockV0.AggregationSourceDestinationPrefix,
+					AggregationSourceDestinationPrefixCaidaCompliant: blockV0.AggregationSourceDestinationPrefixCaidaCompliant,
+					AggregationSourcePrefix:                          blockV0.AggregationSourcePrefix,
+					LocalDump:                                        blockV0.LocalDump,
+					NoLocalDump:                                      blockV0.NoLocalDump,
+					Hostname:                                         blockV0.Hostname,
+					Port:                                             blockV0.Port,
+					AutonomousSystemType:                             blockV0.AutonomousSystemType,
+					Dscp:                                             blockV0.Dscp,
+					ForwardingClass:                                  blockV0.ForwardingClass,
+					RoutingInstance:                                  blockV0.RoutingInstance,
+					SourceAddress:                                    blockV0.SourceAddress,
+					Version9Template:                                 blockV0.Version9Template,
+					VersionIPFixTemplate:                             blockV0.VersionIPFixTemplate,
+				},
+			)
+		}
 	}
 	if len(dataV0.FamilyMplsInput) > 0 {
-		dataV1.FamilyMplsInput = &dataV0.FamilyMplsInput[0]
+		dataV1.FamilyMplsInput = &forwardingoptionsSamplingInstanceBlockInput{
+			MaxPacketsPerSecond: dataV0.FamilyMplsInput[0].MaxPacketsPerSecond,
+			MaximumPacketLength: dataV0.FamilyMplsInput[0].MaximumPacketLength,
+			Rate:                dataV0.FamilyMplsInput[0].Rate,
+			RunLength:           dataV0.FamilyMplsInput[0].RunLength,
+		}
 	}
 	if len(dataV0.FamilyMplsOutput) > 0 {
-		dataV1.FamilyMplsOutput = &dataV0.FamilyMplsOutput[0]
+		dataV1.FamilyMplsOutput = &forwardingoptionsSamplingInstanceBlockFamilyMplsOutput{
+			AggregateExportInterval:  dataV0.FamilyMplsOutput[0].AggregateExportInterval,
+			FlowActiveTimeout:        dataV0.FamilyMplsOutput[0].FlowActiveTimeout,
+			FlowInactiveTimeout:      dataV0.FamilyMplsOutput[0].FlowInactiveTimeout,
+			InlineJflowExportRate:    dataV0.FamilyMplsOutput[0].InlineJflowExportRate,
+			InlineJflowSourceAddress: dataV0.FamilyMplsOutput[0].InlineJflowSourceAddress,
+			Interface:                dataV0.FamilyMplsOutput[0].Interface,
+		}
+		for _, blockV0 := range dataV0.FamilyMplsOutput[0].FlowServer {
+			dataV1.FamilyMplsOutput.FlowServer = append(dataV1.FamilyMplsOutput.FlowServer,
+				forwardingoptionsSamplingInstanceBlockOutputBlockFlowServer{
+					AggregationAutonomousSystem:                      blockV0.AggregationAutonomousSystem,
+					AggregationDestinationPrefix:                     blockV0.AggregationDestinationPrefix,
+					AggregationProtocolPort:                          blockV0.AggregationProtocolPort,
+					AggregationSourceDestinationPrefix:               blockV0.AggregationSourceDestinationPrefix,
+					AggregationSourceDestinationPrefixCaidaCompliant: blockV0.AggregationSourceDestinationPrefixCaidaCompliant,
+					AggregationSourcePrefix:                          blockV0.AggregationSourcePrefix,
+					LocalDump:                                        blockV0.LocalDump,
+					NoLocalDump:                                      blockV0.NoLocalDump,
+					Hostname:                                         blockV0.Hostname,
+					Port:                                             blockV0.Port,
+					AutonomousSystemType:                             blockV0.AutonomousSystemType,
+					Dscp:                                             blockV0.Dscp,
+					ForwardingClass:                                  blockV0.ForwardingClass,
+					RoutingInstance:                                  blockV0.RoutingInstance,
+					SourceAddress:                                    blockV0.SourceAddress,
+					Version9Template:                                 blockV0.Version9Template,
+					VersionIPFixTemplate:                             blockV0.VersionIPFixTemplate,
+				},
+			)
+		}
 	}
 	if len(dataV0.Input) > 0 {
-		dataV1.Input = &dataV0.Input[0]
+		dataV1.Input = &forwardingoptionsSamplingInstanceBlockInput{
+			MaxPacketsPerSecond: dataV0.Input[0].MaxPacketsPerSecond,
+			MaximumPacketLength: dataV0.Input[0].MaximumPacketLength,
+			Rate:                dataV0.Input[0].Rate,
+			RunLength:           dataV0.Input[0].RunLength,
+		}
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, dataV1)...)

--- a/internal/providerfwk/upgradestate_interface_logical.go
+++ b/internal/providerfwk/upgradestate_interface_logical.go
@@ -460,27 +460,128 @@ func upgradeInterfaceLogicalV0toV1(
 		SecurityZone             types.String   `tfsdk:"security_zone"`
 		VlanID                   types.Int64    `tfsdk:"vlan_id"`
 		FamilyInet               []struct {
-			SamplingInput  types.Bool                                    `tfsdk:"sampling_input"`
-			SamplingOutput types.Bool                                    `tfsdk:"sampling_output"`
-			FilterInput    types.String                                  `tfsdk:"filter_input"`
-			FilterOutput   types.String                                  `tfsdk:"filter_output"`
-			Mtu            types.Int64                                   `tfsdk:"mtu"`
-			Address        []interfaceLogicalBlockFamilyInetBlockAddress `tfsdk:"address"`
-			DHCP           []interfaceLogicalBlockFamilyInetBlockDhcp    `tfsdk:"dhcp"`
-			RPFCheck       []interfaceLogicalBlockFamilyBlockRPFCheck    `tfsdk:"rpf_check"`
+			SamplingInput  types.Bool   `tfsdk:"sampling_input"`
+			SamplingOutput types.Bool   `tfsdk:"sampling_output"`
+			FilterInput    types.String `tfsdk:"filter_input"`
+			FilterOutput   types.String `tfsdk:"filter_output"`
+			Mtu            types.Int64  `tfsdk:"mtu"`
+			Address        []struct {
+				Preferred types.Bool   `tfsdk:"preferred"`
+				Primary   types.Bool   `tfsdk:"primary"`
+				CidrIP    types.String `tfsdk:"cidr_ip"`
+				VRRPGroup []struct {
+					AcceptData              types.Bool     `tfsdk:"accept_data"`
+					NoAcceptData            types.Bool     `tfsdk:"no_accept_data"`
+					Preempt                 types.Bool     `tfsdk:"preempt"`
+					NoPreempt               types.Bool     `tfsdk:"no_preempt"`
+					Identifier              types.Int64    `tfsdk:"identifier"`
+					VirtualAddress          []types.String `tfsdk:"virtual_address"`
+					AdvertiseInterval       types.Int64    `tfsdk:"advertise_interval"`
+					AdvertisementsThreshold types.Int64    `tfsdk:"advertisements_threshold"`
+					AuthenticationKey       types.String   `tfsdk:"authentication_key"`
+					AuthenticationType      types.String   `tfsdk:"authentication_type"`
+					Priority                types.Int64    `tfsdk:"priority"`
+					TrackInterface          []struct {
+						Interface    types.String `tfsdk:"interface"`
+						PriorityCost types.Int64  `tfsdk:"priority_cost"`
+					} `tfsdk:"track_interface"`
+					TrackRoute []struct {
+						Route           types.String `tfsdk:"route"`
+						RoutingInstance types.String `tfsdk:"routing_instance"`
+						PriorityCost    types.Int64  `tfsdk:"priority_cost"`
+					} `tfsdk:"track_route"`
+				} `tfsdk:"vrrp_group"`
+			} `tfsdk:"address"`
+			DHCP []struct {
+				SrxOldOptionName                          types.Bool   `tfsdk:"srx_old_option_name"`
+				ClientIdentifierPrefixHostname            types.Bool   `tfsdk:"client_identifier_prefix_hostname"`
+				ClientIdentifierPrefixRoutingInstanceName types.Bool   `tfsdk:"client_identifier_prefix_routing_instance_name"`
+				ForceDiscover                             types.Bool   `tfsdk:"force_discover"`
+				LeaseTimeInfinite                         types.Bool   `tfsdk:"lease_time_infinite"`
+				NoDNSInstall                              types.Bool   `tfsdk:"no_dns_install"`
+				OptionsNoHostname                         types.Bool   `tfsdk:"options_no_hostname"`
+				UpdateServer                              types.Bool   `tfsdk:"update_server"`
+				ClientIdentifierASCII                     types.String `tfsdk:"client_identifier_ascii"`
+				ClientIdentifierHexadecimal               types.String `tfsdk:"client_identifier_hexadecimal"`
+				ClientIdentifierUseInterfaceDescription   types.String `tfsdk:"client_identifier_use_interface_description"`
+				ClientIdentifierUseridASCII               types.String `tfsdk:"client_identifier_userid_ascii"`
+				ClientIdentifierUseridHexadecimal         types.String `tfsdk:"client_identifier_userid_hexadecimal"`
+				LeaseTime                                 types.Int64  `tfsdk:"lease_time"`
+				Metric                                    types.Int64  `tfsdk:"metric"`
+				RetransmissionAttempt                     types.Int64  `tfsdk:"retransmission_attempt"`
+				RetransmissionInterval                    types.Int64  `tfsdk:"retransmission_interval"`
+				ServerAddress                             types.String `tfsdk:"server_address"`
+				VendorID                                  types.String `tfsdk:"vendor_id"`
+			} `tfsdk:"dhcp"`
+			RPFCheck []struct {
+				FailFilter types.String `tfsdk:"fail_filter"`
+				ModeLoose  types.Bool   `tfsdk:"mode_loose"`
+			} `tfsdk:"rpf_check"`
 		} `tfsdk:"family_inet"`
 		FamilyInet6 []struct {
-			DadDisable     types.Bool                                          `tfsdk:"dad_disable"`
-			SamplingInput  types.Bool                                          `tfsdk:"sampling_input"`
-			SamplingOutput types.Bool                                          `tfsdk:"sampling_output"`
-			FilterInput    types.String                                        `tfsdk:"filter_input"`
-			FilterOutput   types.String                                        `tfsdk:"filter_output"`
-			Mtu            types.Int64                                         `tfsdk:"mtu"`
-			Address        []interfaceLogicalBlockFamilyInet6BlockAddress      `tfsdk:"address"`
-			DHCPv6Client   []interfaceLogicalBlockFamilyInet6BlockDhcpV6Client `tfsdk:"dhcpv6_client"`
-			RPFCheck       []interfaceLogicalBlockFamilyBlockRPFCheck          `tfsdk:"rpf_check"`
+			DadDisable     types.Bool   `tfsdk:"dad_disable"`
+			SamplingInput  types.Bool   `tfsdk:"sampling_input"`
+			SamplingOutput types.Bool   `tfsdk:"sampling_output"`
+			FilterInput    types.String `tfsdk:"filter_input"`
+			FilterOutput   types.String `tfsdk:"filter_output"`
+			Mtu            types.Int64  `tfsdk:"mtu"`
+			Address        []struct {
+				Preferred types.Bool   `tfsdk:"preferred"`
+				Primary   types.Bool   `tfsdk:"primary"`
+				CidrIP    types.String `tfsdk:"cidr_ip"`
+				VRRPGroup []struct {
+					AcceptData              types.Bool     `tfsdk:"accept_data"`
+					NoAcceptData            types.Bool     `tfsdk:"no_accept_data"`
+					Preempt                 types.Bool     `tfsdk:"preempt"`
+					NoPreempt               types.Bool     `tfsdk:"no_preempt"`
+					Identifier              types.Int64    `tfsdk:"identifier"`
+					VirtualAddress          []types.String `tfsdk:"virtual_address"`
+					VirutalLinkLocalAddress types.String   `tfsdk:"virtual_link_local_address"`
+					AdvertiseInterval       types.Int64    `tfsdk:"advertise_interval"`
+					AdvertisementsThreshold types.Int64    `tfsdk:"advertisements_threshold"`
+					Priority                types.Int64    `tfsdk:"priority"`
+					TrackInterface          []struct {
+						Interface    types.String `tfsdk:"interface"`
+						PriorityCost types.Int64  `tfsdk:"priority_cost"`
+					} `tfsdk:"track_interface"`
+					TrackRoute []struct {
+						Route           types.String `tfsdk:"route"`
+						RoutingInstance types.String `tfsdk:"routing_instance"`
+						PriorityCost    types.Int64  `tfsdk:"priority_cost"`
+					} `tfsdk:"track_route"`
+				} `tfsdk:"vrrp_group"`
+			} `tfsdk:"address"`
+			DHCPv6Client []struct {
+				ClientIATypeNA                        types.Bool     `tfsdk:"client_ia_type_na"`
+				ClientIATypePD                        types.Bool     `tfsdk:"client_ia_type_pd"`
+				NoDNSInstall                          types.Bool     `tfsdk:"no_dns_install"`
+				RapidCommit                           types.Bool     `tfsdk:"rapid_commit"`
+				ClientIdentifierDuidType              types.String   `tfsdk:"client_identifier_duid_type"`
+				ClientType                            types.String   `tfsdk:"client_type"`
+				PrefixDelegatingPreferredPrefixLength types.Int64    `tfsdk:"prefix_delegating_preferred_prefix_length"`
+				PrefixDelegatingSubPrefixLength       types.Int64    `tfsdk:"prefix_delegating_sub_prefix_length"`
+				ReqOption                             []types.String `tfsdk:"req_option"`
+				RetransmissionAttempt                 types.Int64    `tfsdk:"retransmission_attempt"`
+				UpdateRouterAdvertisementInterface    []types.String `tfsdk:"update_router_advertisement_interface"`
+				UpdateServer                          types.Bool     `tfsdk:"update_server"`
+			} `tfsdk:"dhcpv6_client"`
+			RPFCheck []struct {
+				FailFilter types.String `tfsdk:"fail_filter"`
+				ModeLoose  types.Bool   `tfsdk:"mode_loose"`
+			} `tfsdk:"rpf_check"`
 		} `tfsdk:"family_inet6"`
-		Tunnel []interfaceLogicalBlockTunnel `tfsdk:"tunnel"`
+		Tunnel []struct {
+			AllowFragmentation         types.Bool   `tfsdk:"allow_fragmentation"`
+			DoNotFragment              types.Bool   `tfsdk:"do_not_fragment"`
+			PathMtuDiscovery           types.Bool   `tfsdk:"path_mtu_discovery"`
+			NoPathMtuDiscovery         types.Bool   `tfsdk:"no_path_mtu_discovery"`
+			Destination                types.String `tfsdk:"destination"`
+			Source                     types.String `tfsdk:"source"`
+			FlowLabel                  types.Int64  `tfsdk:"flow_label"`
+			RoutingInstanceDestination types.String `tfsdk:"routing_instance_destination"`
+			TrafficClass               types.Int64  `tfsdk:"traffic_class"`
+			TTL                        types.Int64  `tfsdk:"ttl"`
+		} `tfsdk:"tunnel"`
 	}
 
 	var dataV0 modelV0
@@ -509,39 +610,168 @@ func upgradeInterfaceLogicalV0toV1(
 	}
 	if len(dataV0.FamilyInet) > 0 {
 		dataV1.FamilyInet = &interfaceLogicalBlockFamilyInet{
+			SamplingInput:  dataV0.FamilyInet[0].SamplingInput,
+			SamplingOutput: dataV0.FamilyInet[0].SamplingOutput,
 			FilterInput:    dataV0.FamilyInet[0].FilterInput,
 			FilterOutput:   dataV0.FamilyInet[0].FilterOutput,
 			Mtu:            dataV0.FamilyInet[0].Mtu,
-			SamplingInput:  dataV0.FamilyInet[0].SamplingInput,
-			SamplingOutput: dataV0.FamilyInet[0].SamplingOutput,
-			Address:        dataV0.FamilyInet[0].Address,
+		}
+		for _, blockV0 := range dataV0.FamilyInet[0].Address {
+			blockV1 := interfaceLogicalBlockFamilyInetBlockAddress{
+				Preferred: blockV0.Preferred,
+				Primary:   blockV0.Primary,
+				CidrIP:    blockV0.CidrIP,
+			}
+			for _, subBlockV0 := range blockV0.VRRPGroup {
+				subBlockV1 := interfaceLogicalBlockFamilyInetBlockAddressBlockVRRPGroup{
+					AcceptData:              subBlockV0.AcceptData,
+					NoAcceptData:            subBlockV0.NoAcceptData,
+					Preempt:                 subBlockV0.Preempt,
+					NoPreempt:               subBlockV0.NoPreempt,
+					Identifier:              subBlockV0.Identifier,
+					VirtualAddress:          subBlockV0.VirtualAddress,
+					AdvertiseInterval:       subBlockV0.AdvertiseInterval,
+					AdvertisementsThreshold: subBlockV0.AdvertisementsThreshold,
+					AuthenticationKey:       subBlockV0.AuthenticationKey,
+					AuthenticationType:      subBlockV0.AuthenticationType,
+					Priority:                subBlockV0.Priority,
+				}
+				for _, subSubBlockV0 := range subBlockV0.TrackInterface {
+					subBlockV1.TrackInterface = append(subBlockV1.TrackInterface,
+						interfaceLogicalBlockFamilyBlockAddressBlockVRRPGroupBlockTrackInterface{
+							Interface:    subSubBlockV0.Interface,
+							PriorityCost: subSubBlockV0.PriorityCost,
+						},
+					)
+				}
+				for _, subSubBlockV0 := range subBlockV0.TrackRoute {
+					subBlockV1.TrackRoute = append(subBlockV1.TrackRoute,
+						interfaceLogicalBlockFamilyBlockAddressBlockVRRPGroupBlockTrackRoute{
+							Route:           subSubBlockV0.Route,
+							RoutingInstance: subSubBlockV0.RoutingInstance,
+							PriorityCost:    subSubBlockV0.PriorityCost,
+						},
+					)
+				}
+				blockV1.VRRPGroup = append(blockV1.VRRPGroup, subBlockV1)
+			}
+			dataV1.FamilyInet.Address = append(dataV1.FamilyInet.Address, blockV1)
 		}
 		if len(dataV0.FamilyInet[0].DHCP) > 0 {
-			dataV1.FamilyInet.DHCP = &dataV0.FamilyInet[0].DHCP[0]
+			dataV1.FamilyInet.DHCP = &interfaceLogicalBlockFamilyInetBlockDhcp{
+				SrxOldOptionName:                          dataV0.FamilyInet[0].DHCP[0].SrxOldOptionName,
+				ClientIdentifierPrefixHostname:            dataV0.FamilyInet[0].DHCP[0].ClientIdentifierPrefixHostname,
+				ClientIdentifierPrefixRoutingInstanceName: dataV0.FamilyInet[0].DHCP[0].ClientIdentifierPrefixRoutingInstanceName,
+				ForceDiscover:                             dataV0.FamilyInet[0].DHCP[0].ForceDiscover,
+				LeaseTimeInfinite:                         dataV0.FamilyInet[0].DHCP[0].LeaseTimeInfinite,
+				NoDNSInstall:                              dataV0.FamilyInet[0].DHCP[0].NoDNSInstall,
+				OptionsNoHostname:                         dataV0.FamilyInet[0].DHCP[0].OptionsNoHostname,
+				UpdateServer:                              dataV0.FamilyInet[0].DHCP[0].UpdateServer,
+				ClientIdentifierASCII:                     dataV0.FamilyInet[0].DHCP[0].ClientIdentifierASCII,
+				ClientIdentifierHexadecimal:               dataV0.FamilyInet[0].DHCP[0].ClientIdentifierHexadecimal,
+				ClientIdentifierUseInterfaceDescription:   dataV0.FamilyInet[0].DHCP[0].ClientIdentifierUseInterfaceDescription,
+				ClientIdentifierUseridASCII:               dataV0.FamilyInet[0].DHCP[0].ClientIdentifierUseridASCII,
+				ClientIdentifierUseridHexadecimal:         dataV0.FamilyInet[0].DHCP[0].ClientIdentifierUseridHexadecimal,
+				LeaseTime:                                 dataV0.FamilyInet[0].DHCP[0].LeaseTime,
+				Metric:                                    dataV0.FamilyInet[0].DHCP[0].Metric,
+				RetransmissionAttempt:                     dataV0.FamilyInet[0].DHCP[0].RetransmissionAttempt,
+				RetransmissionInterval:                    dataV0.FamilyInet[0].DHCP[0].RetransmissionInterval,
+				ServerAddress:                             dataV0.FamilyInet[0].DHCP[0].ServerAddress,
+				VendorID:                                  dataV0.FamilyInet[0].DHCP[0].VendorID,
+			}
 		}
 		if len(dataV0.FamilyInet[0].RPFCheck) > 0 {
-			dataV1.FamilyInet.RPFCheck = &dataV0.FamilyInet[0].RPFCheck[0]
+			dataV1.FamilyInet.RPFCheck = &interfaceLogicalBlockFamilyBlockRPFCheck{
+				FailFilter: dataV0.FamilyInet[0].RPFCheck[0].FailFilter,
+				ModeLoose:  dataV0.FamilyInet[0].RPFCheck[0].ModeLoose,
+			}
 		}
 	}
 	if len(dataV0.FamilyInet6) > 0 {
 		dataV1.FamilyInet6 = &interfaceLogicalBlockFamilyInet6{
 			DadDisable:     dataV0.FamilyInet6[0].DadDisable,
+			SamplingInput:  dataV0.FamilyInet6[0].SamplingInput,
+			SamplingOutput: dataV0.FamilyInet6[0].SamplingOutput,
 			FilterInput:    dataV0.FamilyInet6[0].FilterInput,
 			FilterOutput:   dataV0.FamilyInet6[0].FilterOutput,
 			Mtu:            dataV0.FamilyInet6[0].Mtu,
-			SamplingInput:  dataV0.FamilyInet6[0].SamplingInput,
-			SamplingOutput: dataV0.FamilyInet6[0].SamplingOutput,
-			Address:        dataV0.FamilyInet6[0].Address,
+		}
+		for _, blockV0 := range dataV0.FamilyInet6[0].Address {
+			blockV1 := interfaceLogicalBlockFamilyInet6BlockAddress{
+				Preferred: blockV0.Preferred,
+				Primary:   blockV0.Primary,
+				CidrIP:    blockV0.CidrIP,
+			}
+			for _, subBlockV0 := range blockV0.VRRPGroup {
+				subBlockV1 := interfaceLogicalBlockFamilyInet6BlockAddressBlockVRRPGroup{
+					AcceptData:              subBlockV0.AcceptData,
+					NoAcceptData:            subBlockV0.NoAcceptData,
+					Preempt:                 subBlockV0.Preempt,
+					NoPreempt:               subBlockV0.NoPreempt,
+					Identifier:              subBlockV0.Identifier,
+					VirtualAddress:          subBlockV0.VirtualAddress,
+					VirutalLinkLocalAddress: subBlockV0.VirutalLinkLocalAddress,
+					AdvertiseInterval:       subBlockV0.AdvertiseInterval,
+					AdvertisementsThreshold: subBlockV0.AdvertisementsThreshold,
+					Priority:                subBlockV0.Priority,
+				}
+				for _, subSubBlockV0 := range subBlockV0.TrackInterface {
+					subBlockV1.TrackInterface = append(subBlockV1.TrackInterface,
+						interfaceLogicalBlockFamilyBlockAddressBlockVRRPGroupBlockTrackInterface{
+							Interface:    subSubBlockV0.Interface,
+							PriorityCost: subSubBlockV0.PriorityCost,
+						},
+					)
+				}
+				for _, subSubBlockV0 := range subBlockV0.TrackRoute {
+					subBlockV1.TrackRoute = append(subBlockV1.TrackRoute,
+						interfaceLogicalBlockFamilyBlockAddressBlockVRRPGroupBlockTrackRoute{
+							Route:           subSubBlockV0.Route,
+							RoutingInstance: subSubBlockV0.RoutingInstance,
+							PriorityCost:    subSubBlockV0.PriorityCost,
+						},
+					)
+				}
+				blockV1.VRRPGroup = append(blockV1.VRRPGroup, subBlockV1)
+			}
+			dataV1.FamilyInet6.Address = append(dataV1.FamilyInet6.Address, blockV1)
 		}
 		if len(dataV0.FamilyInet6[0].DHCPv6Client) > 0 {
-			dataV1.FamilyInet6.DHCPv6Client = &dataV0.FamilyInet6[0].DHCPv6Client[0]
+			dataV1.FamilyInet6.DHCPv6Client = &interfaceLogicalBlockFamilyInet6BlockDhcpV6Client{
+				ClientIATypeNA:                        dataV0.FamilyInet6[0].DHCPv6Client[0].ClientIATypeNA,
+				ClientIATypePD:                        dataV0.FamilyInet6[0].DHCPv6Client[0].ClientIATypePD,
+				NoDNSInstall:                          dataV0.FamilyInet6[0].DHCPv6Client[0].NoDNSInstall,
+				RapidCommit:                           dataV0.FamilyInet6[0].DHCPv6Client[0].RapidCommit,
+				ClientIdentifierDuidType:              dataV0.FamilyInet6[0].DHCPv6Client[0].ClientIdentifierDuidType,
+				ClientType:                            dataV0.FamilyInet6[0].DHCPv6Client[0].ClientType,
+				PrefixDelegatingPreferredPrefixLength: dataV0.FamilyInet6[0].DHCPv6Client[0].PrefixDelegatingPreferredPrefixLength,
+				PrefixDelegatingSubPrefixLength:       dataV0.FamilyInet6[0].DHCPv6Client[0].PrefixDelegatingSubPrefixLength,
+				ReqOption:                             dataV0.FamilyInet6[0].DHCPv6Client[0].ReqOption,
+				RetransmissionAttempt:                 dataV0.FamilyInet6[0].DHCPv6Client[0].RetransmissionAttempt,
+				UpdateRouterAdvertisementInterface:    dataV0.FamilyInet6[0].DHCPv6Client[0].UpdateRouterAdvertisementInterface,
+				UpdateServer:                          dataV0.FamilyInet6[0].DHCPv6Client[0].UpdateServer,
+			}
 		}
 		if len(dataV0.FamilyInet6[0].RPFCheck) > 0 {
-			dataV1.FamilyInet6.RPFCheck = &dataV0.FamilyInet6[0].RPFCheck[0]
+			dataV1.FamilyInet6.RPFCheck = &interfaceLogicalBlockFamilyBlockRPFCheck{
+				FailFilter: dataV0.FamilyInet6[0].RPFCheck[0].FailFilter,
+				ModeLoose:  dataV0.FamilyInet6[0].RPFCheck[0].ModeLoose,
+			}
 		}
 	}
 	if len(dataV0.Tunnel) > 0 {
-		dataV1.Tunnel = &dataV0.Tunnel[0]
+		dataV1.Tunnel = &interfaceLogicalBlockTunnel{
+			AllowFragmentation:         dataV0.Tunnel[0].AllowFragmentation,
+			DoNotFragment:              dataV0.Tunnel[0].DoNotFragment,
+			PathMtuDiscovery:           dataV0.Tunnel[0].PathMtuDiscovery,
+			NoPathMtuDiscovery:         dataV0.Tunnel[0].NoPathMtuDiscovery,
+			Destination:                dataV0.Tunnel[0].Destination,
+			Source:                     dataV0.Tunnel[0].Source,
+			FlowLabel:                  dataV0.Tunnel[0].FlowLabel,
+			RoutingInstanceDestination: dataV0.Tunnel[0].RoutingInstanceDestination,
+			TrafficClass:               dataV0.Tunnel[0].TrafficClass,
+			TTL:                        dataV0.Tunnel[0].TTL,
+		}
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, dataV1)...)

--- a/internal/providerfwk/upgradestate_interface_physical.go
+++ b/internal/providerfwk/upgradestate_interface_physical.go
@@ -245,37 +245,82 @@ func (rsc *interfacePhysical) UpgradeState(_ context.Context) map[int64]resource
 	}
 }
 
-//nolint:lll
 func upgradeInterfacePhysicalV0toV1(
 	ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse,
 ) {
 	type modelV0 struct {
-		NoDisableOnDestroy types.Bool                        `tfsdk:"no_disable_on_destroy"`
-		Disable            types.Bool                        `tfsdk:"disable"`
-		Trunk              types.Bool                        `tfsdk:"trunk"`
-		VlanTagging        types.Bool                        `tfsdk:"vlan_tagging"`
-		ID                 types.String                      `tfsdk:"id"`
-		Name               types.String                      `tfsdk:"name"`
-		Description        types.String                      `tfsdk:"description"`
-		Mtu                types.Int64                       `tfsdk:"mtu"`
-		VlanMembers        []types.String                    `tfsdk:"vlan_members"`
-		VlanNative         types.Int64                       `tfsdk:"vlan_native"`
-		ESI                []interfacePhysicalBlockESI       `tfsdk:"esi"`
-		EtherOpts          []interfacePhysicalBlockEtherOpts `tfsdk:"ether_opts"`
-		GigetherOpts       []interfacePhysicalBlockEtherOpts `tfsdk:"gigether_opts"`
-		ParentEtherOpts    []struct {
-			FlowControl          types.Bool                                                       `tfsdk:"flow_control"`
-			NoFlowControl        types.Bool                                                       `tfsdk:"no_flow_control"`
-			Loopback             types.Bool                                                       `tfsdk:"loopback"`
-			NoLoopback           types.Bool                                                       `tfsdk:"no_loopback"`
-			SourceFiltering      types.Bool                                                       `tfsdk:"source_filtering"`
-			LinkSpeed            types.String                                                     `tfsdk:"link_speed"`
-			MinimumBandwidth     types.String                                                     `tfsdk:"minimum_bandwidth"`
-			MinimumLinks         types.Int64                                                      `tfsdk:"minimum_links"`
-			RedundancyGroup      types.Int64                                                      `tfsdk:"redundancy_group"`
-			SourceAddressFilter  []types.String                                                   `tfsdk:"source_address_filter"`
-			BFDLivenessDetection []interfacePhysicalBlockParentEtherOptsBlockBFDLivenessDetection `tfsdk:"bfd_liveness_detection"`
-			Lacp                 []interfacePhysicalBlockParentEtherOptsBlockLacp                 `tfsdk:"lacp"`
+		NoDisableOnDestroy types.Bool     `tfsdk:"no_disable_on_destroy"`
+		Disable            types.Bool     `tfsdk:"disable"`
+		Trunk              types.Bool     `tfsdk:"trunk"`
+		VlanTagging        types.Bool     `tfsdk:"vlan_tagging"`
+		ID                 types.String   `tfsdk:"id"`
+		Name               types.String   `tfsdk:"name"`
+		Description        types.String   `tfsdk:"description"`
+		Mtu                types.Int64    `tfsdk:"mtu"`
+		VlanMembers        []types.String `tfsdk:"vlan_members"`
+		VlanNative         types.Int64    `tfsdk:"vlan_native"`
+		ESI                []struct {
+			AutoDeriveLacp types.Bool   `tfsdk:"auto_derive_lacp"`
+			Mode           types.String `tfsdk:"mode"`
+			DFElectionType types.String `tfsdk:"df_election_type"`
+			Identifier     types.String `tfsdk:"identifier"`
+			SourceBMAC     types.String `tfsdk:"source_bmac"`
+		} `tfsdk:"esi"`
+		EtherOpts []struct {
+			AutoNegotiation   types.Bool   `tfsdk:"auto_negotiation"`
+			NoAutoNegotiation types.Bool   `tfsdk:"no_auto_negotiation"`
+			FlowControl       types.Bool   `tfsdk:"flow_control"`
+			NoFlowControl     types.Bool   `tfsdk:"no_flow_control"`
+			Loopback          types.Bool   `tfsdk:"loopback"`
+			NoLoopback        types.Bool   `tfsdk:"no_loopback"`
+			Ae8023ad          types.String `tfsdk:"ae_8023ad"`
+			RedundantParent   types.String `tfsdk:"redundant_parent"`
+		} `tfsdk:"ether_opts"`
+		GigetherOpts []struct {
+			AutoNegotiation   types.Bool   `tfsdk:"auto_negotiation"`
+			NoAutoNegotiation types.Bool   `tfsdk:"no_auto_negotiation"`
+			FlowControl       types.Bool   `tfsdk:"flow_control"`
+			NoFlowControl     types.Bool   `tfsdk:"no_flow_control"`
+			Loopback          types.Bool   `tfsdk:"loopback"`
+			NoLoopback        types.Bool   `tfsdk:"no_loopback"`
+			Ae8023ad          types.String `tfsdk:"ae_8023ad"`
+			RedundantParent   types.String `tfsdk:"redundant_parent"`
+		} `tfsdk:"gigether_opts"`
+		ParentEtherOpts []struct {
+			FlowControl          types.Bool     `tfsdk:"flow_control"`
+			NoFlowControl        types.Bool     `tfsdk:"no_flow_control"`
+			Loopback             types.Bool     `tfsdk:"loopback"`
+			NoLoopback           types.Bool     `tfsdk:"no_loopback"`
+			SourceFiltering      types.Bool     `tfsdk:"source_filtering"`
+			LinkSpeed            types.String   `tfsdk:"link_speed"`
+			MinimumBandwidth     types.String   `tfsdk:"minimum_bandwidth"`
+			MinimumLinks         types.Int64    `tfsdk:"minimum_links"`
+			RedundancyGroup      types.Int64    `tfsdk:"redundancy_group"`
+			SourceAddressFilter  []types.String `tfsdk:"source_address_filter"`
+			BFDLivenessDetection []struct {
+				AuthenticationLooseCheck        types.Bool   `tfsdk:"authentication_loose_check"`
+				NoAdaptation                    types.Bool   `tfsdk:"no_adaptation"`
+				LocalAddress                    types.String `tfsdk:"local_address"`
+				AuthenticationAlgorithm         types.String `tfsdk:"authentication_algorithm"`
+				AuthenticationKeyChain          types.String `tfsdk:"authentication_key_chain"`
+				DetectionTimeThreshold          types.Int64  `tfsdk:"detection_time_threshold"`
+				HolddownInterval                types.Int64  `tfsdk:"holddown_interval"`
+				MinimumInterval                 types.Int64  `tfsdk:"minimum_interval"`
+				MinimumReceiveInterval          types.Int64  `tfsdk:"minimum_receive_interval"`
+				Multiplier                      types.Int64  `tfsdk:"multiplier"`
+				Neighbor                        types.String `tfsdk:"neighbor"`
+				TransmitIntervalMinimumInterval types.Int64  `tfsdk:"transmit_interval_minimum_interval"`
+				TransmitIntervalThreshold       types.Int64  `tfsdk:"transmit_interval_threshold"`
+				Version                         types.String `tfsdk:"version"`
+			} `tfsdk:"bfd_liveness_detection"`
+			Lacp []struct {
+				Mode           types.String `tfsdk:"mode"`
+				AdminKey       types.Int64  `tfsdk:"admin_key"`
+				Periodic       types.String `tfsdk:"periodic"`
+				SyncReset      types.String `tfsdk:"sync_reset"`
+				SystemID       types.String `tfsdk:"system_id"`
+				SystemPriority types.Int64  `tfsdk:"system_priority"`
+			} `tfsdk:"lacp"`
 		} `tfsdk:"parent_ether_opts"`
 	}
 
@@ -300,13 +345,37 @@ func upgradeInterfacePhysicalV0toV1(
 	dataV1.VlanNative = dataV0.VlanNative
 	dataV1.VlanTagging = dataV0.VlanTagging
 	if len(dataV0.ESI) > 0 {
-		dataV1.ESI = &dataV0.ESI[0]
+		dataV1.ESI = &interfacePhysicalBlockESI{
+			AutoDeriveLacp: dataV0.ESI[0].AutoDeriveLacp,
+			Mode:           dataV0.ESI[0].Mode,
+			DFElectionType: dataV0.ESI[0].DFElectionType,
+			Identifier:     dataV0.ESI[0].Identifier,
+			SourceBMAC:     dataV0.ESI[0].SourceBMAC,
+		}
 	}
 	if len(dataV0.EtherOpts) > 0 {
-		dataV1.EtherOpts = &dataV0.EtherOpts[0]
+		dataV1.EtherOpts = &interfacePhysicalBlockEtherOpts{
+			AutoNegotiation:   dataV0.EtherOpts[0].AutoNegotiation,
+			NoAutoNegotiation: dataV0.EtherOpts[0].NoAutoNegotiation,
+			FlowControl:       dataV0.EtherOpts[0].FlowControl,
+			NoFlowControl:     dataV0.EtherOpts[0].NoFlowControl,
+			Loopback:          dataV0.EtherOpts[0].Loopback,
+			NoLoopback:        dataV0.EtherOpts[0].NoLoopback,
+			Ae8023ad:          dataV0.EtherOpts[0].Ae8023ad,
+			RedundantParent:   dataV0.EtherOpts[0].RedundantParent,
+		}
 	}
 	if len(dataV0.GigetherOpts) > 0 {
-		dataV1.GigetherOpts = &dataV0.GigetherOpts[0]
+		dataV1.GigetherOpts = &interfacePhysicalBlockEtherOpts{
+			AutoNegotiation:   dataV0.GigetherOpts[0].AutoNegotiation,
+			NoAutoNegotiation: dataV0.GigetherOpts[0].NoAutoNegotiation,
+			FlowControl:       dataV0.GigetherOpts[0].FlowControl,
+			NoFlowControl:     dataV0.GigetherOpts[0].NoFlowControl,
+			Loopback:          dataV0.GigetherOpts[0].Loopback,
+			NoLoopback:        dataV0.GigetherOpts[0].NoLoopback,
+			Ae8023ad:          dataV0.GigetherOpts[0].Ae8023ad,
+			RedundantParent:   dataV0.GigetherOpts[0].RedundantParent,
+		}
 	}
 	if len(dataV0.ParentEtherOpts) > 0 {
 		dataV1.ParentEtherOpts = &interfacePhysicalBlockParentEtherOpts{
@@ -322,10 +391,32 @@ func upgradeInterfacePhysicalV0toV1(
 			SourceFiltering:     dataV0.ParentEtherOpts[0].SourceFiltering,
 		}
 		if len(dataV0.ParentEtherOpts[0].BFDLivenessDetection) > 0 {
-			dataV1.ParentEtherOpts.BFDLivenessDetection = &dataV0.ParentEtherOpts[0].BFDLivenessDetection[0]
+			dataV1.ParentEtherOpts.BFDLivenessDetection = &interfacePhysicalBlockParentEtherOptsBlockBFDLivenessDetection{
+				AuthenticationLooseCheck:        dataV0.ParentEtherOpts[0].BFDLivenessDetection[0].AuthenticationLooseCheck,
+				NoAdaptation:                    dataV0.ParentEtherOpts[0].BFDLivenessDetection[0].NoAdaptation,
+				LocalAddress:                    dataV0.ParentEtherOpts[0].BFDLivenessDetection[0].LocalAddress,
+				AuthenticationAlgorithm:         dataV0.ParentEtherOpts[0].BFDLivenessDetection[0].AuthenticationAlgorithm,
+				AuthenticationKeyChain:          dataV0.ParentEtherOpts[0].BFDLivenessDetection[0].AuthenticationKeyChain,
+				DetectionTimeThreshold:          dataV0.ParentEtherOpts[0].BFDLivenessDetection[0].DetectionTimeThreshold,
+				HolddownInterval:                dataV0.ParentEtherOpts[0].BFDLivenessDetection[0].HolddownInterval,
+				MinimumInterval:                 dataV0.ParentEtherOpts[0].BFDLivenessDetection[0].MinimumInterval,
+				MinimumReceiveInterval:          dataV0.ParentEtherOpts[0].BFDLivenessDetection[0].MinimumReceiveInterval,
+				Multiplier:                      dataV0.ParentEtherOpts[0].BFDLivenessDetection[0].Multiplier,
+				Neighbor:                        dataV0.ParentEtherOpts[0].BFDLivenessDetection[0].Neighbor,
+				TransmitIntervalMinimumInterval: dataV0.ParentEtherOpts[0].BFDLivenessDetection[0].TransmitIntervalMinimumInterval,
+				TransmitIntervalThreshold:       dataV0.ParentEtherOpts[0].BFDLivenessDetection[0].TransmitIntervalThreshold,
+				Version:                         dataV0.ParentEtherOpts[0].BFDLivenessDetection[0].Version,
+			}
 		}
 		if len(dataV0.ParentEtherOpts[0].Lacp) > 0 {
-			dataV1.ParentEtherOpts.Lacp = &dataV0.ParentEtherOpts[0].Lacp[0]
+			dataV1.ParentEtherOpts.Lacp = &interfacePhysicalBlockParentEtherOptsBlockLacp{
+				Mode:           dataV0.ParentEtherOpts[0].Lacp[0].Mode,
+				AdminKey:       dataV0.ParentEtherOpts[0].Lacp[0].AdminKey,
+				Periodic:       dataV0.ParentEtherOpts[0].Lacp[0].Periodic,
+				SyncReset:      dataV0.ParentEtherOpts[0].Lacp[0].SyncReset,
+				SystemID:       dataV0.ParentEtherOpts[0].Lacp[0].SystemID,
+				SystemPriority: dataV0.ParentEtherOpts[0].Lacp[0].SystemPriority,
+			}
 		}
 	}
 

--- a/internal/providerfwk/upgradestate_policyoptions_policy_statement.go
+++ b/internal/providerfwk/upgradestate_policyoptions_policy_statement.go
@@ -37,7 +37,32 @@ func (rsc *policyoptionsPolicyStatement) UpgradeState(_ context.Context) map[int
 					},
 					"then": schema.ListNestedBlock{
 						NestedObject: schema.NestedBlockObject{
-							Attributes: rsc.schemaThenAttributes(),
+							Attributes: map[string]schema.Attribute{
+								"action": schema.StringAttribute{
+									Optional: true,
+								},
+								"as_path_expand": schema.StringAttribute{
+									Optional: true,
+								},
+								"as_path_prepend": schema.StringAttribute{
+									Optional: true,
+								},
+								"default_action": schema.StringAttribute{
+									Optional: true,
+								},
+								"load_balance": schema.StringAttribute{
+									Optional: true,
+								},
+								"next": schema.StringAttribute{
+									Optional: true,
+								},
+								"next_hop": schema.StringAttribute{
+									Optional: true,
+								},
+								"origin": schema.StringAttribute{
+									Optional: true,
+								},
+							},
 							Blocks: map[string]schema.Block{
 								"community": schema.ListNestedBlock{
 									NestedObject: schema.NestedBlockObject{
@@ -111,7 +136,32 @@ func (rsc *policyoptionsPolicyStatement) UpgradeState(_ context.Context) map[int
 								},
 								"then": schema.ListNestedBlock{
 									NestedObject: schema.NestedBlockObject{
-										Attributes: rsc.schemaThenAttributes(),
+										Attributes: map[string]schema.Attribute{
+											"action": schema.StringAttribute{
+												Optional: true,
+											},
+											"as_path_expand": schema.StringAttribute{
+												Optional: true,
+											},
+											"as_path_prepend": schema.StringAttribute{
+												Optional: true,
+											},
+											"default_action": schema.StringAttribute{
+												Optional: true,
+											},
+											"load_balance": schema.StringAttribute{
+												Optional: true,
+											},
+											"next": schema.StringAttribute{
+												Optional: true,
+											},
+											"next_hop": schema.StringAttribute{
+												Optional: true,
+											},
+											"origin": schema.StringAttribute{
+												Optional: true,
+											},
+										},
 										Blocks: map[string]schema.Block{
 											"community": schema.ListNestedBlock{
 												NestedObject: schema.NestedBlockObject{
@@ -184,36 +234,60 @@ func upgradePolicyoptionsPolicyStatementStateV0toV1(
 		From                         []policyoptionsPolicyStatementBlockFrom `tfsdk:"from"`
 		To                           []policyoptionsPolicyStatementBlockTo   `tfsdk:"to"`
 		Then                         []struct {
-			Action          types.String                                                 `tfsdk:"action"`
-			ASPathExpand    types.String                                                 `tfsdk:"as_path_expand"`
-			ASPathPrepend   types.String                                                 `tfsdk:"as_path_prepend"`
-			DefaultAction   types.String                                                 `tfsdk:"default_action"`
-			LoadBalance     types.String                                                 `tfsdk:"load_balance"`
-			Next            types.String                                                 `tfsdk:"next"`
-			NextHop         types.String                                                 `tfsdk:"next_hop"`
-			Origin          types.String                                                 `tfsdk:"origin"`
-			Community       []policyoptionsPolicyStatementBlockThenBlockActionValue      `tfsdk:"community"`
-			LocalPreference []policyoptionsPolicyStatementBlockThenBlockActionValueInt64 `tfsdk:"local_preference"`
-			Metric          []policyoptionsPolicyStatementBlockThenBlockActionValueInt64 `tfsdk:"metric"`
-			Preference      []policyoptionsPolicyStatementBlockThenBlockActionValueInt64 `tfsdk:"preference"`
+			Action        types.String `tfsdk:"action"`
+			ASPathExpand  types.String `tfsdk:"as_path_expand"`
+			ASPathPrepend types.String `tfsdk:"as_path_prepend"`
+			DefaultAction types.String `tfsdk:"default_action"`
+			LoadBalance   types.String `tfsdk:"load_balance"`
+			Next          types.String `tfsdk:"next"`
+			NextHop       types.String `tfsdk:"next_hop"`
+			Origin        types.String `tfsdk:"origin"`
+			Community     []struct {
+				Action types.String `tfsdk:"action"`
+				Value  types.String `tfsdk:"value"`
+			} `tfsdk:"community"`
+			LocalPreference []struct {
+				Action types.String `tfsdk:"action"`
+				Value  types.Int64  `tfsdk:"value"`
+			} `tfsdk:"local_preference"`
+			Metric []struct {
+				Action types.String `tfsdk:"action"`
+				Value  types.Int64  `tfsdk:"value"`
+			} `tfsdk:"metric"`
+			Preference []struct {
+				Action types.String `tfsdk:"action"`
+				Value  types.Int64  `tfsdk:"value"`
+			} `tfsdk:"preference"`
 		} `tfsdk:"then"`
 		Term []struct {
 			Name types.String                            `tfsdk:"name"`
 			From []policyoptionsPolicyStatementBlockFrom `tfsdk:"from"`
 			To   []policyoptionsPolicyStatementBlockTo   `tfsdk:"to"`
 			Then []struct {
-				Action          types.String                                                 `tfsdk:"action"`
-				ASPathExpand    types.String                                                 `tfsdk:"as_path_expand"`
-				ASPathPrepend   types.String                                                 `tfsdk:"as_path_prepend"`
-				DefaultAction   types.String                                                 `tfsdk:"default_action"`
-				LoadBalance     types.String                                                 `tfsdk:"load_balance"`
-				Next            types.String                                                 `tfsdk:"next"`
-				NextHop         types.String                                                 `tfsdk:"next_hop"`
-				Origin          types.String                                                 `tfsdk:"origin"`
-				Community       []policyoptionsPolicyStatementBlockThenBlockActionValue      `tfsdk:"community"`
-				LocalPreference []policyoptionsPolicyStatementBlockThenBlockActionValueInt64 `tfsdk:"local_preference"`
-				Metric          []policyoptionsPolicyStatementBlockThenBlockActionValueInt64 `tfsdk:"metric"`
-				Preference      []policyoptionsPolicyStatementBlockThenBlockActionValueInt64 `tfsdk:"preference"`
+				Action        types.String `tfsdk:"action"`
+				ASPathExpand  types.String `tfsdk:"as_path_expand"`
+				ASPathPrepend types.String `tfsdk:"as_path_prepend"`
+				DefaultAction types.String `tfsdk:"default_action"`
+				LoadBalance   types.String `tfsdk:"load_balance"`
+				Next          types.String `tfsdk:"next"`
+				NextHop       types.String `tfsdk:"next_hop"`
+				Origin        types.String `tfsdk:"origin"`
+				Community     []struct {
+					Action types.String `tfsdk:"action"`
+					Value  types.String `tfsdk:"value"`
+				} `tfsdk:"community"`
+				LocalPreference []struct {
+					Action types.String `tfsdk:"action"`
+					Value  types.Int64  `tfsdk:"value"`
+				} `tfsdk:"local_preference"`
+				Metric []struct {
+					Action types.String `tfsdk:"action"`
+					Value  types.Int64  `tfsdk:"value"`
+				} `tfsdk:"metric"`
+				Preference []struct {
+					Action types.String `tfsdk:"action"`
+					Value  types.Int64  `tfsdk:"value"`
+				} `tfsdk:"preference"`
 			} `tfsdk:"then"`
 		} `tfsdk:"term"`
 	}
@@ -247,16 +321,32 @@ func upgradePolicyoptionsPolicyStatementStateV0toV1(
 			Next:          dataV0.Then[0].Next,
 			NextHop:       dataV0.Then[0].NextHop,
 			Origin:        dataV0.Then[0].Origin,
-			Community:     dataV0.Then[0].Community,
+		}
+		for _, blockV0 := range dataV0.Then[0].Community {
+			dataV1.Then.Community = append(dataV1.Then.Community,
+				policyoptionsPolicyStatementBlockThenBlockActionValue{
+					Action: blockV0.Action,
+					Value:  blockV0.Value,
+				},
+			)
 		}
 		if len(dataV0.Then[0].LocalPreference) > 0 {
-			dataV1.Then.LocalPreference = &dataV0.Then[0].LocalPreference[0]
+			dataV1.Then.LocalPreference = &policyoptionsPolicyStatementBlockThenBlockActionValueInt64{
+				Action: dataV0.Then[0].LocalPreference[0].Action,
+				Value:  dataV0.Then[0].LocalPreference[0].Value,
+			}
 		}
 		if len(dataV0.Then[0].Metric) > 0 {
-			dataV1.Then.Metric = &dataV0.Then[0].Metric[0]
+			dataV1.Then.Metric = &policyoptionsPolicyStatementBlockThenBlockActionValueInt64{
+				Action: dataV0.Then[0].Metric[0].Action,
+				Value:  dataV0.Then[0].Metric[0].Value,
+			}
 		}
 		if len(dataV0.Then[0].Preference) > 0 {
-			dataV1.Then.Preference = &dataV0.Then[0].Preference[0]
+			dataV1.Then.Preference = &policyoptionsPolicyStatementBlockThenBlockActionValueInt64{
+				Action: dataV0.Then[0].Preference[0].Action,
+				Value:  dataV0.Then[0].Preference[0].Value,
+			}
 		}
 	}
 	for _, blockV0 := range dataV0.Term {
@@ -279,16 +369,32 @@ func upgradePolicyoptionsPolicyStatementStateV0toV1(
 				Next:          blockV0.Then[0].Next,
 				NextHop:       blockV0.Then[0].NextHop,
 				Origin:        blockV0.Then[0].Origin,
-				Community:     blockV0.Then[0].Community,
+			}
+			for _, subBlockV0 := range blockV0.Then[0].Community {
+				blockV1.Then.Community = append(blockV1.Then.Community,
+					policyoptionsPolicyStatementBlockThenBlockActionValue{
+						Action: subBlockV0.Action,
+						Value:  subBlockV0.Value,
+					},
+				)
 			}
 			if len(blockV0.Then[0].LocalPreference) > 0 {
-				blockV1.Then.LocalPreference = &blockV0.Then[0].LocalPreference[0]
+				blockV1.Then.LocalPreference = &policyoptionsPolicyStatementBlockThenBlockActionValueInt64{
+					Action: blockV0.Then[0].LocalPreference[0].Action,
+					Value:  blockV0.Then[0].LocalPreference[0].Value,
+				}
 			}
 			if len(blockV0.Then[0].Metric) > 0 {
-				blockV1.Then.Metric = &blockV0.Then[0].Metric[0]
+				blockV1.Then.Metric = &policyoptionsPolicyStatementBlockThenBlockActionValueInt64{
+					Action: blockV0.Then[0].Metric[0].Action,
+					Value:  blockV0.Then[0].Metric[0].Value,
+				}
 			}
 			if len(dataV0.Then[0].Preference) > 0 {
-				blockV1.Then.Preference = &blockV0.Then[0].Preference[0]
+				blockV1.Then.Preference = &policyoptionsPolicyStatementBlockThenBlockActionValueInt64{
+					Action: blockV0.Then[0].Preference[0].Action,
+					Value:  blockV0.Then[0].Preference[0].Value,
+				}
 			}
 		}
 		dataV1.Term = append(dataV1.Term, blockV1)

--- a/internal/providerfwk/upgradestate_security.go
+++ b/internal/providerfwk/upgradestate_security.go
@@ -560,25 +560,48 @@ func upgradeSecurityV0toV1(
 	ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse,
 ) {
 	type modelV0 struct {
-		CleanOnDestroy types.Bool         `tfsdk:"clean_on_destroy"`
-		ID             types.String       `tfsdk:"id"`
-		Alg            []securityBlockAlg `tfsdk:"alg"`
-		Flow           []struct {
-			AllowDNSReply                    types.Bool                              `tfsdk:"allow_dns_reply"`
-			AllowEmbeddedIcmp                types.Bool                              `tfsdk:"allow_embedded_icmp"`
-			AllowReverseEcmp                 types.Bool                              `tfsdk:"allow_reverse_ecmp"`
-			EnableRerouteUniformLinkCheckNat types.Bool                              `tfsdk:"enable_reroute_uniform_link_check_nat"`
-			ForceIPReassembly                types.Bool                              `tfsdk:"force_ip_reassembly"`
-			IpsecPerformanceAcceleration     types.Bool                              `tfsdk:"ipsec_performance_acceleration"`
-			McastBufferEnhance               types.Bool                              `tfsdk:"mcast_buffer_enhance"`
-			PreserveIncomingFragmentSize     types.Bool                              `tfsdk:"preserve_incoming_fragment_size"`
-			SyncIcmpSession                  types.Bool                              `tfsdk:"sync_icmp_session"`
-			PendingSessQueueLength           types.String                            `tfsdk:"pending_sess_queue_length"`
-			RouteChangeTimeout               types.Int64                             `tfsdk:"route_change_timeout"`
-			SynFloodProtectionMode           types.String                            `tfsdk:"syn_flood_protection_mode"`
-			AdvancedOptions                  []securityBlockFlowBlockAdvancedOptions `tfsdk:"advanced_options"`
-			Aging                            []securityBlockFlowBlockAging           `tfsdk:"aging"`
-			EthernetSwitching                []struct {
+		CleanOnDestroy types.Bool   `tfsdk:"clean_on_destroy"`
+		ID             types.String `tfsdk:"id"`
+		Alg            []struct {
+			DNSDisable    types.Bool `tfsdk:"dns_disable"`
+			FtpDisable    types.Bool `tfsdk:"ftp_disable"`
+			H323Disable   types.Bool `tfsdk:"h323_disable"`
+			MgcpDisable   types.Bool `tfsdk:"mgcp_disable"`
+			MsrpcDisable  types.Bool `tfsdk:"msrpc_disable"`
+			PptpDisable   types.Bool `tfsdk:"pptp_disable"`
+			RshDisable    types.Bool `tfsdk:"rsh_disable"`
+			RtspDisable   types.Bool `tfsdk:"rtsp_disable"`
+			SccpDisable   types.Bool `tfsdk:"sccp_disable"`
+			SIPDisable    types.Bool `tfsdk:"sip_disable"`
+			SQLDisable    types.Bool `tfsdk:"sql_disable"`
+			SunrpcDisable types.Bool `tfsdk:"sunrpc_disable"`
+			TalkDisable   types.Bool `tfsdk:"talk_disable"`
+			TftpDisable   types.Bool `tfsdk:"tftp_disable"`
+		} `tfsdk:"alg"`
+		Flow []struct {
+			AllowDNSReply                    types.Bool   `tfsdk:"allow_dns_reply"`
+			AllowEmbeddedIcmp                types.Bool   `tfsdk:"allow_embedded_icmp"`
+			AllowReverseEcmp                 types.Bool   `tfsdk:"allow_reverse_ecmp"`
+			EnableRerouteUniformLinkCheckNat types.Bool   `tfsdk:"enable_reroute_uniform_link_check_nat"`
+			ForceIPReassembly                types.Bool   `tfsdk:"force_ip_reassembly"`
+			IpsecPerformanceAcceleration     types.Bool   `tfsdk:"ipsec_performance_acceleration"`
+			McastBufferEnhance               types.Bool   `tfsdk:"mcast_buffer_enhance"`
+			PreserveIncomingFragmentSize     types.Bool   `tfsdk:"preserve_incoming_fragment_size"`
+			SyncIcmpSession                  types.Bool   `tfsdk:"sync_icmp_session"`
+			PendingSessQueueLength           types.String `tfsdk:"pending_sess_queue_length"`
+			RouteChangeTimeout               types.Int64  `tfsdk:"route_change_timeout"`
+			SynFloodProtectionMode           types.String `tfsdk:"syn_flood_protection_mode"`
+			AdvancedOptions                  []struct {
+				DropMatchingLinkLocalAddress  types.Bool `tfsdk:"drop_matching_link_local_address"`
+				DropMatchingReservedIPAddress types.Bool `tfsdk:"drop_matching_reserved_ip_address"`
+				ReverseRoutePacketModeVR      types.Bool `tfsdk:"reverse_route_packet_mode_vr"`
+			} `tfsdk:"advanced_options"`
+			Aging []struct {
+				EarlyAgeout   types.Int64 `tfsdk:"early_ageout"`
+				HighWatermark types.Int64 `tfsdk:"high_watermark"`
+				LowWatermark  types.Int64 `tfsdk:"low_watermark"`
+			} `tfsdk:"aging"`
+			EthernetSwitching []struct {
 				BlockNonIPAll      types.Bool `tfsdk:"block_non_ip_all"`
 				BypassNonIPUnicast types.Bool `tfsdk:"bypass_non_ip_unicast"`
 				BpduVlanFlooding   types.Bool `tfsdk:"bpdu_vlan_flooding"`
@@ -599,53 +622,115 @@ func upgradeSecurityV0toV1(
 				} `tfsdk:"ipsec_vpn"`
 			} `tfsdk:"tcp_mss"`
 			TCPSession []struct {
-				FinInvalidateSession types.Bool                                           `tfsdk:"fin_invalidate_session"`
-				NoSequenceCheck      types.Bool                                           `tfsdk:"no_sequence_check"`
-				NoSynCheck           types.Bool                                           `tfsdk:"no_syn_check"`
-				NoSynCheckInTunnel   types.Bool                                           `tfsdk:"no_syn_check_in_tunnel"`
-				RstInvalidateSession types.Bool                                           `tfsdk:"rst_invalidate_session"`
-				RstSequenceCheck     types.Bool                                           `tfsdk:"rst_sequence_check"`
-				StrictSynCheck       types.Bool                                           `tfsdk:"strict_syn_check"`
-				MaximumWindow        types.String                                         `tfsdk:"maximum_window"`
-				TCPInitialTimeout    types.Int64                                          `tfsdk:"tcp_initial_timeout"`
-				TimeWaitState        []securityBlockFlowBlockTCPSessionBlockTimeWaitState `tfsdk:"time_wait_state"`
+				FinInvalidateSession types.Bool   `tfsdk:"fin_invalidate_session"`
+				NoSequenceCheck      types.Bool   `tfsdk:"no_sequence_check"`
+				NoSynCheck           types.Bool   `tfsdk:"no_syn_check"`
+				NoSynCheckInTunnel   types.Bool   `tfsdk:"no_syn_check_in_tunnel"`
+				RstInvalidateSession types.Bool   `tfsdk:"rst_invalidate_session"`
+				RstSequenceCheck     types.Bool   `tfsdk:"rst_sequence_check"`
+				StrictSynCheck       types.Bool   `tfsdk:"strict_syn_check"`
+				MaximumWindow        types.String `tfsdk:"maximum_window"`
+				TCPInitialTimeout    types.Int64  `tfsdk:"tcp_initial_timeout"`
+				TimeWaitState        []struct {
+					ApplyToHalfCloseState types.Bool  `tfsdk:"apply_to_half_close_state"`
+					SessionAgeout         types.Bool  `tfsdk:"session_ageout"`
+					SessionTimeout        types.Int64 `tfsdk:"session_timeout"`
+				} `tfsdk:"time_wait_state"`
 			} `tfsdk:"tcp_session"`
 		} `tfsdk:"flow"`
-		ForwardingOptions      []securityBlockForwardingOptions  `tfsdk:"forwarding_options"`
-		ForwardingProcess      []securityBlockForwardingProcess  `tfsdk:"forwarding_process"`
-		IdpSecurityPackage     []securityBlockIdpSecurityPackage `tfsdk:"idp_security_package"`
+		ForwardingOptions []struct {
+			Inet6Mode          types.String `tfsdk:"inet6_mode"`
+			IsoModePacketBased types.Bool   `tfsdk:"iso_mode_packet_based"`
+			MplsMode           types.String `tfsdk:"mpls_mode"`
+		} `tfsdk:"forwarding_options"`
+		ForwardingProcess []struct {
+			EnhancedServicesMode types.Bool `tfsdk:"enhanced_services_mode"`
+		} `tfsdk:"forwarding_process"`
+		IdpSecurityPackage []struct {
+			AutomaticEnable           types.Bool   `tfsdk:"automatic_enable"`
+			InstallIgnoreVersionCheck types.Bool   `tfsdk:"install_ignore_version_check"`
+			AutomaticInterval         types.Int64  `tfsdk:"automatic_interval"`
+			AutomaticStartTime        types.String `tfsdk:"automatic_start_time"`
+			ProxyProfile              types.String `tfsdk:"proxy_profile"`
+			SourceAddress             types.String `tfsdk:"source_address"`
+			URL                       types.String `tfsdk:"url"`
+		} `tfsdk:"idp_security_package"`
 		IdpSensorConfiguration []struct {
-			LogCacheSize                        types.Int64                                              `tfsdk:"log_cache_size"`
-			SecurityConfigurationProtectionMode types.String                                             `tfsdk:"security_configuration_protection_mode"`
-			LogSuppression                      []securityBlockIdpSensorConfigurationBlockLogSuppression `tfsdk:"log_suppression"`
-			PacketLog                           []securityBlockIdpSensorConfigurationBlockPacketLog      `tfsdk:"packet_log"`
+			LogCacheSize                        types.Int64  `tfsdk:"log_cache_size"`
+			SecurityConfigurationProtectionMode types.String `tfsdk:"security_configuration_protection_mode"`
+			LogSuppression                      []struct {
+				Disable                     types.Bool  `tfsdk:"disable"`
+				IncludeDestinationAddress   types.Bool  `tfsdk:"include_destination_address"`
+				NoIncludeDestinationAddress types.Bool  `tfsdk:"no_include_destination_address"`
+				MaxLogsOperate              types.Int64 `tfsdk:"max_logs_operate"`
+				MaxTimeReport               types.Int64 `tfsdk:"max_time_report"`
+				StartLog                    types.Int64 `tfsdk:"start_log"`
+			} `tfsdk:"log_suppression"`
+			PacketLog []struct {
+				SourceAddress            types.String `tfsdk:"source_address"`
+				HostAddress              types.String `tfsdk:"host_address"`
+				HostPort                 types.Int64  `tfsdk:"host_port"`
+				MaxSessions              types.Int64  `tfsdk:"max_sessions"`
+				ThresholdLoggingInterval types.Int64  `tfsdk:"threshold_logging_interval"`
+				TotalMemory              types.Int64  `tfsdk:"total_memory"`
+			} `tfsdk:"packet_log"`
 		} `tfsdk:"idp_sensor_configuration"`
 		IkeTraceoptions []struct {
-			Flag          []types.String                          `tfsdk:"flag"`
-			NoRemoteTrace types.Bool                              `tfsdk:"no_remote_trace"`
-			RateLimit     types.Int64                             `tfsdk:"rate_limit"`
-			File          []securityBlockIkeTraceoptionsBlockFile `tfsdk:"file"`
+			Flag          []types.String `tfsdk:"flag"`
+			NoRemoteTrace types.Bool     `tfsdk:"no_remote_trace"`
+			RateLimit     types.Int64    `tfsdk:"rate_limit"`
+			File          []struct {
+				NoWorldReadable types.Bool   `tfsdk:"no_world_readable"`
+				WorldReadable   types.Bool   `tfsdk:"world_readable"`
+				Name            types.String `tfsdk:"name"`
+				Files           types.Int64  `tfsdk:"files"`
+				Match           types.String `tfsdk:"match"`
+				Size            types.Int64  `tfsdk:"size"`
+			} `tfsdk:"file"`
 		} `tfsdk:"ike_traceoptions"`
 		Log []struct {
-			Disable           types.Bool                       `tfsdk:"disable"`
-			Report            types.Bool                       `tfsdk:"report"`
-			UtcTimestamp      types.Bool                       `tfsdk:"utc_timestamp"`
-			EventRate         types.Int64                      `tfsdk:"event_rate"`
-			FacilityOverride  types.String                     `tfsdk:"facility_override"`
-			Format            types.String                     `tfsdk:"format"`
-			MaxDatabaseRecord types.Int64                      `tfsdk:"max_database_record"`
-			Mode              types.String                     `tfsdk:"mode"`
-			RateCap           types.Int64                      `tfsdk:"rate_cap"`
-			SourceAddress     types.String                     `tfsdk:"source_address"`
-			SourceInterface   types.String                     `tfsdk:"source_interface"`
-			File              []securityBlockLogBlockFile      `tfsdk:"file"`
-			Transport         []securityBlockLogBlockTransport `tfsdk:"transport"`
+			Disable           types.Bool   `tfsdk:"disable"`
+			Report            types.Bool   `tfsdk:"report"`
+			UtcTimestamp      types.Bool   `tfsdk:"utc_timestamp"`
+			EventRate         types.Int64  `tfsdk:"event_rate"`
+			FacilityOverride  types.String `tfsdk:"facility_override"`
+			Format            types.String `tfsdk:"format"`
+			MaxDatabaseRecord types.Int64  `tfsdk:"max_database_record"`
+			Mode              types.String `tfsdk:"mode"`
+			RateCap           types.Int64  `tfsdk:"rate_cap"`
+			SourceAddress     types.String `tfsdk:"source_address"`
+			SourceInterface   types.String `tfsdk:"source_interface"`
+			File              []struct {
+				Files types.Int64  `tfsdk:"files"`
+				Name  types.String `tfsdk:"name"`
+				Path  types.String `tfsdk:"path"`
+				Size  types.Int64  `tfsdk:"size"`
+			} `tfsdk:"file"`
+			Transport []struct {
+				Protocol       types.String `tfsdk:"protocol"`
+				TCPConnections types.Int64  `tfsdk:"tcp_connections"`
+				TLSProfile     types.String `tfsdk:"tls_profile"`
+			} `tfsdk:"transport"`
 		} `tfsdk:"log"`
-		Policies                     []securityBlockPolicies                     `tfsdk:"policies"`
-		UserIdentificationAuthSource []securityBlockUserIdentificationAuthSource `tfsdk:"user_identification_auth_source"`
-		Utm                          []struct {
-			FeatureProfileWebFilteringType                  types.String                                                           `tfsdk:"feature_profile_web_filtering_type"`
-			FeatureProfileWebFilteringJuniperEnhancedServer []securityBlockUtmBlockFeatureProfileWebFilteringJuniperEnhancedServer `tfsdk:"feature_profile_web_filtering_juniper_enhanced_server"`
+		Policies []struct {
+			PolicyRematch          types.Bool `tfsdk:"policy_rematch"`
+			PolicyRematchExtensive types.Bool `tfsdk:"policy_rematch_extensive"`
+		} `tfsdk:"policies"`
+		UserIdentificationAuthSource []struct {
+			ADAuthPriority               types.Int64 `tfsdk:"ad_auth_priority"`
+			ArubaClearpassPriority       types.Int64 `tfsdk:"aruba_clearpass_priority"`
+			FirewallAuthPriority         types.Int64 `tfsdk:"firewall_auth_priority"`
+			LocalAuthPriority            types.Int64 `tfsdk:"local_auth_priority"`
+			UnifiedAccessControlPriority types.Int64 `tfsdk:"unified_access_control_priority"`
+		} `tfsdk:"user_identification_auth_source"`
+		Utm []struct {
+			FeatureProfileWebFilteringType                  types.String `tfsdk:"feature_profile_web_filtering_type"`
+			FeatureProfileWebFilteringJuniperEnhancedServer []struct {
+				Host            types.String `tfsdk:"host"`
+				Port            types.Int64  `tfsdk:"port"`
+				ProxyProfile    types.String `tfsdk:"proxy_profile"`
+				RoutingInstance types.String `tfsdk:"routing_instance"`
+			} `tfsdk:"feature_profile_web_filtering_juniper_enhanced_server"`
 		} `tfsdk:"utm"`
 	}
 
@@ -662,7 +747,22 @@ func upgradeSecurityV0toV1(
 		dataV1.CleanOnDestroy = types.BoolNull()
 	}
 	if len(dataV0.Alg) > 0 {
-		dataV1.Alg = &dataV0.Alg[0]
+		dataV1.Alg = &securityBlockAlg{
+			DNSDisable:    dataV0.Alg[0].DNSDisable,
+			FtpDisable:    dataV0.Alg[0].FtpDisable,
+			H323Disable:   dataV0.Alg[0].H323Disable,
+			MgcpDisable:   dataV0.Alg[0].MgcpDisable,
+			MsrpcDisable:  dataV0.Alg[0].MsrpcDisable,
+			PptpDisable:   dataV0.Alg[0].PptpDisable,
+			RshDisable:    dataV0.Alg[0].RshDisable,
+			RtspDisable:   dataV0.Alg[0].RtspDisable,
+			SccpDisable:   dataV0.Alg[0].SccpDisable,
+			SIPDisable:    dataV0.Alg[0].SIPDisable,
+			SQLDisable:    dataV0.Alg[0].SQLDisable,
+			SunrpcDisable: dataV0.Alg[0].SunrpcDisable,
+			TalkDisable:   dataV0.Alg[0].TalkDisable,
+			TftpDisable:   dataV0.Alg[0].TftpDisable,
+		}
 	}
 	if len(dataV0.Flow) > 0 {
 		dataV1.Flow = &securityBlockFlow{
@@ -680,10 +780,18 @@ func upgradeSecurityV0toV1(
 			SynFloodProtectionMode:           dataV0.Flow[0].SynFloodProtectionMode,
 		}
 		if len(dataV0.Flow[0].AdvancedOptions) > 0 {
-			dataV1.Flow.AdvancedOptions = &dataV0.Flow[0].AdvancedOptions[0]
+			dataV1.Flow.AdvancedOptions = &securityBlockFlowBlockAdvancedOptions{
+				DropMatchingLinkLocalAddress:  dataV0.Flow[0].AdvancedOptions[0].DropMatchingLinkLocalAddress,
+				DropMatchingReservedIPAddress: dataV0.Flow[0].AdvancedOptions[0].DropMatchingReservedIPAddress,
+				ReverseRoutePacketModeVR:      dataV0.Flow[0].AdvancedOptions[0].ReverseRoutePacketModeVR,
+			}
 		}
 		if len(dataV0.Flow[0].Aging) > 0 {
-			dataV1.Flow.Aging = &dataV0.Flow[0].Aging[0]
+			dataV1.Flow.Aging = &securityBlockFlowBlockAging{
+				EarlyAgeout:   dataV0.Flow[0].Aging[0].EarlyAgeout,
+				HighWatermark: dataV0.Flow[0].Aging[0].HighWatermark,
+				LowWatermark:  dataV0.Flow[0].Aging[0].LowWatermark,
+			}
 		}
 		if len(dataV0.Flow[0].EthernetSwitching) > 0 {
 			dataV1.Flow.EthernetSwitching = &securityBlockFlowBlockEthernetSwitching{
@@ -722,18 +830,36 @@ func upgradeSecurityV0toV1(
 				TCPInitialTimeout:    dataV0.Flow[0].TCPSession[0].TCPInitialTimeout,
 			}
 			if len(dataV0.Flow[0].TCPSession[0].TimeWaitState) > 0 {
-				dataV1.Flow.TCPSession.TimeWaitState = &dataV0.Flow[0].TCPSession[0].TimeWaitState[0]
+				dataV1.Flow.TCPSession.TimeWaitState = &securityBlockFlowBlockTCPSessionBlockTimeWaitState{
+					ApplyToHalfCloseState: dataV0.Flow[0].TCPSession[0].TimeWaitState[0].ApplyToHalfCloseState,
+					SessionAgeout:         dataV0.Flow[0].TCPSession[0].TimeWaitState[0].SessionAgeout,
+					SessionTimeout:        dataV0.Flow[0].TCPSession[0].TimeWaitState[0].SessionTimeout,
+				}
 			}
 		}
 	}
 	if len(dataV0.ForwardingOptions) > 0 {
-		dataV1.ForwardingOptions = &dataV0.ForwardingOptions[0]
+		dataV1.ForwardingOptions = &securityBlockForwardingOptions{
+			Inet6Mode:          dataV0.ForwardingOptions[0].Inet6Mode,
+			IsoModePacketBased: dataV0.ForwardingOptions[0].IsoModePacketBased,
+			MplsMode:           dataV0.ForwardingOptions[0].MplsMode,
+		}
 	}
 	if len(dataV0.ForwardingProcess) > 0 {
-		dataV1.ForwardingProcess = &dataV0.ForwardingProcess[0]
+		dataV1.ForwardingProcess = &securityBlockForwardingProcess{
+			EnhancedServicesMode: dataV0.ForwardingProcess[0].EnhancedServicesMode,
+		}
 	}
 	if len(dataV0.IdpSecurityPackage) > 0 {
-		dataV1.IdpSecurityPackage = &dataV0.IdpSecurityPackage[0]
+		dataV1.IdpSecurityPackage = &securityBlockIdpSecurityPackage{
+			AutomaticEnable:           dataV0.IdpSecurityPackage[0].AutomaticEnable,
+			InstallIgnoreVersionCheck: dataV0.IdpSecurityPackage[0].InstallIgnoreVersionCheck,
+			AutomaticInterval:         dataV0.IdpSecurityPackage[0].AutomaticInterval,
+			AutomaticStartTime:        dataV0.IdpSecurityPackage[0].AutomaticStartTime,
+			ProxyProfile:              dataV0.IdpSecurityPackage[0].ProxyProfile,
+			SourceAddress:             dataV0.IdpSecurityPackage[0].SourceAddress,
+			URL:                       dataV0.IdpSecurityPackage[0].URL,
+		}
 	}
 	if len(dataV0.IdpSensorConfiguration) > 0 {
 		dataV1.IdpSensorConfiguration = &securityBlockIdpSensorConfiguration{
@@ -741,10 +867,24 @@ func upgradeSecurityV0toV1(
 			SecurityConfigurationProtectionMode: dataV0.IdpSensorConfiguration[0].SecurityConfigurationProtectionMode,
 		}
 		if len(dataV0.IdpSensorConfiguration[0].LogSuppression) > 0 {
-			dataV1.IdpSensorConfiguration.LogSuppression = &dataV0.IdpSensorConfiguration[0].LogSuppression[0]
+			dataV1.IdpSensorConfiguration.LogSuppression = &securityBlockIdpSensorConfigurationBlockLogSuppression{
+				Disable:                     dataV0.IdpSensorConfiguration[0].LogSuppression[0].Disable,
+				IncludeDestinationAddress:   dataV0.IdpSensorConfiguration[0].LogSuppression[0].IncludeDestinationAddress,
+				NoIncludeDestinationAddress: dataV0.IdpSensorConfiguration[0].LogSuppression[0].NoIncludeDestinationAddress,
+				MaxLogsOperate:              dataV0.IdpSensorConfiguration[0].LogSuppression[0].MaxLogsOperate,
+				MaxTimeReport:               dataV0.IdpSensorConfiguration[0].LogSuppression[0].MaxTimeReport,
+				StartLog:                    dataV0.IdpSensorConfiguration[0].LogSuppression[0].StartLog,
+			}
 		}
 		if len(dataV0.IdpSensorConfiguration[0].PacketLog) > 0 {
-			dataV1.IdpSensorConfiguration.PacketLog = &dataV0.IdpSensorConfiguration[0].PacketLog[0]
+			dataV1.IdpSensorConfiguration.PacketLog = &securityBlockIdpSensorConfigurationBlockPacketLog{
+				SourceAddress:            dataV0.IdpSensorConfiguration[0].PacketLog[0].SourceAddress,
+				HostAddress:              dataV0.IdpSensorConfiguration[0].PacketLog[0].HostAddress,
+				HostPort:                 dataV0.IdpSensorConfiguration[0].PacketLog[0].HostPort,
+				MaxSessions:              dataV0.IdpSensorConfiguration[0].PacketLog[0].MaxSessions,
+				ThresholdLoggingInterval: dataV0.IdpSensorConfiguration[0].PacketLog[0].ThresholdLoggingInterval,
+				TotalMemory:              dataV0.IdpSensorConfiguration[0].PacketLog[0].TotalMemory,
+			}
 		}
 	}
 	if len(dataV0.IkeTraceoptions) > 0 {
@@ -754,7 +894,14 @@ func upgradeSecurityV0toV1(
 			RateLimit:     dataV0.IkeTraceoptions[0].RateLimit,
 		}
 		if len(dataV0.IkeTraceoptions[0].File) > 0 {
-			dataV1.IkeTraceoptions.File = &dataV0.IkeTraceoptions[0].File[0]
+			dataV1.IkeTraceoptions.File = &securityBlockIkeTraceoptionsBlockFile{
+				NoWorldReadable: dataV0.IkeTraceoptions[0].File[0].NoWorldReadable,
+				WorldReadable:   dataV0.IkeTraceoptions[0].File[0].WorldReadable,
+				Name:            dataV0.IkeTraceoptions[0].File[0].Name,
+				Files:           dataV0.IkeTraceoptions[0].File[0].Files,
+				Match:           dataV0.IkeTraceoptions[0].File[0].Match,
+				Size:            dataV0.IkeTraceoptions[0].File[0].Size,
+			}
 		}
 	}
 	if len(dataV0.Log) > 0 {
@@ -772,24 +919,47 @@ func upgradeSecurityV0toV1(
 			SourceInterface:   dataV0.Log[0].SourceInterface,
 		}
 		if len(dataV0.Log[0].File) > 0 {
-			dataV1.Log.File = &dataV0.Log[0].File[0]
+			dataV1.Log.File = &securityBlockLogBlockFile{
+				Files: dataV0.Log[0].File[0].Files,
+				Name:  dataV0.Log[0].File[0].Name,
+				Path:  dataV0.Log[0].File[0].Path,
+				Size:  dataV0.Log[0].File[0].Size,
+			}
 		}
 		if len(dataV0.Log[0].Transport) > 0 {
-			dataV1.Log.Transport = &dataV0.Log[0].Transport[0]
+			dataV1.Log.Transport = &securityBlockLogBlockTransport{
+				Protocol:       dataV0.Log[0].Transport[0].Protocol,
+				TCPConnections: dataV0.Log[0].Transport[0].TCPConnections,
+				TLSProfile:     dataV0.Log[0].Transport[0].TLSProfile,
+			}
 		}
 	}
 	if len(dataV0.Policies) > 0 {
-		dataV1.Policies = &dataV0.Policies[0]
+		dataV1.Policies = &securityBlockPolicies{
+			PolicyRematch:          dataV0.Policies[0].PolicyRematch,
+			PolicyRematchExtensive: dataV0.Policies[0].PolicyRematchExtensive,
+		}
 	}
 	if len(dataV0.UserIdentificationAuthSource) > 0 {
-		dataV1.UserIdentificationAuthSource = &dataV0.UserIdentificationAuthSource[0]
+		dataV1.UserIdentificationAuthSource = &securityBlockUserIdentificationAuthSource{
+			ADAuthPriority:               dataV0.UserIdentificationAuthSource[0].ADAuthPriority,
+			ArubaClearpassPriority:       dataV0.UserIdentificationAuthSource[0].ArubaClearpassPriority,
+			FirewallAuthPriority:         dataV0.UserIdentificationAuthSource[0].FirewallAuthPriority,
+			LocalAuthPriority:            dataV0.UserIdentificationAuthSource[0].LocalAuthPriority,
+			UnifiedAccessControlPriority: dataV0.UserIdentificationAuthSource[0].UnifiedAccessControlPriority,
+		}
 	}
 	if len(dataV0.Utm) > 0 {
 		dataV1.Utm = &securityBlockUtm{
 			FeatureProfileWebFilteringType: dataV0.Utm[0].FeatureProfileWebFilteringType,
 		}
 		if len(dataV0.Utm[0].FeatureProfileWebFilteringJuniperEnhancedServer) > 0 {
-			dataV1.Utm.FeatureProfileWebFilteringJuniperEnhancedServer = &dataV0.Utm[0].FeatureProfileWebFilteringJuniperEnhancedServer[0]
+			dataV1.Utm.FeatureProfileWebFilteringJuniperEnhancedServer = &securityBlockUtmBlockFeatureProfileWebFilteringJuniperEnhancedServer{
+				Host:            dataV0.Utm[0].FeatureProfileWebFilteringJuniperEnhancedServer[0].Host,
+				Port:            dataV0.Utm[0].FeatureProfileWebFilteringJuniperEnhancedServer[0].Port,
+				ProxyProfile:    dataV0.Utm[0].FeatureProfileWebFilteringJuniperEnhancedServer[0].ProxyProfile,
+				RoutingInstance: dataV0.Utm[0].FeatureProfileWebFilteringJuniperEnhancedServer[0].RoutingInstance,
+			}
 		}
 	}
 

--- a/internal/providerfwk/upgradestate_security_ike_gateway.go
+++ b/internal/providerfwk/upgradestate_security_ike_gateway.go
@@ -149,30 +149,43 @@ func (rsc *securityIkeGateway) UpgradeState(_ context.Context) map[int64]resourc
 func upgradeSecurityIkeGatewayV0toV1(
 	ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse,
 ) {
-	//nolint:lll
 	type modelV0 struct {
-		GeneralIkeID      types.Bool                                 `tfsdk:"general_ike_id"`
-		NoNatTraversal    types.Bool                                 `tfsdk:"no_nat_traversal"`
-		ID                types.String                               `tfsdk:"id"`
-		Name              types.String                               `tfsdk:"name"`
-		ExternalInterface types.String                               `tfsdk:"external_interface"`
-		Policy            types.String                               `tfsdk:"policy"`
-		Address           []types.String                             `tfsdk:"address"`
-		LocalAddress      types.String                               `tfsdk:"local_address"`
-		Version           types.String                               `tfsdk:"version"`
-		Aaa               []securityIkeGatewayBlockAaa               `tfsdk:"aaa"`
-		DeadPeerDetection []securityIkeGatewayBlockDeadPeerDetection `tfsdk:"dead_peer_detection"`
-		DynamicRemote     []struct {
-			ConnectionsLimit          types.Int64                                                  `tfsdk:"connections_limit"`
-			Hostname                  types.String                                                 `tfsdk:"hostname"`
-			IkeUserType               types.String                                                 `tfsdk:"ike_user_type"`
-			Inet                      types.String                                                 `tfsdk:"inet"`
-			Inet6                     types.String                                                 `tfsdk:"inet6"`
-			RejectDuplicateConnection types.Bool                                                   `tfsdk:"reject_duplicate_connection"`
-			UserAtHostname            types.String                                                 `tfsdk:"user_at_hostname"`
-			DistinguishedName         []securityIkeGatewayBlockDynamicRemoteBlockDistinguishedName `tfsdk:"distinguished_name"`
+		GeneralIkeID      types.Bool     `tfsdk:"general_ike_id"`
+		NoNatTraversal    types.Bool     `tfsdk:"no_nat_traversal"`
+		ID                types.String   `tfsdk:"id"`
+		Name              types.String   `tfsdk:"name"`
+		ExternalInterface types.String   `tfsdk:"external_interface"`
+		Policy            types.String   `tfsdk:"policy"`
+		Address           []types.String `tfsdk:"address"`
+		LocalAddress      types.String   `tfsdk:"local_address"`
+		Version           types.String   `tfsdk:"version"`
+		Aaa               []struct {
+			AccessProfile  types.String `tfsdk:"access_profile"`
+			ClientPassword types.String `tfsdk:"client_password"`
+			ClientUsername types.String `tfsdk:"client_username"`
+		} `tfsdk:"aaa"`
+		DeadPeerDetection []struct {
+			Interval  types.Int64  `tfsdk:"interval"`
+			SendMode  types.String `tfsdk:"send_mode"`
+			Threshold types.Int64  `tfsdk:"threshold"`
+		} `tfsdk:"dead_peer_detection"`
+		DynamicRemote []struct {
+			ConnectionsLimit          types.Int64  `tfsdk:"connections_limit"`
+			Hostname                  types.String `tfsdk:"hostname"`
+			IkeUserType               types.String `tfsdk:"ike_user_type"`
+			Inet                      types.String `tfsdk:"inet"`
+			Inet6                     types.String `tfsdk:"inet6"`
+			RejectDuplicateConnection types.Bool   `tfsdk:"reject_duplicate_connection"`
+			UserAtHostname            types.String `tfsdk:"user_at_hostname"`
+			DistinguishedName         []struct {
+				Container types.String `tfsdk:"container"`
+				Wildcard  types.String `tfsdk:"wildcard"`
+			} `tfsdk:"distinguished_name"`
 		} `tfsdk:"dynamic_remote"`
-		LocalIdentity  []securityIkeGatewayBlockLocalIdentity `tfsdk:"local_identity"`
+		LocalIdentity []struct {
+			Type  types.String `tfsdk:"type"`
+			Value types.String `tfsdk:"value"`
+		} `tfsdk:"local_identity"`
 		RemoteIdentity []struct {
 			Type  types.String `tfsdk:"type"`
 			Value types.String `tfsdk:"value"`
@@ -206,17 +219,31 @@ func upgradeSecurityIkeGatewayV0toV1(
 			UserAtHostname:            dataV0.DynamicRemote[0].UserAtHostname,
 		}
 		if len(dataV0.DynamicRemote[0].DistinguishedName) > 0 {
-			dataV1.DynamicRemote.DistinguishedName = &dataV0.DynamicRemote[0].DistinguishedName[0]
+			dataV1.DynamicRemote.DistinguishedName = &securityIkeGatewayBlockDynamicRemoteBlockDistinguishedName{
+				Container: dataV0.DynamicRemote[0].DistinguishedName[0].Container,
+				Wildcard:  dataV0.DynamicRemote[0].DistinguishedName[0].Wildcard,
+			}
 		}
 	}
 	if len(dataV0.Aaa) > 0 {
-		dataV1.Aaa = &dataV0.Aaa[0]
+		dataV1.Aaa = &securityIkeGatewayBlockAaa{
+			AccessProfile:  dataV0.Aaa[0].AccessProfile,
+			ClientPassword: dataV0.Aaa[0].ClientPassword,
+			ClientUsername: dataV0.Aaa[0].ClientUsername,
+		}
 	}
 	if len(dataV0.DeadPeerDetection) > 0 {
-		dataV1.DeadPeerDetection = &dataV0.DeadPeerDetection[0]
+		dataV1.DeadPeerDetection = &securityIkeGatewayBlockDeadPeerDetection{
+			Interval:  dataV0.DeadPeerDetection[0].Interval,
+			SendMode:  dataV0.DeadPeerDetection[0].SendMode,
+			Threshold: dataV0.DeadPeerDetection[0].Threshold,
+		}
 	}
 	if len(dataV0.LocalIdentity) > 0 {
-		dataV1.LocalIdentity = &dataV0.LocalIdentity[0]
+		dataV1.LocalIdentity = &securityIkeGatewayBlockLocalIdentity{
+			Type:  dataV0.LocalIdentity[0].Type,
+			Value: dataV0.LocalIdentity[0].Value,
+		}
 	}
 	if len(dataV0.RemoteIdentity) > 0 {
 		dataV1.RemoteIdentity = &securityIkeGatewayBlockRemoteIdentity{

--- a/internal/providerfwk/upgradestate_security_nat_destination.go
+++ b/internal/providerfwk/upgradestate_security_nat_destination.go
@@ -97,20 +97,26 @@ func upgradeSecurityNatDestinationV0toV1(
 	ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse,
 ) {
 	type modelV0 struct {
-		ID          types.String                      `tfsdk:"id"`
-		Name        types.String                      `tfsdk:"name"`
-		Description types.String                      `tfsdk:"description"`
-		From        []securityNatDestinationBlockFrom `tfsdk:"from"`
-		Rule        []struct {
-			Name                   types.String                               `tfsdk:"name"`
-			DestinationAddress     types.String                               `tfsdk:"destination_address"`
-			DestinationAddressName types.String                               `tfsdk:"destination_address_name"`
-			Application            []types.String                             `tfsdk:"application"`
-			DestinationPort        []types.String                             `tfsdk:"destination_port"`
-			Protocol               []types.String                             `tfsdk:"protocol"`
-			SourceAddress          []types.String                             `tfsdk:"source_address"`
-			SourceAddressName      []types.String                             `tfsdk:"source_address_name"`
-			Then                   []securityNatDestinationBlockRuleBlockThen `tfsdk:"then"`
+		ID          types.String `tfsdk:"id"`
+		Name        types.String `tfsdk:"name"`
+		Description types.String `tfsdk:"description"`
+		From        []struct {
+			Type  types.String   `tfsdk:"type"`
+			Value []types.String `tfsdk:"value"`
+		} `tfsdk:"from"`
+		Rule []struct {
+			Name                   types.String   `tfsdk:"name"`
+			DestinationAddress     types.String   `tfsdk:"destination_address"`
+			DestinationAddressName types.String   `tfsdk:"destination_address_name"`
+			Application            []types.String `tfsdk:"application"`
+			DestinationPort        []types.String `tfsdk:"destination_port"`
+			Protocol               []types.String `tfsdk:"protocol"`
+			SourceAddress          []types.String `tfsdk:"source_address"`
+			SourceAddressName      []types.String `tfsdk:"source_address_name"`
+			Then                   []struct {
+				Type types.String `tfsdk:"type"`
+				Pool types.String `tfsdk:"pool"`
+			} `tfsdk:"then"`
 		} `tfsdk:"rule"`
 	}
 
@@ -125,7 +131,10 @@ func upgradeSecurityNatDestinationV0toV1(
 	dataV1.Name = dataV0.Name
 	dataV1.Description = dataV0.Description
 	if len(dataV0.From) > 0 {
-		dataV1.From = &dataV0.From[0]
+		dataV1.From = &securityNatDestinationBlockFrom{
+			Type:  dataV0.From[0].Type,
+			Value: dataV0.From[0].Value,
+		}
 	}
 	for _, blockV0 := range dataV0.Rule {
 		blockV1 := securityNatDestinationBlockRule{
@@ -139,7 +148,10 @@ func upgradeSecurityNatDestinationV0toV1(
 			SourceAddressName:      blockV0.SourceAddressName,
 		}
 		if len(blockV0.Then) > 0 {
-			blockV1.Then = &blockV0.Then[0]
+			blockV1.Then = &securityNatDestinationBlockRuleBlockThen{
+				Type: blockV0.Then[0].Type,
+				Pool: blockV0.Then[0].Pool,
+			}
 		}
 		dataV1.Rule = append(dataV1.Rule, blockV1)
 	}

--- a/internal/providerfwk/upgradestate_security_nat_source.go
+++ b/internal/providerfwk/upgradestate_security_nat_source.go
@@ -122,15 +122,33 @@ func upgradeSecurityNatSourceV0toV1(
 	ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse,
 ) {
 	type modelV0 struct {
-		ID          types.String                   `tfsdk:"id"`
-		Name        types.String                   `tfsdk:"name"`
-		Description types.String                   `tfsdk:"description"`
-		From        []securityNatSourceBlockFromTo `tfsdk:"from"`
-		To          []securityNatSourceBlockFromTo `tfsdk:"to"`
-		Rule        []struct {
-			Name  types.String                           `tfsdk:"name"`
-			Match []securityNatSourceBlockRuleBlockMatch `tfsdk:"match"`
-			Then  []securityNatSourceBlockRuleBlockThen  `tfsdk:"then"`
+		ID          types.String `tfsdk:"id"`
+		Name        types.String `tfsdk:"name"`
+		Description types.String `tfsdk:"description"`
+		From        []struct {
+			Type  types.String   `tfsdk:"type"`
+			Value []types.String `tfsdk:"value"`
+		} `tfsdk:"from"`
+		To []struct {
+			Type  types.String   `tfsdk:"type"`
+			Value []types.String `tfsdk:"value"`
+		} `tfsdk:"to"`
+		Rule []struct {
+			Name  types.String `tfsdk:"name"`
+			Match []struct {
+				Application            []types.String `tfsdk:"application"`
+				DestinationAddress     []types.String `tfsdk:"destination_address"`
+				DestinationAddressName []types.String `tfsdk:"destination_address_name"`
+				DestinationPort        []types.String `tfsdk:"destination_port"`
+				Protocol               []types.String `tfsdk:"protocol"`
+				SourceAddress          []types.String `tfsdk:"source_address"`
+				SourceAddressName      []types.String `tfsdk:"source_address_name"`
+				SourcePort             []types.String `tfsdk:"source_port"`
+			} `tfsdk:"match"`
+			Then []struct {
+				Type types.String `tfsdk:"type"`
+				Pool types.String `tfsdk:"pool"`
+			} `tfsdk:"then"`
 		} `tfsdk:"rule"`
 	}
 
@@ -145,20 +163,38 @@ func upgradeSecurityNatSourceV0toV1(
 	dataV1.Name = dataV0.Name
 	dataV1.Description = dataV0.Description
 	if len(dataV0.From) > 0 {
-		dataV1.From = &dataV0.From[0]
+		dataV1.From = &securityNatSourceBlockFromTo{
+			Type:  dataV0.From[0].Type,
+			Value: dataV0.From[0].Value,
+		}
 	}
 	if len(dataV0.To) > 0 {
-		dataV1.To = &dataV0.To[0]
+		dataV1.To = &securityNatSourceBlockFromTo{
+			Type:  dataV0.To[0].Type,
+			Value: dataV0.To[0].Value,
+		}
 	}
 	for _, blockV0 := range dataV0.Rule {
 		blockV1 := securityNatSourceBlockRule{
 			Name: blockV0.Name,
 		}
 		if len(blockV0.Match) > 0 {
-			blockV1.Match = &blockV0.Match[0]
+			blockV1.Match = &securityNatSourceBlockRuleBlockMatch{
+				Application:            blockV0.Match[0].Application,
+				DestinationAddress:     blockV0.Match[0].DestinationAddress,
+				DestinationAddressName: blockV0.Match[0].DestinationAddressName,
+				DestinationPort:        blockV0.Match[0].DestinationPort,
+				Protocol:               blockV0.Match[0].Protocol,
+				SourceAddress:          blockV0.Match[0].SourceAddress,
+				SourceAddressName:      blockV0.Match[0].SourceAddressName,
+				SourcePort:             blockV0.Match[0].SourcePort,
+			}
 		}
 		if len(blockV0.Then) > 0 {
-			blockV1.Then = &blockV0.Then[0]
+			blockV1.Then = &securityNatSourceBlockRuleBlockThen{
+				Type: blockV0.Then[0].Type,
+				Pool: blockV0.Then[0].Pool,
+			}
 		}
 		dataV1.Rule = append(dataV1.Rule, blockV1)
 	}

--- a/internal/providerfwk/upgradestate_security_nat_static.go
+++ b/internal/providerfwk/upgradestate_security_nat_static.go
@@ -107,21 +107,30 @@ func upgradeSecurityNatStaticV0toV1(
 	ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse,
 ) {
 	type modelV0 struct {
-		ConfigureRulesSingly types.Bool                   `tfsdk:"configure_rules_singly"`
-		ID                   types.String                 `tfsdk:"id"`
-		Name                 types.String                 `tfsdk:"name"`
-		Description          types.String                 `tfsdk:"description"`
-		From                 []securityNatStaticBlockFrom `tfsdk:"from"`
-		Rule                 []struct {
-			Name                   types.String                     `tfsdk:"name"`
-			DestinationAddress     types.String                     `tfsdk:"destination_address"`
-			DestinationAddressName types.String                     `tfsdk:"destination_address_name"`
-			DestinationPort        types.Int64                      `tfsdk:"destination_port"`
-			DestiantionPortTo      types.Int64                      `tfsdk:"destination_port_to"`
-			SourceAddress          []types.String                   `tfsdk:"source_address"`
-			SourceAddressName      []types.String                   `tfsdk:"source_address_name"`
-			SourcePort             []types.String                   `tfsdk:"source_port"`
-			Then                   []securityNatStaticRuleBlockThen `tfsdk:"then"`
+		ConfigureRulesSingly types.Bool   `tfsdk:"configure_rules_singly"`
+		ID                   types.String `tfsdk:"id"`
+		Name                 types.String `tfsdk:"name"`
+		Description          types.String `tfsdk:"description"`
+		From                 []struct {
+			Type  types.String   `tfsdk:"type"`
+			Value []types.String `tfsdk:"value"`
+		} `tfsdk:"from"`
+		Rule []struct {
+			Name                   types.String   `tfsdk:"name"`
+			DestinationAddress     types.String   `tfsdk:"destination_address"`
+			DestinationAddressName types.String   `tfsdk:"destination_address_name"`
+			DestinationPort        types.Int64    `tfsdk:"destination_port"`
+			DestiantionPortTo      types.Int64    `tfsdk:"destination_port_to"`
+			SourceAddress          []types.String `tfsdk:"source_address"`
+			SourceAddressName      []types.String `tfsdk:"source_address_name"`
+			SourcePort             []types.String `tfsdk:"source_port"`
+			Then                   []struct {
+				Type            types.String `tfsdk:"type"`
+				MappedPort      types.Int64  `tfsdk:"mapped_port"`
+				MappedPortTo    types.Int64  `tfsdk:"mapped_port_to"`
+				Prefix          types.String `tfsdk:"prefix"`
+				RoutingInstance types.String `tfsdk:"routing_instance"`
+			} `tfsdk:"then"`
 		} `tfsdk:"rule"`
 	}
 
@@ -137,7 +146,10 @@ func upgradeSecurityNatStaticV0toV1(
 	dataV1.ConfigureRulesSingly = dataV0.ConfigureRulesSingly
 	dataV1.Description = dataV0.Description
 	if len(dataV0.From) > 0 {
-		dataV1.From = &dataV0.From[0]
+		dataV1.From = &securityNatStaticBlockFrom{
+			Type:  dataV0.From[0].Type,
+			Value: dataV0.From[0].Value,
+		}
 	}
 	for _, blockV0 := range dataV0.Rule {
 		blockV1 := securityNatStaticBlockRule{
@@ -151,7 +163,13 @@ func upgradeSecurityNatStaticV0toV1(
 			SourcePort:             blockV0.SourcePort,
 		}
 		if len(blockV0.Then) > 0 {
-			blockV1.Then = &blockV0.Then[0]
+			blockV1.Then = &securityNatStaticRuleBlockThen{
+				Type:            blockV0.Then[0].Type,
+				MappedPort:      blockV0.Then[0].MappedPort,
+				MappedPortTo:    blockV0.Then[0].MappedPortTo,
+				Prefix:          blockV0.Then[0].Prefix,
+				RoutingInstance: blockV0.Then[0].RoutingInstance,
+			}
 		}
 		dataV1.Rule = append(dataV1.Rule, blockV1)
 	}

--- a/internal/providerfwk/upgradestate_security_nat_static_rule.go
+++ b/internal/providerfwk/upgradestate_security_nat_static_rule.go
@@ -80,17 +80,23 @@ func upgradeSecurityNatStaticRuleV0toV1(
 	ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse,
 ) {
 	type modelV0 struct {
-		ID                     types.String                     `tfsdk:"id"`
-		Name                   types.String                     `tfsdk:"name"`
-		RuleSet                types.String                     `tfsdk:"rule_set"`
-		DestinationAddress     types.String                     `tfsdk:"destination_address"`
-		DestinationAddressName types.String                     `tfsdk:"destination_address_name"`
-		DestinationPort        types.Int64                      `tfsdk:"destination_port"`
-		DestiantionPortTo      types.Int64                      `tfsdk:"destination_port_to"`
-		SourceAddress          []types.String                   `tfsdk:"source_address"`
-		SourceAddressName      []types.String                   `tfsdk:"source_address_name"`
-		SourcePort             []types.String                   `tfsdk:"source_port"`
-		Then                   []securityNatStaticRuleBlockThen `tfsdk:"then"`
+		ID                     types.String   `tfsdk:"id"`
+		Name                   types.String   `tfsdk:"name"`
+		RuleSet                types.String   `tfsdk:"rule_set"`
+		DestinationAddress     types.String   `tfsdk:"destination_address"`
+		DestinationAddressName types.String   `tfsdk:"destination_address_name"`
+		DestinationPort        types.Int64    `tfsdk:"destination_port"`
+		DestiantionPortTo      types.Int64    `tfsdk:"destination_port_to"`
+		SourceAddress          []types.String `tfsdk:"source_address"`
+		SourceAddressName      []types.String `tfsdk:"source_address_name"`
+		SourcePort             []types.String `tfsdk:"source_port"`
+		Then                   []struct {
+			Type            types.String `tfsdk:"type"`
+			MappedPort      types.Int64  `tfsdk:"mapped_port"`
+			MappedPortTo    types.Int64  `tfsdk:"mapped_port_to"`
+			Prefix          types.String `tfsdk:"prefix"`
+			RoutingInstance types.String `tfsdk:"routing_instance"`
+		} `tfsdk:"then"`
 	}
 
 	var dataV0 modelV0
@@ -111,7 +117,13 @@ func upgradeSecurityNatStaticRuleV0toV1(
 	dataV1.SourceAddressName = dataV0.SourceAddressName
 	dataV1.SourcePort = dataV0.SourcePort
 	if len(dataV0.Then) > 0 {
-		dataV1.Then = &dataV0.Then[0]
+		dataV1.Then = &securityNatStaticRuleBlockThen{
+			Type:            dataV0.Then[0].Type,
+			MappedPort:      dataV0.Then[0].MappedPort,
+			MappedPortTo:    dataV0.Then[0].MappedPortTo,
+			Prefix:          dataV0.Then[0].Prefix,
+			RoutingInstance: dataV0.Then[0].RoutingInstance,
+		}
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, dataV1)...)

--- a/internal/providerfwk/upgradestate_services_flowmonitoring_vipfix_template.go
+++ b/internal/providerfwk/upgradestate_services_flowmonitoring_vipfix_template.go
@@ -83,24 +83,26 @@ func (rsc *servicesFlowMonitoringVIPFixTemplate) UpgradeState(_ context.Context)
 func upgradeServicesFlowMonitoringVIPFixTemplateStateV0toV1(
 	ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse,
 ) {
-	//nolint:lll
 	type modelV0 struct {
-		FlowKeyFlowDirection      types.Bool                                             `tfsdk:"flow_key_flow_direction"`
-		FlowKeyVlanID             types.Bool                                             `tfsdk:"flow_key_vlan_id"`
-		NexthopLearningEnable     types.Bool                                             `tfsdk:"nexthop_learning_enable"`
-		NexthopLearningDisable    types.Bool                                             `tfsdk:"nexthop_learning_disable"`
-		TunnelObservationIPv4     types.Bool                                             `tfsdk:"tunnel_observation_ipv4"`
-		TunnelObservationIPv6     types.Bool                                             `tfsdk:"tunnel_observation_ipv6"`
-		ID                        types.String                                           `tfsdk:"id"`
-		Name                      types.String                                           `tfsdk:"name"`
-		Type                      types.String                                           `tfsdk:"type"`
-		FlowActiveTimeout         types.Int64                                            `tfsdk:"flow_active_timeout"`
-		FlowInactiveTimeout       types.Int64                                            `tfsdk:"flow_inactive_timeout"`
-		IPTemplateExportExtension []types.String                                         `tfsdk:"ip_template_export_extension"`
-		ObservationDomainID       types.Int64                                            `tfsdk:"observation_domain_id"`
-		OptionTemplateID          types.Int64                                            `tfsdk:"option_template_id"`
-		TemplateID                types.Int64                                            `tfsdk:"template_id"`
-		OptionRefreshRate         []servicesFlowMonitoringVIPFixTemplateBlockRefreshRate `tfsdk:"option_refresh_rate"`
+		FlowKeyFlowDirection      types.Bool     `tfsdk:"flow_key_flow_direction"`
+		FlowKeyVlanID             types.Bool     `tfsdk:"flow_key_vlan_id"`
+		NexthopLearningEnable     types.Bool     `tfsdk:"nexthop_learning_enable"`
+		NexthopLearningDisable    types.Bool     `tfsdk:"nexthop_learning_disable"`
+		TunnelObservationIPv4     types.Bool     `tfsdk:"tunnel_observation_ipv4"`
+		TunnelObservationIPv6     types.Bool     `tfsdk:"tunnel_observation_ipv6"`
+		ID                        types.String   `tfsdk:"id"`
+		Name                      types.String   `tfsdk:"name"`
+		Type                      types.String   `tfsdk:"type"`
+		FlowActiveTimeout         types.Int64    `tfsdk:"flow_active_timeout"`
+		FlowInactiveTimeout       types.Int64    `tfsdk:"flow_inactive_timeout"`
+		IPTemplateExportExtension []types.String `tfsdk:"ip_template_export_extension"`
+		ObservationDomainID       types.Int64    `tfsdk:"observation_domain_id"`
+		OptionTemplateID          types.Int64    `tfsdk:"option_template_id"`
+		TemplateID                types.Int64    `tfsdk:"template_id"`
+		OptionRefreshRate         []struct {
+			Packets types.Int64 `tfsdk:"packets"`
+			Seconds types.Int64 `tfsdk:"seconds"`
+		} `tfsdk:"option_refresh_rate"`
 	}
 
 	var dataV0 modelV0
@@ -126,7 +128,10 @@ func upgradeServicesFlowMonitoringVIPFixTemplateStateV0toV1(
 	dataV1.TunnelObservationIPv4 = dataV0.TunnelObservationIPv4
 	dataV1.TunnelObservationIPv6 = dataV0.TunnelObservationIPv6
 	if len(dataV0.OptionRefreshRate) > 0 {
-		dataV1.OptionRefreshRate = &dataV0.OptionRefreshRate[0]
+		dataV1.OptionRefreshRate = &servicesFlowMonitoringVIPFixTemplateBlockRefreshRate{
+			Packets: dataV0.OptionRefreshRate[0].Packets,
+			Seconds: dataV0.OptionRefreshRate[0].Seconds,
+		}
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, dataV1)...)


### PR DESCRIPTION
providerfwk/upgradestate: avoid using latest struct
from the new version of resource schema when reading state with old version schema
to prevent potential `Value Conversion Error` after adding an argument in block