### PR TITLE
Release v2.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 <!-- markdownlint-disable-file MD013 MD041 -->
 # changelog
 
+BUG FIXES:
+
+* **resource/junos_firewall_filter**: allow use `protocol` and `protocol_except` arguments in `from` block in `term` block when `family` is set to `ethernet-switching` (Fix [#577](https://github.com/jeremmfr/terraform-provider-junos/issues/577))
+
 ## v2.3.1 (November 10, 2023)
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 <!-- markdownlint-disable-file MD013 MD041 -->
 # changelog
 
+## v2.3.2 (November 16, 2023)
+
 BUG FIXES:
 
 * **resource/junos_firewall_filter**: allow use `protocol` and `protocol_except` arguments in `from` block in `term` block when `family` is set to `ethernet-switching` (Fix [#577](https://github.com/jeremmfr/terraform-provider-junos/issues/577))

--- a/internal/providerfwk/resource_firewall_filter.go
+++ b/internal/providerfwk/resource_firewall_filter.go
@@ -1481,7 +1481,7 @@ func (block *firewallFilterBlockTermBlockFromConfig) validateWithFamily(
 		)
 	}
 	if !block.Protocol.IsNull() && !bchk.InSlice(family, []string{
-		junos.InetW,
+		junos.InetW, "ethernet-switching",
 	}) {
 		resp.Diagnostics.AddAttributeError(
 			pathRoot.AtName("protocol"),
@@ -1490,7 +1490,7 @@ func (block *firewallFilterBlockTermBlockFromConfig) validateWithFamily(
 		)
 	}
 	if !block.ProtocolExcept.IsNull() && !bchk.InSlice(family, []string{
-		junos.InetW,
+		junos.InetW, "ethernet-switching",
 	}) {
 		resp.Diagnostics.AddAttributeError(
 			pathRoot.AtName("protocol_except"),


### PR DESCRIPTION
BUG FIXES:

* **resource/junos_firewall_filter**: allow use `protocol` and `protocol_except` arguments in `from` block in `term` block when `family` is set to `ethernet-switching` (Fix #577)

