### PR TITLE
r/system: add web_management_session_* arguments

### DIFF
--- a/.changes/issue-594.md
+++ b/.changes/issue-594.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable-file MD013 MD041 -->
+ENHANCEMENTS:
+
+* **resource/junos_system**: add `web_management_session_idle_timeout` and `web_management_session_limit` arguments in `services` block (Fix [#594](https://github.com/jeremmfr/terraform-provider-junos/issues/594))

--- a/docs/resources/system.md
+++ b/docs/resources/system.md
@@ -170,6 +170,10 @@ The following arguments are supported:
   - **web_management_https** (Optional, Block)  
     Declare `web-management https` configuration.  
     See [below for nested schema](#web_management_https-arguments-for-services).
+  - **web_management_session_idle_timeout** (Optional, Number)  
+    Default timeout of web-management sessions (1..1440 minutes).
+  - **web_management_session_limit** (Optional, Number)  
+    Maximum number of web-management sessions to allow (1..1024).
 - **syslog** (Optional, Block)  
   Declare `syslog` configuration.
   - **archive** (Optional, Block)  

--- a/internal/providerfwk/testdata/TestAccResourceSystem_basic/1/main.tf
+++ b/internal/providerfwk/testdata/TestAccResourceSystem_basic/1/main.tf
@@ -141,6 +141,8 @@ resource "junos_system" "testacc_system" {
       root_login                     = "deny"
       tcp_forwarding                 = true
     }
+    web_management_session_idle_timeout = 600
+    web_management_session_limit        = 100
     web_management_http {
       interface = ["fxp0.0"]
       port      = 80


### PR DESCRIPTION
ENHANCEMENTS:

* **resource/junos_system**: add `web_management_session_idle_timeout` and `web_management_session_limit` arguments in `services` block (Fix #594)