### PR TITLE
r/*route: fix missing no-empty value validator

### DIFF
--- a/.changes/r-route-not-empty-validator.md
+++ b/.changes/r-route-not-empty-validator.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable-file MD013 MD041 -->
+BUG FIXES:
+
+* **resource/junos_aggregate_route**, **resource/junos_generate_route**, **resource/junos_static_route**: fix missing no-empty value validator on `as_path_path` and `next_table` arguments

--- a/internal/providerfwk/resource_aggregate_route.go
+++ b/internal/providerfwk/resource_aggregate_route.go
@@ -153,6 +153,7 @@ func (rsc *aggregateRoute) Schema(
 				Optional:    true,
 				Description: "Path to as-path.",
 				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
 					tfvalidator.StringDoubleQuoteExclusion(),
 				},
 			},

--- a/internal/providerfwk/resource_generate_route.go
+++ b/internal/providerfwk/resource_generate_route.go
@@ -153,6 +153,7 @@ func (rsc *generateRoute) Schema(
 				Optional:    true,
 				Description: "Path to as-path.",
 				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
 					tfvalidator.StringDoubleQuoteExclusion(),
 				},
 			},
@@ -200,6 +201,7 @@ func (rsc *generateRoute) Schema(
 				Optional:    true,
 				Description: "Next hop to another table.",
 				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
 					tfvalidator.StringDoubleQuoteExclusion(),
 				},
 			},

--- a/internal/providerfwk/resource_static_route.go
+++ b/internal/providerfwk/resource_static_route.go
@@ -153,6 +153,7 @@ func (rsc *staticRoute) Schema(
 				Optional:    true,
 				Description: "Path to as-path.",
 				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
 					tfvalidator.StringDoubleQuoteExclusion(),
 				},
 			},
@@ -215,6 +216,7 @@ func (rsc *staticRoute) Schema(
 				Optional:    true,
 				Description: "Next hop to another table.",
 				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
 					tfvalidator.StringDoubleQuoteExclusion(),
 				},
 			},


### PR DESCRIPTION
BUG FIXES:

* **resource/junos_aggregate_route**, **resource/junos_generate_route**, **resource/junos_static_route**: fix missing no-empty value validator on `as_path_path` and `next_table` arguments
