### PR TITLE
Release v2.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 <!-- markdownlint-disable-file MD013 MD041 -->
 # changelog
 
+BUG FIXES:
+
+* **resource/junos_system**: fix crash when `web_management_https` is defined and `web_management_http` is not (Fix [#588](https://github.com/jeremmfr/terraform-provider-junos/issues/588))
+
 ## v2.3.2 (November 16, 2023)
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 <!-- markdownlint-disable-file MD013 MD041 -->
 # changelog
 
+## v2.3.3 (December 07, 2023)
+
 BUG FIXES:
 
 * **resource/junos_system**: fix crash when `web_management_https` is defined and `web_management_http` is not (Fix [#588](https://github.com/jeremmfr/terraform-provider-junos/issues/588))

--- a/internal/providerfwk/resource_system.go
+++ b/internal/providerfwk/resource_system.go
@@ -3573,7 +3573,7 @@ func (block *systemBlockServices) configSet() (
 			configSet = append(configSet,
 				setPrefix+"web-management https pki-local-certificate \""+v+"\"")
 		}
-		if !block.WebManagementHTTP.Port.IsNull() {
+		if !block.WebManagementHTTPS.Port.IsNull() {
 			configSet = append(configSet, setPrefix+"web-management https port "+
 				utils.ConvI64toa(block.WebManagementHTTPS.Port.ValueInt64()))
 		}


### PR DESCRIPTION
BUG FIXES:

* **resource/junos_system**: fix crash when `web_management_https` is defined and `web_management_http` is not (Fix #588)