### PR TITLE
tests: bump golangci lint to v1.57

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -19,7 +19,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4
         with:
-          version: 'v1.56.1'
+          version: 'v1.57.1'
           args: -c .golangci.yml -v
 
   markdown-lint:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,12 +3,12 @@ run:
 linters:
   enable-all: true
   disable:
-    # maligned # deprecated 1.38 but govet-fieldalignment not usuable
+    - maligned # deprecated 1.38
     - interfacer # deprecated 1.38
     - scopelint # deprecated 1.39
     - golint # deprecated 1.41
     - exhaustivestruct # deprecated 1.46
-    # ifshort deprecated 1.48 but no replacement
+    - ifshort # deprecated 1.48
     - deadcode # deprecated 1.49
     - structcheck # deprecated 1.49
     - varcheck # deprecated 1.49

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,6 +60,37 @@ linters-settings:
     disable:
       - fieldalignment
       - shadow
+  revive:
+    rules:
+      # defaults
+      - name: blank-imports
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: dot-imports
+      - name: empty-block
+      - name: error-naming
+      - name: error-return
+      - name: error-strings
+      - name: errorf
+      - name: exported
+      - name: increment-decrement
+      - name: indent-error-flow
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: redefines-builtin-id
+      - name: superfluous-else
+      - name: time-naming
+      - name: unexported-return
+      - name: unreachable-code
+      - name: unused-parameter
+      - name: var-declaration
+      - name: var-naming
+      # additionals
+      - name: confusing-naming
+      - name: import-alias-naming
+      - name: import-shadowing
+      - name: unhandled-error
 issues:
   exclude-rules:
     - text: "github.com/jeremmfr/terraform-provider-junos/internal"

--- a/docs/resources/eventoptions_generate_event.md
+++ b/docs/resources/eventoptions_generate_event.md
@@ -24,6 +24,8 @@ The following arguments are supported:
 
 - **name** (Required, String, Forces new resource)  
   Name of the event to be generated.
+- **no_drift** (Optional, Boolean)  
+  Avoid event generation delay propagating to next event.
 - **start_time** (Optional, String)  
   Start-time to generate event (YYYY-MM-DD.HH:MM:SS).  
   `time_interval` need to be set.
@@ -31,8 +33,6 @@ The following arguments are supported:
   Frequency for generating the event (60..2592000 seconds).
 - **time_of_day** (Optional, String)  
   Time of day at which to generate event (HH:MM:SS).
-- **no_drift** (Optional, Boolean)  
-  Avoid event generation delay propagating to next event.
 
 ## Attribute Reference
 

--- a/docs/resources/forwardingoptions_sampling.md
+++ b/docs/resources/forwardingoptions_sampling.md
@@ -99,16 +99,16 @@ The following arguments are supported:
     Disable sampled packet dumps.
   - **files** (Optional, Number)  
     Maximum number of sampled packet dump files (2..10000).
-  - **no_stamp** (Optional, Boolean)  
-    Don't timestamp every packet in the dump.
-  - **no_world_readable** (Optional, Boolean)  
-    Don't allow any user to read the sampled dump.
   - **size** (Optional, Number)  
     Maximum sample dump file size (1024..104857600).
   - **stamp** (Optional, Boolean)  
     Timestamp every packet in the dump.
+  - **no_stamp** (Optional, Boolean)  
+    Don't timestamp every packet in the dump.
   - **world_readable** (Optional, Boolean)  
     Allow any user to read the sampled dump.
+  - **no_world_readable** (Optional, Boolean)  
+    Don't allow any user to read the sampled dump.
 - **flow_active_timeout** (Optional, Number)  
   Interval after which an active flow is exported (60..1800 seconds).
 - **flow_inactive_timeout** (Optional, Number)  

--- a/docs/resources/security.md
+++ b/docs/resources/security.md
@@ -175,12 +175,12 @@ The following arguments are supported:
   Maximum number of trace files (2..1000).
 - **match** (Optional, String)  
   Regular expression for lines to be logged.
-- **no_world_readable** (Optional, Boolean)  
-  Don't allow any user to read the log file.
 - **size** (Optional, Number)  
   Maximum trace file size (10240..1073741824).
 - **world_readable** (Optional, Boolean)  
   Allow any user to read the log file.
+- **no_world_readable** (Optional, Boolean)  
+  Don't allow any user to read the log file.
 
 ---
 

--- a/internal/junos/client.go
+++ b/internal/junos/client.go
@@ -8,27 +8,27 @@ const directoryPermission = 0o755
 
 // Client information to connect on Junos Device and more.
 type Client struct {
-	fakeUpdateAlso                  bool
-	fakeDeleteAlso                  bool
-	junosCommitConfirmed            int
-	junosCommitConfirmedWaitPercent int
-	junosPort                       int
-	junosSSHTimeoutToEstab          int
-	junosSSHRetryToEstab            int
-	sleepLock                       int
-	sleepShort                      int
-	sleepSSHClosed                  int
-	filePermission                  int64
 	junosIP                         string
+	junosPort                       int
 	junosUserName                   string
 	junosPassword                   string
 	junosSSHKeyPEM                  string
 	junosSSHKeyFile                 string
 	junosSSHKeyPass                 string
 	groupIntDel                     string
+	sleepShort                      int
+	sleepLock                       int
+	junosCommitConfirmed            int
+	junosCommitConfirmedWaitPercent int
+	sleepSSHClosed                  int
+	junosSSHCiphers                 []string
+	junosSSHTimeoutToEstab          int
+	junosSSHRetryToEstab            int
+	filePermission                  int64
 	logFileDst                      string
 	fakeCreateSetFile               string
-	junosSSHCiphers                 []string
+	fakeUpdateAlso                  bool
+	fakeDeleteAlso                  bool
 }
 
 func NewClient(ip string) *Client {

--- a/internal/junos/session.go
+++ b/internal/junos/session.go
@@ -113,7 +113,7 @@ toretry:
 		}
 		s, err := netconf.NewSSHSession(conn, sshOpts.ClientConfig)
 		if err != nil {
-			conn.Close()
+			_ = conn.Close()
 			select {
 			case <-ctx.Done():
 				return nil, fmt.Errorf("initializing SSH session to %s: %w", host, err)

--- a/internal/providerfwk/data_source_applications.go
+++ b/internal/providerfwk/data_source_applications.go
@@ -186,25 +186,8 @@ func (dsc *applicationsDataSource) Schema(
 type applicationsDataSourceData struct {
 	ID           types.String                              `tfsdk:"id"`
 	MatchName    types.String                              `tfsdk:"match_name"`
-	MatchOptions []applicationsDataSourceBlockMatchOptions `tfsdk:"match_options"`
 	Applications []applicationsDataSourceBlockApplications `tfsdk:"applications"`
-}
-
-type applicationsDataSourceBlockMatchOptions struct {
-	Alg                    types.String `tfsdk:"alg"`
-	ApplicationProtocol    types.String `tfsdk:"application_protocol"`
-	DestinationPort        types.String `tfsdk:"destination_port"`
-	EtherType              types.String `tfsdk:"ether_type"`
-	IcmpCode               types.String `tfsdk:"icmp_code"`
-	IcmpType               types.String `tfsdk:"icmp_type"`
-	Icmp6Code              types.String `tfsdk:"icmp6_code"`
-	Icmp6Type              types.String `tfsdk:"icmp6_type"`
-	InactivityTimeout      types.Int64  `tfsdk:"inactivity_timeout"`
-	InactivityTimeoutNever types.Bool   `tfsdk:"inactivity_timeout_never"`
-	Protocol               types.String `tfsdk:"protocol"`
-	RPCRrogramNumber       types.String `tfsdk:"rpc_program_number"`
-	SourcePort             types.String `tfsdk:"source_port"`
-	UUID                   types.String `tfsdk:"uuid"`
+	MatchOptions []applicationsDataSourceBlockMatchOptions `tfsdk:"match_options"`
 }
 
 type applicationsDataSourceBlockApplications struct {
@@ -226,6 +209,23 @@ type applicationsDataSourceBlockApplicationsBlockTerm struct {
 	Name                   types.String `tfsdk:"name"`
 	Alg                    types.String `tfsdk:"alg"`
 	DestinationPort        types.String `tfsdk:"destination_port"`
+	IcmpCode               types.String `tfsdk:"icmp_code"`
+	IcmpType               types.String `tfsdk:"icmp_type"`
+	Icmp6Code              types.String `tfsdk:"icmp6_code"`
+	Icmp6Type              types.String `tfsdk:"icmp6_type"`
+	InactivityTimeout      types.Int64  `tfsdk:"inactivity_timeout"`
+	InactivityTimeoutNever types.Bool   `tfsdk:"inactivity_timeout_never"`
+	Protocol               types.String `tfsdk:"protocol"`
+	RPCRrogramNumber       types.String `tfsdk:"rpc_program_number"`
+	SourcePort             types.String `tfsdk:"source_port"`
+	UUID                   types.String `tfsdk:"uuid"`
+}
+
+type applicationsDataSourceBlockMatchOptions struct {
+	Alg                    types.String `tfsdk:"alg"`
+	ApplicationProtocol    types.String `tfsdk:"application_protocol"`
+	DestinationPort        types.String `tfsdk:"destination_port"`
+	EtherType              types.String `tfsdk:"ether_type"`
 	IcmpCode               types.String `tfsdk:"icmp_code"`
 	IcmpType               types.String `tfsdk:"icmp_type"`
 	Icmp6Code              types.String `tfsdk:"icmp6_code"`

--- a/internal/providerfwk/data_source_interface_logical.go
+++ b/internal/providerfwk/data_source_interface_logical.go
@@ -265,12 +265,12 @@ func (dsc *interfaceLogicalDataSource) Schema(
 }
 
 type interfaceLogicalDataSourceData struct {
-	Disable                  types.Bool                        `tfsdk:"disable"`
 	ID                       types.String                      `tfsdk:"id"`
 	ConfigInterface          types.String                      `tfsdk:"config_interface"`
 	Match                    types.String                      `tfsdk:"match"`
 	Name                     types.String                      `tfsdk:"name"`
 	Description              types.String                      `tfsdk:"description"`
+	Disable                  types.Bool                        `tfsdk:"disable"`
 	RoutingInstance          types.String                      `tfsdk:"routing_instance"`
 	SecurityInboundProtocols []types.String                    `tfsdk:"security_inbound_protocols"`
 	SecurityInboundServices  []types.String                    `tfsdk:"security_inbound_services"`

--- a/internal/providerfwk/data_source_interface_physical.go
+++ b/internal/providerfwk/data_source_interface_physical.go
@@ -270,29 +270,29 @@ func (dsc *interfacePhysicalDataSource) Schema(
 }
 
 type interfacePhysicalDataSourceData struct {
-	Disable                types.Bool                             `tfsdk:"disable"`
-	FlexibleVlanTagging    types.Bool                             `tfsdk:"flexible_vlan_tagging"`
-	GratuitousArpReply     types.Bool                             `tfsdk:"gratuitous_arp_reply"`
-	NoGratuitousArpReply   types.Bool                             `tfsdk:"no_gratuitous_arp_reply"`
-	NoGratuitousArpRequest types.Bool                             `tfsdk:"no_gratuitous_arp_request"`
-	Trunk                  types.Bool                             `tfsdk:"trunk"`
-	TrunkNonELS            types.Bool                             `tfsdk:"trunk_non_els"`
-	VlanTagging            types.Bool                             `tfsdk:"vlan_tagging"`
 	ID                     types.String                           `tfsdk:"id"`
 	ConfigInterface        types.String                           `tfsdk:"config_interface"`
 	Match                  types.String                           `tfsdk:"match"`
 	Name                   types.String                           `tfsdk:"name"`
 	Description            types.String                           `tfsdk:"description"`
+	Disable                types.Bool                             `tfsdk:"disable"`
 	Encapsulation          types.String                           `tfsdk:"encapsulation"`
+	FlexibleVlanTagging    types.Bool                             `tfsdk:"flexible_vlan_tagging"`
+	GratuitousArpReply     types.Bool                             `tfsdk:"gratuitous_arp_reply"`
+	NoGratuitousArpReply   types.Bool                             `tfsdk:"no_gratuitous_arp_reply"`
 	HoldTimeDown           types.Int64                            `tfsdk:"hold_time_down"`
 	HoldTimeUp             types.Int64                            `tfsdk:"hold_time_up"`
 	LinkMode               types.String                           `tfsdk:"link_mode"`
 	Mtu                    types.Int64                            `tfsdk:"mtu"`
+	NoGratuitousArpRequest types.Bool                             `tfsdk:"no_gratuitous_arp_request"`
 	Speed                  types.String                           `tfsdk:"speed"`
 	StormControl           types.String                           `tfsdk:"storm_control"`
+	Trunk                  types.Bool                             `tfsdk:"trunk"`
+	TrunkNonELS            types.Bool                             `tfsdk:"trunk_non_els"`
 	VlanMembers            []types.String                         `tfsdk:"vlan_members"`
 	VlanNative             types.Int64                            `tfsdk:"vlan_native"`
 	VlanNativeNonELS       types.String                           `tfsdk:"vlan_native_non_els"`
+	VlanTagging            types.Bool                             `tfsdk:"vlan_tagging"`
 	ESI                    *interfacePhysicalBlockESI             `tfsdk:"esi"`
 	EtherOpts              *interfacePhysicalBlockEtherOpts       `tfsdk:"ether_opts"`
 	GigetherOpts           *interfacePhysicalBlockEtherOpts       `tfsdk:"gigether_opts"`

--- a/internal/providerfwk/data_source_security_zone.go
+++ b/internal/providerfwk/data_source_security_zone.go
@@ -195,17 +195,17 @@ func (dsc *securityZoneDataSource) Schema(
 }
 
 type securityZoneDataSourceData struct {
-	ApplicationTracking              types.Bool                             `tfsdk:"application_tracking"`
-	ReverseReroute                   types.Bool                             `tfsdk:"reverse_reroute"`
-	SourceIdentityLog                types.Bool                             `tfsdk:"source_identity_log"`
-	TCPRst                           types.Bool                             `tfsdk:"tcp_rst"`
 	ID                               types.String                           `tfsdk:"id"`
 	Name                             types.String                           `tfsdk:"name"`
 	AdvancePolicyBasedRoutingProfile types.String                           `tfsdk:"advance_policy_based_routing_profile"`
+	ApplicationTracking              types.Bool                             `tfsdk:"application_tracking"`
 	Description                      types.String                           `tfsdk:"description"`
 	Screen                           types.String                           `tfsdk:"screen"`
 	InboundProtocols                 []types.String                         `tfsdk:"inbound_protocols"`
 	InboundServices                  []types.String                         `tfsdk:"inbound_services"`
+	ReverseReroute                   types.Bool                             `tfsdk:"reverse_reroute"`
+	SourceIdentityLog                types.Bool                             `tfsdk:"source_identity_log"`
+	TCPRst                           types.Bool                             `tfsdk:"tcp_rst"`
 	AddressBook                      []securityZoneBlockAddressBook         `tfsdk:"address_book"`
 	AddressBookDNS                   []securityZoneBlockAddressBookDNS      `tfsdk:"address_book_dns"`
 	AddressBookRange                 []securityZoneBlockAddressBookRange    `tfsdk:"address_book_range"`

--- a/internal/providerfwk/resource_aggregate_route.go
+++ b/internal/providerfwk/resource_aggregate_route.go
@@ -229,41 +229,41 @@ func (rsc *aggregateRoute) Schema(
 }
 
 type aggregateRouteData struct {
-	Active                   types.Bool     `tfsdk:"active"`
-	ASPathAtomicAggregate    types.Bool     `tfsdk:"as_path_atomic_aggregate"`
-	Brief                    types.Bool     `tfsdk:"brief"`
-	Discard                  types.Bool     `tfsdk:"discard"`
-	Full                     types.Bool     `tfsdk:"full"`
-	Passive                  types.Bool     `tfsdk:"passive"`
 	ID                       types.String   `tfsdk:"id"`
 	Destination              types.String   `tfsdk:"destination"`
 	RoutingInstance          types.String   `tfsdk:"routing_instance"`
+	Active                   types.Bool     `tfsdk:"active"`
 	ASPathAggregatorAddress  types.String   `tfsdk:"as_path_aggregator_address"`
 	ASPathAggregatorASNumber types.String   `tfsdk:"as_path_aggregator_as_number"`
+	ASPathAtomicAggregate    types.Bool     `tfsdk:"as_path_atomic_aggregate"`
 	ASPathOrigin             types.String   `tfsdk:"as_path_origin"`
 	ASPathPath               types.String   `tfsdk:"as_path_path"`
+	Brief                    types.Bool     `tfsdk:"brief"`
 	Community                []types.String `tfsdk:"community"`
+	Discard                  types.Bool     `tfsdk:"discard"`
+	Full                     types.Bool     `tfsdk:"full"`
 	Metric                   types.Int64    `tfsdk:"metric"`
+	Passive                  types.Bool     `tfsdk:"passive"`
 	Policy                   []types.String `tfsdk:"policy"`
 	Preference               types.Int64    `tfsdk:"preference"`
 }
 
 type aggregateRouteConfig struct {
-	Active                   types.Bool   `tfsdk:"active"`
-	ASPathAtomicAggregate    types.Bool   `tfsdk:"as_path_atomic_aggregate"`
-	Brief                    types.Bool   `tfsdk:"brief"`
-	Discard                  types.Bool   `tfsdk:"discard"`
-	Full                     types.Bool   `tfsdk:"full"`
-	Passive                  types.Bool   `tfsdk:"passive"`
 	ID                       types.String `tfsdk:"id"`
 	Destination              types.String `tfsdk:"destination"`
 	RoutingInstance          types.String `tfsdk:"routing_instance"`
+	Active                   types.Bool   `tfsdk:"active"`
 	ASPathAggregatorAddress  types.String `tfsdk:"as_path_aggregator_address"`
 	ASPathAggregatorASNumber types.String `tfsdk:"as_path_aggregator_as_number"`
+	ASPathAtomicAggregate    types.Bool   `tfsdk:"as_path_atomic_aggregate"`
 	ASPathOrigin             types.String `tfsdk:"as_path_origin"`
 	ASPathPath               types.String `tfsdk:"as_path_path"`
+	Brief                    types.Bool   `tfsdk:"brief"`
 	Community                types.List   `tfsdk:"community"`
+	Discard                  types.Bool   `tfsdk:"discard"`
+	Full                     types.Bool   `tfsdk:"full"`
 	Metric                   types.Int64  `tfsdk:"metric"`
+	Passive                  types.Bool   `tfsdk:"passive"`
 	Policy                   types.List   `tfsdk:"policy"`
 	Preference               types.Int64  `tfsdk:"preference"`
 }

--- a/internal/providerfwk/resource_application.go
+++ b/internal/providerfwk/resource_application.go
@@ -300,7 +300,6 @@ func (rsc *application) Schema(
 }
 
 type applicationData struct {
-	InactivityTimeoutNever types.Bool             `tfsdk:"inactivity_timeout_never"`
 	ID                     types.String           `tfsdk:"id"`
 	Name                   types.String           `tfsdk:"name"`
 	ApplicationProtocol    types.String           `tfsdk:"application_protocol"`
@@ -308,6 +307,7 @@ type applicationData struct {
 	DestinationPort        types.String           `tfsdk:"destination_port"`
 	EtherType              types.String           `tfsdk:"ether_type"`
 	InactivityTimeout      types.Int64            `tfsdk:"inactivity_timeout"`
+	InactivityTimeoutNever types.Bool             `tfsdk:"inactivity_timeout_never"`
 	Protocol               types.String           `tfsdk:"protocol"`
 	RPCProgramNumber       types.String           `tfsdk:"rpc_program_number"`
 	SourcePort             types.String           `tfsdk:"source_port"`
@@ -316,7 +316,6 @@ type applicationData struct {
 }
 
 type applicationConfig struct {
-	InactivityTimeoutNever types.Bool   `tfsdk:"inactivity_timeout_never"`
 	ID                     types.String `tfsdk:"id"`
 	Name                   types.String `tfsdk:"name"`
 	ApplicationProtocol    types.String `tfsdk:"application_protocol"`
@@ -324,6 +323,7 @@ type applicationConfig struct {
 	DestinationPort        types.String `tfsdk:"destination_port"`
 	EtherType              types.String `tfsdk:"ether_type"`
 	InactivityTimeout      types.Int64  `tfsdk:"inactivity_timeout"`
+	InactivityTimeoutNever types.Bool   `tfsdk:"inactivity_timeout_never"`
 	Protocol               types.String `tfsdk:"protocol"`
 	RPCProgramNumber       types.String `tfsdk:"rpc_program_number"`
 	SourcePort             types.String `tfsdk:"source_port"`
@@ -332,7 +332,6 @@ type applicationConfig struct {
 }
 
 type applicationBlockTerm struct {
-	InactivityTimeoutNever types.Bool   `tfsdk:"inactivity_timeout_never"`
 	Name                   types.String `tfsdk:"name"`
 	Protocol               types.String `tfsdk:"protocol"`
 	Alg                    types.String `tfsdk:"alg"`
@@ -342,6 +341,7 @@ type applicationBlockTerm struct {
 	Icmp6Code              types.String `tfsdk:"icmp6_code"`
 	Icmp6Type              types.String `tfsdk:"icmp6_type"`
 	InactivityTimeout      types.Int64  `tfsdk:"inactivity_timeout"`
+	InactivityTimeoutNever types.Bool   `tfsdk:"inactivity_timeout_never"`
 	RPCRrogramNumber       types.String `tfsdk:"rpc_program_number"`
 	SourcePort             types.String `tfsdk:"source_port"`
 	UUID                   types.String `tfsdk:"uuid"`

--- a/internal/providerfwk/resource_bgp_group.go
+++ b/internal/providerfwk/resource_bgp_group.go
@@ -762,6 +762,10 @@ func (rsc *bgpGroup) schemaFamilyPrefixLimitAttributes() map[string]schema.Attri
 }
 
 type bgpGroupData struct {
+	ID                           types.String                  `tfsdk:"id"`
+	Name                         types.String                  `tfsdk:"name"`
+	RoutingInstance              types.String                  `tfsdk:"routing_instance"`
+	Type                         types.String                  `tfsdk:"type"`
 	AcceptRemoteNexthop          types.Bool                    `tfsdk:"accept_remote_nexthop"`
 	AdvertiseExternal            types.Bool                    `tfsdk:"advertise_external"`
 	AdvertiseExternalConditional types.Bool                    `tfsdk:"advertise_external_conditional"`
@@ -769,45 +773,41 @@ type bgpGroupData struct {
 	AdvertisePeerAS              types.Bool                    `tfsdk:"advertise_peer_as"`
 	NoAdvertisePeerAS            types.Bool                    `tfsdk:"no_advertise_peer_as"`
 	ASOverride                   types.Bool                    `tfsdk:"as_override"`
-	Damping                      types.Bool                    `tfsdk:"damping"`
-	KeepAll                      types.Bool                    `tfsdk:"keep_all"`
-	KeepNone                     types.Bool                    `tfsdk:"keep_none"`
-	LocalASAlias                 types.Bool                    `tfsdk:"local_as_alias"`
-	LocalASNoPrependGlobalAS     types.Bool                    `tfsdk:"local_as_no_prepend_global_as"`
-	LocalASPrivate               types.Bool                    `tfsdk:"local_as_private"`
-	LogUpdown                    types.Bool                    `tfsdk:"log_updown"`
-	MetricOutIgp                 types.Bool                    `tfsdk:"metric_out_igp"`
-	MetricOutIgpDelayMedUpdate   types.Bool                    `tfsdk:"metric_out_igp_delay_med_update"`
-	MetricOutMinimumIgp          types.Bool                    `tfsdk:"metric_out_minimum_igp"`
-	MtuDiscovery                 types.Bool                    `tfsdk:"mtu_discovery"`
-	Multihop                     types.Bool                    `tfsdk:"multihop"`
-	NoClientReflect              types.Bool                    `tfsdk:"no_client_reflect"`
-	Passive                      types.Bool                    `tfsdk:"passive"`
-	RemovePrivate                types.Bool                    `tfsdk:"remove_private"`
-	TCPAggressiveTransmission    types.Bool                    `tfsdk:"tcp_aggressive_transmission"`
 	AuthenticationAlgorithm      types.String                  `tfsdk:"authentication_algorithm"`
 	AuthenticationKey            types.String                  `tfsdk:"authentication_key"`
 	AuthenticationKeyChain       types.String                  `tfsdk:"authentication_key_chain"`
 	Cluster                      types.String                  `tfsdk:"cluster"`
+	Damping                      types.Bool                    `tfsdk:"damping"`
 	Description                  types.String                  `tfsdk:"description"`
 	Export                       []types.String                `tfsdk:"export"`
 	HoldTime                     types.Int64                   `tfsdk:"hold_time"`
-	ID                           types.String                  `tfsdk:"id"`
 	Import                       []types.String                `tfsdk:"import"`
+	KeepAll                      types.Bool                    `tfsdk:"keep_all"`
+	KeepNone                     types.Bool                    `tfsdk:"keep_none"`
 	LocalAddress                 types.String                  `tfsdk:"local_address"`
 	LocalAS                      types.String                  `tfsdk:"local_as"`
+	LocalASAlias                 types.Bool                    `tfsdk:"local_as_alias"`
 	LocalASLoops                 types.Int64                   `tfsdk:"local_as_loops"`
+	LocalASNoPrependGlobalAS     types.Bool                    `tfsdk:"local_as_no_prepend_global_as"`
+	LocalASPrivate               types.Bool                    `tfsdk:"local_as_private"`
 	LocalInterface               types.String                  `tfsdk:"local_interface"`
 	LocalPreference              types.Int64                   `tfsdk:"local_preference"`
+	LogUpdown                    types.Bool                    `tfsdk:"log_updown"`
 	MetricOut                    types.Int64                   `tfsdk:"metric_out"`
+	MetricOutIgp                 types.Bool                    `tfsdk:"metric_out_igp"`
+	MetricOutIgpDelayMedUpdate   types.Bool                    `tfsdk:"metric_out_igp_delay_med_update"`
 	MetricOutIgpOffset           types.Int64                   `tfsdk:"metric_out_igp_offset"`
+	MetricOutMinimumIgp          types.Bool                    `tfsdk:"metric_out_minimum_igp"`
 	MetricOutMinimumIgpOffset    types.Int64                   `tfsdk:"metric_out_minimum_igp_offset"`
-	Name                         types.String                  `tfsdk:"name"`
+	MtuDiscovery                 types.Bool                    `tfsdk:"mtu_discovery"`
+	Multihop                     types.Bool                    `tfsdk:"multihop"`
+	NoClientReflect              types.Bool                    `tfsdk:"no_client_reflect"`
 	OutDelay                     types.Int64                   `tfsdk:"out_delay"`
+	Passive                      types.Bool                    `tfsdk:"passive"`
 	PeerAS                       types.String                  `tfsdk:"peer_as"`
 	Preference                   types.Int64                   `tfsdk:"preference"`
-	RoutingInstance              types.String                  `tfsdk:"routing_instance"`
-	Type                         types.String                  `tfsdk:"type"`
+	RemovePrivate                types.Bool                    `tfsdk:"remove_private"`
+	TCPAggressiveTransmission    types.Bool                    `tfsdk:"tcp_aggressive_transmission"`
 	BfdLivenessDetection         *bgpBlockBfdLivenessDetection `tfsdk:"bfd_liveness_detection"`
 	BgpErrorTolerance            *bgpBlockBgpErrorTolerance    `tfsdk:"bgp_error_tolerance"`
 	BgpMultipath                 *bgpBlockBgpMultipath         `tfsdk:"bgp_multipath"`
@@ -818,6 +818,10 @@ type bgpGroupData struct {
 }
 
 type bgpGroupConfig struct {
+	ID                           types.String                  `tfsdk:"id"`
+	Name                         types.String                  `tfsdk:"name"`
+	RoutingInstance              types.String                  `tfsdk:"routing_instance"`
+	Type                         types.String                  `tfsdk:"type"`
 	AcceptRemoteDesktop          types.Bool                    `tfsdk:"accept_remote_nexthop"`
 	AdvertiseExternal            types.Bool                    `tfsdk:"advertise_external"`
 	AdvertiseExternalConditional types.Bool                    `tfsdk:"advertise_external_conditional"`
@@ -825,45 +829,41 @@ type bgpGroupConfig struct {
 	AdvertisePeerAS              types.Bool                    `tfsdk:"advertise_peer_as"`
 	NoAdvertisePeerAS            types.Bool                    `tfsdk:"no_advertise_peer_as"`
 	ASOverride                   types.Bool                    `tfsdk:"as_override"`
-	Damping                      types.Bool                    `tfsdk:"damping"`
-	KeepAll                      types.Bool                    `tfsdk:"keep_all"`
-	KeepNone                     types.Bool                    `tfsdk:"keep_none"`
-	LocalASAlias                 types.Bool                    `tfsdk:"local_as_alias"`
-	LocalASNoPrependGlobalAS     types.Bool                    `tfsdk:"local_as_no_prepend_global_as"`
-	LocalASPrivate               types.Bool                    `tfsdk:"local_as_private"`
-	LogUpdown                    types.Bool                    `tfsdk:"log_updown"`
-	MetricOutIgp                 types.Bool                    `tfsdk:"metric_out_igp"`
-	MetricOutIgpDelayMedUpdate   types.Bool                    `tfsdk:"metric_out_igp_delay_med_update"`
-	MetricOutMinimumIgp          types.Bool                    `tfsdk:"metric_out_minimum_igp"`
-	MtuDiscovery                 types.Bool                    `tfsdk:"mtu_discovery"`
-	Multihop                     types.Bool                    `tfsdk:"multihop"`
-	NoClientReflect              types.Bool                    `tfsdk:"no_client_reflect"`
-	Passive                      types.Bool                    `tfsdk:"passive"`
-	RemotePrivate                types.Bool                    `tfsdk:"remove_private"`
-	TCPAggressiveTransmission    types.Bool                    `tfsdk:"tcp_aggressive_transmission"`
 	AuthenticationAlgorithm      types.String                  `tfsdk:"authentication_algorithm"`
 	AuthenticationKey            types.String                  `tfsdk:"authentication_key"`
 	AuthenticationKeyChain       types.String                  `tfsdk:"authentication_key_chain"`
 	Cluster                      types.String                  `tfsdk:"cluster"`
+	Damping                      types.Bool                    `tfsdk:"damping"`
 	Description                  types.String                  `tfsdk:"description"`
 	Export                       types.List                    `tfsdk:"export"`
 	HoldTime                     types.Int64                   `tfsdk:"hold_time"`
-	ID                           types.String                  `tfsdk:"id"`
 	Import                       types.List                    `tfsdk:"import"`
+	KeepAll                      types.Bool                    `tfsdk:"keep_all"`
+	KeepNone                     types.Bool                    `tfsdk:"keep_none"`
 	LocalAddress                 types.String                  `tfsdk:"local_address"`
 	LocalAS                      types.String                  `tfsdk:"local_as"`
+	LocalASAlias                 types.Bool                    `tfsdk:"local_as_alias"`
 	LocalASLoops                 types.Int64                   `tfsdk:"local_as_loops"`
+	LocalASNoPrependGlobalAS     types.Bool                    `tfsdk:"local_as_no_prepend_global_as"`
+	LocalASPrivate               types.Bool                    `tfsdk:"local_as_private"`
 	LocalInterface               types.String                  `tfsdk:"local_interface"`
 	LocalPreference              types.Int64                   `tfsdk:"local_preference"`
+	LogUpdown                    types.Bool                    `tfsdk:"log_updown"`
 	MetricOut                    types.Int64                   `tfsdk:"metric_out"`
+	MetricOutIgp                 types.Bool                    `tfsdk:"metric_out_igp"`
+	MetricOutIgpDelayMedUpdate   types.Bool                    `tfsdk:"metric_out_igp_delay_med_update"`
 	MetricOutIgpOffset           types.Int64                   `tfsdk:"metric_out_igp_offset"`
+	MetricOutMinimumIgp          types.Bool                    `tfsdk:"metric_out_minimum_igp"`
 	MetricOutMinimumIgpOffset    types.Int64                   `tfsdk:"metric_out_minimum_igp_offset"`
-	Name                         types.String                  `tfsdk:"name"`
+	MtuDiscovery                 types.Bool                    `tfsdk:"mtu_discovery"`
+	Multihop                     types.Bool                    `tfsdk:"multihop"`
+	NoClientReflect              types.Bool                    `tfsdk:"no_client_reflect"`
 	OutDelay                     types.Int64                   `tfsdk:"out_delay"`
+	Passive                      types.Bool                    `tfsdk:"passive"`
 	PeerAS                       types.String                  `tfsdk:"peer_as"`
 	Preference                   types.Int64                   `tfsdk:"preference"`
-	RoutingInstance              types.String                  `tfsdk:"routing_instance"`
-	Type                         types.String                  `tfsdk:"type"`
+	RemotePrivate                types.Bool                    `tfsdk:"remove_private"`
+	TCPAggressiveTransmission    types.Bool                    `tfsdk:"tcp_aggressive_transmission"`
 	BfdLivenessDetection         *bgpBlockBfdLivenessDetection `tfsdk:"bfd_liveness_detection"`
 	BgpErrorTolerance            *bgpBlockBgpErrorTolerance    `tfsdk:"bgp_error_tolerance"`
 	BgpMultipah                  *bgpBlockBgpMultipath         `tfsdk:"bgp_multipath"`

--- a/internal/providerfwk/resource_bgp_neighbor.go
+++ b/internal/providerfwk/resource_bgp_neighbor.go
@@ -761,6 +761,10 @@ func (rsc *bgpNeighbor) schemaFamilyPrefixLimitAttributes() map[string]schema.At
 }
 
 type bgpNeighborData struct {
+	ID                           types.String                  `tfsdk:"id"`
+	IP                           types.String                  `tfsdk:"ip"`
+	RoutingInstance              types.String                  `tfsdk:"routing_instance"`
+	Group                        types.String                  `tfsdk:"group"`
 	AcceptRemoteNexthop          types.Bool                    `tfsdk:"accept_remote_nexthop"`
 	AdvertiseExternal            types.Bool                    `tfsdk:"advertise_external"`
 	AdvertiseExternalConditional types.Bool                    `tfsdk:"advertise_external_conditional"`
@@ -768,45 +772,41 @@ type bgpNeighborData struct {
 	AdvertisePeerAS              types.Bool                    `tfsdk:"advertise_peer_as"`
 	NoAdvertisePeerAS            types.Bool                    `tfsdk:"no_advertise_peer_as"`
 	ASOverride                   types.Bool                    `tfsdk:"as_override"`
-	Damping                      types.Bool                    `tfsdk:"damping"`
-	KeepAll                      types.Bool                    `tfsdk:"keep_all"`
-	KeepNone                     types.Bool                    `tfsdk:"keep_none"`
-	LocalASAlias                 types.Bool                    `tfsdk:"local_as_alias"`
-	LocalASNoPrependGlobalAS     types.Bool                    `tfsdk:"local_as_no_prepend_global_as"`
-	LocalASPrivate               types.Bool                    `tfsdk:"local_as_private"`
-	LogUpdown                    types.Bool                    `tfsdk:"log_updown"`
-	MetricOutIgp                 types.Bool                    `tfsdk:"metric_out_igp"`
-	MetricOutIgpDelayMedUpdate   types.Bool                    `tfsdk:"metric_out_igp_delay_med_update"`
-	MetricOutMinimumIgp          types.Bool                    `tfsdk:"metric_out_minimum_igp"`
-	MtuDiscovery                 types.Bool                    `tfsdk:"mtu_discovery"`
-	Multihop                     types.Bool                    `tfsdk:"multihop"`
-	NoClientReflect              types.Bool                    `tfsdk:"no_client_reflect"`
-	Passive                      types.Bool                    `tfsdk:"passive"`
-	RemovePrivate                types.Bool                    `tfsdk:"remove_private"`
-	TCPAggressiveTransmission    types.Bool                    `tfsdk:"tcp_aggressive_transmission"`
 	AuthenticationAlgorithm      types.String                  `tfsdk:"authentication_algorithm"`
 	AuthenticationKey            types.String                  `tfsdk:"authentication_key"`
 	AuthenticationKeyChain       types.String                  `tfsdk:"authentication_key_chain"`
 	Cluster                      types.String                  `tfsdk:"cluster"`
+	Damping                      types.Bool                    `tfsdk:"damping"`
 	Description                  types.String                  `tfsdk:"description"`
 	Export                       []types.String                `tfsdk:"export"`
-	Group                        types.String                  `tfsdk:"group"`
 	HoldTime                     types.Int64                   `tfsdk:"hold_time"`
-	ID                           types.String                  `tfsdk:"id"`
 	Import                       []types.String                `tfsdk:"import"`
-	IP                           types.String                  `tfsdk:"ip"`
+	KeepAll                      types.Bool                    `tfsdk:"keep_all"`
+	KeepNone                     types.Bool                    `tfsdk:"keep_none"`
 	LocalAddress                 types.String                  `tfsdk:"local_address"`
 	LocalAS                      types.String                  `tfsdk:"local_as"`
+	LocalASAlias                 types.Bool                    `tfsdk:"local_as_alias"`
 	LocalASLoops                 types.Int64                   `tfsdk:"local_as_loops"`
+	LocalASNoPrependGlobalAS     types.Bool                    `tfsdk:"local_as_no_prepend_global_as"`
+	LocalASPrivate               types.Bool                    `tfsdk:"local_as_private"`
 	LocalInterface               types.String                  `tfsdk:"local_interface"`
 	LocalPreference              types.Int64                   `tfsdk:"local_preference"`
+	LogUpdown                    types.Bool                    `tfsdk:"log_updown"`
 	MetricOut                    types.Int64                   `tfsdk:"metric_out"`
+	MetricOutIgp                 types.Bool                    `tfsdk:"metric_out_igp"`
+	MetricOutIgpDelayMedUpdate   types.Bool                    `tfsdk:"metric_out_igp_delay_med_update"`
 	MetricOutIgpOffset           types.Int64                   `tfsdk:"metric_out_igp_offset"`
+	MetricOutMinimumIgp          types.Bool                    `tfsdk:"metric_out_minimum_igp"`
 	MetricOutMinimumIgpOffset    types.Int64                   `tfsdk:"metric_out_minimum_igp_offset"`
+	MtuDiscovery                 types.Bool                    `tfsdk:"mtu_discovery"`
+	Multihop                     types.Bool                    `tfsdk:"multihop"`
+	NoClientReflect              types.Bool                    `tfsdk:"no_client_reflect"`
 	OutDelay                     types.Int64                   `tfsdk:"out_delay"`
+	Passive                      types.Bool                    `tfsdk:"passive"`
 	PeerAS                       types.String                  `tfsdk:"peer_as"`
 	Preference                   types.Int64                   `tfsdk:"preference"`
-	RoutingInstance              types.String                  `tfsdk:"routing_instance"`
+	RemovePrivate                types.Bool                    `tfsdk:"remove_private"`
+	TCPAggressiveTransmission    types.Bool                    `tfsdk:"tcp_aggressive_transmission"`
 	BfdLivenessDetection         *bgpBlockBfdLivenessDetection `tfsdk:"bfd_liveness_detection"`
 	BgpErrorTolerance            *bgpBlockBgpErrorTolerance    `tfsdk:"bgp_error_tolerance"`
 	BgpMultipath                 *bgpBlockBgpMultipath         `tfsdk:"bgp_multipath"`
@@ -817,6 +817,10 @@ type bgpNeighborData struct {
 }
 
 type bgpNeighborConfig struct {
+	ID                           types.String                  `tfsdk:"id"`
+	IP                           types.String                  `tfsdk:"ip"`
+	RoutingInstance              types.String                  `tfsdk:"routing_instance"`
+	Group                        types.String                  `tfsdk:"group"`
 	AcceptRemoteDesktop          types.Bool                    `tfsdk:"accept_remote_nexthop"`
 	AdvertiseExternal            types.Bool                    `tfsdk:"advertise_external"`
 	AdvertiseExternalConditional types.Bool                    `tfsdk:"advertise_external_conditional"`
@@ -824,45 +828,41 @@ type bgpNeighborConfig struct {
 	AdvertisePeerAS              types.Bool                    `tfsdk:"advertise_peer_as"`
 	NoAdvertisePeerAS            types.Bool                    `tfsdk:"no_advertise_peer_as"`
 	ASOverride                   types.Bool                    `tfsdk:"as_override"`
-	Damping                      types.Bool                    `tfsdk:"damping"`
-	KeepAll                      types.Bool                    `tfsdk:"keep_all"`
-	KeepNone                     types.Bool                    `tfsdk:"keep_none"`
-	LocalASAlias                 types.Bool                    `tfsdk:"local_as_alias"`
-	LocalASNoPrependGlobalAS     types.Bool                    `tfsdk:"local_as_no_prepend_global_as"`
-	LocalASPrivate               types.Bool                    `tfsdk:"local_as_private"`
-	LogUpdown                    types.Bool                    `tfsdk:"log_updown"`
-	MetricOutIgp                 types.Bool                    `tfsdk:"metric_out_igp"`
-	MetricOutIgpDelayMedUpdate   types.Bool                    `tfsdk:"metric_out_igp_delay_med_update"`
-	MetricOutMinimumIgp          types.Bool                    `tfsdk:"metric_out_minimum_igp"`
-	MtuDiscovery                 types.Bool                    `tfsdk:"mtu_discovery"`
-	Multihop                     types.Bool                    `tfsdk:"multihop"`
-	NoClientReflect              types.Bool                    `tfsdk:"no_client_reflect"`
-	Passive                      types.Bool                    `tfsdk:"passive"`
-	RemotePrivate                types.Bool                    `tfsdk:"remove_private"`
-	TCPAggressiveTransmission    types.Bool                    `tfsdk:"tcp_aggressive_transmission"`
 	AuthenticationAlgorithm      types.String                  `tfsdk:"authentication_algorithm"`
 	AuthenticationKey            types.String                  `tfsdk:"authentication_key"`
 	AuthenticationKeyChain       types.String                  `tfsdk:"authentication_key_chain"`
 	Cluster                      types.String                  `tfsdk:"cluster"`
+	Damping                      types.Bool                    `tfsdk:"damping"`
 	Description                  types.String                  `tfsdk:"description"`
 	Export                       types.List                    `tfsdk:"export"`
-	Group                        types.String                  `tfsdk:"group"`
 	HoldTime                     types.Int64                   `tfsdk:"hold_time"`
-	ID                           types.String                  `tfsdk:"id"`
 	Import                       types.List                    `tfsdk:"import"`
-	IP                           types.String                  `tfsdk:"ip"`
+	KeepAll                      types.Bool                    `tfsdk:"keep_all"`
+	KeepNone                     types.Bool                    `tfsdk:"keep_none"`
 	LocalAddress                 types.String                  `tfsdk:"local_address"`
 	LocalAS                      types.String                  `tfsdk:"local_as"`
+	LocalASAlias                 types.Bool                    `tfsdk:"local_as_alias"`
 	LocalASLoops                 types.Int64                   `tfsdk:"local_as_loops"`
+	LocalASNoPrependGlobalAS     types.Bool                    `tfsdk:"local_as_no_prepend_global_as"`
+	LocalASPrivate               types.Bool                    `tfsdk:"local_as_private"`
 	LocalInterface               types.String                  `tfsdk:"local_interface"`
 	LocalPreference              types.Int64                   `tfsdk:"local_preference"`
+	LogUpdown                    types.Bool                    `tfsdk:"log_updown"`
 	MetricOut                    types.Int64                   `tfsdk:"metric_out"`
+	MetricOutIgp                 types.Bool                    `tfsdk:"metric_out_igp"`
+	MetricOutIgpDelayMedUpdate   types.Bool                    `tfsdk:"metric_out_igp_delay_med_update"`
 	MetricOutIgpOffset           types.Int64                   `tfsdk:"metric_out_igp_offset"`
+	MetricOutMinimumIgp          types.Bool                    `tfsdk:"metric_out_minimum_igp"`
 	MetricOutMinimumIgpOffset    types.Int64                   `tfsdk:"metric_out_minimum_igp_offset"`
+	MtuDiscovery                 types.Bool                    `tfsdk:"mtu_discovery"`
+	Multihop                     types.Bool                    `tfsdk:"multihop"`
+	NoClientReflect              types.Bool                    `tfsdk:"no_client_reflect"`
 	OutDelay                     types.Int64                   `tfsdk:"out_delay"`
+	Passive                      types.Bool                    `tfsdk:"passive"`
 	PeerAS                       types.String                  `tfsdk:"peer_as"`
 	Preference                   types.Int64                   `tfsdk:"preference"`
-	RoutingInstance              types.String                  `tfsdk:"routing_instance"`
+	RemotePrivate                types.Bool                    `tfsdk:"remove_private"`
+	TCPAggressiveTransmission    types.Bool                    `tfsdk:"tcp_aggressive_transmission"`
 	BfdLivenessDetection         *bgpBlockBfdLivenessDetection `tfsdk:"bfd_liveness_detection"`
 	BgpErrorTolerance            *bgpBlockBgpErrorTolerance    `tfsdk:"bgp_error_tolerance"`
 	BgpMultipah                  *bgpBlockBgpMultipath         `tfsdk:"bgp_multipath"`

--- a/internal/providerfwk/resource_bridge_domain.go
+++ b/internal/providerfwk/resource_bridge_domain.go
@@ -278,13 +278,13 @@ func (rsc *bridgeDomain) Schema(
 }
 
 type bridgeDomainData struct {
-	DomainTypeBridge types.Bool              `tfsdk:"domain_type_bridge"`
 	ID               types.String            `tfsdk:"id"`
 	Name             types.String            `tfsdk:"name"`
 	RoutingInstance  types.String            `tfsdk:"routing_instance"`
 	CommunityVlans   []types.String          `tfsdk:"community_vlans"`
 	Description      types.String            `tfsdk:"description"`
 	DomainID         types.Int64             `tfsdk:"domain_id"`
+	DomainTypeBridge types.Bool              `tfsdk:"domain_type_bridge"`
 	Interface        []types.String          `tfsdk:"interface"`
 	IsolatedVLAN     types.Int64             `tfsdk:"isolated_vlan"`
 	RoutingInterface types.String            `tfsdk:"routing_interface"`
@@ -295,13 +295,13 @@ type bridgeDomainData struct {
 }
 
 type bridgeDomainConfig struct {
-	DomainTypeBridge types.Bool              `tfsdk:"domain_type_bridge"`
 	ID               types.String            `tfsdk:"id"`
 	Name             types.String            `tfsdk:"name"`
 	RoutingInstance  types.String            `tfsdk:"routing_instance"`
 	CommunityVlans   types.Set               `tfsdk:"community_vlans"`
 	Description      types.String            `tfsdk:"description"`
 	DomainID         types.Int64             `tfsdk:"domain_id"`
+	DomainTypeBridge types.Bool              `tfsdk:"domain_type_bridge"`
 	Interface        types.Set               `tfsdk:"interface"`
 	IsolatedVLAN     types.Int64             `tfsdk:"isolated_vlan"`
 	RoutingInterface types.String            `tfsdk:"routing_interface"`
@@ -316,14 +316,14 @@ func (rscConfig *bridgeDomainConfig) isEmpty() bool {
 }
 
 type bridgeDomainBlockVXLAN struct {
-	VNIExtendEvpn              types.Bool   `tfsdk:"vni_extend_evpn"`
+	VNI                        types.Int64  `tfsdk:"vni"`
 	DecapsulateAcceptInnerVlan types.Bool   `tfsdk:"decapsulate_accept_inner_vlan"`
 	EncapsulateInnerVlan       types.Bool   `tfsdk:"encapsulate_inner_vlan"`
 	IngressNodeReplication     types.Bool   `tfsdk:"ingress_node_replication"`
-	OvsdbManaged               types.Bool   `tfsdk:"ovsdb_managed"`
-	VNI                        types.Int64  `tfsdk:"vni"`
 	MulticastGroup             types.String `tfsdk:"multicast_group"`
+	OvsdbManaged               types.Bool   `tfsdk:"ovsdb_managed"`
 	UnreachableVtepAgingTimer  types.Int64  `tfsdk:"unreachable_vtep_aging_timer"`
+	VNIExtendEvpn              types.Bool   `tfsdk:"vni_extend_evpn"`
 }
 
 func (rsc *bridgeDomain) ValidateConfig(

--- a/internal/providerfwk/resource_eventoptions_policy.go
+++ b/internal/providerfwk/resource_eventoptions_policy.go
@@ -609,9 +609,9 @@ type eventoptionsPolicyConfig struct {
 
 type eventoptionsPolicyBlockThen struct {
 	Ignore                   types.Bool                                          `tfsdk:"ignore"`
-	RaiseTrap                types.Bool                                          `tfsdk:"raise_trap"`
 	PriorityOverrideFacility types.String                                        `tfsdk:"priority_override_facility"`
 	PriorityOverrideSeverity types.String                                        `tfsdk:"priority_override_severity"`
+	RaiseTrap                types.Bool                                          `tfsdk:"raise_trap"`
 	ChangeConfiguration      *eventoptionsPolicyBlockThenBlockChangeConfigurtion `tfsdk:"change_configuration"`
 	EventScript              []eventoptionsPolicyBlockThenBlockEventScript       `tfsdk:"event_script"`
 	ExecuteCommands          *eventoptionsPolicyBlockThenBlockExecuteCommands    `tfsdk:"execute_commands"`
@@ -624,9 +624,9 @@ func (block *eventoptionsPolicyBlockThen) isEmpty() bool {
 
 type eventoptionsPolicyBlockThenConfig struct {
 	Ignore                   types.Bool                                                `tfsdk:"ignore"`
-	RaiseTrap                types.Bool                                                `tfsdk:"raise_trap"`
 	PriorityOverrideFacility types.String                                              `tfsdk:"priority_override_facility"`
 	PriorityOverrideSeverity types.String                                              `tfsdk:"priority_override_severity"`
+	RaiseTrap                types.Bool                                                `tfsdk:"raise_trap"`
 	ChangeConfiguration      *eventoptionsPolicyBlockThenBlockChangeConfigurtionConfig `tfsdk:"change_configuration"`
 	EventScript              types.List                                                `tfsdk:"event_script"`
 	ExecuteCommands          *eventoptionsPolicyBlockThenBlockExecuteCommandsConfig    `tfsdk:"execute_commands"`
@@ -638,24 +638,24 @@ func (block *eventoptionsPolicyBlockThenConfig) isEmpty() bool {
 }
 
 type eventoptionsPolicyBlockThenBlockChangeConfigurtion struct {
+	Commands                      []types.String `tfsdk:"commands"`
 	CommitOptionsCheck            types.Bool     `tfsdk:"commit_options_check"`
 	CommitOptionsCheckSynchronize types.Bool     `tfsdk:"commit_options_check_synchronize"`
 	CommitOptionsForce            types.Bool     `tfsdk:"commit_options_force"`
-	CommitOptionsSynchronize      types.Bool     `tfsdk:"commit_options_synchronize"`
-	Commands                      []types.String `tfsdk:"commands"`
 	CommitOptionsLog              types.String   `tfsdk:"commit_options_log"`
+	CommitOptionsSynchronize      types.Bool     `tfsdk:"commit_options_synchronize"`
 	RetryCount                    types.Int64    `tfsdk:"retry_count"`
 	RetryInterval                 types.Int64    `tfsdk:"retry_interval"`
 	Username                      types.String   `tfsdk:"user_name"`
 }
 
 type eventoptionsPolicyBlockThenBlockChangeConfigurtionConfig struct {
+	Commands                      types.List   `tfsdk:"commands"`
 	CommitOptionsCheck            types.Bool   `tfsdk:"commit_options_check"`
 	CommitOptionsCheckSynchronize types.Bool   `tfsdk:"commit_options_check_synchronize"`
 	CommitOptionsForce            types.Bool   `tfsdk:"commit_options_force"`
-	CommitOptionsSynchronize      types.Bool   `tfsdk:"commit_options_synchronize"`
-	Commands                      types.List   `tfsdk:"commands"`
 	CommitOptionsLog              types.String `tfsdk:"commit_options_log"`
+	CommitOptionsSynchronize      types.Bool   `tfsdk:"commit_options_synchronize"`
 	RetryCount                    types.Int64  `tfsdk:"retry_count"`
 	RetryInterval                 types.Int64  `tfsdk:"retry_interval"`
 	Username                      types.String `tfsdk:"user_name"`

--- a/internal/providerfwk/resource_evpn.go
+++ b/internal/providerfwk/resource_evpn.go
@@ -252,23 +252,23 @@ func (rsc *evpn) Schema(
 }
 
 type evpnData struct {
-	RoutingInstanceEvpn   types.Bool                      `tfsdk:"routing_instance_evpn"`
 	ID                    types.String                    `tfsdk:"id"`
 	RoutingInstance       types.String                    `tfsdk:"routing_instance"`
 	Encapsulation         types.String                    `tfsdk:"encapsulation"`
 	DefaultGateway        types.String                    `tfsdk:"default_gateway"`
 	MulticastMode         types.String                    `tfsdk:"multicast_mode"`
+	RoutingInstanceEvpn   types.Bool                      `tfsdk:"routing_instance_evpn"`
 	DuplicateMacDetection *evpnBlockDuplicateMACDetection `tfsdk:"duplicate_mac_detection"`
 	SwitchOrRIOptions     *evpnBlockSwitchOrRIOptions     `tfsdk:"switch_or_ri_options"`
 }
 
 type evpnConfig struct {
-	RoutingInstanceEvpn   types.Bool                        `tfsdk:"routing_instance_evpn"`
 	ID                    types.String                      `tfsdk:"id"`
 	RoutingInstance       types.String                      `tfsdk:"routing_instance"`
 	Encapsulation         types.String                      `tfsdk:"encapsulation"`
 	DefaultGateway        types.String                      `tfsdk:"default_gateway"`
 	MulticastMode         types.String                      `tfsdk:"multicast_mode"`
+	RoutingInstanceEvpn   types.Bool                        `tfsdk:"routing_instance_evpn"`
 	DuplicateMacDetection *evpnBlockDuplicateMACDetection   `tfsdk:"duplicate_mac_detection"`
 	SwitchOrRIOptions     *evpnBlockSwitchOrRIOptionsConfig `tfsdk:"switch_or_ri_options"`
 }
@@ -284,21 +284,21 @@ func (block *evpnBlockDuplicateMACDetection) isEmpty() bool {
 }
 
 type evpnBlockSwitchOrRIOptions struct {
-	VRFTargetAuto      types.Bool     `tfsdk:"vrf_target_auto"`
 	RouteDistinguisher types.String   `tfsdk:"route_distinguisher"`
 	VRFExport          []types.String `tfsdk:"vrf_export"`
 	VRFImport          []types.String `tfsdk:"vrf_import"`
 	VRFTarget          types.String   `tfsdk:"vrf_target"`
+	VRFTargetAuto      types.Bool     `tfsdk:"vrf_target_auto"`
 	VRFTargetExport    types.String   `tfsdk:"vrf_target_export"`
 	VRFTargetImport    types.String   `tfsdk:"vrf_target_import"`
 }
 
 type evpnBlockSwitchOrRIOptionsConfig struct {
-	VRFTargetAuto      types.Bool   `tfsdk:"vrf_target_auto"`
 	RouteDistinguisher types.String `tfsdk:"route_distinguisher"`
 	VRFExport          types.List   `tfsdk:"vrf_export"`
 	VRFImport          types.List   `tfsdk:"vrf_import"`
 	VRFTarget          types.String `tfsdk:"vrf_target"`
+	VRFTargetAuto      types.Bool   `tfsdk:"vrf_target_auto"`
 	VRFTargetExport    types.String `tfsdk:"vrf_target_export"`
 	VRFTargetImport    types.String `tfsdk:"vrf_target_import"`
 }

--- a/internal/providerfwk/resource_firewall_filter.go
+++ b/internal/providerfwk/resource_firewall_filter.go
@@ -761,18 +761,18 @@ func (rsc *firewallFilter) Schema(
 }
 
 type firewallFilterData struct {
-	InterfaceSpecific types.Bool                `tfsdk:"interface_specific"`
 	ID                types.String              `tfsdk:"id"`
 	Name              types.String              `tfsdk:"name"`
 	Family            types.String              `tfsdk:"family"`
+	InterfaceSpecific types.Bool                `tfsdk:"interface_specific"`
 	Term              []firewallFilterBlockTerm `tfsdk:"term"`
 }
 
 type firewallFilterConfig struct {
-	InterfaceSpecific types.Bool   `tfsdk:"interface_specific"`
 	ID                types.String `tfsdk:"id"`
 	Name              types.String `tfsdk:"name"`
 	Family            types.String `tfsdk:"family"`
+	InterfaceSpecific types.Bool   `tfsdk:"interface_specific"`
 	Term              types.List   `tfsdk:"term"`
 }
 
@@ -795,9 +795,6 @@ func (block *firewallFilterBlockTermConfig) isEmpty() bool {
 }
 
 type firewallFilterBlockTermBlockFrom struct {
-	IsFragment                  types.Bool     `tfsdk:"is_fragment"`
-	TCPEstablished              types.Bool     `tfsdk:"tcp_established"`
-	TCPInitial                  types.Bool     `tfsdk:"tcp_initial"`
 	Address                     []types.String `tfsdk:"address"`
 	AddressExcept               []types.String `tfsdk:"address_except"`
 	DestinationAddress          []types.String `tfsdk:"destination_address"`
@@ -815,6 +812,7 @@ type firewallFilterBlockTermBlockFrom struct {
 	IcmpType                    []types.String `tfsdk:"icmp_type"`
 	IcmpTypeExcept              []types.String `tfsdk:"icmp_type_except"`
 	Interface                   []types.String `tfsdk:"interface"`
+	IsFragment                  types.Bool     `tfsdk:"is_fragment"`
 	LossPriority                []types.String `tfsdk:"loss_priority"`
 	LossPriorityExcept          []types.String `tfsdk:"loss_priority_except"`
 	NextHeader                  []types.String `tfsdk:"next_header"`
@@ -837,13 +835,12 @@ type firewallFilterBlockTermBlockFrom struct {
 	SourcePortExcept            []types.String `tfsdk:"source_port_except"`
 	SourcePrefixList            []types.String `tfsdk:"source_prefix_list"`
 	SourcePrefixListExcept      []types.String `tfsdk:"source_prefix_list_except"`
+	TCPEstablished              types.Bool     `tfsdk:"tcp_established"`
 	TCPFlags                    types.String   `tfsdk:"tcp_flags"`
+	TCPInitial                  types.Bool     `tfsdk:"tcp_initial"`
 }
 
 type firewallFilterBlockTermBlockFromConfig struct {
-	IsFragment                  types.Bool   `tfsdk:"is_fragment"`
-	TCPEstablished              types.Bool   `tfsdk:"tcp_established"`
-	TCPInitial                  types.Bool   `tfsdk:"tcp_initial"`
 	Address                     types.Set    `tfsdk:"address"`
 	AddressExcept               types.Set    `tfsdk:"address_except"`
 	DestinationAddress          types.Set    `tfsdk:"destination_address"`
@@ -861,6 +858,7 @@ type firewallFilterBlockTermBlockFromConfig struct {
 	IcmpType                    types.Set    `tfsdk:"icmp_type"`
 	IcmpTypeExcept              types.Set    `tfsdk:"icmp_type_except"`
 	Interface                   types.Set    `tfsdk:"interface"`
+	IsFragment                  types.Bool   `tfsdk:"is_fragment"`
 	LossPriority                types.Set    `tfsdk:"loss_priority"`
 	LossPriorityExcept          types.Set    `tfsdk:"loss_priority_except"`
 	NextHeader                  types.Set    `tfsdk:"next_header"`
@@ -883,7 +881,9 @@ type firewallFilterBlockTermBlockFromConfig struct {
 	SourcePortExcept            types.Set    `tfsdk:"source_port_except"`
 	SourcePrefixList            types.Set    `tfsdk:"source_prefix_list"`
 	SourcePrefixListExcept      types.Set    `tfsdk:"source_prefix_list_except"`
+	TCPEstablished              types.Bool   `tfsdk:"tcp_established"`
 	TCPFlags                    types.String `tfsdk:"tcp_flags"`
+	TCPInitial                  types.Bool   `tfsdk:"tcp_initial"`
 }
 
 func (block *firewallFilterBlockTermBlockFromConfig) isEmpty() bool {
@@ -891,18 +891,18 @@ func (block *firewallFilterBlockTermBlockFromConfig) isEmpty() bool {
 }
 
 type firewallFilterBlockTermBlockThen struct {
-	Log               types.Bool   `tfsdk:"log"`
-	PacketMode        types.Bool   `tfsdk:"packet_mode"`
-	PortMirror        types.Bool   `tfsdk:"port_mirror"`
-	Sample            types.Bool   `tfsdk:"sample"`
-	ServiceAccounting types.Bool   `tfsdk:"service_accounting"`
-	Syslog            types.Bool   `tfsdk:"syslog"`
 	Action            types.String `tfsdk:"action"`
 	Count             types.String `tfsdk:"count"`
 	ForwardingClass   types.String `tfsdk:"forwarding_class"`
+	Log               types.Bool   `tfsdk:"log"`
 	LossPriority      types.String `tfsdk:"loss_priority"`
+	PacketMode        types.Bool   `tfsdk:"packet_mode"`
 	Policer           types.String `tfsdk:"policer"`
+	PortMirror        types.Bool   `tfsdk:"port_mirror"`
 	RoutingInstance   types.String `tfsdk:"routing_instance"`
+	Sample            types.Bool   `tfsdk:"sample"`
+	ServiceAccounting types.Bool   `tfsdk:"service_accounting"`
+	Syslog            types.Bool   `tfsdk:"syslog"`
 }
 
 func (block *firewallFilterBlockTermBlockThen) isEmpty() bool {

--- a/internal/providerfwk/resource_firewall_policer.go
+++ b/internal/providerfwk/resource_firewall_policer.go
@@ -240,13 +240,13 @@ func (rsc *firewallPolicer) Schema(
 }
 
 type firewallPolicerData struct {
+	ID                       types.String                        `tfsdk:"id"`
+	Name                     types.String                        `tfsdk:"name"`
 	FilterSpecific           types.Bool                          `tfsdk:"filter_specific"`
 	LogicalBandwidthPolicer  types.Bool                          `tfsdk:"logical_bandwidth_policer"`
 	LogicalInterfacePolicer  types.Bool                          `tfsdk:"logical_interface_policer"`
 	PhysicalInterfacePolicer types.Bool                          `tfsdk:"physical_interface_policer"`
 	SharedBandwidthPolicer   types.Bool                          `tfsdk:"shared_bandwidth_policer"`
-	ID                       types.String                        `tfsdk:"id"`
-	Name                     types.String                        `tfsdk:"name"`
 	IfExceeding              *firewallPolicerBlockIfExceeding    `tfsdk:"if_exceeding"`
 	IfExceedingPPS           *firewallPolicerBlockIfExceedingPPS `tfsdk:"if_exceeding_pps"`
 	Then                     *firewallPolicerBlockThen           `tfsdk:"then"`
@@ -273,9 +273,9 @@ func (block *firewallPolicerBlockIfExceedingPPS) hasKnownValue() bool {
 
 type firewallPolicerBlockThen struct {
 	Discard         types.Bool   `tfsdk:"discard"`
-	OutOfProfile    types.Bool   `tfsdk:"out_of_profile"`
 	ForwardingClass types.String `tfsdk:"forwarding_class"`
 	LossPriority    types.String `tfsdk:"loss_priority"`
+	OutOfProfile    types.Bool   `tfsdk:"out_of_profile"`
 }
 
 func (block *firewallPolicerBlockThen) isEmpty() bool {

--- a/internal/providerfwk/resource_forwardingoptions_sampling.go
+++ b/internal/providerfwk/resource_forwardingoptions_sampling.go
@@ -165,20 +165,6 @@ func (rsc *forwardingoptionsSampling) Schema(
 									int64validator.Between(2, 10000),
 								},
 							},
-							"no_stamp": schema.BoolAttribute{
-								Optional:    true,
-								Description: "Don't timestamp every packet in the dump.",
-								Validators: []validator.Bool{
-									tfvalidator.BoolTrue(),
-								},
-							},
-							"no_world_readable": schema.BoolAttribute{
-								Optional:    true,
-								Description: "Don't allow any user to read the sampled dump.",
-								Validators: []validator.Bool{
-									tfvalidator.BoolTrue(),
-								},
-							},
 							"size": schema.Int64Attribute{
 								Optional:    true,
 								Description: "Maximum sample dump file size (1024..104857600).",
@@ -193,9 +179,23 @@ func (rsc *forwardingoptionsSampling) Schema(
 									tfvalidator.BoolTrue(),
 								},
 							},
+							"no_stamp": schema.BoolAttribute{
+								Optional:    true,
+								Description: "Don't timestamp every packet in the dump.",
+								Validators: []validator.Bool{
+									tfvalidator.BoolTrue(),
+								},
+							},
 							"world_readable": schema.BoolAttribute{
 								Optional:    true,
 								Description: "Allow any user to read the sampled dump.",
+								Validators: []validator.Bool{
+									tfvalidator.BoolTrue(),
+								},
+							},
+							"no_world_readable": schema.BoolAttribute{
+								Optional:    true,
+								Description: "Don't allow any user to read the sampled dump.",
 								Validators: []validator.Bool{
 									tfvalidator.BoolTrue(),
 								},
@@ -663,11 +663,11 @@ func (rsc *forwardingoptionsSampling) schemaOutputInterfaceAttributes() map[stri
 }
 
 type forwardingoptionsSamplingData struct {
+	ID                types.String                                     `tfsdk:"id"`
+	RoutingInstance   types.String                                     `tfsdk:"routing_instance"`
 	Disable           types.Bool                                       `tfsdk:"disable"`
 	PreRewriteTos     types.Bool                                       `tfsdk:"pre_rewrite_tos"`
 	SampleOnce        types.Bool                                       `tfsdk:"sample_once"`
-	ID                types.String                                     `tfsdk:"id"`
-	RoutingInstance   types.String                                     `tfsdk:"routing_instance"`
 	FamilyInetInput   *forwardingoptionsSamplingBlockInput             `tfsdk:"family_inet_input"`
 	FamilyInetOutput  *forwardingoptionsSamplingBlockFamilyInetOutput  `tfsdk:"family_inet_output"`
 	FamilyInet6Input  *forwardingoptionsSamplingBlockInput             `tfsdk:"family_inet6_input"`
@@ -678,11 +678,11 @@ type forwardingoptionsSamplingData struct {
 }
 
 type forwardingoptionsSamplingConfig struct {
+	ID                types.String                                           `tfsdk:"id"`
+	RoutingInstance   types.String                                           `tfsdk:"routing_instance"`
 	Disable           types.Bool                                             `tfsdk:"disable"`
 	PreRewriteTos     types.Bool                                             `tfsdk:"pre_rewrite_tos"`
 	SampleOnce        types.Bool                                             `tfsdk:"sample_once"`
-	ID                types.String                                           `tfsdk:"id"`
-	RoutingInstance   types.String                                           `tfsdk:"routing_instance"`
 	FamilyInetInput   *forwardingoptionsSamplingBlockInput                   `tfsdk:"family_inet_input"`
 	FamilyInetOutput  *forwardingoptionsSamplingBlockFamilyInetOutputConfig  `tfsdk:"family_inet_output"`
 	FamilyInet6Input  *forwardingoptionsSamplingBlockInput                   `tfsdk:"family_inet6_input"`
@@ -737,31 +737,31 @@ func (block *forwardingoptionsSamplingBlockFamilyInetOutputConfig) isEmpty() boo
 }
 
 type forwardingoptionsSamplingBlockFamilyInetOutputBlockFile struct {
-	Disable         types.Bool   `tfsdk:"disable"`
-	NoStamp         types.Bool   `tfsdk:"no_stamp"`
-	NoWorldReadable types.Bool   `tfsdk:"no_world_readable"`
-	Stamp           types.Bool   `tfsdk:"stamp"`
-	WorldReadable   types.Bool   `tfsdk:"world_readable"`
 	Filename        types.String `tfsdk:"filename"`
+	Disable         types.Bool   `tfsdk:"disable"`
 	Files           types.Int64  `tfsdk:"files"`
 	Size            types.Int64  `tfsdk:"size"`
+	Stamp           types.Bool   `tfsdk:"stamp"`
+	NoStamp         types.Bool   `tfsdk:"no_stamp"`
+	WorldReadable   types.Bool   `tfsdk:"world_readable"`
+	NoWorldReadable types.Bool   `tfsdk:"no_world_readable"`
 }
 
 //nolint:lll
 type forwardingoptionsSamplingBlockFamilyInetOutputBlockFlowServer struct {
+	Hostname                                         types.String `tfsdk:"hostname"`
+	Port                                             types.Int64  `tfsdk:"port"`
 	AggregationAutonomousSystem                      types.Bool   `tfsdk:"aggregation_autonomous_system"`
 	AggregationDestinationPrefix                     types.Bool   `tfsdk:"aggregation_destination_prefix"`
 	AggregationProtocolPort                          types.Bool   `tfsdk:"aggregation_protocol_port"`
 	AggregationSourceDestinationPrefix               types.Bool   `tfsdk:"aggregation_source_destination_prefix"`
 	AggregationSourceDestinationPrefixCaidaCompliant types.Bool   `tfsdk:"aggregation_source_destination_prefix_caida_compliant"`
 	AggregationSourcePrefix                          types.Bool   `tfsdk:"aggregation_source_prefix"`
-	LocalDump                                        types.Bool   `tfsdk:"local_dump"`
-	NoLocalDump                                      types.Bool   `tfsdk:"no_local_dump"`
-	Hostname                                         types.String `tfsdk:"hostname"`
-	Port                                             types.Int64  `tfsdk:"port"`
 	AutonomousSystemType                             types.String `tfsdk:"autonomous_system_type"`
 	Dscp                                             types.Int64  `tfsdk:"dscp"`
 	ForwardingClass                                  types.String `tfsdk:"forwarding_class"`
+	LocalDump                                        types.Bool   `tfsdk:"local_dump"`
+	NoLocalDump                                      types.Bool   `tfsdk:"no_local_dump"`
 	RoutingInstance                                  types.String `tfsdk:"routing_instance"`
 	SourceAddress                                    types.String `tfsdk:"source_address"`
 	Version                                          types.Int64  `tfsdk:"version"`
@@ -816,19 +816,19 @@ func (block *forwardingoptionsSamplingBlockFamilyMplsOutputConfig) isEmpty() boo
 
 //nolint:lll
 type forwardingoptionsSamplingBlockOutputBlockFlowServer struct {
+	Hostname                                         types.String `tfsdk:"hostname"`
+	Port                                             types.Int64  `tfsdk:"port"`
 	AggregationAutonomousSystem                      types.Bool   `tfsdk:"aggregation_autonomous_system"`
 	AggregationDestinationPrefix                     types.Bool   `tfsdk:"aggregation_destination_prefix"`
 	AggregationProtocolPort                          types.Bool   `tfsdk:"aggregation_protocol_port"`
 	AggregationSourceDestinationPrefix               types.Bool   `tfsdk:"aggregation_source_destination_prefix"`
 	AggregationSourceDestinationPrefixCaidaCompliant types.Bool   `tfsdk:"aggregation_source_destination_prefix_caida_compliant"`
 	AggregationSourcePrefix                          types.Bool   `tfsdk:"aggregation_source_prefix"`
-	LocalDump                                        types.Bool   `tfsdk:"local_dump"`
-	NoLocalDump                                      types.Bool   `tfsdk:"no_local_dump"`
-	Hostname                                         types.String `tfsdk:"hostname"`
-	Port                                             types.Int64  `tfsdk:"port"`
 	AutonomousSystemType                             types.String `tfsdk:"autonomous_system_type"`
 	Dscp                                             types.Int64  `tfsdk:"dscp"`
 	ForwardingClass                                  types.String `tfsdk:"forwarding_class"`
+	LocalDump                                        types.Bool   `tfsdk:"local_dump"`
+	NoLocalDump                                      types.Bool   `tfsdk:"no_local_dump"`
 	RoutingInstance                                  types.String `tfsdk:"routing_instance"`
 	SourceAddress                                    types.String `tfsdk:"source_address"`
 	Version9Template                                 types.String `tfsdk:"version9_template"`

--- a/internal/providerfwk/resource_forwardingoptions_sampling_instance.go
+++ b/internal/providerfwk/resource_forwardingoptions_sampling_instance.go
@@ -624,10 +624,10 @@ func (rsc *forwardingoptionsSamplingInstance) schemaOutputInterfaceAttributes() 
 }
 
 type forwardingoptionsSamplingInstanceData struct {
-	Disable           types.Bool                                               `tfsdk:"disable"`
 	ID                types.String                                             `tfsdk:"id"`
 	Name              types.String                                             `tfsdk:"name"`
 	RoutingInstance   types.String                                             `tfsdk:"routing_instance"`
+	Disable           types.Bool                                               `tfsdk:"disable"`
 	FamilyInetInput   *forwardingoptionsSamplingInstanceBlockInput             `tfsdk:"family_inet_input"`
 	FamilyInetOutput  *forwardingoptionsSamplingInstanceBlockFamilyInetOutput  `tfsdk:"family_inet_output"`
 	FamilyInet6Input  *forwardingoptionsSamplingInstanceBlockInput             `tfsdk:"family_inet6_input"`
@@ -638,10 +638,10 @@ type forwardingoptionsSamplingInstanceData struct {
 }
 
 type forwardingoptionsSamplingInstanceConfig struct {
-	Disable           types.Bool                                                    `tfsdk:"disable"`
 	ID                types.String                                                  `tfsdk:"id"`
 	Name              types.String                                                  `tfsdk:"name"`
 	RoutingInstance   types.String                                                  `tfsdk:"routing_instance"`
+	Disable           types.Bool                                                    `tfsdk:"disable"`
 	FamilyInetInput   *forwardingoptionsSamplingInstanceBlockInput                  `tfsdk:"family_inet_input"`
 	FamilyInetOutput  *forwardingoptionsSamplingInstanceBlockFamilyInetOutputConfig `tfsdk:"family_inet_output"`
 	FamilyInet6Input  *forwardingoptionsSamplingInstanceBlockInput                  `tfsdk:"family_inet6_input"`
@@ -695,19 +695,19 @@ func (block *forwardingoptionsSamplingInstanceBlockFamilyInetOutputConfig) isEmp
 
 //nolint:lll
 type forwardingoptionsSamplingInstanceBlockFamilyInetOutputBlockFlowServer struct {
+	Hostname                                         types.String `tfsdk:"hostname"`
+	Port                                             types.Int64  `tfsdk:"port"`
 	AggregationAutonomousSystem                      types.Bool   `tfsdk:"aggregation_autonomous_system"`
 	AggregationDestinationPrefix                     types.Bool   `tfsdk:"aggregation_destination_prefix"`
 	AggregationProtocolPort                          types.Bool   `tfsdk:"aggregation_protocol_port"`
 	AggregationSourceDestinationPrefix               types.Bool   `tfsdk:"aggregation_source_destination_prefix"`
 	AggregationSourceDestinationPrefixCaidaCompliant types.Bool   `tfsdk:"aggregation_source_destination_prefix_caida_compliant"`
 	AggregationSourcePrefix                          types.Bool   `tfsdk:"aggregation_source_prefix"`
-	LocalDump                                        types.Bool   `tfsdk:"local_dump"`
-	NoLocalDump                                      types.Bool   `tfsdk:"no_local_dump"`
-	Hostname                                         types.String `tfsdk:"hostname"`
-	Port                                             types.Int64  `tfsdk:"port"`
 	AutonomousSystemType                             types.String `tfsdk:"autonomous_system_type"`
 	Dscp                                             types.Int64  `tfsdk:"dscp"`
 	ForwardingClass                                  types.String `tfsdk:"forwarding_class"`
+	LocalDump                                        types.Bool   `tfsdk:"local_dump"`
+	NoLocalDump                                      types.Bool   `tfsdk:"no_local_dump"`
 	RoutingInstance                                  types.String `tfsdk:"routing_instance"`
 	SourceAddress                                    types.String `tfsdk:"source_address"`
 	Version                                          types.Int64  `tfsdk:"version"`
@@ -754,19 +754,19 @@ func (block *forwardingoptionsSamplingInstanceBlockFamilyMplsOutputConfig) isEmp
 
 //nolint:lll
 type forwardingoptionsSamplingInstanceBlockOutputBlockFlowServer struct {
+	Hostname                                         types.String `tfsdk:"hostname"`
+	Port                                             types.Int64  `tfsdk:"port"`
 	AggregationAutonomousSystem                      types.Bool   `tfsdk:"aggregation_autonomous_system"`
 	AggregationDestinationPrefix                     types.Bool   `tfsdk:"aggregation_destination_prefix"`
 	AggregationProtocolPort                          types.Bool   `tfsdk:"aggregation_protocol_port"`
 	AggregationSourceDestinationPrefix               types.Bool   `tfsdk:"aggregation_source_destination_prefix"`
 	AggregationSourceDestinationPrefixCaidaCompliant types.Bool   `tfsdk:"aggregation_source_destination_prefix_caida_compliant"`
 	AggregationSourcePrefix                          types.Bool   `tfsdk:"aggregation_source_prefix"`
-	LocalDump                                        types.Bool   `tfsdk:"local_dump"`
-	NoLocalDump                                      types.Bool   `tfsdk:"no_local_dump"`
-	Hostname                                         types.String `tfsdk:"hostname"`
-	Port                                             types.Int64  `tfsdk:"port"`
 	AutonomousSystemType                             types.String `tfsdk:"autonomous_system_type"`
 	Dscp                                             types.Int64  `tfsdk:"dscp"`
 	ForwardingClass                                  types.String `tfsdk:"forwarding_class"`
+	LocalDump                                        types.Bool   `tfsdk:"local_dump"`
+	NoLocalDump                                      types.Bool   `tfsdk:"no_local_dump"`
 	RoutingInstance                                  types.String `tfsdk:"routing_instance"`
 	SourceAddress                                    types.String `tfsdk:"source_address"`
 	Version9Template                                 types.String `tfsdk:"version9_template"`

--- a/internal/providerfwk/resource_forwardingoptions_storm_control_profile.go
+++ b/internal/providerfwk/resource_forwardingoptions_storm_control_profile.go
@@ -175,21 +175,21 @@ func (rsc *forwardingoptionsStormControlProfile) Schema(
 }
 
 type forwardingoptionsStormControlProfileData struct {
-	ActionShutdown types.Bool                                    `tfsdk:"action_shutdown"`
 	ID             types.String                                  `tfsdk:"id"`
 	Name           types.String                                  `tfsdk:"name"`
+	ActionShutdown types.Bool                                    `tfsdk:"action_shutdown"`
 	All            *forwardingoptionsStormControlProfileBlockAll `tfsdk:"all"`
 }
 
 type forwardingoptionsStormControlProfileBlockAll struct {
+	BandwidthLevel          types.Int64 `tfsdk:"bandwidth_level"`
+	BandwidthPercentage     types.Int64 `tfsdk:"bandwidth_percentage"`
+	BurstSize               types.Int64 `tfsdk:"burst_size"`
 	NoBroadcast             types.Bool  `tfsdk:"no_broadcast"`
 	NoMulticast             types.Bool  `tfsdk:"no_multicast"`
 	NoRegisteredMulticast   types.Bool  `tfsdk:"no_registered_multicast"`
 	NoUnknownUnicast        types.Bool  `tfsdk:"no_unknown_unicast"`
 	NoUnregisteredMulticast types.Bool  `tfsdk:"no_unregistered_multicast"`
-	BandwidthLevel          types.Int64 `tfsdk:"bandwidth_level"`
-	BandwidthPercentage     types.Int64 `tfsdk:"bandwidth_percentage"`
-	BurstSize               types.Int64 `tfsdk:"burst_size"`
 }
 
 func (rsc *forwardingoptionsStormControlProfile) ValidateConfig(

--- a/internal/providerfwk/resource_generate_route.go
+++ b/internal/providerfwk/resource_generate_route.go
@@ -237,43 +237,43 @@ func (rsc *generateRoute) Schema(
 }
 
 type generateRouteData struct {
-	Active                   types.Bool     `tfsdk:"active"`
-	ASPathAtomicAggregate    types.Bool     `tfsdk:"as_path_atomic_aggregate"`
-	Brief                    types.Bool     `tfsdk:"brief"`
-	Discard                  types.Bool     `tfsdk:"discard"`
-	Full                     types.Bool     `tfsdk:"full"`
-	Passive                  types.Bool     `tfsdk:"passive"`
 	ID                       types.String   `tfsdk:"id"`
 	Destination              types.String   `tfsdk:"destination"`
 	RoutingInstance          types.String   `tfsdk:"routing_instance"`
+	Active                   types.Bool     `tfsdk:"active"`
 	ASPathAggregatorAddress  types.String   `tfsdk:"as_path_aggregator_address"`
 	ASPathAggregatorASNumber types.String   `tfsdk:"as_path_aggregator_as_number"`
+	ASPathAtomicAggregate    types.Bool     `tfsdk:"as_path_atomic_aggregate"`
 	ASPathOrigin             types.String   `tfsdk:"as_path_origin"`
 	ASPathPath               types.String   `tfsdk:"as_path_path"`
+	Brief                    types.Bool     `tfsdk:"brief"`
 	Community                []types.String `tfsdk:"community"`
+	Discard                  types.Bool     `tfsdk:"discard"`
+	Full                     types.Bool     `tfsdk:"full"`
 	Metric                   types.Int64    `tfsdk:"metric"`
 	NextTable                types.String   `tfsdk:"next_table"`
+	Passive                  types.Bool     `tfsdk:"passive"`
 	Policy                   []types.String `tfsdk:"policy"`
 	Preference               types.Int64    `tfsdk:"preference"`
 }
 
 type generateRouteConfig struct {
-	Active                   types.Bool   `tfsdk:"active"`
-	ASPathAtomicAggregate    types.Bool   `tfsdk:"as_path_atomic_aggregate"`
-	Brief                    types.Bool   `tfsdk:"brief"`
-	Discard                  types.Bool   `tfsdk:"discard"`
-	Full                     types.Bool   `tfsdk:"full"`
-	Passive                  types.Bool   `tfsdk:"passive"`
 	ID                       types.String `tfsdk:"id"`
 	Destination              types.String `tfsdk:"destination"`
 	RoutingInstance          types.String `tfsdk:"routing_instance"`
+	Active                   types.Bool   `tfsdk:"active"`
 	ASPathAggregatorAddress  types.String `tfsdk:"as_path_aggregator_address"`
 	ASPathAggregatorASNumber types.String `tfsdk:"as_path_aggregator_as_number"`
+	ASPathAtomicAggregate    types.Bool   `tfsdk:"as_path_atomic_aggregate"`
 	ASPathOrigin             types.String `tfsdk:"as_path_origin"`
 	ASPathPath               types.String `tfsdk:"as_path_path"`
+	Brief                    types.Bool   `tfsdk:"brief"`
 	Community                types.List   `tfsdk:"community"`
+	Discard                  types.Bool   `tfsdk:"discard"`
+	Full                     types.Bool   `tfsdk:"full"`
 	Metric                   types.Int64  `tfsdk:"metric"`
 	NextTable                types.String `tfsdk:"next_table"`
+	Passive                  types.Bool   `tfsdk:"passive"`
 	Policy                   types.List   `tfsdk:"policy"`
 	Preference               types.Int64  `tfsdk:"preference"`
 }

--- a/internal/providerfwk/resource_iccp_peer.go
+++ b/internal/providerfwk/resource_iccp_peer.go
@@ -243,11 +243,11 @@ type iccpPeerBlockBackupLivenessDetection struct {
 }
 
 type iccpPeerBlockLivenessDetection struct {
-	NoAdaptation                    types.Bool   `tfsdk:"no_adaptation"`
 	DetectionTimeThreshold          types.Int64  `tfsdk:"detection_time_threshold"`
 	MinimumInterval                 types.Int64  `tfsdk:"minimum_interval"`
 	MinimumReceiveInterval          types.Int64  `tfsdk:"minimum_receive_interval"`
 	Multiplier                      types.Int64  `tfsdk:"multiplier"`
+	NoAdaptation                    types.Bool   `tfsdk:"no_adaptation"`
 	TransmitIntervalMinimumInterval types.Int64  `tfsdk:"transmit_interval_minimum_interval"`
 	TransmitIntervalThreshold       types.Int64  `tfsdk:"transmit_interval_threshold"`
 	Version                         types.String `tfsdk:"version"`

--- a/internal/providerfwk/resource_interface_logical.go
+++ b/internal/providerfwk/resource_interface_logical.go
@@ -1012,56 +1012,56 @@ func (rsc *interfaceLogical) Schema(
 }
 
 type interfaceLogicalData struct {
-	St0AlsoOnDestroy         types.Bool                        `tfsdk:"st0_also_on_destroy"`
-	VlanNoCompute            types.Bool                        `tfsdk:"vlan_no_compute"`
-	Disable                  types.Bool                        `tfsdk:"disable"`
 	ID                       types.String                      `tfsdk:"id"`
 	Name                     types.String                      `tfsdk:"name"`
+	St0AlsoOnDestroy         types.Bool                        `tfsdk:"st0_also_on_destroy"`
 	Description              types.String                      `tfsdk:"description"`
+	Disable                  types.Bool                        `tfsdk:"disable"`
 	RoutingInstance          types.String                      `tfsdk:"routing_instance"`
 	SecurityInboundProtocols []types.String                    `tfsdk:"security_inbound_protocols"`
 	SecurityInboundServices  []types.String                    `tfsdk:"security_inbound_services"`
 	SecurityZone             types.String                      `tfsdk:"security_zone"`
 	VlanID                   types.Int64                       `tfsdk:"vlan_id"`
+	VlanNoCompute            types.Bool                        `tfsdk:"vlan_no_compute"`
 	FamilyInet               *interfaceLogicalBlockFamilyInet  `tfsdk:"family_inet"`
 	FamilyInet6              *interfaceLogicalBlockFamilyInet6 `tfsdk:"family_inet6"`
 	Tunnel                   *interfaceLogicalBlockTunnel      `tfsdk:"tunnel"`
 }
 
 type interfaceLogicalConfig struct {
-	St0AlsoOnDestroy         types.Bool                              `tfsdk:"st0_also_on_destroy"`
-	VlanNoCompute            types.Bool                              `tfsdk:"vlan_no_compute"`
-	Disable                  types.Bool                              `tfsdk:"disable"`
 	ID                       types.String                            `tfsdk:"id"`
 	Name                     types.String                            `tfsdk:"name"`
+	St0AlsoOnDestroy         types.Bool                              `tfsdk:"st0_also_on_destroy"`
 	Description              types.String                            `tfsdk:"description"`
+	Disable                  types.Bool                              `tfsdk:"disable"`
 	RoutingInstance          types.String                            `tfsdk:"routing_instance"`
 	SecurityInboundProtocols types.Set                               `tfsdk:"security_inbound_protocols"`
 	SecurityInboundServices  types.Set                               `tfsdk:"security_inbound_services"`
 	SecurityZone             types.String                            `tfsdk:"security_zone"`
 	VlanID                   types.Int64                             `tfsdk:"vlan_id"`
+	VlanNoCompute            types.Bool                              `tfsdk:"vlan_no_compute"`
 	FamilyInet               *interfaceLogicalBlockFamilyInetConfig  `tfsdk:"family_inet"`
 	FamilyInet6              *interfaceLogicalBlockFamilyInet6Config `tfsdk:"family_inet6"`
 	Tunnel                   *interfaceLogicalBlockTunnel            `tfsdk:"tunnel"`
 }
 
 type interfaceLogicalBlockFamilyInet struct {
-	SamplingInput  types.Bool                                    `tfsdk:"sampling_input"`
-	SamplingOutput types.Bool                                    `tfsdk:"sampling_output"`
 	FilterInput    types.String                                  `tfsdk:"filter_input"`
 	FilterOutput   types.String                                  `tfsdk:"filter_output"`
 	Mtu            types.Int64                                   `tfsdk:"mtu"`
+	SamplingInput  types.Bool                                    `tfsdk:"sampling_input"`
+	SamplingOutput types.Bool                                    `tfsdk:"sampling_output"`
 	Address        []interfaceLogicalBlockFamilyInetBlockAddress `tfsdk:"address"`
 	DHCP           *interfaceLogicalBlockFamilyInetBlockDhcp     `tfsdk:"dhcp"`
 	RPFCheck       *interfaceLogicalBlockFamilyBlockRPFCheck     `tfsdk:"rpf_check"`
 }
 
 type interfaceLogicalBlockFamilyInetConfig struct {
-	SamplingInput  types.Bool                                `tfsdk:"sampling_input"`
-	SamplingOutput types.Bool                                `tfsdk:"sampling_output"`
 	FilterInput    types.String                              `tfsdk:"filter_input"`
 	FilterOutput   types.String                              `tfsdk:"filter_output"`
 	Mtu            types.Int64                               `tfsdk:"mtu"`
+	SamplingInput  types.Bool                                `tfsdk:"sampling_input"`
+	SamplingOutput types.Bool                                `tfsdk:"sampling_output"`
 	Address        types.List                                `tfsdk:"address"`
 	DHCP           *interfaceLogicalBlockFamilyInetBlockDhcp `tfsdk:"dhcp"`
 	RPFCheck       *interfaceLogicalBlockFamilyBlockRPFCheck `tfsdk:"rpf_check"`
@@ -1073,47 +1073,47 @@ type interfaceLogicalBlockFamilyBlockRPFCheck struct {
 }
 
 type interfaceLogicalBlockFamilyInetBlockAddress struct {
+	CidrIP    types.String                                                `tfsdk:"cidr_ip"`
 	Preferred types.Bool                                                  `tfsdk:"preferred"`
 	Primary   types.Bool                                                  `tfsdk:"primary"`
-	CidrIP    types.String                                                `tfsdk:"cidr_ip"`
 	VRRPGroup []interfaceLogicalBlockFamilyInetBlockAddressBlockVRRPGroup `tfsdk:"vrrp_group"`
 }
 
 type interfaceLogicalBlockFamilyInetBlockAddressConfig struct {
+	CidrIP    types.String `tfsdk:"cidr_ip"`
 	Preferred types.Bool   `tfsdk:"preferred"`
 	Primary   types.Bool   `tfsdk:"primary"`
-	CidrIP    types.String `tfsdk:"cidr_ip"`
 	VRRPGroup types.List   `tfsdk:"vrrp_group"`
 }
 
 //nolint:lll
 type interfaceLogicalBlockFamilyInetBlockAddressBlockVRRPGroup struct {
-	AcceptData              types.Bool                                                                 `tfsdk:"accept_data"`
-	NoAcceptData            types.Bool                                                                 `tfsdk:"no_accept_data"`
-	Preempt                 types.Bool                                                                 `tfsdk:"preempt"`
-	NoPreempt               types.Bool                                                                 `tfsdk:"no_preempt"`
 	Identifier              types.Int64                                                                `tfsdk:"identifier"`
 	VirtualAddress          []types.String                                                             `tfsdk:"virtual_address"`
+	AcceptData              types.Bool                                                                 `tfsdk:"accept_data"`
+	NoAcceptData            types.Bool                                                                 `tfsdk:"no_accept_data"`
 	AdvertiseInterval       types.Int64                                                                `tfsdk:"advertise_interval"`
 	AdvertisementsThreshold types.Int64                                                                `tfsdk:"advertisements_threshold"`
 	AuthenticationKey       types.String                                                               `tfsdk:"authentication_key"`
 	AuthenticationType      types.String                                                               `tfsdk:"authentication_type"`
+	Preempt                 types.Bool                                                                 `tfsdk:"preempt"`
+	NoPreempt               types.Bool                                                                 `tfsdk:"no_preempt"`
 	Priority                types.Int64                                                                `tfsdk:"priority"`
 	TrackInterface          []interfaceLogicalBlockFamilyBlockAddressBlockVRRPGroupBlockTrackInterface `tfsdk:"track_interface"`
 	TrackRoute              []interfaceLogicalBlockFamilyBlockAddressBlockVRRPGroupBlockTrackRoute     `tfsdk:"track_route"`
 }
 
 type interfaceLogicalBlockFamilyInetBlockAddressBlockVRRPGroupConfig struct {
-	AcceptData              types.Bool   `tfsdk:"accept_data"`
-	NoAcceptData            types.Bool   `tfsdk:"no_accept_data"`
-	Preempt                 types.Bool   `tfsdk:"preempt"`
-	NoPreempt               types.Bool   `tfsdk:"no_preempt"`
 	Identifier              types.Int64  `tfsdk:"identifier"`
 	VirtualAddress          types.List   `tfsdk:"virtual_address"`
+	AcceptData              types.Bool   `tfsdk:"accept_data"`
+	NoAcceptData            types.Bool   `tfsdk:"no_accept_data"`
 	AdvertiseInterval       types.Int64  `tfsdk:"advertise_interval"`
 	AdvertisementsThreshold types.Int64  `tfsdk:"advertisements_threshold"`
 	AuthenticationKey       types.String `tfsdk:"authentication_key"`
 	AuthenticationType      types.String `tfsdk:"authentication_type"`
+	Preempt                 types.Bool   `tfsdk:"preempt"`
+	NoPreempt               types.Bool   `tfsdk:"no_preempt"`
 	Priority                types.Int64  `tfsdk:"priority"`
 	TrackInterface          types.List   `tfsdk:"track_interface"`
 	TrackRoute              types.List   `tfsdk:"track_route"`
@@ -1132,23 +1132,23 @@ type interfaceLogicalBlockFamilyBlockAddressBlockVRRPGroupBlockTrackRoute struct
 
 type interfaceLogicalBlockFamilyInetBlockDhcp struct {
 	SrxOldOptionName                          types.Bool   `tfsdk:"srx_old_option_name"`
-	ClientIdentifierPrefixHostname            types.Bool   `tfsdk:"client_identifier_prefix_hostname"`
-	ClientIdentifierPrefixRoutingInstanceName types.Bool   `tfsdk:"client_identifier_prefix_routing_instance_name"`
-	ForceDiscover                             types.Bool   `tfsdk:"force_discover"`
-	LeaseTimeInfinite                         types.Bool   `tfsdk:"lease_time_infinite"`
-	NoDNSInstall                              types.Bool   `tfsdk:"no_dns_install"`
-	OptionsNoHostname                         types.Bool   `tfsdk:"options_no_hostname"`
-	UpdateServer                              types.Bool   `tfsdk:"update_server"`
 	ClientIdentifierASCII                     types.String `tfsdk:"client_identifier_ascii"`
 	ClientIdentifierHexadecimal               types.String `tfsdk:"client_identifier_hexadecimal"`
+	ClientIdentifierPrefixHostname            types.Bool   `tfsdk:"client_identifier_prefix_hostname"`
+	ClientIdentifierPrefixRoutingInstanceName types.Bool   `tfsdk:"client_identifier_prefix_routing_instance_name"`
 	ClientIdentifierUseInterfaceDescription   types.String `tfsdk:"client_identifier_use_interface_description"`
 	ClientIdentifierUseridASCII               types.String `tfsdk:"client_identifier_userid_ascii"`
 	ClientIdentifierUseridHexadecimal         types.String `tfsdk:"client_identifier_userid_hexadecimal"`
+	ForceDiscover                             types.Bool   `tfsdk:"force_discover"`
 	LeaseTime                                 types.Int64  `tfsdk:"lease_time"`
+	LeaseTimeInfinite                         types.Bool   `tfsdk:"lease_time_infinite"`
 	Metric                                    types.Int64  `tfsdk:"metric"`
+	NoDNSInstall                              types.Bool   `tfsdk:"no_dns_install"`
+	OptionsNoHostname                         types.Bool   `tfsdk:"options_no_hostname"`
 	RetransmissionAttempt                     types.Int64  `tfsdk:"retransmission_attempt"`
 	RetransmissionInterval                    types.Int64  `tfsdk:"retransmission_interval"`
 	ServerAddress                             types.String `tfsdk:"server_address"`
+	UpdateServer                              types.Bool   `tfsdk:"update_server"`
 	VendorID                                  types.String `tfsdk:"vendor_id"`
 }
 
@@ -1158,11 +1158,11 @@ func (block *interfaceLogicalBlockFamilyInetBlockDhcp) hasKnownValue() bool {
 
 type interfaceLogicalBlockFamilyInet6 struct {
 	DadDisable     types.Bool                                         `tfsdk:"dad_disable"`
-	SamplingInput  types.Bool                                         `tfsdk:"sampling_input"`
-	SamplingOutput types.Bool                                         `tfsdk:"sampling_output"`
 	FilterInput    types.String                                       `tfsdk:"filter_input"`
 	FilterOutput   types.String                                       `tfsdk:"filter_output"`
 	Mtu            types.Int64                                        `tfsdk:"mtu"`
+	SamplingInput  types.Bool                                         `tfsdk:"sampling_input"`
+	SamplingOutput types.Bool                                         `tfsdk:"sampling_output"`
 	Address        []interfaceLogicalBlockFamilyInet6BlockAddress     `tfsdk:"address"`
 	DHCPv6Client   *interfaceLogicalBlockFamilyInet6BlockDhcpV6Client `tfsdk:"dhcpv6_client"`
 	RPFCheck       *interfaceLogicalBlockFamilyBlockRPFCheck          `tfsdk:"rpf_check"`
@@ -1170,70 +1170,70 @@ type interfaceLogicalBlockFamilyInet6 struct {
 
 type interfaceLogicalBlockFamilyInet6Config struct {
 	DadDisable     types.Bool                                               `tfsdk:"dad_disable"`
-	SamplingInput  types.Bool                                               `tfsdk:"sampling_input"`
-	SamplingOutput types.Bool                                               `tfsdk:"sampling_output"`
 	FilterInput    types.String                                             `tfsdk:"filter_input"`
 	FilterOutput   types.String                                             `tfsdk:"filter_output"`
 	Mtu            types.Int64                                              `tfsdk:"mtu"`
+	SamplingInput  types.Bool                                               `tfsdk:"sampling_input"`
+	SamplingOutput types.Bool                                               `tfsdk:"sampling_output"`
 	Address        types.List                                               `tfsdk:"address"`
 	DHCPv6Client   *interfaceLogicalBlockFamilyInet6BlockDhcpV6ClientConfig `tfsdk:"dhcpv6_client"`
 	RPFCheck       *interfaceLogicalBlockFamilyBlockRPFCheck                `tfsdk:"rpf_check"`
 }
 
 type interfaceLogicalBlockFamilyInet6BlockAddress struct {
+	CidrIP    types.String                                                 `tfsdk:"cidr_ip"`
 	Preferred types.Bool                                                   `tfsdk:"preferred"`
 	Primary   types.Bool                                                   `tfsdk:"primary"`
-	CidrIP    types.String                                                 `tfsdk:"cidr_ip"`
 	VRRPGroup []interfaceLogicalBlockFamilyInet6BlockAddressBlockVRRPGroup `tfsdk:"vrrp_group"`
 }
 
 type interfaceLogicalBlockFamilyInet6BlockAddressConfig struct {
+	CidrIP    types.String `tfsdk:"cidr_ip"`
 	Preferred types.Bool   `tfsdk:"preferred"`
 	Primary   types.Bool   `tfsdk:"primary"`
-	CidrIP    types.String `tfsdk:"cidr_ip"`
 	VRRPGroup types.List   `tfsdk:"vrrp_group"`
 }
 
 //nolint:lll
 type interfaceLogicalBlockFamilyInet6BlockAddressBlockVRRPGroup struct {
-	AcceptData              types.Bool                                                                 `tfsdk:"accept_data"`
-	NoAcceptData            types.Bool                                                                 `tfsdk:"no_accept_data"`
-	Preempt                 types.Bool                                                                 `tfsdk:"preempt"`
-	NoPreempt               types.Bool                                                                 `tfsdk:"no_preempt"`
 	Identifier              types.Int64                                                                `tfsdk:"identifier"`
 	VirtualAddress          []types.String                                                             `tfsdk:"virtual_address"`
 	VirutalLinkLocalAddress types.String                                                               `tfsdk:"virtual_link_local_address"`
+	AcceptData              types.Bool                                                                 `tfsdk:"accept_data"`
+	NoAcceptData            types.Bool                                                                 `tfsdk:"no_accept_data"`
 	AdvertiseInterval       types.Int64                                                                `tfsdk:"advertise_interval"`
 	AdvertisementsThreshold types.Int64                                                                `tfsdk:"advertisements_threshold"`
+	Preempt                 types.Bool                                                                 `tfsdk:"preempt"`
+	NoPreempt               types.Bool                                                                 `tfsdk:"no_preempt"`
 	Priority                types.Int64                                                                `tfsdk:"priority"`
 	TrackInterface          []interfaceLogicalBlockFamilyBlockAddressBlockVRRPGroupBlockTrackInterface `tfsdk:"track_interface"`
 	TrackRoute              []interfaceLogicalBlockFamilyBlockAddressBlockVRRPGroupBlockTrackRoute     `tfsdk:"track_route"`
 }
 
 type interfaceLogicalBlockFamilyInet6BlockAddressBlockVRRPGroupConfig struct {
-	AcceptData              types.Bool   `tfsdk:"accept_data"`
-	NoAcceptData            types.Bool   `tfsdk:"no_accept_data"`
-	Preempt                 types.Bool   `tfsdk:"preempt"`
-	NoPreempt               types.Bool   `tfsdk:"no_preempt"`
 	Identifier              types.Int64  `tfsdk:"identifier"`
 	VirtualAddress          types.List   `tfsdk:"virtual_address"`
 	VirutalLinkLocalAddress types.String `tfsdk:"virtual_link_local_address"`
+	AcceptData              types.Bool   `tfsdk:"accept_data"`
+	NoAcceptData            types.Bool   `tfsdk:"no_accept_data"`
 	AdvertiseInterval       types.Int64  `tfsdk:"advertise_interval"`
 	AdvertisementsThreshold types.Int64  `tfsdk:"advertisements_threshold"`
+	Preempt                 types.Bool   `tfsdk:"preempt"`
+	NoPreempt               types.Bool   `tfsdk:"no_preempt"`
 	Priority                types.Int64  `tfsdk:"priority"`
 	TrackInterface          types.List   `tfsdk:"track_interface"`
 	TrackRoute              types.List   `tfsdk:"track_route"`
 }
 
 type interfaceLogicalBlockFamilyInet6BlockDhcpV6Client struct {
+	ClientIdentifierDuidType              types.String   `tfsdk:"client_identifier_duid_type"`
+	ClientType                            types.String   `tfsdk:"client_type"`
 	ClientIATypeNA                        types.Bool     `tfsdk:"client_ia_type_na"`
 	ClientIATypePD                        types.Bool     `tfsdk:"client_ia_type_pd"`
 	NoDNSInstall                          types.Bool     `tfsdk:"no_dns_install"`
-	RapidCommit                           types.Bool     `tfsdk:"rapid_commit"`
-	ClientIdentifierDuidType              types.String   `tfsdk:"client_identifier_duid_type"`
-	ClientType                            types.String   `tfsdk:"client_type"`
 	PrefixDelegatingPreferredPrefixLength types.Int64    `tfsdk:"prefix_delegating_preferred_prefix_length"`
 	PrefixDelegatingSubPrefixLength       types.Int64    `tfsdk:"prefix_delegating_sub_prefix_length"`
+	RapidCommit                           types.Bool     `tfsdk:"rapid_commit"`
 	ReqOption                             []types.String `tfsdk:"req_option"`
 	RetransmissionAttempt                 types.Int64    `tfsdk:"retransmission_attempt"`
 	UpdateRouterAdvertisementInterface    []types.String `tfsdk:"update_router_advertisement_interface"`
@@ -1241,14 +1241,14 @@ type interfaceLogicalBlockFamilyInet6BlockDhcpV6Client struct {
 }
 
 type interfaceLogicalBlockFamilyInet6BlockDhcpV6ClientConfig struct {
+	ClientIdentifierDuidType              types.String `tfsdk:"client_identifier_duid_type"`
+	ClientType                            types.String `tfsdk:"client_type"`
 	ClientIATypeNA                        types.Bool   `tfsdk:"client_ia_type_na"`
 	ClientIATypePD                        types.Bool   `tfsdk:"client_ia_type_pd"`
 	NoDNSInstall                          types.Bool   `tfsdk:"no_dns_install"`
-	RapidCommit                           types.Bool   `tfsdk:"rapid_commit"`
-	ClientIdentifierDuidType              types.String `tfsdk:"client_identifier_duid_type"`
-	ClientType                            types.String `tfsdk:"client_type"`
 	PrefixDelegatingPreferredPrefixLength types.Int64  `tfsdk:"prefix_delegating_preferred_prefix_length"`
 	PrefixDelegatingSubPrefixLength       types.Int64  `tfsdk:"prefix_delegating_sub_prefix_length"`
+	RapidCommit                           types.Bool   `tfsdk:"rapid_commit"`
 	ReqOption                             types.Set    `tfsdk:"req_option"`
 	RetransmissionAttempt                 types.Int64  `tfsdk:"retransmission_attempt"`
 	UpdateRouterAdvertisementInterface    types.Set    `tfsdk:"update_router_advertisement_interface"`
@@ -1260,13 +1260,13 @@ func (block *interfaceLogicalBlockFamilyInet6BlockDhcpV6ClientConfig) hasKnownVa
 }
 
 type interfaceLogicalBlockTunnel struct {
-	AllowFragmentation         types.Bool   `tfsdk:"allow_fragmentation"`
-	DoNotFragment              types.Bool   `tfsdk:"do_not_fragment"`
-	PathMtuDiscovery           types.Bool   `tfsdk:"path_mtu_discovery"`
-	NoPathMtuDiscovery         types.Bool   `tfsdk:"no_path_mtu_discovery"`
 	Destination                types.String `tfsdk:"destination"`
 	Source                     types.String `tfsdk:"source"`
+	AllowFragmentation         types.Bool   `tfsdk:"allow_fragmentation"`
+	DoNotFragment              types.Bool   `tfsdk:"do_not_fragment"`
 	FlowLabel                  types.Int64  `tfsdk:"flow_label"`
+	PathMtuDiscovery           types.Bool   `tfsdk:"path_mtu_discovery"`
+	NoPathMtuDiscovery         types.Bool   `tfsdk:"no_path_mtu_discovery"`
 	RoutingInstanceDestination types.String `tfsdk:"routing_instance_destination"`
 	TrafficClass               types.Int64  `tfsdk:"traffic_class"`
 	TTL                        types.Int64  `tfsdk:"ttl"`

--- a/internal/providerfwk/resource_interface_physical.go
+++ b/internal/providerfwk/resource_interface_physical.go
@@ -736,28 +736,28 @@ func (rsc *interfacePhysical) schemaEtherOptsAttributes() map[string]schema.Attr
 }
 
 type interfacePhysicalData struct {
-	NoDisableOnDestroy     types.Bool                             `tfsdk:"no_disable_on_destroy"`
-	Disable                types.Bool                             `tfsdk:"disable"`
-	FlexibleVlanTagging    types.Bool                             `tfsdk:"flexible_vlan_tagging"`
-	GratuitousArpReply     types.Bool                             `tfsdk:"gratuitous_arp_reply"`
-	NoGratuitousArpReply   types.Bool                             `tfsdk:"no_gratuitous_arp_reply"`
-	NoGratuitousArpRequest types.Bool                             `tfsdk:"no_gratuitous_arp_request"`
-	Trunk                  types.Bool                             `tfsdk:"trunk"`
-	TrunkNonELS            types.Bool                             `tfsdk:"trunk_non_els"`
-	VlanTagging            types.Bool                             `tfsdk:"vlan_tagging"`
 	ID                     types.String                           `tfsdk:"id"`
 	Name                   types.String                           `tfsdk:"name"`
+	NoDisableOnDestroy     types.Bool                             `tfsdk:"no_disable_on_destroy"`
 	Description            types.String                           `tfsdk:"description"`
+	Disable                types.Bool                             `tfsdk:"disable"`
 	Encapsulation          types.String                           `tfsdk:"encapsulation"`
+	FlexibleVlanTagging    types.Bool                             `tfsdk:"flexible_vlan_tagging"`
+	GratuitousArpReply     types.Bool                             `tfsdk:"gratuitous_arp_reply"`
 	HoldTimeDown           types.Int64                            `tfsdk:"hold_time_down"`
 	HoldTimeUp             types.Int64                            `tfsdk:"hold_time_up"`
 	LinkMode               types.String                           `tfsdk:"link_mode"`
 	Mtu                    types.Int64                            `tfsdk:"mtu"`
+	NoGratuitousArpReply   types.Bool                             `tfsdk:"no_gratuitous_arp_reply"`
+	NoGratuitousArpRequest types.Bool                             `tfsdk:"no_gratuitous_arp_request"`
 	Speed                  types.String                           `tfsdk:"speed"`
 	StormControl           types.String                           `tfsdk:"storm_control"`
+	Trunk                  types.Bool                             `tfsdk:"trunk"`
+	TrunkNonELS            types.Bool                             `tfsdk:"trunk_non_els"`
 	VlanMembers            []types.String                         `tfsdk:"vlan_members"`
 	VlanNative             types.Int64                            `tfsdk:"vlan_native"`
 	VlanNativeNonELS       types.String                           `tfsdk:"vlan_native_non_els"`
+	VlanTagging            types.Bool                             `tfsdk:"vlan_tagging"`
 	ESI                    *interfacePhysicalBlockESI             `tfsdk:"esi"`
 	EtherOpts              *interfacePhysicalBlockEtherOpts       `tfsdk:"ether_opts"`
 	GigetherOpts           *interfacePhysicalBlockEtherOpts       `tfsdk:"gigether_opts"`
@@ -765,28 +765,28 @@ type interfacePhysicalData struct {
 }
 
 type interfacePhysicalConfig struct {
-	NoDisableOnDestroy     types.Bool                                   `tfsdk:"no_disable_on_destroy"`
-	Disable                types.Bool                                   `tfsdk:"disable"`
-	FlexibleVlanTagging    types.Bool                                   `tfsdk:"flexible_vlan_tagging"`
-	GratuitousArpReply     types.Bool                                   `tfsdk:"gratuitous_arp_reply"`
-	NoGratuitousArpReply   types.Bool                                   `tfsdk:"no_gratuitous_arp_reply"`
-	NoGratuitousArpRequest types.Bool                                   `tfsdk:"no_gratuitous_arp_request"`
-	Trunk                  types.Bool                                   `tfsdk:"trunk"`
-	TrunkNonELS            types.Bool                                   `tfsdk:"trunk_non_els"`
-	VlanTagging            types.Bool                                   `tfsdk:"vlan_tagging"`
 	ID                     types.String                                 `tfsdk:"id"`
 	Name                   types.String                                 `tfsdk:"name"`
+	NoDisableOnDestroy     types.Bool                                   `tfsdk:"no_disable_on_destroy"`
 	Description            types.String                                 `tfsdk:"description"`
+	Disable                types.Bool                                   `tfsdk:"disable"`
 	Encapsulation          types.String                                 `tfsdk:"encapsulation"`
+	FlexibleVlanTagging    types.Bool                                   `tfsdk:"flexible_vlan_tagging"`
+	GratuitousArpReply     types.Bool                                   `tfsdk:"gratuitous_arp_reply"`
 	HoldTimeDown           types.Int64                                  `tfsdk:"hold_time_down"`
 	HoldTimeUp             types.Int64                                  `tfsdk:"hold_time_up"`
 	LinkMode               types.String                                 `tfsdk:"link_mode"`
 	Mtu                    types.Int64                                  `tfsdk:"mtu"`
+	NoGratuitousArpReply   types.Bool                                   `tfsdk:"no_gratuitous_arp_reply"`
+	NoGratuitousArpRequest types.Bool                                   `tfsdk:"no_gratuitous_arp_request"`
 	Speed                  types.String                                 `tfsdk:"speed"`
 	StormControl           types.String                                 `tfsdk:"storm_control"`
+	Trunk                  types.Bool                                   `tfsdk:"trunk"`
+	TrunkNonELS            types.Bool                                   `tfsdk:"trunk_non_els"`
 	VlanMembers            types.List                                   `tfsdk:"vlan_members"`
 	VlanNative             types.Int64                                  `tfsdk:"vlan_native"`
 	VlanNativeNonELS       types.String                                 `tfsdk:"vlan_native_non_els"`
+	VlanTagging            types.Bool                                   `tfsdk:"vlan_tagging"`
 	ESI                    *interfacePhysicalBlockESI                   `tfsdk:"esi"`
 	EtherOpts              *interfacePhysicalBlockEtherOpts             `tfsdk:"ether_opts"`
 	GigetherOpts           *interfacePhysicalBlockEtherOpts             `tfsdk:"gigether_opts"`
@@ -794,21 +794,21 @@ type interfacePhysicalConfig struct {
 }
 
 type interfacePhysicalBlockESI struct {
-	AutoDeriveLACP types.Bool   `tfsdk:"auto_derive_lacp"`
 	Mode           types.String `tfsdk:"mode"`
+	AutoDeriveLACP types.Bool   `tfsdk:"auto_derive_lacp"`
 	DFElectionType types.String `tfsdk:"df_election_type"`
 	Identifier     types.String `tfsdk:"identifier"`
 	SourceBMAC     types.String `tfsdk:"source_bmac"`
 }
 
 type interfacePhysicalBlockEtherOpts struct {
+	Ae8023ad          types.String `tfsdk:"ae_8023ad"`
 	AutoNegotiation   types.Bool   `tfsdk:"auto_negotiation"`
 	NoAutoNegotiation types.Bool   `tfsdk:"no_auto_negotiation"`
 	FlowControl       types.Bool   `tfsdk:"flow_control"`
 	NoFlowControl     types.Bool   `tfsdk:"no_flow_control"`
 	Loopback          types.Bool   `tfsdk:"loopback"`
 	NoLoopback        types.Bool   `tfsdk:"no_loopback"`
-	Ae8023ad          types.String `tfsdk:"ae_8023ad"`
 	RedundantParent   types.String `tfsdk:"redundant_parent"`
 }
 
@@ -825,12 +825,12 @@ type interfacePhysicalBlockParentEtherOpts struct {
 	NoFlowControl        types.Bool                                                      `tfsdk:"no_flow_control"`
 	Loopback             types.Bool                                                      `tfsdk:"loopback"`
 	NoLoopback           types.Bool                                                      `tfsdk:"no_loopback"`
-	SourceFiltering      types.Bool                                                      `tfsdk:"source_filtering"`
 	LinkSpeed            types.String                                                    `tfsdk:"link_speed"`
 	MinimumBandwidth     types.String                                                    `tfsdk:"minimum_bandwidth"`
 	MinimumLinks         types.Int64                                                     `tfsdk:"minimum_links"`
 	RedundancyGroup      types.Int64                                                     `tfsdk:"redundancy_group"`
 	SourceAddressFilter  []types.String                                                  `tfsdk:"source_address_filter"`
+	SourceFiltering      types.Bool                                                      `tfsdk:"source_filtering"`
 	BFDLivenessDetection *interfacePhysicalBlockParentEtherOptsBlockBFDLivenessDetection `tfsdk:"bfd_liveness_detection"`
 	LACP                 *interfacePhysicalBlockParentEtherOptsBlockLACP                 `tfsdk:"lacp"`
 	MCAE                 *interfacePhysicalBlockParentEtherOptsBlockMCAE                 `tfsdk:"mc_ae"`
@@ -841,12 +841,12 @@ type interfacePhysicalBlockParentEtherOptsConfig struct {
 	NoFlowControl        types.Bool                                                      `tfsdk:"no_flow_control"`
 	Loopback             types.Bool                                                      `tfsdk:"loopback"`
 	NoLoopback           types.Bool                                                      `tfsdk:"no_loopback"`
-	SourceFiltering      types.Bool                                                      `tfsdk:"source_filtering"`
 	LinkSpeed            types.String                                                    `tfsdk:"link_speed"`
 	MinimumBandwidth     types.String                                                    `tfsdk:"minimum_bandwidth"`
 	MinimumLinks         types.Int64                                                     `tfsdk:"minimum_links"`
 	RedundancyGroup      types.Int64                                                     `tfsdk:"redundancy_group"`
 	SourceAddressFilter  types.List                                                      `tfsdk:"source_address_filter"`
+	SourceFiltering      types.Bool                                                      `tfsdk:"source_filtering"`
 	BFDLivenessDetection *interfacePhysicalBlockParentEtherOptsBlockBFDLivenessDetection `tfsdk:"bfd_liveness_detection"`
 	LACP                 *interfacePhysicalBlockParentEtherOptsBlockLACP                 `tfsdk:"lacp"`
 	MCAE                 *interfacePhysicalBlockParentEtherOptsBlockMCAE                 `tfsdk:"mc_ae"`
@@ -861,17 +861,17 @@ func (block *interfacePhysicalBlockParentEtherOptsConfig) hasKnownValue() bool {
 }
 
 type interfacePhysicalBlockParentEtherOptsBlockBFDLivenessDetection struct {
-	AuthenticationLooseCheck        types.Bool   `tfsdk:"authentication_loose_check"`
-	NoAdaptation                    types.Bool   `tfsdk:"no_adaptation"`
 	LocalAddress                    types.String `tfsdk:"local_address"`
 	AuthenticationAlgorithm         types.String `tfsdk:"authentication_algorithm"`
 	AuthenticationKeyChain          types.String `tfsdk:"authentication_key_chain"`
+	AuthenticationLooseCheck        types.Bool   `tfsdk:"authentication_loose_check"`
 	DetectionTimeThreshold          types.Int64  `tfsdk:"detection_time_threshold"`
 	HolddownInterval                types.Int64  `tfsdk:"holddown_interval"`
 	MinimumInterval                 types.Int64  `tfsdk:"minimum_interval"`
 	MinimumReceiveInterval          types.Int64  `tfsdk:"minimum_receive_interval"`
 	Multiplier                      types.Int64  `tfsdk:"multiplier"`
 	Neighbor                        types.String `tfsdk:"neighbor"`
+	NoAdaptation                    types.Bool   `tfsdk:"no_adaptation"`
 	TransmitIntervalMinimumInterval types.Int64  `tfsdk:"transmit_interval_minimum_interval"`
 	TransmitIntervalThreshold       types.Int64  `tfsdk:"transmit_interval_threshold"`
 	Version                         types.String `tfsdk:"version"`
@@ -888,11 +888,11 @@ type interfacePhysicalBlockParentEtherOptsBlockLACP struct {
 
 //nolint:lll
 type interfacePhysicalBlockParentEtherOptsBlockMCAE struct {
-	EnhancedConvergence types.Bool                                                             `tfsdk:"enhanced_convergence"`
 	ChassisID           types.Int64                                                            `tfsdk:"chassis_id"`
 	MCAEID              types.Int64                                                            `tfsdk:"mc_ae_id"`
 	Mode                types.String                                                           `tfsdk:"mode"`
 	StatusControl       types.String                                                           `tfsdk:"status_control"`
+	EnhancedConvergence types.Bool                                                             `tfsdk:"enhanced_convergence"`
 	InitDelayTime       types.Int64                                                            `tfsdk:"init_delay_time"`
 	RedundancyGroup     types.Int64                                                            `tfsdk:"redundancy_group"`
 	RevertTime          types.Int64                                                            `tfsdk:"revert_time"`

--- a/internal/providerfwk/resource_multichassis.go
+++ b/internal/providerfwk/resource_multichassis.go
@@ -108,9 +108,9 @@ func (rsc *multichassis) Schema(
 }
 
 type multichassisData struct {
+	ID                                        types.String `tfsdk:"id"`
 	CleanOnDestroy                            types.Bool   `tfsdk:"clean_on_destroy"`
 	MCLagConsistencyCheck                     types.Bool   `tfsdk:"mc_lag_consistency_check"`
-	ID                                        types.String `tfsdk:"id"`
 	MCLagConsistencyCheckComparaisonDelayTime types.Int64  `tfsdk:"mc_lag_consistency_check_comparison_delay_time"`
 }
 

--- a/internal/providerfwk/resource_policyoptions_as_path.go
+++ b/internal/providerfwk/resource_policyoptions_as_path.go
@@ -112,9 +112,9 @@ func (rsc *policyoptionsASPath) Schema(
 }
 
 type policyoptionsASPathData struct {
-	DynamicDB types.Bool   `tfsdk:"dynamic_db"`
 	ID        types.String `tfsdk:"id"`
 	Name      types.String `tfsdk:"name"`
+	DynamicDB types.Bool   `tfsdk:"dynamic_db"`
 	Path      types.String `tfsdk:"path"`
 }
 

--- a/internal/providerfwk/resource_policyoptions_as_path_group.go
+++ b/internal/providerfwk/resource_policyoptions_as_path_group.go
@@ -132,16 +132,16 @@ func (rsc *policyoptionsASPathGroup) Schema(
 }
 
 type policyoptionsASPathGroupData struct {
-	DynamicDB types.Bool                            `tfsdk:"dynamic_db"`
 	ID        types.String                          `tfsdk:"id"`
 	Name      types.String                          `tfsdk:"name"`
+	DynamicDB types.Bool                            `tfsdk:"dynamic_db"`
 	ASPath    []policyoptionsASPathGroupBlockASPAth `tfsdk:"as_path"`
 }
 
 type policyoptionsASPathGroupConfig struct {
-	DynamicDB types.Bool   `tfsdk:"dynamic_db"`
 	ID        types.String `tfsdk:"id"`
 	Name      types.String `tfsdk:"name"`
+	DynamicDB types.Bool   `tfsdk:"dynamic_db"`
 	ASPath    types.List   `tfsdk:"as_path"`
 }
 

--- a/internal/providerfwk/resource_policyoptions_community.go
+++ b/internal/providerfwk/resource_policyoptions_community.go
@@ -125,18 +125,18 @@ func (rsc *policyoptionsCommunity) Schema(
 }
 
 type policyoptionsCommunityData struct {
-	DynamicDB   types.Bool     `tfsdk:"dynamic_db"`
-	InvertMatch types.Bool     `tfsdk:"invert_match"`
 	ID          types.String   `tfsdk:"id"`
 	Name        types.String   `tfsdk:"name"`
+	DynamicDB   types.Bool     `tfsdk:"dynamic_db"`
+	InvertMatch types.Bool     `tfsdk:"invert_match"`
 	Members     []types.String `tfsdk:"members"`
 }
 
 type policyoptionsCommunityConfig struct {
-	DynamicDB   types.Bool   `tfsdk:"dynamic_db"`
-	InvertMatch types.Bool   `tfsdk:"invert_match"`
 	ID          types.String `tfsdk:"id"`
 	Name        types.String `tfsdk:"name"`
+	DynamicDB   types.Bool   `tfsdk:"dynamic_db"`
+	InvertMatch types.Bool   `tfsdk:"invert_match"`
 	Members     types.List   `tfsdk:"members"`
 }
 

--- a/internal/providerfwk/resource_policyoptions_policy_statement.go
+++ b/internal/providerfwk/resource_policyoptions_policy_statement.go
@@ -895,10 +895,10 @@ func (rsc *policyoptionsPolicyStatement) schemaThenBlocks() map[string]schema.Bl
 }
 
 type policyoptionsPolicyStatementData struct {
-	AddItToForwardingTableExport types.Bool                              `tfsdk:"add_it_to_forwarding_table_export"`
-	DynamicDB                    types.Bool                              `tfsdk:"dynamic_db"`
 	ID                           types.String                            `tfsdk:"id"`
 	Name                         types.String                            `tfsdk:"name"`
+	AddItToForwardingTableExport types.Bool                              `tfsdk:"add_it_to_forwarding_table_export"`
+	DynamicDB                    types.Bool                              `tfsdk:"dynamic_db"`
 	From                         *policyoptionsPolicyStatementBlockFrom  `tfsdk:"from"`
 	To                           *policyoptionsPolicyStatementBlockTo    `tfsdk:"to"`
 	Then                         *policyoptionsPolicyStatementBlockThen  `tfsdk:"then"`
@@ -906,10 +906,10 @@ type policyoptionsPolicyStatementData struct {
 }
 
 type policyoptionsPolicyStatementConfig struct {
-	AddItToForwardingTableExport types.Bool                                   `tfsdk:"add_it_to_forwarding_table_export"`
-	DynamicDB                    types.Bool                                   `tfsdk:"dynamic_db"`
 	ID                           types.String                                 `tfsdk:"id"`
 	Name                         types.String                                 `tfsdk:"name"`
+	AddItToForwardingTableExport types.Bool                                   `tfsdk:"add_it_to_forwarding_table_export"`
+	DynamicDB                    types.Bool                                   `tfsdk:"dynamic_db"`
 	From                         *policyoptionsPolicyStatementBlockFromConfig `tfsdk:"from"`
 	To                           *policyoptionsPolicyStatementBlockToConfig   `tfsdk:"to"`
 	Then                         *policyoptionsPolicyStatementBlockThenConfig `tfsdk:"then"`
@@ -940,7 +940,6 @@ func (block *policyoptionsPolicyStatementBlockTermConfig) isEmpty() bool {
 
 type policyoptionsPolicyStatementBlockFrom struct {
 	AggregateContributor types.Bool                                              `tfsdk:"aggregate_contributor"`
-	NextHopTypeMerged    types.Bool                                              `tfsdk:"next_hop_type_merged"`
 	BgpASPath            []types.String                                          `tfsdk:"bgp_as_path"`
 	BgpASPathGroup       []types.String                                          `tfsdk:"bgp_as_path_group"`
 	BgpCommunity         []types.String                                          `tfsdk:"bgp_community"`
@@ -956,6 +955,7 @@ type policyoptionsPolicyStatementBlockFrom struct {
 	Metric               types.Int64                                             `tfsdk:"metric"`
 	Neighbor             []types.String                                          `tfsdk:"neighbor"`
 	NextHop              []types.String                                          `tfsdk:"next_hop"`
+	NextHopTypeMerged    types.Bool                                              `tfsdk:"next_hop_type_merged"`
 	OspfArea             types.String                                            `tfsdk:"ospf_area"`
 	Policy               []types.String                                          `tfsdk:"policy"`
 	Preference           types.Int64                                             `tfsdk:"preference"`
@@ -980,7 +980,6 @@ func (block *policyoptionsPolicyStatementBlockFrom) isEmpty() bool {
 
 type policyoptionsPolicyStatementBlockFromConfig struct {
 	AggregateContributor types.Bool   `tfsdk:"aggregate_contributor"`
-	NextHopTypeMerged    types.Bool   `tfsdk:"next_hop_type_merged"`
 	BgpASPath            types.Set    `tfsdk:"bgp_as_path"`
 	BgpASPathGroup       types.Set    `tfsdk:"bgp_as_path_group"`
 	BgpCommunity         types.Set    `tfsdk:"bgp_community"`
@@ -996,6 +995,7 @@ type policyoptionsPolicyStatementBlockFromConfig struct {
 	Metric               types.Int64  `tfsdk:"metric"`
 	Neighbor             types.Set    `tfsdk:"neighbor"`
 	NextHop              types.Set    `tfsdk:"next_hop"`
+	NextHopTypeMerged    types.Bool   `tfsdk:"next_hop_type_merged"`
 	OspfArea             types.String `tfsdk:"ospf_area"`
 	Policy               types.List   `tfsdk:"policy"`
 	Preference           types.Int64  `tfsdk:"preference"`

--- a/internal/providerfwk/resource_policyoptions_prefix_list.go
+++ b/internal/providerfwk/resource_policyoptions_prefix_list.go
@@ -125,10 +125,10 @@ func (rsc *policyoptionsPrefixList) Schema(
 }
 
 type policyoptionsPrefixListData struct {
-	DynamicDB types.Bool     `tfsdk:"dynamic_db"`
 	ID        types.String   `tfsdk:"id"`
 	Name      types.String   `tfsdk:"name"`
 	ApplyPath types.String   `tfsdk:"apply_path"`
+	DynamicDB types.Bool     `tfsdk:"dynamic_db"`
 	Prefix    []types.String `tfsdk:"prefix"`
 }
 

--- a/internal/providerfwk/resource_routing_instance.go
+++ b/internal/providerfwk/resource_routing_instance.go
@@ -261,11 +261,10 @@ func (rsc *routingInstance) Schema(
 }
 
 type routingInstanceData struct {
-	ConfigureRDVrfOptSingly types.Bool     `tfsdk:"configure_rd_vrfopts_singly"`
-	ConfigureTypeSingly     types.Bool     `tfsdk:"configure_type_singly"`
-	VRFTargetAuto           types.Bool     `tfsdk:"vrf_target_auto"`
 	ID                      types.String   `tfsdk:"id"`
 	Name                    types.String   `tfsdk:"name"`
+	ConfigureRDVrfOptSingly types.Bool     `tfsdk:"configure_rd_vrfopts_singly"`
+	ConfigureTypeSingly     types.Bool     `tfsdk:"configure_type_singly"`
 	Type                    types.String   `tfsdk:"type"`
 	AS                      types.String   `tfsdk:"as"`
 	Description             types.String   `tfsdk:"description"`
@@ -276,6 +275,7 @@ type routingInstanceData struct {
 	VRFExport               []types.String `tfsdk:"vrf_export"`
 	VRFImport               []types.String `tfsdk:"vrf_import"`
 	VRFTarget               types.String   `tfsdk:"vrf_target"`
+	VRFTargetAuto           types.Bool     `tfsdk:"vrf_target_auto"`
 	VRFTargetExport         types.String   `tfsdk:"vrf_target_export"`
 	VRFTargetImport         types.String   `tfsdk:"vrf_target_import"`
 	VTEPSourceInterface     types.String   `tfsdk:"vtep_source_interface"`
@@ -283,11 +283,10 @@ type routingInstanceData struct {
 }
 
 type routingInstanceConfig struct {
-	ConfigureRDVrfOptSingly types.Bool   `tfsdk:"configure_rd_vrfopts_singly"`
-	ConfigureTypeSingly     types.Bool   `tfsdk:"configure_type_singly"`
-	VRFTargetAuto           types.Bool   `tfsdk:"vrf_target_auto"`
 	ID                      types.String `tfsdk:"id"`
 	Name                    types.String `tfsdk:"name"`
+	ConfigureRDVrfOptSingly types.Bool   `tfsdk:"configure_rd_vrfopts_singly"`
+	ConfigureTypeSingly     types.Bool   `tfsdk:"configure_type_singly"`
 	Type                    types.String `tfsdk:"type"`
 	AS                      types.String `tfsdk:"as"`
 	Description             types.String `tfsdk:"description"`
@@ -298,6 +297,7 @@ type routingInstanceConfig struct {
 	VRFExport               types.List   `tfsdk:"vrf_export"`
 	VRFImport               types.List   `tfsdk:"vrf_import"`
 	VRFTarget               types.String `tfsdk:"vrf_target"`
+	VRFTargetAuto           types.Bool   `tfsdk:"vrf_target_auto"`
 	VRFTargetExport         types.String `tfsdk:"vrf_target_export"`
 	VRFTargetImport         types.String `tfsdk:"vrf_target_import"`
 	VTEPSourceInterface     types.String `tfsdk:"vtep_source_interface"`

--- a/internal/providerfwk/resource_security.go
+++ b/internal/providerfwk/resource_security.go
@@ -868,16 +868,16 @@ func (rsc *security) Schema(
 									int64validator.Between(10240, 1073741824),
 								},
 							},
-							"no_world_readable": schema.BoolAttribute{
+							"world_readable": schema.BoolAttribute{
 								Optional:    true,
-								Description: "Don't allow any user to read the log file.",
+								Description: "Allow any user to read the log file.",
 								Validators: []validator.Bool{
 									tfvalidator.BoolTrue(),
 								},
 							},
-							"world_readable": schema.BoolAttribute{
+							"no_world_readable": schema.BoolAttribute{
 								Optional:    true,
-								Description: "Allow any user to read the log file.",
+								Description: "Don't allow any user to read the log file.",
 								Validators: []validator.Bool{
 									tfvalidator.BoolTrue(),
 								},
@@ -1275,8 +1275,8 @@ func (rsc *security) Schema(
 }
 
 type securityData struct {
-	CleanOnDestroy               types.Bool                                 `tfsdk:"clean_on_destroy"`
 	ID                           types.String                               `tfsdk:"id"`
+	CleanOnDestroy               types.Bool                                 `tfsdk:"clean_on_destroy"`
 	Alg                          *securityBlockAlg                          `tfsdk:"alg"`
 	Flow                         *securityBlockFlow                         `tfsdk:"flow"`
 	ForwardingOptions            *securityBlockForwardingOptions            `tfsdk:"forwarding_options"`
@@ -1292,8 +1292,8 @@ type securityData struct {
 }
 
 type securityConfig struct {
-	CleanOnDestroy               types.Bool                                 `tfsdk:"clean_on_destroy"`
 	ID                           types.String                               `tfsdk:"id"`
+	CleanOnDestroy               types.Bool                                 `tfsdk:"clean_on_destroy"`
 	Alg                          *securityBlockAlg                          `tfsdk:"alg"`
 	Flow                         *securityBlockFlow                         `tfsdk:"flow"`
 	ForwardingOptions            *securityBlockForwardingOptions            `tfsdk:"forwarding_options"`
@@ -1338,11 +1338,11 @@ type securityBlockFlow struct {
 	ForceIPReassembly                types.Bool                               `tfsdk:"force_ip_reassembly"`
 	IpsecPerformanceAcceleration     types.Bool                               `tfsdk:"ipsec_performance_acceleration"`
 	McastBufferEnhance               types.Bool                               `tfsdk:"mcast_buffer_enhance"`
-	PreserveIncomingFragmentSize     types.Bool                               `tfsdk:"preserve_incoming_fragment_size"`
-	SyncIcmpSession                  types.Bool                               `tfsdk:"sync_icmp_session"`
 	PendingSessQueueLength           types.String                             `tfsdk:"pending_sess_queue_length"`
+	PreserveIncomingFragmentSize     types.Bool                               `tfsdk:"preserve_incoming_fragment_size"`
 	RouteChangeTimeout               types.Int64                              `tfsdk:"route_change_timeout"`
 	SynFloodProtectionMode           types.String                             `tfsdk:"syn_flood_protection_mode"`
+	SyncIcmpSession                  types.Bool                               `tfsdk:"sync_icmp_session"`
 	AdvancedOptions                  *securityBlockFlowBlockAdvancedOptions   `tfsdk:"advanced_options"`
 	Aging                            *securityBlockFlowBlockAging             `tfsdk:"aging"`
 	EthernetSwitching                *securityBlockFlowBlockEthernetSwitching `tfsdk:"ethernet_switching"`
@@ -1406,13 +1406,13 @@ func (block *securityBlockFlowBlockTCPMss) isEmpty() bool {
 
 type securityBlockFlowBlockTCPSession struct {
 	FinInvalidateSession types.Bool                                          `tfsdk:"fin_invalidate_session"`
+	MaximumWindow        types.String                                        `tfsdk:"maximum_window"`
 	NoSequenceCheck      types.Bool                                          `tfsdk:"no_sequence_check"`
 	NoSynCheck           types.Bool                                          `tfsdk:"no_syn_check"`
 	NoSynCheckInTunnel   types.Bool                                          `tfsdk:"no_syn_check_in_tunnel"`
 	RstInvalidateSession types.Bool                                          `tfsdk:"rst_invalidate_session"`
 	RstSequenceCheck     types.Bool                                          `tfsdk:"rst_sequence_check"`
 	StrictSynCheck       types.Bool                                          `tfsdk:"strict_syn_check"`
-	MaximumWindow        types.String                                        `tfsdk:"maximum_window"`
 	TCPInitialTimeout    types.Int64                                         `tfsdk:"tcp_initial_timeout"`
 	TimeWaitState        *securityBlockFlowBlockTCPSessionBlockTimeWaitState `tfsdk:"time_wait_state"`
 }
@@ -1447,9 +1447,9 @@ func (block *securityBlockForwardingProcess) isEmpty() bool {
 
 type securityBlockIdpSecurityPackage struct {
 	AutomaticEnable           types.Bool   `tfsdk:"automatic_enable"`
-	InstallIgnoreVersionCheck types.Bool   `tfsdk:"install_ignore_version_check"`
 	AutomaticInterval         types.Int64  `tfsdk:"automatic_interval"`
 	AutomaticStartTime        types.String `tfsdk:"automatic_start_time"`
+	InstallIgnoreVersionCheck types.Bool   `tfsdk:"install_ignore_version_check"`
 	ProxyProfile              types.String `tfsdk:"proxy_profile"`
 	SourceAddress             types.String `tfsdk:"source_address"`
 	URL                       types.String `tfsdk:"url"`
@@ -1512,12 +1512,12 @@ func (block *securityBlockIkeTraceoptionsConfig) isEmpty() bool {
 }
 
 type securityBlockIkeTraceoptionsBlockFile struct {
-	NoWorldReadable types.Bool   `tfsdk:"no_world_readable"`
-	WorldReadable   types.Bool   `tfsdk:"world_readable"`
 	Name            types.String `tfsdk:"name"`
 	Files           types.Int64  `tfsdk:"files"`
 	Match           types.String `tfsdk:"match"`
 	Size            types.Int64  `tfsdk:"size"`
+	WorldReadable   types.Bool   `tfsdk:"world_readable"`
+	NoWorldReadable types.Bool   `tfsdk:"no_world_readable"`
 }
 
 func (block *securityBlockIkeTraceoptionsBlockFile) isEmpty() bool {
@@ -1526,16 +1526,16 @@ func (block *securityBlockIkeTraceoptionsBlockFile) isEmpty() bool {
 
 type securityBlockLog struct {
 	Disable           types.Bool                      `tfsdk:"disable"`
-	Report            types.Bool                      `tfsdk:"report"`
-	UtcTimestamp      types.Bool                      `tfsdk:"utc_timestamp"`
 	EventRate         types.Int64                     `tfsdk:"event_rate"`
 	FacilityOverride  types.String                    `tfsdk:"facility_override"`
 	Format            types.String                    `tfsdk:"format"`
 	MaxDatabaseRecord types.Int64                     `tfsdk:"max_database_record"`
 	Mode              types.String                    `tfsdk:"mode"`
 	RateCap           types.Int64                     `tfsdk:"rate_cap"`
+	Report            types.Bool                      `tfsdk:"report"`
 	SourceAddress     types.String                    `tfsdk:"source_address"`
 	SourceInterface   types.String                    `tfsdk:"source_interface"`
+	UtcTimestamp      types.Bool                      `tfsdk:"utc_timestamp"`
 	File              *securityBlockLogBlockFile      `tfsdk:"file"`
 	Transport         *securityBlockLogBlockTransport `tfsdk:"transport"`
 }
@@ -1563,17 +1563,17 @@ type securityBlockLogBlockTransport struct {
 
 type securityBlockNatSource struct {
 	AddressPersistent                  types.Bool  `tfsdk:"address_persistent"`
-	InterfacePortOverloadingOff        types.Bool  `tfsdk:"interface_port_overloading_off"`
-	PortRandomizationDisable           types.Bool  `tfsdk:"port_randomization_disable"`
-	SessionPersistenceScan             types.Bool  `tfsdk:"session_persistence_scan"`
 	InterfacePortOverloadingFactor     types.Int64 `tfsdk:"interface_port_overloading_factor"`
+	InterfacePortOverloadingOff        types.Bool  `tfsdk:"interface_port_overloading_off"`
 	PoolDefaultPortRange               types.Int64 `tfsdk:"pool_default_port_range"`
 	PoolDefaultPortRangeTo             types.Int64 `tfsdk:"pool_default_port_range_to"`
 	PoolDefaultTwinPortRange           types.Int64 `tfsdk:"pool_default_twin_port_range"`
 	PoolDefaultTwinPortRangeTo         types.Int64 `tfsdk:"pool_default_twin_port_range_to"`
 	PoolUtilizationAlarmClearThreshold types.Int64 `tfsdk:"pool_utilization_alarm_clear_threshold"`
 	PoolUtilizationAlarmRaiseThreshold types.Int64 `tfsdk:"pool_utilization_alarm_raise_threshold"`
+	PortRandomizationDisable           types.Bool  `tfsdk:"port_randomization_disable"`
 	SessionDropHoldDown                types.Int64 `tfsdk:"session_drop_hold_down"`
+	SessionPersistenceScan             types.Bool  `tfsdk:"session_persistence_scan"`
 }
 
 func (block *securityBlockNatSource) isEmpty() bool {

--- a/internal/providerfwk/resource_security_global_policy.go
+++ b/internal/providerfwk/resource_security_global_policy.go
@@ -375,39 +375,39 @@ type securityGlobalPolicyConfig struct {
 
 //nolint:lll
 type securityGlobalPolicyBlockPolicy struct {
-	Count                           types.Bool                                               `tfsdk:"count"`
-	LogInit                         types.Bool                                               `tfsdk:"log_init"`
-	LogClose                        types.Bool                                               `tfsdk:"log_close"`
-	MatchDestinationAddressExcluded types.Bool                                               `tfsdk:"match_destination_address_excluded"`
-	MatchSourceAddressExcluded      types.Bool                                               `tfsdk:"match_source_address_excluded"`
 	Name                            types.String                                             `tfsdk:"name"`
-	Then                            types.String                                             `tfsdk:"then"`
-	MatchSourceEndUserProfile       types.String                                             `tfsdk:"match_source_end_user_profile"`
 	MatchSourceAddress              []types.String                                           `tfsdk:"match_source_address"`
 	MatchDestinationAddress         []types.String                                           `tfsdk:"match_destination_address"`
 	MatchFromZone                   []types.String                                           `tfsdk:"match_from_zone"`
 	MatchToZone                     []types.String                                           `tfsdk:"match_to_zone"`
+	Then                            types.String                                             `tfsdk:"then"`
+	Count                           types.Bool                                               `tfsdk:"count"`
+	LogInit                         types.Bool                                               `tfsdk:"log_init"`
+	LogClose                        types.Bool                                               `tfsdk:"log_close"`
 	MatchApplication                []types.String                                           `tfsdk:"match_application"`
+	MatchDestinationAddressExcluded types.Bool                                               `tfsdk:"match_destination_address_excluded"`
 	MatchDynamicApplication         []types.String                                           `tfsdk:"match_dynamic_application"`
+	MatchSourceAddressExcluded      types.Bool                                               `tfsdk:"match_source_address_excluded"`
+	MatchSourceEndUserProfile       types.String                                             `tfsdk:"match_source_end_user_profile"`
 	PermitApplicationServices       *securityPolicyBlockPolicyBlockPermitApplicationServices `tfsdk:"permit_application_services"`
 }
 
 //nolint:lll
 type securityGlobalPolicyBlockPolicyConfig struct {
-	Count                           types.Bool                                               `tfsdk:"count"`
-	LogInit                         types.Bool                                               `tfsdk:"log_init"`
-	LogClose                        types.Bool                                               `tfsdk:"log_close"`
-	MatchDestinationAddressExcluded types.Bool                                               `tfsdk:"match_destination_address_excluded"`
-	MatchSourceAddressExcluded      types.Bool                                               `tfsdk:"match_source_address_excluded"`
 	Name                            types.String                                             `tfsdk:"name"`
-	Then                            types.String                                             `tfsdk:"then"`
-	MatchSourceEndUserProfile       types.String                                             `tfsdk:"match_source_end_user_profile"`
 	MatchSourceAddress              types.Set                                                `tfsdk:"match_source_address"`
 	MatchDestinationAddress         types.Set                                                `tfsdk:"match_destination_address"`
 	MatchFromZone                   types.Set                                                `tfsdk:"match_from_zone"`
 	MatchToZone                     types.Set                                                `tfsdk:"match_to_zone"`
+	Then                            types.String                                             `tfsdk:"then"`
+	Count                           types.Bool                                               `tfsdk:"count"`
+	LogInit                         types.Bool                                               `tfsdk:"log_init"`
+	LogClose                        types.Bool                                               `tfsdk:"log_close"`
 	MatchApplication                types.Set                                                `tfsdk:"match_application"`
+	MatchDestinationAddressExcluded types.Bool                                               `tfsdk:"match_destination_address_excluded"`
 	MatchDynamicApplication         types.Set                                                `tfsdk:"match_dynamic_application"`
+	MatchSourceAddressExcluded      types.Bool                                               `tfsdk:"match_source_address_excluded"`
+	MatchSourceEndUserProfile       types.String                                             `tfsdk:"match_source_end_user_profile"`
 	PermitApplicationServices       *securityPolicyBlockPolicyBlockPermitApplicationServices `tfsdk:"permit_application_services"`
 }
 

--- a/internal/providerfwk/resource_security_ike_gateway.go
+++ b/internal/providerfwk/resource_security_ike_gateway.go
@@ -374,14 +374,14 @@ func (rsc *securityIkeGateway) Schema(
 }
 
 type securityIkeGatewayData struct {
-	GeneralIkeID      types.Bool                                `tfsdk:"general_ike_id"`
-	NoNatTraversal    types.Bool                                `tfsdk:"no_nat_traversal"`
 	ID                types.String                              `tfsdk:"id"`
 	Name              types.String                              `tfsdk:"name"`
 	ExternalInterface types.String                              `tfsdk:"external_interface"`
 	Policy            types.String                              `tfsdk:"policy"`
 	Address           []types.String                            `tfsdk:"address"`
+	GeneralIkeID      types.Bool                                `tfsdk:"general_ike_id"`
 	LocalAddress      types.String                              `tfsdk:"local_address"`
+	NoNatTraversal    types.Bool                                `tfsdk:"no_nat_traversal"`
 	Version           types.String                              `tfsdk:"version"`
 	Aaa               *securityIkeGatewayBlockAaa               `tfsdk:"aaa"`
 	DeadPeerDetection *securityIkeGatewayBlockDeadPeerDetection `tfsdk:"dead_peer_detection"`
@@ -391,14 +391,14 @@ type securityIkeGatewayData struct {
 }
 
 type securityIkeGatewayConfig struct {
-	GeneralIkeID      types.Bool                                `tfsdk:"general_ike_id"`
-	NoNatTraversal    types.Bool                                `tfsdk:"no_nat_traversal"`
 	ID                types.String                              `tfsdk:"id"`
 	Name              types.String                              `tfsdk:"name"`
 	ExternalInterface types.String                              `tfsdk:"external_interface"`
 	Policy            types.String                              `tfsdk:"policy"`
 	Address           types.List                                `tfsdk:"address"`
+	GeneralIkeID      types.Bool                                `tfsdk:"general_ike_id"`
 	LocalAddress      types.String                              `tfsdk:"local_address"`
+	NoNatTraversal    types.Bool                                `tfsdk:"no_nat_traversal"`
 	Version           types.String                              `tfsdk:"version"`
 	Aaa               *securityIkeGatewayBlockAaa               `tfsdk:"aaa"`
 	DeadPeerDetection *securityIkeGatewayBlockDeadPeerDetection `tfsdk:"dead_peer_detection"`

--- a/internal/providerfwk/resource_security_ipsec_vpn.go
+++ b/internal/providerfwk/resource_security_ipsec_vpn.go
@@ -377,10 +377,10 @@ func (rsc *securityIpsecVpn) Schema(
 }
 
 type securityIpsecVpnData struct {
-	CopyOuterDscp          types.Bool                             `tfsdk:"copy_outer_dscp"`
 	ID                     types.String                           `tfsdk:"id"`
 	Name                   types.String                           `tfsdk:"name"`
 	BindInterface          types.String                           `tfsdk:"bind_interface"`
+	CopyOuterDscp          types.Bool                             `tfsdk:"copy_outer_dscp"`
 	DfBit                  types.String                           `tfsdk:"df_bit"`
 	EstablishTunnels       types.String                           `tfsdk:"establish_tunnels"`
 	Ike                    *securityIpsecVpnBlockIke              `tfsdk:"ike"`
@@ -392,10 +392,10 @@ type securityIpsecVpnData struct {
 }
 
 type securityIpsecVpnConfig struct {
-	CopyOuterDscp          types.Bool                           `tfsdk:"copy_outer_dscp"`
 	ID                     types.String                         `tfsdk:"id"`
 	Name                   types.String                         `tfsdk:"name"`
 	BindInterface          types.String                         `tfsdk:"bind_interface"`
+	CopyOuterDscp          types.Bool                           `tfsdk:"copy_outer_dscp"`
 	DfBit                  types.String                         `tfsdk:"df_bit"`
 	EstablishTunnels       types.String                         `tfsdk:"establish_tunnels"`
 	Ike                    *securityIpsecVpnBlockIke            `tfsdk:"ike"`
@@ -446,10 +446,10 @@ type securityIpsecVpnBlockUDPEncapsulate struct {
 }
 
 type securityIpsecVpnBlockVpnMonitor struct {
-	Optimized           types.Bool   `tfsdk:"optimized"`
-	SourceInterfaceAuto types.Bool   `tfsdk:"source_interface_auto"`
 	DestinationIP       types.String `tfsdk:"destination_ip"`
+	Optimized           types.Bool   `tfsdk:"optimized"`
 	SourceInterface     types.String `tfsdk:"source_interface"`
+	SourceInterfaceAuto types.Bool   `tfsdk:"source_interface_auto"`
 }
 
 func (block *securityIpsecVpnBlockVpnMonitor) hasKnownValue() bool {

--- a/internal/providerfwk/resource_security_nat_static.go
+++ b/internal/providerfwk/resource_security_nat_static.go
@@ -287,18 +287,18 @@ func (rsc *securityNatStatic) Schema(
 }
 
 type securityNatStaticData struct {
-	ConfigureRulesSingly types.Bool                   `tfsdk:"configure_rules_singly"`
 	ID                   types.String                 `tfsdk:"id"`
 	Name                 types.String                 `tfsdk:"name"`
+	ConfigureRulesSingly types.Bool                   `tfsdk:"configure_rules_singly"`
 	Description          types.String                 `tfsdk:"description"`
 	From                 *securityNatStaticBlockFrom  `tfsdk:"from"`
 	Rule                 []securityNatStaticBlockRule `tfsdk:"rule"`
 }
 
 type securityNatStaticConfig struct {
-	ConfigureRulesSingly types.Bool                        `tfsdk:"configure_rules_singly"`
 	ID                   types.String                      `tfsdk:"id"`
 	Name                 types.String                      `tfsdk:"name"`
+	ConfigureRulesSingly types.Bool                        `tfsdk:"configure_rules_singly"`
 	Description          types.String                      `tfsdk:"description"`
 	From                 *securityNatStaticBlockFromConfig `tfsdk:"from"`
 	Rule                 types.List                        `tfsdk:"rule"`

--- a/internal/providerfwk/resource_security_policy.go
+++ b/internal/providerfwk/resource_security_policy.go
@@ -386,58 +386,58 @@ type securityPolicyConfig struct {
 
 //nolint:lll
 type securityPolicyBlockPolicy struct {
+	Name                            types.String                                             `tfsdk:"name"`
+	MatchSourceAddress              []types.String                                           `tfsdk:"match_source_address"`
+	MatchDestinationAddress         []types.String                                           `tfsdk:"match_destination_address"`
+	Then                            types.String                                             `tfsdk:"then"`
 	Count                           types.Bool                                               `tfsdk:"count"`
 	LogInit                         types.Bool                                               `tfsdk:"log_init"`
 	LogClose                        types.Bool                                               `tfsdk:"log_close"`
+	MatchApplication                []types.String                                           `tfsdk:"match_application"`
 	MatchDestinationAddressExcluded types.Bool                                               `tfsdk:"match_destination_address_excluded"`
+	MatchDynamicApplication         []types.String                                           `tfsdk:"match_dynamic_application"`
 	MatchSourceAddressExcluded      types.Bool                                               `tfsdk:"match_source_address_excluded"`
-	Name                            types.String                                             `tfsdk:"name"`
-	Then                            types.String                                             `tfsdk:"then"`
 	MatchSourceEndUserProfile       types.String                                             `tfsdk:"match_source_end_user_profile"`
 	PermitTunnelIpsecVpn            types.String                                             `tfsdk:"permit_tunnel_ipsec_vpn"`
-	MatchSourceAddress              []types.String                                           `tfsdk:"match_source_address"`
-	MatchDestinationAddress         []types.String                                           `tfsdk:"match_destination_address"`
-	MatchApplication                []types.String                                           `tfsdk:"match_application"`
-	MatchDynamicApplication         []types.String                                           `tfsdk:"match_dynamic_application"`
 	PermitApplicationServices       *securityPolicyBlockPolicyBlockPermitApplicationServices `tfsdk:"permit_application_services"`
 }
 
 //nolint:lll
 type securityPolicyBlockPolicyConfig struct {
+	Name                            types.String                                             `tfsdk:"name"`
+	MatchSourceAddress              types.Set                                                `tfsdk:"match_source_address"`
+	MatchDestinationAddress         types.Set                                                `tfsdk:"match_destination_address"`
+	Then                            types.String                                             `tfsdk:"then"`
 	Count                           types.Bool                                               `tfsdk:"count"`
 	LogInit                         types.Bool                                               `tfsdk:"log_init"`
 	LogClose                        types.Bool                                               `tfsdk:"log_close"`
+	MatchApplication                types.Set                                                `tfsdk:"match_application"`
 	MatchDestinationAddressExcluded types.Bool                                               `tfsdk:"match_destination_address_excluded"`
+	MatchDynamicApplication         types.Set                                                `tfsdk:"match_dynamic_application"`
 	MatchSourceAddressExcluded      types.Bool                                               `tfsdk:"match_source_address_excluded"`
-	Name                            types.String                                             `tfsdk:"name"`
-	Then                            types.String                                             `tfsdk:"then"`
 	MatchSourceEndUserProfile       types.String                                             `tfsdk:"match_source_end_user_profile"`
 	PermitTunnelIpsecVpn            types.String                                             `tfsdk:"permit_tunnel_ipsec_vpn"`
-	MatchSourceAddress              types.Set                                                `tfsdk:"match_source_address"`
-	MatchDestinationAddress         types.Set                                                `tfsdk:"match_destination_address"`
-	MatchApplication                types.Set                                                `tfsdk:"match_application"`
-	MatchDynamicApplication         types.Set                                                `tfsdk:"match_dynamic_application"`
 	PermitApplicationServices       *securityPolicyBlockPolicyBlockPermitApplicationServices `tfsdk:"permit_application_services"`
 }
 
 type securityPolicyBlockPolicyBlockPermitApplicationServices struct {
-	Idp                              types.Bool   `tfsdk:"idp"`
-	RedirectWx                       types.Bool   `tfsdk:"redirect_wx"`
-	ReverseRedirectWx                types.Bool   `tfsdk:"reverse_redirect_wx"`
 	AdvancedAntiMalwarePolicy        types.String `tfsdk:"advanced_anti_malware_policy"`
 	ApplicationFirewallRuleSet       types.String `tfsdk:"application_firewall_rule_set"`
 	ApplicationTrafficControlRuleSet types.String `tfsdk:"application_traffic_control_rule_set"`
 	GprsGtpProfile                   types.String `tfsdk:"gprs_gtp_profile"`
 	GprsSctpProfile                  types.String `tfsdk:"gprs_sctp_profile"`
+	Idp                              types.Bool   `tfsdk:"idp"`
 	IdpPolicy                        types.String `tfsdk:"idp_policy"`
+	RedirectWx                       types.Bool   `tfsdk:"redirect_wx"`
+	ReverseRedirectWx                types.Bool   `tfsdk:"reverse_redirect_wx"`
 	SecurityIntelligencePolicy       types.String `tfsdk:"security_intelligence_policy"`
+	UtmPolicy                        types.String `tfsdk:"utm_policy"`
 	SSLProxy                         *struct {
 		ProfileName types.String `tfsdk:"profile_name"`
 	} `tfsdk:"ssl_proxy"`
 	UacPolicy *struct {
 		CaptivePortal types.String `tfsdk:"captive_portal"`
 	} `tfsdk:"uac_policy"`
-	UtmPolicy types.String `tfsdk:"utm_policy"`
 }
 
 func (block *securityPolicyBlockPolicyBlockPermitApplicationServices) isEmpty() bool {
@@ -1043,6 +1043,8 @@ func (block *securityPolicyBlockPolicyBlockPermitApplicationServices) read(
 		block.ReverseRedirectWx = types.BoolValue(true)
 	case balt.CutPrefixInString(&itemTrim, "security-intelligence-policy "):
 		block.SecurityIntelligencePolicy = types.StringValue(strings.Trim(itemTrim, "\""))
+	case balt.CutPrefixInString(&itemTrim, "utm-policy "):
+		block.UtmPolicy = types.StringValue(strings.Trim(itemTrim, "\""))
 	case balt.CutPrefixInString(&itemTrim, "ssl-proxy"):
 		if balt.CutPrefixInString(&itemTrim, " profile-name ") {
 			block.SSLProxy = &struct {
@@ -1067,8 +1069,6 @@ func (block *securityPolicyBlockPolicyBlockPermitApplicationServices) read(
 				CaptivePortal types.String `tfsdk:"captive_portal"`
 			}{}
 		}
-	case balt.CutPrefixInString(&itemTrim, "utm-policy "):
-		block.UtmPolicy = types.StringValue(strings.Trim(itemTrim, "\""))
 	}
 }
 

--- a/internal/providerfwk/resource_security_zone.go
+++ b/internal/providerfwk/resource_security_zone.go
@@ -376,18 +376,18 @@ func (rsc *securityZone) Schema(
 }
 
 type securityZoneData struct {
-	AddressBookConfigureSingly       types.Bool                             `tfsdk:"address_book_configure_singly"`
-	ApplicationTracking              types.Bool                             `tfsdk:"application_tracking"`
-	ReverseReroute                   types.Bool                             `tfsdk:"reverse_reroute"`
-	SourceIdentityLog                types.Bool                             `tfsdk:"source_identity_log"`
-	TCPRst                           types.Bool                             `tfsdk:"tcp_rst"`
 	ID                               types.String                           `tfsdk:"id"`
 	Name                             types.String                           `tfsdk:"name"`
+	AddressBookConfigureSingly       types.Bool                             `tfsdk:"address_book_configure_singly"`
 	AdvancePolicyBasedRoutingProfile types.String                           `tfsdk:"advance_policy_based_routing_profile"`
+	ApplicationTracking              types.Bool                             `tfsdk:"application_tracking"`
 	Description                      types.String                           `tfsdk:"description"`
-	Screen                           types.String                           `tfsdk:"screen"`
 	InboundProtocols                 []types.String                         `tfsdk:"inbound_protocols"`
 	InboundServices                  []types.String                         `tfsdk:"inbound_services"`
+	ReverseReroute                   types.Bool                             `tfsdk:"reverse_reroute"`
+	Screen                           types.String                           `tfsdk:"screen"`
+	SourceIdentityLog                types.Bool                             `tfsdk:"source_identity_log"`
+	TCPRst                           types.Bool                             `tfsdk:"tcp_rst"`
 	AddressBook                      []securityZoneBlockAddressBook         `tfsdk:"address_book"`
 	AddressBookDNS                   []securityZoneBlockAddressBookDNS      `tfsdk:"address_book_dns"`
 	AddressBookRange                 []securityZoneBlockAddressBookRange    `tfsdk:"address_book_range"`
@@ -397,18 +397,18 @@ type securityZoneData struct {
 }
 
 type securityZoneConfig struct {
-	AddressBookConfigureSingly       types.Bool   `tfsdk:"address_book_configure_singly"`
-	ApplicationTracking              types.Bool   `tfsdk:"application_tracking"`
-	ReverseReroute                   types.Bool   `tfsdk:"reverse_reroute"`
-	SourceIdentityLog                types.Bool   `tfsdk:"source_identity_log"`
-	TCPRst                           types.Bool   `tfsdk:"tcp_rst"`
 	ID                               types.String `tfsdk:"id"`
 	Name                             types.String `tfsdk:"name"`
+	AddressBookConfigureSingly       types.Bool   `tfsdk:"address_book_configure_singly"`
 	AdvancePolicyBasedRoutingProfile types.String `tfsdk:"advance_policy_based_routing_profile"`
+	ApplicationTracking              types.Bool   `tfsdk:"application_tracking"`
 	Description                      types.String `tfsdk:"description"`
-	Screen                           types.String `tfsdk:"screen"`
 	InboundProtocols                 types.Set    `tfsdk:"inbound_protocols"`
 	InboundServices                  types.Set    `tfsdk:"inbound_services"`
+	ReverseReroute                   types.Bool   `tfsdk:"reverse_reroute"`
+	Screen                           types.String `tfsdk:"screen"`
+	SourceIdentityLog                types.Bool   `tfsdk:"source_identity_log"`
+	TCPRst                           types.Bool   `tfsdk:"tcp_rst"`
 	AddressBook                      types.Set    `tfsdk:"address_book"`
 	AddressBookDNS                   types.Set    `tfsdk:"address_book_dns"`
 	AddressBookRange                 types.Set    `tfsdk:"address_book_range"`

--- a/internal/providerfwk/resource_services_flowmonitoring_v9_template.go
+++ b/internal/providerfwk/resource_services_flowmonitoring_v9_template.go
@@ -271,47 +271,47 @@ func (rsc *servicesFlowMonitoringV9Template) Schema(
 }
 
 type servicesFlowMonitoringV9TemplateData struct {
-	FlowKeyFlowDirection      types.Bool                                        `tfsdk:"flow_key_flow_direction"`
-	FlowKeyOutputInterface    types.Bool                                        `tfsdk:"flow_key_output_interface"`
-	FlowKeyVlanID             types.Bool                                        `tfsdk:"flow_key_vlan_id"`
-	NexthopLearningEnable     types.Bool                                        `tfsdk:"nexthop_learning_enable"`
-	NexthopLearningDisable    types.Bool                                        `tfsdk:"nexthop_learning_disable"`
-	TunnelObservationIPv4     types.Bool                                        `tfsdk:"tunnel_observation_ipv4"`
-	TunnelObservationIPv6     types.Bool                                        `tfsdk:"tunnel_observation_ipv6"`
 	ID                        types.String                                      `tfsdk:"id"`
 	Name                      types.String                                      `tfsdk:"name"`
 	Type                      types.String                                      `tfsdk:"type"`
 	FlowActiveTimeout         types.Int64                                       `tfsdk:"flow_active_timeout"`
 	FlowInactiveTimeout       types.Int64                                       `tfsdk:"flow_inactive_timeout"`
+	FlowKeyFlowDirection      types.Bool                                        `tfsdk:"flow_key_flow_direction"`
+	FlowKeyOutputInterface    types.Bool                                        `tfsdk:"flow_key_output_interface"`
+	FlowKeyVlanID             types.Bool                                        `tfsdk:"flow_key_vlan_id"`
 	IPTemplateExportExtension []types.String                                    `tfsdk:"ip_template_export_extension"`
 	MPLSTemplateLabelPosition []types.Int64                                     `tfsdk:"mpls_template_label_position"`
+	NexthopLearningEnable     types.Bool                                        `tfsdk:"nexthop_learning_enable"`
+	NexthopLearningDisable    types.Bool                                        `tfsdk:"nexthop_learning_disable"`
 	OptionTemplateID          types.Int64                                       `tfsdk:"option_template_id"`
 	SourceID                  types.Int64                                       `tfsdk:"source_id"`
 	TemplateID                types.Int64                                       `tfsdk:"template_id"`
 	OptionRefreshRate         *servicesFlowMonitoringV9TemplateBlockRefreshRate `tfsdk:"option_refresh_rate"`
 	TemplateRefreshRate       *servicesFlowMonitoringV9TemplateBlockRefreshRate `tfsdk:"template_refresh_rate"`
+	TunnelObservationIPv4     types.Bool                                        `tfsdk:"tunnel_observation_ipv4"`
+	TunnelObservationIPv6     types.Bool                                        `tfsdk:"tunnel_observation_ipv6"`
 }
 
 type servicesFlowMonitoringV9TemplateConfig struct {
-	FlowKeyFlowDirection      types.Bool                                        `tfsdk:"flow_key_flow_direction"`
-	FlowKeyOutputInterface    types.Bool                                        `tfsdk:"flow_key_output_interface"`
-	FlowKeyVlanID             types.Bool                                        `tfsdk:"flow_key_vlan_id"`
-	NexthopLearningEnable     types.Bool                                        `tfsdk:"nexthop_learning_enable"`
-	NexthopLearningDisable    types.Bool                                        `tfsdk:"nexthop_learning_disable"`
-	TunnelObservationIPv4     types.Bool                                        `tfsdk:"tunnel_observation_ipv4"`
-	TunnelObservationIPv6     types.Bool                                        `tfsdk:"tunnel_observation_ipv6"`
 	ID                        types.String                                      `tfsdk:"id"`
 	Name                      types.String                                      `tfsdk:"name"`
 	Type                      types.String                                      `tfsdk:"type"`
 	FlowActiveTimeout         types.Int64                                       `tfsdk:"flow_active_timeout"`
 	FlowInactiveTimeout       types.Int64                                       `tfsdk:"flow_inactive_timeout"`
+	FlowKeyFlowDirection      types.Bool                                        `tfsdk:"flow_key_flow_direction"`
+	FlowKeyOutputInterface    types.Bool                                        `tfsdk:"flow_key_output_interface"`
+	FlowKeyVlanID             types.Bool                                        `tfsdk:"flow_key_vlan_id"`
 	IPTemplateExportExtension types.Set                                         `tfsdk:"ip_template_export_extension"`
 	MPLSTemplateLabelPosition types.List                                        `tfsdk:"mpls_template_label_position"`
+	NexthopLearningEnable     types.Bool                                        `tfsdk:"nexthop_learning_enable"`
+	NexthopLearningDisable    types.Bool                                        `tfsdk:"nexthop_learning_disable"`
 	OptionTemplateID          types.Int64                                       `tfsdk:"option_template_id"`
 	SourceID                  types.Int64                                       `tfsdk:"source_id"`
 	TemplateID                types.Int64                                       `tfsdk:"template_id"`
 	OptionRefreshRate         *servicesFlowMonitoringV9TemplateBlockRefreshRate `tfsdk:"option_refresh_rate"`
 	TemplateRefreshRate       *servicesFlowMonitoringV9TemplateBlockRefreshRate `tfsdk:"template_refresh_rate"`
+	TunnelObservationIPv4     types.Bool                                        `tfsdk:"tunnel_observation_ipv4"`
+	TunnelObservationIPv6     types.Bool                                        `tfsdk:"tunnel_observation_ipv6"`
 }
 
 type servicesFlowMonitoringV9TemplateBlockRefreshRate struct {

--- a/internal/providerfwk/resource_services_flowmonitoring_vipfix_template.go
+++ b/internal/providerfwk/resource_services_flowmonitoring_vipfix_template.go
@@ -267,47 +267,47 @@ func (rsc *servicesFlowMonitoringVIPFixTemplate) Schema(
 }
 
 type servicesFlowMonitoringVIPFixTemplateData struct {
-	FlowKeyFlowDirection      types.Bool                                            `tfsdk:"flow_key_flow_direction"`
-	FlowKeyOutputInterface    types.Bool                                            `tfsdk:"flow_key_output_interface"`
-	FlowKeyVlanID             types.Bool                                            `tfsdk:"flow_key_vlan_id"`
-	NexthopLearningEnable     types.Bool                                            `tfsdk:"nexthop_learning_enable"`
-	NexthopLearningDisable    types.Bool                                            `tfsdk:"nexthop_learning_disable"`
-	TunnelObservationIPv4     types.Bool                                            `tfsdk:"tunnel_observation_ipv4"`
-	TunnelObservationIPv6     types.Bool                                            `tfsdk:"tunnel_observation_ipv6"`
 	ID                        types.String                                          `tfsdk:"id"`
 	Name                      types.String                                          `tfsdk:"name"`
 	Type                      types.String                                          `tfsdk:"type"`
 	FlowActiveTimeout         types.Int64                                           `tfsdk:"flow_active_timeout"`
 	FlowInactiveTimeout       types.Int64                                           `tfsdk:"flow_inactive_timeout"`
+	FlowKeyFlowDirection      types.Bool                                            `tfsdk:"flow_key_flow_direction"`
+	FlowKeyOutputInterface    types.Bool                                            `tfsdk:"flow_key_output_interface"`
+	FlowKeyVlanID             types.Bool                                            `tfsdk:"flow_key_vlan_id"`
 	IPTemplateExportExtension []types.String                                        `tfsdk:"ip_template_export_extension"`
 	MPLSTemplateLabelPosition []types.Int64                                         `tfsdk:"mpls_template_label_position"`
+	NexthopLearningEnable     types.Bool                                            `tfsdk:"nexthop_learning_enable"`
+	NexthopLearningDisable    types.Bool                                            `tfsdk:"nexthop_learning_disable"`
 	ObservationDomainID       types.Int64                                           `tfsdk:"observation_domain_id"`
 	OptionTemplateID          types.Int64                                           `tfsdk:"option_template_id"`
 	TemplateID                types.Int64                                           `tfsdk:"template_id"`
 	OptionRefreshRate         *servicesFlowMonitoringVIPFixTemplateBlockRefreshRate `tfsdk:"option_refresh_rate"`
 	TemplateRefreshRate       *servicesFlowMonitoringVIPFixTemplateBlockRefreshRate `tfsdk:"template_refresh_rate"`
+	TunnelObservationIPv4     types.Bool                                            `tfsdk:"tunnel_observation_ipv4"`
+	TunnelObservationIPv6     types.Bool                                            `tfsdk:"tunnel_observation_ipv6"`
 }
 
 type servicesFlowMonitoringVIPFixTemplateConfig struct {
-	FlowKeyFlowDirection      types.Bool                                            `tfsdk:"flow_key_flow_direction"`
-	FlowKeyOutputInterface    types.Bool                                            `tfsdk:"flow_key_output_interface"`
-	FlowKeyVlanID             types.Bool                                            `tfsdk:"flow_key_vlan_id"`
-	NexthopLearningEnable     types.Bool                                            `tfsdk:"nexthop_learning_enable"`
-	NexthopLearningDisable    types.Bool                                            `tfsdk:"nexthop_learning_disable"`
-	TunnelObservationIPv4     types.Bool                                            `tfsdk:"tunnel_observation_ipv4"`
-	TunnelObservationIPv6     types.Bool                                            `tfsdk:"tunnel_observation_ipv6"`
 	ID                        types.String                                          `tfsdk:"id"`
 	Name                      types.String                                          `tfsdk:"name"`
 	Type                      types.String                                          `tfsdk:"type"`
 	FlowActiveTimeout         types.Int64                                           `tfsdk:"flow_active_timeout"`
 	FlowInactiveTimeout       types.Int64                                           `tfsdk:"flow_inactive_timeout"`
+	FlowKeyFlowDirection      types.Bool                                            `tfsdk:"flow_key_flow_direction"`
+	FlowKeyOutputInterface    types.Bool                                            `tfsdk:"flow_key_output_interface"`
+	FlowKeyVlanID             types.Bool                                            `tfsdk:"flow_key_vlan_id"`
 	IPTemplateExportExtension types.Set                                             `tfsdk:"ip_template_export_extension"`
 	MPLSTemplateLabelPosition types.List                                            `tfsdk:"mpls_template_label_position"`
+	NexthopLearningEnable     types.Bool                                            `tfsdk:"nexthop_learning_enable"`
+	NexthopLearningDisable    types.Bool                                            `tfsdk:"nexthop_learning_disable"`
 	ObservationDomainID       types.Int64                                           `tfsdk:"observation_domain_id"`
 	OptionTemplateID          types.Int64                                           `tfsdk:"option_template_id"`
 	TemplateID                types.Int64                                           `tfsdk:"template_id"`
 	OptionRefreshRate         *servicesFlowMonitoringVIPFixTemplateBlockRefreshRate `tfsdk:"option_refresh_rate"`
 	TemplateRefreshRate       *servicesFlowMonitoringVIPFixTemplateBlockRefreshRate `tfsdk:"template_refresh_rate"`
+	TunnelObservationIPv4     types.Bool                                            `tfsdk:"tunnel_observation_ipv4"`
+	TunnelObservationIPv6     types.Bool                                            `tfsdk:"tunnel_observation_ipv6"`
 }
 
 type servicesFlowMonitoringVIPFixTemplateBlockRefreshRate struct {

--- a/internal/providerfwk/resource_snmp.go
+++ b/internal/providerfwk/resource_snmp.go
@@ -272,46 +272,46 @@ func (rsc *snmp) Schema(
 }
 
 type snmpData struct {
+	ID                          types.String            `tfsdk:"id"`
 	CleanOnDestroy              types.Bool              `tfsdk:"clean_on_destroy"`
 	ARP                         types.Bool              `tfsdk:"arp"`
 	ARPHostNameResolution       types.Bool              `tfsdk:"arp_host_name_resolution"`
-	FilterDuplicates            types.Bool              `tfsdk:"filter_duplicates"`
-	FilterInternalInterfaces    types.Bool              `tfsdk:"filter_internal_interfaces"`
-	IfCountWithFilterInterfaces types.Bool              `tfsdk:"if_count_with_filter_interfaces"`
-	RoutingInstanceAccess       types.Bool              `tfsdk:"routing_instance_access"`
-	ID                          types.String            `tfsdk:"id"`
 	Contact                     types.String            `tfsdk:"contact"`
 	Description                 types.String            `tfsdk:"description"`
 	EngineID                    types.String            `tfsdk:"engine_id"`
+	FilterDuplicates            types.Bool              `tfsdk:"filter_duplicates"`
 	FilterInterfaces            []types.String          `tfsdk:"filter_interfaces"`
+	FilterInternalInterfaces    types.Bool              `tfsdk:"filter_internal_interfaces"`
+	IfCountWithFilterInterfaces types.Bool              `tfsdk:"if_count_with_filter_interfaces"`
 	Interface                   []types.String          `tfsdk:"interface"`
 	Location                    types.String            `tfsdk:"location"`
+	RoutingInstanceAccess       types.Bool              `tfsdk:"routing_instance_access"`
 	RoutingInstanceAccessList   []types.String          `tfsdk:"routing_instance_access_list"`
 	HealthMonitor               *snmpBlockHealthMonitor `tfsdk:"health_monitor"`
 }
 
 type snmpConfig struct {
+	ID                          types.String            `tfsdk:"id"`
 	CleanOnDestroy              types.Bool              `tfsdk:"clean_on_destroy"`
 	ARP                         types.Bool              `tfsdk:"arp"`
 	ARPHostNameResolution       types.Bool              `tfsdk:"arp_host_name_resolution"`
-	FilterDuplicates            types.Bool              `tfsdk:"filter_duplicates"`
-	FilterInternalInterfaces    types.Bool              `tfsdk:"filter_internal_interfaces"`
-	IfCountWithFilterInterfaces types.Bool              `tfsdk:"if_count_with_filter_interfaces"`
-	RoutingInstanceAccess       types.Bool              `tfsdk:"routing_instance_access"`
-	ID                          types.String            `tfsdk:"id"`
 	Contact                     types.String            `tfsdk:"contact"`
 	Description                 types.String            `tfsdk:"description"`
 	EngineID                    types.String            `tfsdk:"engine_id"`
+	FilterDuplicates            types.Bool              `tfsdk:"filter_duplicates"`
 	FilterInterfaces            types.Set               `tfsdk:"filter_interfaces"`
+	FilterInternalInterfaces    types.Bool              `tfsdk:"filter_internal_interfaces"`
+	IfCountWithFilterInterfaces types.Bool              `tfsdk:"if_count_with_filter_interfaces"`
 	Interface                   types.Set               `tfsdk:"interface"`
 	Location                    types.String            `tfsdk:"location"`
+	RoutingInstanceAccess       types.Bool              `tfsdk:"routing_instance_access"`
 	RoutingInstanceAccessList   types.Set               `tfsdk:"routing_instance_access_list"`
 	HealthMonitor               *snmpBlockHealthMonitor `tfsdk:"health_monitor"`
 }
 
 type snmpBlockHealthMonitor struct {
-	Idp                 types.Bool  `tfsdk:"idp"`
 	FallingThreshold    types.Int64 `tfsdk:"falling_threshold"`
+	Idp                 types.Bool  `tfsdk:"idp"`
 	IdpFallingThreshold types.Int64 `tfsdk:"idp_falling_threshold"`
 	IdpInterval         types.Int64 `tfsdk:"idp_interval"`
 	IdpRisingThreshold  types.Int64 `tfsdk:"idp_rising_threshold"`

--- a/internal/providerfwk/resource_snmp_community.go
+++ b/internal/providerfwk/resource_snmp_community.go
@@ -180,10 +180,10 @@ func (rsc *snmpCommunity) Schema(
 }
 
 type snmpCommunityData struct {
-	AuthorizationReadOnly  types.Bool                          `tfsdk:"authorization_read_only"`
-	AuthorizationReadWrite types.Bool                          `tfsdk:"authorization_read_write"`
 	ID                     types.String                        `tfsdk:"id"`
 	Name                   types.String                        `tfsdk:"name"`
+	AuthorizationReadOnly  types.Bool                          `tfsdk:"authorization_read_only"`
+	AuthorizationReadWrite types.Bool                          `tfsdk:"authorization_read_write"`
 	ClientListName         types.String                        `tfsdk:"client_list_name"`
 	Clients                []types.String                      `tfsdk:"clients"`
 	View                   types.String                        `tfsdk:"view"`
@@ -191,10 +191,10 @@ type snmpCommunityData struct {
 }
 
 type snmpCommunityConfig struct {
-	AuthorizationReadOnly  types.Bool   `tfsdk:"authorization_read_only"`
-	AuthorizationReadWrite types.Bool   `tfsdk:"authorization_read_write"`
 	ID                     types.String `tfsdk:"id"`
 	Name                   types.String `tfsdk:"name"`
+	AuthorizationReadOnly  types.Bool   `tfsdk:"authorization_read_only"`
+	AuthorizationReadWrite types.Bool   `tfsdk:"authorization_read_write"`
 	ClientListName         types.String `tfsdk:"client_list_name"`
 	Clients                types.Set    `tfsdk:"clients"`
 	View                   types.String `tfsdk:"view"`

--- a/internal/providerfwk/resource_static_route.go
+++ b/internal/providerfwk/resource_static_route.go
@@ -338,12 +338,24 @@ func (rsc *staticRoute) Schema(
 }
 
 type staticRouteData struct {
+	ID                       types.String                       `tfsdk:"id"`
+	Destination              types.String                       `tfsdk:"destination"`
+	RoutingInstance          types.String                       `tfsdk:"routing_instance"`
 	Active                   types.Bool                         `tfsdk:"active"`
+	ASPathAggregatorAddress  types.String                       `tfsdk:"as_path_aggregator_address"`
+	ASPathAggregatorASNumber types.String                       `tfsdk:"as_path_aggregator_as_number"`
 	ASPathAtomicAggregate    types.Bool                         `tfsdk:"as_path_atomic_aggregate"`
+	ASPathOrigin             types.String                       `tfsdk:"as_path_origin"`
+	ASPathPath               types.String                       `tfsdk:"as_path_path"`
+	Community                []types.String                     `tfsdk:"community"`
 	Discard                  types.Bool                         `tfsdk:"discard"`
 	Install                  types.Bool                         `tfsdk:"install"`
 	NoInstall                types.Bool                         `tfsdk:"no_install"`
+	Metric                   types.Int64                        `tfsdk:"metric"`
+	NextHop                  []types.String                     `tfsdk:"next_hop"`
+	NextTable                types.String                       `tfsdk:"next_table"`
 	Passive                  types.Bool                         `tfsdk:"passive"`
+	Preference               types.Int64                        `tfsdk:"preference"`
 	Readvertise              types.Bool                         `tfsdk:"readvertise"`
 	NoReadvertise            types.Bool                         `tfsdk:"no_readvertise"`
 	Receive                  types.Bool                         `tfsdk:"receive"`
@@ -352,28 +364,28 @@ type staticRouteData struct {
 	NoResolve                types.Bool                         `tfsdk:"no_resolve"`
 	Retain                   types.Bool                         `tfsdk:"retain"`
 	NoRetain                 types.Bool                         `tfsdk:"no_retain"`
-	ID                       types.String                       `tfsdk:"id"`
-	Destination              types.String                       `tfsdk:"destination"`
-	RoutingInstance          types.String                       `tfsdk:"routing_instance"`
-	ASPathAggregatorAddress  types.String                       `tfsdk:"as_path_aggregator_address"`
-	ASPathAggregatorASNumber types.String                       `tfsdk:"as_path_aggregator_as_number"`
-	ASPathOrigin             types.String                       `tfsdk:"as_path_origin"`
-	ASPathPath               types.String                       `tfsdk:"as_path_path"`
-	Community                []types.String                     `tfsdk:"community"`
-	Metric                   types.Int64                        `tfsdk:"metric"`
-	NextHop                  []types.String                     `tfsdk:"next_hop"`
-	NextTable                types.String                       `tfsdk:"next_table"`
-	Preference               types.Int64                        `tfsdk:"preference"`
 	QualifiedNextHop         []staticRouteBlockQualifiedNextHop `tfsdk:"qualified_next_hop"`
 }
 
 type staticRouteConfig struct {
+	ID                       types.String `tfsdk:"id"`
+	Destination              types.String `tfsdk:"destination"`
+	RoutingInstance          types.String `tfsdk:"routing_instance"`
 	Active                   types.Bool   `tfsdk:"active"`
+	ASPathAggregatorAddress  types.String `tfsdk:"as_path_aggregator_address"`
+	ASPathAggregatorASNumber types.String `tfsdk:"as_path_aggregator_as_number"`
 	ASPathAtomicAggregate    types.Bool   `tfsdk:"as_path_atomic_aggregate"`
+	ASPathOrigin             types.String `tfsdk:"as_path_origin"`
+	ASPathPath               types.String `tfsdk:"as_path_path"`
+	Community                types.List   `tfsdk:"community"`
 	Discard                  types.Bool   `tfsdk:"discard"`
 	Install                  types.Bool   `tfsdk:"install"`
 	NoInstall                types.Bool   `tfsdk:"no_install"`
+	Metric                   types.Int64  `tfsdk:"metric"`
+	NextHop                  types.List   `tfsdk:"next_hop"`
+	NextTable                types.String `tfsdk:"next_table"`
 	Passive                  types.Bool   `tfsdk:"passive"`
+	Preference               types.Int64  `tfsdk:"preference"`
 	Readvertise              types.Bool   `tfsdk:"readvertise"`
 	NoReadvertise            types.Bool   `tfsdk:"no_readvertise"`
 	Receive                  types.Bool   `tfsdk:"receive"`
@@ -382,18 +394,6 @@ type staticRouteConfig struct {
 	NoResolve                types.Bool   `tfsdk:"no_resolve"`
 	Retain                   types.Bool   `tfsdk:"retain"`
 	NoRetain                 types.Bool   `tfsdk:"no_retain"`
-	ID                       types.String `tfsdk:"id"`
-	Destination              types.String `tfsdk:"destination"`
-	RoutingInstance          types.String `tfsdk:"routing_instance"`
-	ASPathAggregatorAddress  types.String `tfsdk:"as_path_aggregator_address"`
-	ASPathAggregatorASNumber types.String `tfsdk:"as_path_aggregator_as_number"`
-	ASPathOrigin             types.String `tfsdk:"as_path_origin"`
-	ASPathPath               types.String `tfsdk:"as_path_path"`
-	Community                types.List   `tfsdk:"community"`
-	Metric                   types.Int64  `tfsdk:"metric"`
-	NextHop                  types.List   `tfsdk:"next_hop"`
-	NextTable                types.String `tfsdk:"next_table"`
-	Preference               types.Int64  `tfsdk:"preference"`
 	QualifiedNextHop         types.List   `tfsdk:"qualified_next_hop"`
 }
 

--- a/internal/providerfwk/resource_switch_options.go
+++ b/internal/providerfwk/resource_switch_options.go
@@ -108,8 +108,8 @@ func (rsc *switchOptions) Schema(
 }
 
 type switchOptionsData struct {
-	CleanOnDestroy      types.Bool   `tfsdk:"clean_on_destroy"`
 	ID                  types.String `tfsdk:"id"`
+	CleanOnDestroy      types.Bool   `tfsdk:"clean_on_destroy"`
 	ServiceID           types.Int64  `tfsdk:"service_id"`
 	VTEPSourceInterface types.String `tfsdk:"vtep_source_interface"`
 }

--- a/internal/providerfwk/resource_system.go
+++ b/internal/providerfwk/resource_system.go
@@ -1776,32 +1776,32 @@ func (rsc *system) Schema(
 
 //nolint:lll
 type systemData struct {
-	AutoSnapshot                            types.Bool                        `tfsdk:"auto_snapshot"`
-	DefaultAddressSelection                 types.Bool                        `tfsdk:"default_address_selection"`
-	NoMulticastEcho                         types.Bool                        `tfsdk:"no_multicast_echo"`
-	NoPingRecordRoute                       types.Bool                        `tfsdk:"no_ping_record_route"`
-	NoPingTimestamp                         types.Bool                        `tfsdk:"no_ping_time_stamp"`
-	NoRedirects                             types.Bool                        `tfsdk:"no_redirects"`
-	NoRedirectsIPv6                         types.Bool                        `tfsdk:"no_redirects_ipv6"`
-	RadiusOptionsEnhancedAccounting         types.Bool                        `tfsdk:"radius_options_enhanced_accounting"`
-	RadiusOptionsPasswordProtocolMschapv2   types.Bool                        `tfsdk:"radius_options_password_protocol_mschapv2"`
-	TacplusOptionsEnhancedAccounting        types.Bool                        `tfsdk:"tacplus_options_enhanced_accounting"`
-	TacplusOptionsExcludeCmdAttribute       types.Bool                        `tfsdk:"tacplus_options_exclude_cmd_attribute"`
-	TacplusOptionsNoCmdAttributeValue       types.Bool                        `tfsdk:"tacplus_options_no_cmd_attribute_value"`
-	TacplusOptionsStrictAuthorization       types.Bool                        `tfsdk:"tacplus_options_strict_authorization"`
-	TacplusOptionsNoStrictAuthorization     types.Bool                        `tfsdk:"tacplus_options_no_strict_authorization"`
-	TacplusOptionsTimestampAndTimezone      types.Bool                        `tfsdk:"tacplus_options_timestamp_and_timezone"`
 	ID                                      types.String                      `tfsdk:"id"`
 	AuthenticationOrder                     []types.String                    `tfsdk:"authentication_order"`
+	AutoSnapshot                            types.Bool                        `tfsdk:"auto_snapshot"`
+	DefaultAddressSelection                 types.Bool                        `tfsdk:"default_address_selection"`
 	DomainName                              types.String                      `tfsdk:"domain_name"`
 	HostName                                types.String                      `tfsdk:"host_name"`
 	MaxConfigurationRollbacks               types.Int64                       `tfsdk:"max_configuration_rollbacks"`
 	MaxConfigurationsOnFlash                types.Int64                       `tfsdk:"max_configurations_on_flash"`
 	NameServer                              []types.String                    `tfsdk:"name_server"`
+	NoMulticastEcho                         types.Bool                        `tfsdk:"no_multicast_echo"`
+	NoPingRecordRoute                       types.Bool                        `tfsdk:"no_ping_record_route"`
+	NoPingTimestamp                         types.Bool                        `tfsdk:"no_ping_time_stamp"`
+	NoRedirects                             types.Bool                        `tfsdk:"no_redirects"`
+	NoRedirectsIPv6                         types.Bool                        `tfsdk:"no_redirects_ipv6"`
 	RadiusOptionsAttributesNasID            types.String                      `tfsdk:"radius_options_attributes_nas_id"`
 	RadiusOptionsAttributesNasIpaddress     types.String                      `tfsdk:"radius_options_attributes_nas_ipaddress"`
+	RadiusOptionsEnhancedAccounting         types.Bool                        `tfsdk:"radius_options_enhanced_accounting"`
+	RadiusOptionsPasswordProtocolMschapv2   types.Bool                        `tfsdk:"radius_options_password_protocol_mschapv2"`
 	TacplusOptionsAuthorizationTimeInterval types.Int64                       `tfsdk:"tacplus_options_authorization_time_interval"`
+	TacplusOptionsEnhancedAccounting        types.Bool                        `tfsdk:"tacplus_options_enhanced_accounting"`
+	TacplusOptionsExcludeCmdAttribute       types.Bool                        `tfsdk:"tacplus_options_exclude_cmd_attribute"`
+	TacplusOptionsNoCmdAttributeValue       types.Bool                        `tfsdk:"tacplus_options_no_cmd_attribute_value"`
 	TacplusOptionsServiceName               types.String                      `tfsdk:"tacplus_options_service_name"`
+	TacplusOptionsStrictAuthorization       types.Bool                        `tfsdk:"tacplus_options_strict_authorization"`
+	TacplusOptionsNoStrictAuthorization     types.Bool                        `tfsdk:"tacplus_options_no_strict_authorization"`
+	TacplusOptionsTimestampAndTimezone      types.Bool                        `tfsdk:"tacplus_options_timestamp_and_timezone"`
 	TimeZone                                types.String                      `tfsdk:"time_zone"`
 	TracingDestOverrideSyslogHost           types.String                      `tfsdk:"tracing_dest_override_syslog_host"`
 	Accounting                              *systemBlockAccounting            `tfsdk:"accounting"`
@@ -1819,32 +1819,32 @@ type systemData struct {
 
 //nolint:lll
 type systemConfig struct {
-	AutoSnapshot                            types.Bool                              `tfsdk:"auto_snapshot"`
-	DefaultAddressSelection                 types.Bool                              `tfsdk:"default_address_selection"`
-	NoMulticastEcho                         types.Bool                              `tfsdk:"no_multicast_echo"`
-	NoPingRecordRoute                       types.Bool                              `tfsdk:"no_ping_record_route"`
-	NoPingTimestamp                         types.Bool                              `tfsdk:"no_ping_time_stamp"`
-	NoRedirects                             types.Bool                              `tfsdk:"no_redirects"`
-	NoRedirectsIPv6                         types.Bool                              `tfsdk:"no_redirects_ipv6"`
-	RadiusOptionsEnhancedAccounting         types.Bool                              `tfsdk:"radius_options_enhanced_accounting"`
-	RadiusOptionsPasswordProtocolMschapv2   types.Bool                              `tfsdk:"radius_options_password_protocol_mschapv2"`
-	TacplusOptionsEnhancedAccounting        types.Bool                              `tfsdk:"tacplus_options_enhanced_accounting"`
-	TacplusOptionsExcludeCmdAttribute       types.Bool                              `tfsdk:"tacplus_options_exclude_cmd_attribute"`
-	TacplusOptionsNoCmdAttributeValue       types.Bool                              `tfsdk:"tacplus_options_no_cmd_attribute_value"`
-	TacplusOptionsStrictAuthorization       types.Bool                              `tfsdk:"tacplus_options_strict_authorization"`
-	TacplusOptionsNoStrictAuthorization     types.Bool                              `tfsdk:"tacplus_options_no_strict_authorization"`
-	TacplusOptionsTimestampAndTimezone      types.Bool                              `tfsdk:"tacplus_options_timestamp_and_timezone"`
 	ID                                      types.String                            `tfsdk:"id"`
 	AuthenticationOrder                     types.List                              `tfsdk:"authentication_order"`
+	AutoSnapshot                            types.Bool                              `tfsdk:"auto_snapshot"`
+	DefaultAddressSelection                 types.Bool                              `tfsdk:"default_address_selection"`
 	DomainName                              types.String                            `tfsdk:"domain_name"`
 	HostName                                types.String                            `tfsdk:"host_name"`
 	MaxConfigurationRollbacks               types.Int64                             `tfsdk:"max_configuration_rollbacks"`
 	MaxConfigurationsOnFlash                types.Int64                             `tfsdk:"max_configurations_on_flash"`
 	NameServer                              types.List                              `tfsdk:"name_server"`
+	NoMulticastEcho                         types.Bool                              `tfsdk:"no_multicast_echo"`
+	NoPingRecordRoute                       types.Bool                              `tfsdk:"no_ping_record_route"`
+	NoPingTimestamp                         types.Bool                              `tfsdk:"no_ping_time_stamp"`
+	NoRedirects                             types.Bool                              `tfsdk:"no_redirects"`
+	NoRedirectsIPv6                         types.Bool                              `tfsdk:"no_redirects_ipv6"`
 	RadiusOptionsAttributesNasID            types.String                            `tfsdk:"radius_options_attributes_nas_id"`
 	RadiusOptionsAttributesNasIpaddress     types.String                            `tfsdk:"radius_options_attributes_nas_ipaddress"`
+	RadiusOptionsEnhancedAccounting         types.Bool                              `tfsdk:"radius_options_enhanced_accounting"`
+	RadiusOptionsPasswordProtocolMschapv2   types.Bool                              `tfsdk:"radius_options_password_protocol_mschapv2"`
 	TacplusOptionsAuthorizationTimeInterval types.Int64                             `tfsdk:"tacplus_options_authorization_time_interval"`
+	TacplusOptionsEnhancedAccounting        types.Bool                              `tfsdk:"tacplus_options_enhanced_accounting"`
+	TacplusOptionsExcludeCmdAttribute       types.Bool                              `tfsdk:"tacplus_options_exclude_cmd_attribute"`
+	TacplusOptionsNoCmdAttributeValue       types.Bool                              `tfsdk:"tacplus_options_no_cmd_attribute_value"`
 	TacplusOptionsServiceName               types.String                            `tfsdk:"tacplus_options_service_name"`
+	TacplusOptionsStrictAuthorization       types.Bool                              `tfsdk:"tacplus_options_strict_authorization"`
+	TacplusOptionsNoStrictAuthorization     types.Bool                              `tfsdk:"tacplus_options_no_strict_authorization"`
+	TacplusOptionsTimestampAndTimezone      types.Bool                              `tfsdk:"tacplus_options_timestamp_and_timezone"`
 	TimeZone                                types.String                            `tfsdk:"time_zone"`
 	TracingDestOverrideSyslogHost           types.String                            `tfsdk:"tracing_dest_override_syslog_host"`
 	Accounting                              *systemBlockAccountingConfig            `tfsdk:"accounting"`
@@ -1861,19 +1861,19 @@ type systemConfig struct {
 }
 
 type systemBlockAccounting struct {
+	Events                   []types.String                                       `tfsdk:"events"`
 	DestinationRadius        types.Bool                                           `tfsdk:"destination_radius"`
 	DestinationTacplus       types.Bool                                           `tfsdk:"destination_tacplus"`
 	EnhancedAvsMax           types.Int64                                          `tfsdk:"enhanced_avs_max"`
-	Events                   []types.String                                       `tfsdk:"events"`
 	DestinationRadiusServer  []systemBlockAccountingBlockDestinationRadiusServer  `tfsdk:"destination_radius_server"`
 	DestinationTacplusServer []systemBlockAccountingBlockDestinationTacplusServer `tfsdk:"destination_tacplus_server"`
 }
 
 type systemBlockAccountingConfig struct {
+	Events                   types.Set   `tfsdk:"events"`
 	DestinationRadius        types.Bool  `tfsdk:"destination_radius"`
 	DestinationTacplus       types.Bool  `tfsdk:"destination_tacplus"`
 	EnhancedAvsMax           types.Int64 `tfsdk:"enhanced_avs_max"`
-	Events                   types.Set   `tfsdk:"events"`
 	DestinationRadiusServer  types.List  `tfsdk:"destination_radius_server"`
 	DestinationTacplusServer types.List  `tfsdk:"destination_tacplus_server"`
 }
@@ -1896,24 +1896,24 @@ type systemBlockAccountingBlockDestinationRadiusServer struct {
 }
 
 type systemBlockAccountingBlockDestinationTacplusServer struct {
-	SingleConnection types.Bool   `tfsdk:"single_connection"`
 	Address          types.String `tfsdk:"address"`
 	Port             types.Int64  `tfsdk:"port"`
 	RoutingInstance  types.String `tfsdk:"routing_instance"`
 	Secret           types.String `tfsdk:"secret"`
+	SingleConnection types.Bool   `tfsdk:"single_connection"`
 	SourceAddress    types.String `tfsdk:"source_address"`
 	Timeout          types.Int64  `tfsdk:"timeout"`
 }
 
 type systemBlockArchivalConfiguration struct {
-	TransferOnCommit types.Bool                                         `tfsdk:"transfer_on_commit"`
 	TransferInterval types.Int64                                        `tfsdk:"transfer_interval"`
+	TransferOnCommit types.Bool                                         `tfsdk:"transfer_on_commit"`
 	ArchiveSite      []systemBlockArchivalConfigurationBlockArchiveSite `tfsdk:"archive_site"`
 }
 
 type systemBlockArchivalConfigurationConfig struct {
-	TransferOnCommit types.Bool  `tfsdk:"transfer_on_commit"`
 	TransferInterval types.Int64 `tfsdk:"transfer_interval"`
+	TransferOnCommit types.Bool  `tfsdk:"transfer_on_commit"`
 	ArchiveSite      types.List  `tfsdk:"archive_site"`
 }
 
@@ -1938,21 +1938,21 @@ type systemBlockInternetOptions struct {
 	NoGrePathMtuDiscovery               types.Bool                                    `tfsdk:"no_gre_path_mtu_discovery"`
 	IpipPathMtuDiscovery                types.Bool                                    `tfsdk:"ipip_path_mtu_discovery"`
 	NoIpipPathMtuDiscovery              types.Bool                                    `tfsdk:"no_ipip_path_mtu_discovery"`
+	IPv6DuplicateAddrDetectionTransmits types.Int64                                   `tfsdk:"ipv6_duplicate_addr_detection_transmits"`
 	IPv6PathMtuDiscovery                types.Bool                                    `tfsdk:"ipv6_path_mtu_discovery"`
 	NoIPv6PathMtuDiscovery              types.Bool                                    `tfsdk:"no_ipv6_path_mtu_discovery"`
+	IPv6PathMtuDiscoveryTimeout         types.Int64                                   `tfsdk:"ipv6_path_mtu_discovery_timeout"`
 	IPv6RejectZeroHopLimit              types.Bool                                    `tfsdk:"ipv6_reject_zero_hop_limit"`
 	NoIPv6RejectZeroHopLimit            types.Bool                                    `tfsdk:"no_ipv6_reject_zero_hop_limit"`
+	NoTCPReset                          types.String                                  `tfsdk:"no_tcp_reset"`
 	NoTCPRFC1323                        types.Bool                                    `tfsdk:"no_tcp_rfc1323"`
 	NoTCPRFC1323Paws                    types.Bool                                    `tfsdk:"no_tcp_rfc1323_paws"`
 	PathMtuDiscovery                    types.Bool                                    `tfsdk:"path_mtu_discovery"`
 	NoPathMtuDiscovery                  types.Bool                                    `tfsdk:"no_path_mtu_discovery"`
+	SourcePortUpperLimit                types.Int64                                   `tfsdk:"source_port_upper_limit"`
 	SourceQuench                        types.Bool                                    `tfsdk:"source_quench"`
 	NoSourceQuench                      types.Bool                                    `tfsdk:"no_source_quench"`
 	TCPDropSynfinSet                    types.Bool                                    `tfsdk:"tcp_drop_synfin_set"`
-	IPv6DuplicateAddrDetectionTransmits types.Int64                                   `tfsdk:"ipv6_duplicate_addr_detection_transmits"`
-	IPv6PathMtuDiscoveryTimeout         types.Int64                                   `tfsdk:"ipv6_path_mtu_discovery_timeout"`
-	NoTCPReset                          types.String                                  `tfsdk:"no_tcp_reset"`
-	SourcePortUpperLimit                types.Int64                                   `tfsdk:"source_port_upper_limit"`
 	TCPMss                              types.Int64                                   `tfsdk:"tcp_mss"`
 	IcmpV4RateLimit                     *systemBlockInternetOptionsBlockIcmpRateLimit `tfsdk:"icmpv4_rate_limit"`
 	IcmpV6RateLimit                     *systemBlockInternetOptionsBlockIcmpRateLimit `tfsdk:"icmpv6_rate_limit"`
@@ -2046,10 +2046,10 @@ func (block *systemBlockLoginBlockRetryOptions) isEmpty() bool {
 }
 
 type systemBlockNtp struct {
-	BroadcastClient        types.Bool   `tfsdk:"broadcast_client"`
-	MulticastClient        types.Bool   `tfsdk:"multicast_client"`
 	BootServer             types.String `tfsdk:"boot_server"`
+	BroadcastClient        types.Bool   `tfsdk:"broadcast_client"`
 	IntervalRange          types.Int64  `tfsdk:"interval_range"`
+	MulticastClient        types.Bool   `tfsdk:"multicast_client"`
 	MulticastClientAddress types.String `tfsdk:"multicast_client_address"`
 	ThresholdAction        types.String `tfsdk:"threshold_action"`
 	ThresholdValue         types.Int64  `tfsdk:"threshold_value"`
@@ -2060,15 +2060,15 @@ func (block *systemBlockNtp) isEmpty() bool {
 }
 
 type systemBlockPorts struct {
+	AuxiliaryAuthenticationOrder []types.String `tfsdk:"auxiliary_authentication_order"`
 	AuxiliaryDisable             types.Bool     `tfsdk:"auxiliary_disable"`
 	AuxiliaryInsecure            types.Bool     `tfsdk:"auxiliary_insecure"`
 	AuxiliaryLogoutOnDisconnect  types.Bool     `tfsdk:"auxiliary_logout_on_disconnect"`
+	AuxiliaryType                types.String   `tfsdk:"auxiliary_type"`
+	ConsoleAuthenticationOrder   []types.String `tfsdk:"console_authentication_order"`
 	ConsoleDisable               types.Bool     `tfsdk:"console_disable"`
 	ConsoleInsecure              types.Bool     `tfsdk:"console_insecure"`
 	ConsoleLogoutOnDisconnect    types.Bool     `tfsdk:"console_logout_on_disconnect"`
-	AuxiliaryAuthenticationOrder []types.String `tfsdk:"auxiliary_authentication_order"`
-	AuxiliaryType                types.String   `tfsdk:"auxiliary_type"`
-	ConsoleAuthenticationOrder   []types.String `tfsdk:"console_authentication_order"`
 	ConsoleType                  types.String   `tfsdk:"console_type"`
 }
 
@@ -2077,15 +2077,15 @@ func (block *systemBlockPorts) isEmpty() bool {
 }
 
 type systemBlockPortsConfig struct {
+	AuxiliaryAuthenticationOrder types.List   `tfsdk:"auxiliary_authentication_order"`
 	AuxiliaryDisable             types.Bool   `tfsdk:"auxiliary_disable"`
 	AuxiliaryInsecure            types.Bool   `tfsdk:"auxiliary_insecure"`
 	AuxiliaryLogoutOnDisconnect  types.Bool   `tfsdk:"auxiliary_logout_on_disconnect"`
+	AuxiliaryType                types.String `tfsdk:"auxiliary_type"`
+	ConsoleAuthenticationOrder   types.List   `tfsdk:"console_authentication_order"`
 	ConsoleDisable               types.Bool   `tfsdk:"console_disable"`
 	ConsoleInsecure              types.Bool   `tfsdk:"console_insecure"`
 	ConsoleLogoutOnDisconnect    types.Bool   `tfsdk:"console_logout_on_disconnect"`
-	AuxiliaryAuthenticationOrder types.List   `tfsdk:"auxiliary_authentication_order"`
-	AuxiliaryType                types.String `tfsdk:"auxiliary_type"`
-	ConsoleAuthenticationOrder   types.List   `tfsdk:"console_authentication_order"`
 	ConsoleType                  types.String `tfsdk:"console_type"`
 }
 
@@ -2135,15 +2135,15 @@ func (block *systemBlockServicesBlockNetconfSSH) isEmpty() bool {
 }
 
 type systemBlockServicesBlockNetconfTraceoptions struct {
-	FileWorldReadable   types.Bool     `tfsdk:"file_world_readable"`
-	FileNoWorldReadable types.Bool     `tfsdk:"file_no_world_readable"`
-	NoRemoteTrace       types.Bool     `tfsdk:"no_remote_trace"`
-	OnDemand            types.Bool     `tfsdk:"on_demand"`
 	FileName            types.String   `tfsdk:"file_name"`
 	FileFiles           types.Int64    `tfsdk:"file_files"`
 	FileMatch           types.String   `tfsdk:"file_match"`
 	FileSize            types.Int64    `tfsdk:"file_size"`
+	FileWorldReadable   types.Bool     `tfsdk:"file_world_readable"`
+	FileNoWorldReadable types.Bool     `tfsdk:"file_no_world_readable"`
 	Flag                []types.String `tfsdk:"flag"`
+	NoRemoteTrace       types.Bool     `tfsdk:"no_remote_trace"`
+	OnDemand            types.Bool     `tfsdk:"on_demand"`
 }
 
 func (block *systemBlockServicesBlockNetconfTraceoptions) isEmpty() bool {
@@ -2151,15 +2151,15 @@ func (block *systemBlockServicesBlockNetconfTraceoptions) isEmpty() bool {
 }
 
 type systemBlockServicesBlockNetconfTraceoptionsConfig struct {
-	FileWorldReadable   types.Bool   `tfsdk:"file_world_readable"`
-	FileNoWorldReadable types.Bool   `tfsdk:"file_no_world_readable"`
-	NoRemoteTrace       types.Bool   `tfsdk:"no_remote_trace"`
-	OnDemand            types.Bool   `tfsdk:"on_demand"`
 	FileName            types.String `tfsdk:"file_name"`
 	FileFiles           types.Int64  `tfsdk:"file_files"`
 	FileMatch           types.String `tfsdk:"file_match"`
 	FileSize            types.Int64  `tfsdk:"file_size"`
+	FileWorldReadable   types.Bool   `tfsdk:"file_world_readable"`
+	FileNoWorldReadable types.Bool   `tfsdk:"file_no_world_readable"`
 	Flag                types.Set    `tfsdk:"flag"`
+	NoRemoteTrace       types.Bool   `tfsdk:"no_remote_trace"`
+	OnDemand            types.Bool   `tfsdk:"on_demand"`
 }
 
 func (block *systemBlockServicesBlockNetconfTraceoptionsConfig) isEmpty() bool {
@@ -2167,11 +2167,6 @@ func (block *systemBlockServicesBlockNetconfTraceoptionsConfig) isEmpty() bool {
 }
 
 type systemBlockServicesBlockSSH struct {
-	LogKeyChanges               types.Bool     `tfsdk:"log_key_changes"`
-	NoPasswords                 types.Bool     `tfsdk:"no_passwords"`
-	NoPublicKeys                types.Bool     `tfsdk:"no_public_keys"`
-	TCPForwarding               types.Bool     `tfsdk:"tcp_forwarding"`
-	NoTCPForwarding             types.Bool     `tfsdk:"no_tcp_forwarding"`
 	AuthenticationOrder         []types.String `tfsdk:"authentication_order"`
 	Ciphers                     []types.String `tfsdk:"ciphers"`
 	ClientAliveCountMax         types.Int64    `tfsdk:"client_alive_count_max"`
@@ -2180,13 +2175,18 @@ type systemBlockServicesBlockSSH struct {
 	FingerprintHash             types.String   `tfsdk:"fingerprint_hash"`
 	HostkeyAlgorithm            []types.String `tfsdk:"hostkey_algorithm"`
 	KeyExchange                 []types.String `tfsdk:"key_exchange"`
+	LogKeyChanges               types.Bool     `tfsdk:"log_key_changes"`
 	Macs                        []types.String `tfsdk:"macs"`
 	MaxPreAuthenticationPackets types.Int64    `tfsdk:"max_pre_authentication_packets"`
 	MaxSessionsPerConnection    types.Int64    `tfsdk:"max_sessions_per_connection"`
+	NoPasswords                 types.Bool     `tfsdk:"no_passwords"`
+	NoPublicKeys                types.Bool     `tfsdk:"no_public_keys"`
 	Port                        types.Int64    `tfsdk:"port"`
 	ProtocolVersion             []types.String `tfsdk:"protocol_version"`
 	RateLimit                   types.Int64    `tfsdk:"rate_limit"`
 	RootLogin                   types.String   `tfsdk:"root_login"`
+	TCPForwarding               types.Bool     `tfsdk:"tcp_forwarding"`
+	NoTCPForwarding             types.Bool     `tfsdk:"no_tcp_forwarding"`
 }
 
 func (block *systemBlockServicesBlockSSH) isEmpty() bool {
@@ -2194,11 +2194,6 @@ func (block *systemBlockServicesBlockSSH) isEmpty() bool {
 }
 
 type systemBlockServicesBlockSSHConfig struct {
-	LogKeyChanges               types.Bool   `tfsdk:"log_key_changes"`
-	NoPasswords                 types.Bool   `tfsdk:"no_passwords"`
-	NoPublicKeys                types.Bool   `tfsdk:"no_public_keys"`
-	TCPForwarding               types.Bool   `tfsdk:"tcp_forwarding"`
-	NoTCPForwarding             types.Bool   `tfsdk:"no_tcp_forwarding"`
 	AuthenticationOrder         types.List   `tfsdk:"authentication_order"`
 	Ciphers                     types.Set    `tfsdk:"ciphers"`
 	ClientAliveCountMax         types.Int64  `tfsdk:"client_alive_count_max"`
@@ -2207,13 +2202,18 @@ type systemBlockServicesBlockSSHConfig struct {
 	FingerprintHash             types.String `tfsdk:"fingerprint_hash"`
 	HostkeyAlgorithm            types.Set    `tfsdk:"hostkey_algorithm"`
 	KeyExchange                 types.Set    `tfsdk:"key_exchange"`
+	LogKeyChanges               types.Bool   `tfsdk:"log_key_changes"`
 	Macs                        types.Set    `tfsdk:"macs"`
 	MaxPreAuthenticationPackets types.Int64  `tfsdk:"max_pre_authentication_packets"`
 	MaxSessionsPerConnection    types.Int64  `tfsdk:"max_sessions_per_connection"`
+	NoPasswords                 types.Bool   `tfsdk:"no_passwords"`
+	NoPublicKeys                types.Bool   `tfsdk:"no_public_keys"`
 	Port                        types.Int64  `tfsdk:"port"`
 	ProtocolVersion             types.Set    `tfsdk:"protocol_version"`
 	RateLimit                   types.Int64  `tfsdk:"rate_limit"`
 	RootLogin                   types.String `tfsdk:"root_login"`
+	TCPForwarding               types.Bool   `tfsdk:"tcp_forwarding"`
+	NoTCPForwarding             types.Bool   `tfsdk:"no_tcp_forwarding"`
 }
 
 func (block *systemBlockServicesBlockSSHConfig) isEmpty() bool {
@@ -2231,26 +2231,26 @@ type systemBlockServicesBlockWebManagementHTTPConfig struct {
 }
 
 type systemBlockServicesBlockWebManagementHTTPS struct {
-	SystemGeneratedCertificate types.Bool     `tfsdk:"system_generated_certificate"`
 	Interface                  []types.String `tfsdk:"interface"`
 	LocalCertificate           types.String   `tfsdk:"local_certificate"`
 	PkiLocalCertificate        types.String   `tfsdk:"pki_local_certificate"`
 	Port                       types.Int64    `tfsdk:"port"`
+	SystemGeneratedCertificate types.Bool     `tfsdk:"system_generated_certificate"`
 }
 
 type systemBlockServicesBlockWebManagementHTTPSConfig struct {
-	SystemGeneratedCertificate types.Bool   `tfsdk:"system_generated_certificate"`
 	Interface                  types.Set    `tfsdk:"interface"`
 	LocalCertificate           types.String `tfsdk:"local_certificate"`
 	PkiLocalCertificate        types.String `tfsdk:"pki_local_certificate"`
 	Port                       types.Int64  `tfsdk:"port"`
+	SystemGeneratedCertificate types.Bool   `tfsdk:"system_generated_certificate"`
 }
 
 type systemBlockSyslog struct {
-	TimeFormatMillisecond types.Bool                     `tfsdk:"time_format_millisecond"`
-	TimeFormatYear        types.Bool                     `tfsdk:"time_format_year"`
 	LogRotateFrequency    types.Int64                    `tfsdk:"log_rotate_frequency"`
 	SourceAddress         types.String                   `tfsdk:"source_address"`
+	TimeFormatMillisecond types.Bool                     `tfsdk:"time_format_millisecond"`
+	TimeFormatYear        types.Bool                     `tfsdk:"time_format_year"`
 	Archive               *systemBlockSyslogBlockArchive `tfsdk:"archive"`
 	Console               *systemBlockSyslogBlockConsole `tfsdk:"console"`
 }
@@ -2262,10 +2262,10 @@ func (block *systemBlockSyslog) isEmpty() bool {
 type systemBlockSyslogBlockArchive struct {
 	BinaryData      types.Bool  `tfsdk:"binary_data"`
 	NoBinaryData    types.Bool  `tfsdk:"no_binary_data"`
-	WorldReadable   types.Bool  `tfsdk:"world_readable"`
-	NoWorldReadable types.Bool  `tfsdk:"no_world_readable"`
 	Files           types.Int64 `tfsdk:"files"`
 	Size            types.Int64 `tfsdk:"size"`
+	WorldReadable   types.Bool  `tfsdk:"world_readable"`
+	NoWorldReadable types.Bool  `tfsdk:"no_world_readable"`
 }
 
 type systemBlockSyslogBlockConsole struct {

--- a/internal/providerfwk/resource_system_syslog_file.go
+++ b/internal/providerfwk/resource_system_syslog_file.go
@@ -366,10 +366,10 @@ func (rsc *systemSyslogFile) Schema(
 }
 
 type systemSyslogFileData struct {
-	AllowDuplicates             types.Bool                           `tfsdk:"allow_duplicates"`
-	ExplicitPriority            types.Bool                           `tfsdk:"explicit_priority"`
 	ID                          types.String                         `tfsdk:"id"`
 	Filename                    types.String                         `tfsdk:"filename"`
+	AllowDuplicates             types.Bool                           `tfsdk:"allow_duplicates"`
+	ExplicitPriority            types.Bool                           `tfsdk:"explicit_priority"`
 	Match                       types.String                         `tfsdk:"match"`
 	MatchStrings                []types.String                       `tfsdk:"match_strings"`
 	AnySeverity                 types.String                         `tfsdk:"any_severity"`
@@ -392,10 +392,10 @@ type systemSyslogFileData struct {
 }
 
 type systemSyslogFileConfig struct {
-	AllowDuplicates             types.Bool                           `tfsdk:"allow_duplicates"`
-	ExplicitPriority            types.Bool                           `tfsdk:"explicit_priority"`
 	ID                          types.String                         `tfsdk:"id"`
 	Filename                    types.String                         `tfsdk:"filename"`
+	AllowDuplicates             types.Bool                           `tfsdk:"allow_duplicates"`
+	ExplicitPriority            types.Bool                           `tfsdk:"explicit_priority"`
 	Match                       types.String                         `tfsdk:"match"`
 	MatchStrings                types.List                           `tfsdk:"match_strings"`
 	AnySeverity                 types.String                         `tfsdk:"any_severity"`
@@ -420,24 +420,24 @@ type systemSyslogFileConfig struct {
 type systemSyslogFileBlockArchive struct {
 	BinaryData       types.Bool                               `tfsdk:"binary_data"`
 	NoBinaryData     types.Bool                               `tfsdk:"no_binary_data"`
-	WorldReadable    types.Bool                               `tfsdk:"world_readable"`
-	NoWorldReadable  types.Bool                               `tfsdk:"no_world_readable"`
 	Files            types.Int64                              `tfsdk:"files"`
 	Size             types.Int64                              `tfsdk:"size"`
 	StartTime        types.String                             `tfsdk:"start_time"`
 	TransferInterval types.Int64                              `tfsdk:"transfer_interval"`
+	WorldReadable    types.Bool                               `tfsdk:"world_readable"`
+	NoWorldReadable  types.Bool                               `tfsdk:"no_world_readable"`
 	Sites            []systemSyslogFileBlockArchiveBlockSites `tfsdk:"sites"`
 }
 
 type systemSyslogFileBlockArchiveConfig struct {
 	BinaryData       types.Bool   `tfsdk:"binary_data"`
 	NoBinaryData     types.Bool   `tfsdk:"no_binary_data"`
-	WorldReadable    types.Bool   `tfsdk:"world_readable"`
-	NoWorldReadable  types.Bool   `tfsdk:"no_world_readable"`
 	Files            types.Int64  `tfsdk:"files"`
 	Size             types.Int64  `tfsdk:"size"`
 	StartTime        types.String `tfsdk:"start_time"`
 	TransferInterval types.Int64  `tfsdk:"transfer_interval"`
+	WorldReadable    types.Bool   `tfsdk:"world_readable"`
+	NoWorldReadable  types.Bool   `tfsdk:"no_world_readable"`
 	Sites            types.List   `tfsdk:"sites"`
 }
 

--- a/internal/providerfwk/resource_system_syslog_host.go
+++ b/internal/providerfwk/resource_system_syslog_host.go
@@ -296,11 +296,11 @@ func (rsc *systemSyslogHost) Schema(
 }
 
 type systemSyslogHostData struct {
+	ID                          types.String                         `tfsdk:"id"`
+	Host                        types.String                         `tfsdk:"host"`
 	AllowDuplicates             types.Bool                           `tfsdk:"allow_duplicates"`
 	ExcludeHostname             types.Bool                           `tfsdk:"exclude_hostname"`
 	ExplicitPriority            types.Bool                           `tfsdk:"explicit_priority"`
-	ID                          types.String                         `tfsdk:"id"`
-	Host                        types.String                         `tfsdk:"host"`
 	FacilityOverride            types.String                         `tfsdk:"facility_override"`
 	LogPrefix                   types.String                         `tfsdk:"log_prefix"`
 	Match                       types.String                         `tfsdk:"match"`

--- a/internal/providerfwk/resource_system_syslog_user.go
+++ b/internal/providerfwk/resource_system_syslog_user.go
@@ -233,9 +233,9 @@ func (rsc *systemSyslogUser) Schema(
 }
 
 type systemSyslogUserData struct {
-	AllowDuplicates             types.Bool     `tfsdk:"allow_duplicates"`
 	ID                          types.String   `tfsdk:"id"`
 	Username                    types.String   `tfsdk:"username"`
+	AllowDuplicates             types.Bool     `tfsdk:"allow_duplicates"`
 	Match                       types.String   `tfsdk:"match"`
 	MatchStrings                []types.String `tfsdk:"match_strings"`
 	AnySeverity                 types.String   `tfsdk:"any_severity"`

--- a/internal/providerfwk/resource_system_tacplus_server.go
+++ b/internal/providerfwk/resource_system_tacplus_server.go
@@ -144,12 +144,12 @@ func (rsc *systemTacplusServer) Schema(
 }
 
 type systemTacplusServerData struct {
-	SingleConnection types.Bool   `tfsdk:"single_connection"`
 	ID               types.String `tfsdk:"id"`
 	Address          types.String `tfsdk:"address"`
 	Port             types.Int64  `tfsdk:"port"`
 	RoutingInstance  types.String `tfsdk:"routing_instance"`
 	Secret           types.String `tfsdk:"secret"`
+	SingleConnection types.Bool   `tfsdk:"single_connection"`
 	SourceAddress    types.String `tfsdk:"source_address"`
 	Timeout          types.Int64  `tfsdk:"timeout"`
 }

--- a/internal/providerfwk/resource_virtual_chassis.go
+++ b/internal/providerfwk/resource_virtual_chassis.go
@@ -317,30 +317,30 @@ func (rsc *virtualChassis) Schema(
 }
 
 type virtualChassisData struct {
+	ID                      types.String                     `tfsdk:"id"`
 	AutoSWUpdate            types.Bool                       `tfsdk:"auto_sw_update"`
+	AutoSWUpdatePackageName types.String                     `tfsdk:"auto_sw_update_package_name"`
 	GracefulRestartDisable  types.Bool                       `tfsdk:"graceful_restart_disable"`
+	Identifier              types.String                     `tfsdk:"identifier"`
+	MacPersistenceTimer     types.String                     `tfsdk:"mac_persistence_timer"`
 	NoSplitDetection        types.Bool                       `tfsdk:"no_split_detection"`
 	Preprovisioned          types.Bool                       `tfsdk:"preprovisioned"`
 	VcpNoHoldTime           types.Bool                       `tfsdk:"vcp_no_hold_time"`
-	ID                      types.String                     `tfsdk:"id"`
-	AutoSWUpdatePackageName types.String                     `tfsdk:"auto_sw_update_package_name"`
-	Identifier              types.String                     `tfsdk:"identifier"`
-	MacPersistenceTimer     types.String                     `tfsdk:"mac_persistence_timer"`
 	Alias                   []virtualChassisBlockAlias       `tfsdk:"alias"`
 	Member                  []virtualChassisBlockMember      `tfsdk:"member"`
 	Traceoptions            *virtualChassisBlockTraceoptions `tfsdk:"traceoptions"`
 }
 
 type virtualChassisConfig struct {
+	ID                      types.String                           `tfsdk:"id"`
 	AutoSWUpdate            types.Bool                             `tfsdk:"auto_sw_update"`
+	AutoSWUpdatePackageName types.String                           `tfsdk:"auto_sw_update_package_name"`
 	GracefulRestartDisable  types.Bool                             `tfsdk:"graceful_restart_disable"`
+	Identifier              types.String                           `tfsdk:"identifier"`
+	MacPersistenceTimer     types.String                           `tfsdk:"mac_persistence_timer"`
 	NoSplitDetection        types.Bool                             `tfsdk:"no_split_detection"`
 	Preprovisioned          types.Bool                             `tfsdk:"preprovisioned"`
 	VcpNoHoldTime           types.Bool                             `tfsdk:"vcp_no_hold_time"`
-	ID                      types.String                           `tfsdk:"id"`
-	AutoSWUpdatePackageName types.String                           `tfsdk:"auto_sw_update_package_name"`
-	Identifier              types.String                           `tfsdk:"identifier"`
-	MacPersistenceTimer     types.String                           `tfsdk:"mac_persistence_timer"`
 	Alias                   types.Set                              `tfsdk:"alias"`
 	Member                  types.List                             `tfsdk:"member"`
 	Traceoptions            *virtualChassisBlockTraceoptionsConfig `tfsdk:"traceoptions"`
@@ -352,10 +352,10 @@ type virtualChassisBlockAlias struct {
 }
 
 type virtualChassisBlockMember struct {
-	NoManagementVlan   types.Bool   `tfsdk:"no_management_vlan"`
 	ID                 types.Int64  `tfsdk:"id"`
 	Location           types.String `tfsdk:"location"`
 	MastershipPriority types.Int64  `tfsdk:"mastership_priority"`
+	NoManagementVlan   types.Bool   `tfsdk:"no_management_vlan"`
 	Role               types.String `tfsdk:"role"`
 	SerialNumber       types.String `tfsdk:"serial_number"`
 }
@@ -383,13 +383,13 @@ func (block *virtualChassisBlockTraceoptionsConfig) isEmpty() bool {
 }
 
 type virtualChassisBlockTraceoptionsBlockFile struct {
-	NoStamp         types.Bool   `tfsdk:"no_stamp"`
-	Replace         types.Bool   `tfsdk:"replace"`
-	WorldReadable   types.Bool   `tfsdk:"world_readable"`
-	NoWorldReadable types.Bool   `tfsdk:"no_world_readable"`
 	Name            types.String `tfsdk:"name"`
 	Files           types.Int64  `tfsdk:"files"`
+	NoStamp         types.Bool   `tfsdk:"no_stamp"`
+	Replace         types.Bool   `tfsdk:"replace"`
 	Size            types.Int64  `tfsdk:"size"`
+	WorldReadable   types.Bool   `tfsdk:"world_readable"`
+	NoWorldReadable types.Bool   `tfsdk:"no_world_readable"`
 }
 
 func (rsc *virtualChassis) ValidateConfig(

--- a/internal/providerfwk/resourcedata_bgp.go
+++ b/internal/providerfwk/resourcedata_bgp.go
@@ -14,9 +14,9 @@ import (
 )
 
 type bgpBlockBfdLivenessDetection struct {
-	AuthenticationLooseCheck        types.Bool   `tfsdk:"authentication_loose_check"`
 	AuthenticationAlgorithm         types.String `tfsdk:"authentication_algorithm"`
 	AuthenticationKeyChain          types.String `tfsdk:"authentication_key_chain"`
+	AuthenticationLooseCheck        types.Bool   `tfsdk:"authentication_loose_check"`
 	DetectionTimeThreshold          types.Int64  `tfsdk:"detection_time_threshold"`
 	HolddownInterval                types.Int64  `tfsdk:"holddown_interval"`
 	MinimumInterval                 types.Int64  `tfsdk:"minimum_interval"`
@@ -33,8 +33,8 @@ func (block *bgpBlockBfdLivenessDetection) isEmpty() bool {
 }
 
 type bgpBlockBgpErrorTolerance struct {
-	NoMalformedRouteLimit      types.Bool  `tfsdk:"no_malformed_route_limit"`
 	MalformedRouteLimit        types.Int64 `tfsdk:"malformed_route_limit"`
+	NoMalformedRouteLimit      types.Bool  `tfsdk:"no_malformed_route_limit"`
 	MalformedUpdateLogInterval types.Int64 `tfsdk:"malformed_update_log_interval"`
 }
 
@@ -51,10 +51,10 @@ type bgpBlockFamily struct {
 }
 
 type bgpBlockFamilyBlockPrefixLimit struct {
-	TeardownIdleTimeoutForever types.Bool  `tfsdk:"teardown_idle_timeout_forever"`
 	Maximum                    types.Int64 `tfsdk:"maximum"`
 	Teardown                   types.Int64 `tfsdk:"teardown"`
 	TeardownIdleTimeout        types.Int64 `tfsdk:"teardown_idle_timeout"`
+	TeardownIdleTimeoutForever types.Bool  `tfsdk:"teardown_idle_timeout_forever"`
 }
 
 type bgpBlockGracefulRestart struct {

--- a/internal/providerfwk/upgradestate_bgp_group.go
+++ b/internal/providerfwk/upgradestate_bgp_group.go
@@ -299,6 +299,10 @@ func upgradeBgpGroupStateV0toV1(
 	ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse,
 ) {
 	type modelV0 struct {
+		ID                           types.String   `tfsdk:"id"`
+		Name                         types.String   `tfsdk:"name"`
+		RoutingInstance              types.String   `tfsdk:"routing_instance"`
+		Type                         types.String   `tfsdk:"type"`
 		AcceptRemoteNexthop          types.Bool     `tfsdk:"accept_remote_nexthop"`
 		AdvertiseExternal            types.Bool     `tfsdk:"advertise_external"`
 		AdvertiseExternalConditional types.Bool     `tfsdk:"advertise_external_conditional"`
@@ -306,46 +310,42 @@ func upgradeBgpGroupStateV0toV1(
 		AdvertisePeerAS              types.Bool     `tfsdk:"advertise_peer_as"`
 		NoAdvertisePeerAS            types.Bool     `tfsdk:"no_advertise_peer_as"`
 		ASOverride                   types.Bool     `tfsdk:"as_override"`
-		Damping                      types.Bool     `tfsdk:"damping"`
-		KeepAll                      types.Bool     `tfsdk:"keep_all"`
-		KeepNone                     types.Bool     `tfsdk:"keep_none"`
-		LocalASAlias                 types.Bool     `tfsdk:"local_as_alias"`
-		LocalASNoPrependGlobalAS     types.Bool     `tfsdk:"local_as_no_prepend_global_as"`
-		LocalASPrivate               types.Bool     `tfsdk:"local_as_private"`
-		LogUpdown                    types.Bool     `tfsdk:"log_updown"`
-		MetricOutIgp                 types.Bool     `tfsdk:"metric_out_igp"`
-		MetricOutIgpDelayMedUpdate   types.Bool     `tfsdk:"metric_out_igp_delay_med_update"`
-		MetricOutMinimumIgp          types.Bool     `tfsdk:"metric_out_minimum_igp"`
-		MtuDiscovery                 types.Bool     `tfsdk:"mtu_discovery"`
-		Multihop                     types.Bool     `tfsdk:"multihop"`
-		Passive                      types.Bool     `tfsdk:"passive"`
-		RemovePrivate                types.Bool     `tfsdk:"remove_private"`
 		AuthenticationAlgorithm      types.String   `tfsdk:"authentication_algorithm"`
 		AuthenticationKey            types.String   `tfsdk:"authentication_key"`
 		AuthenticationKeyChain       types.String   `tfsdk:"authentication_key_chain"`
 		Cluster                      types.String   `tfsdk:"cluster"`
+		Damping                      types.Bool     `tfsdk:"damping"`
 		Export                       []types.String `tfsdk:"export"`
 		HoldTime                     types.Int64    `tfsdk:"hold_time"`
-		ID                           types.String   `tfsdk:"id"`
 		Import                       []types.String `tfsdk:"import"`
+		KeepAll                      types.Bool     `tfsdk:"keep_all"`
+		KeepNone                     types.Bool     `tfsdk:"keep_none"`
 		LocalAddress                 types.String   `tfsdk:"local_address"`
 		LocalAS                      types.String   `tfsdk:"local_as"`
+		LocalASAlias                 types.Bool     `tfsdk:"local_as_alias"`
 		LocalASLoops                 types.Int64    `tfsdk:"local_as_loops"`
+		LocalASNoPrependGlobalAS     types.Bool     `tfsdk:"local_as_no_prepend_global_as"`
+		LocalASPrivate               types.Bool     `tfsdk:"local_as_private"`
 		LocalInterface               types.String   `tfsdk:"local_interface"`
 		LocalPreference              types.Int64    `tfsdk:"local_preference"`
+		LogUpdown                    types.Bool     `tfsdk:"log_updown"`
 		MetricOut                    types.Int64    `tfsdk:"metric_out"`
+		MetricOutIgp                 types.Bool     `tfsdk:"metric_out_igp"`
+		MetricOutIgpDelayMedUpdate   types.Bool     `tfsdk:"metric_out_igp_delay_med_update"`
 		MetricOutIgpOffset           types.Int64    `tfsdk:"metric_out_igp_offset"`
+		MetricOutMinimumIgp          types.Bool     `tfsdk:"metric_out_minimum_igp"`
 		MetricOutMinimumIgpOffset    types.Int64    `tfsdk:"metric_out_minimum_igp_offset"`
-		Name                         types.String   `tfsdk:"name"`
+		MtuDiscovery                 types.Bool     `tfsdk:"mtu_discovery"`
+		Multihop                     types.Bool     `tfsdk:"multihop"`
 		OutDelay                     types.Int64    `tfsdk:"out_delay"`
+		Passive                      types.Bool     `tfsdk:"passive"`
 		PeerAS                       types.String   `tfsdk:"peer_as"`
 		Preference                   types.Int64    `tfsdk:"preference"`
-		RoutingInstance              types.String   `tfsdk:"routing_instance"`
-		Type                         types.String   `tfsdk:"type"`
+		RemovePrivate                types.Bool     `tfsdk:"remove_private"`
 		BfdLivenessDetection         []struct {
-			AuthenticationLooseCheck        types.Bool   `tfsdk:"authentication_loose_check"`
 			AuthenticationAlgorithm         types.String `tfsdk:"authentication_algorithm"`
 			AuthenticationKeyChain          types.String `tfsdk:"authentication_key_chain"`
+			AuthenticationLooseCheck        types.Bool   `tfsdk:"authentication_loose_check"`
 			DetectionTimeThreshold          types.Int64  `tfsdk:"detection_time_threshold"`
 			HolddownInterval                types.Int64  `tfsdk:"holddown_interval"`
 			MinimumInterval                 types.Int64  `tfsdk:"minimum_interval"`

--- a/internal/providerfwk/upgradestate_bgp_neighbor.go
+++ b/internal/providerfwk/upgradestate_bgp_neighbor.go
@@ -298,6 +298,10 @@ func upgradeBgpNeighborStateV0toV1(
 	ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse,
 ) {
 	type modelV0 struct {
+		ID                           types.String   `tfsdk:"id"`
+		IP                           types.String   `tfsdk:"ip"`
+		RoutingInstance              types.String   `tfsdk:"routing_instance"`
+		Group                        types.String   `tfsdk:"group"`
 		AcceptRemoteNexthop          types.Bool     `tfsdk:"accept_remote_nexthop"`
 		AdvertiseExternal            types.Bool     `tfsdk:"advertise_external"`
 		AdvertiseExternalConditional types.Bool     `tfsdk:"advertise_external_conditional"`
@@ -305,46 +309,42 @@ func upgradeBgpNeighborStateV0toV1(
 		AdvertisePeerAS              types.Bool     `tfsdk:"advertise_peer_as"`
 		NoAdvertisePeerAS            types.Bool     `tfsdk:"no_advertise_peer_as"`
 		ASOverride                   types.Bool     `tfsdk:"as_override"`
-		Damping                      types.Bool     `tfsdk:"damping"`
-		KeepAll                      types.Bool     `tfsdk:"keep_all"`
-		KeepNone                     types.Bool     `tfsdk:"keep_none"`
-		LocalASAlias                 types.Bool     `tfsdk:"local_as_alias"`
-		LocalASNoPrependGlobalAS     types.Bool     `tfsdk:"local_as_no_prepend_global_as"`
-		LocalASPrivate               types.Bool     `tfsdk:"local_as_private"`
-		LogUpdown                    types.Bool     `tfsdk:"log_updown"`
-		MetricOutIgp                 types.Bool     `tfsdk:"metric_out_igp"`
-		MetricOutIgpDelayMedUpdate   types.Bool     `tfsdk:"metric_out_igp_delay_med_update"`
-		MetricOutMinimumIgp          types.Bool     `tfsdk:"metric_out_minimum_igp"`
-		MtuDiscovery                 types.Bool     `tfsdk:"mtu_discovery"`
-		Multihop                     types.Bool     `tfsdk:"multihop"`
-		Passive                      types.Bool     `tfsdk:"passive"`
-		RemovePrivate                types.Bool     `tfsdk:"remove_private"`
 		AuthenticationAlgorithm      types.String   `tfsdk:"authentication_algorithm"`
 		AuthenticationKey            types.String   `tfsdk:"authentication_key"`
 		AuthenticationKeyChain       types.String   `tfsdk:"authentication_key_chain"`
 		Cluster                      types.String   `tfsdk:"cluster"`
+		Damping                      types.Bool     `tfsdk:"damping"`
 		Export                       []types.String `tfsdk:"export"`
-		Group                        types.String   `tfsdk:"group"`
 		HoldTime                     types.Int64    `tfsdk:"hold_time"`
-		ID                           types.String   `tfsdk:"id"`
 		Import                       []types.String `tfsdk:"import"`
-		IP                           types.String   `tfsdk:"ip"`
+		KeepAll                      types.Bool     `tfsdk:"keep_all"`
+		KeepNone                     types.Bool     `tfsdk:"keep_none"`
 		LocalAddress                 types.String   `tfsdk:"local_address"`
 		LocalAS                      types.String   `tfsdk:"local_as"`
+		LocalASAlias                 types.Bool     `tfsdk:"local_as_alias"`
 		LocalASLoops                 types.Int64    `tfsdk:"local_as_loops"`
+		LocalASNoPrependGlobalAS     types.Bool     `tfsdk:"local_as_no_prepend_global_as"`
+		LocalASPrivate               types.Bool     `tfsdk:"local_as_private"`
 		LocalInterface               types.String   `tfsdk:"local_interface"`
 		LocalPreference              types.Int64    `tfsdk:"local_preference"`
+		LogUpdown                    types.Bool     `tfsdk:"log_updown"`
 		MetricOut                    types.Int64    `tfsdk:"metric_out"`
+		MetricOutIgp                 types.Bool     `tfsdk:"metric_out_igp"`
+		MetricOutIgpDelayMedUpdate   types.Bool     `tfsdk:"metric_out_igp_delay_med_update"`
 		MetricOutIgpOffset           types.Int64    `tfsdk:"metric_out_igp_offset"`
+		MetricOutMinimumIgp          types.Bool     `tfsdk:"metric_out_minimum_igp"`
 		MetricOutMinimumIgpOffset    types.Int64    `tfsdk:"metric_out_minimum_igp_offset"`
+		MtuDiscovery                 types.Bool     `tfsdk:"mtu_discovery"`
+		Multihop                     types.Bool     `tfsdk:"multihop"`
 		OutDelay                     types.Int64    `tfsdk:"out_delay"`
+		Passive                      types.Bool     `tfsdk:"passive"`
 		PeerAS                       types.String   `tfsdk:"peer_as"`
 		Preference                   types.Int64    `tfsdk:"preference"`
-		RoutingInstance              types.String   `tfsdk:"routing_instance"`
+		RemovePrivate                types.Bool     `tfsdk:"remove_private"`
 		BfdLivenessDetection         []struct {
-			AuthenticationLooseCheck        types.Bool   `tfsdk:"authentication_loose_check"`
 			AuthenticationAlgorithm         types.String `tfsdk:"authentication_algorithm"`
 			AuthenticationKeyChain          types.String `tfsdk:"authentication_key_chain"`
+			AuthenticationLooseCheck        types.Bool   `tfsdk:"authentication_loose_check"`
 			DetectionTimeThreshold          types.Int64  `tfsdk:"detection_time_threshold"`
 			HolddownInterval                types.Int64  `tfsdk:"holddown_interval"`
 			MinimumInterval                 types.Int64  `tfsdk:"minimum_interval"`

--- a/internal/providerfwk/upgradestate_bridge_domain.go
+++ b/internal/providerfwk/upgradestate_bridge_domain.go
@@ -95,26 +95,26 @@ func upgradeBridgeDomainStateV0toV1(
 	ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse,
 ) {
 	type modelV0 struct {
-		DomainTypeBridge types.Bool     `tfsdk:"domain_type_bridge"`
 		ID               types.String   `tfsdk:"id"`
 		Name             types.String   `tfsdk:"name"`
 		RoutingInstance  types.String   `tfsdk:"routing_instance"`
 		CommunityVlans   []types.String `tfsdk:"community_vlans"`
 		Description      types.String   `tfsdk:"description"`
 		DomainID         types.Int64    `tfsdk:"domain_id"`
+		DomainTypeBridge types.Bool     `tfsdk:"domain_type_bridge"`
 		IsolatedVLAN     types.Int64    `tfsdk:"isolated_vlan"`
 		RoutingInterface types.String   `tfsdk:"routing_interface"`
 		ServiceID        types.Int64    `tfsdk:"service_id"`
 		VLANID           types.Int64    `tfsdk:"vlan_id"`
 		VLANIDList       []types.String `tfsdk:"vlan_id_list"`
 		VXLAN            []struct {
+			VNI                        types.Int64  `tfsdk:"vni"`
 			VNIExtendEvpn              types.Bool   `tfsdk:"vni_extend_evpn"`
 			DecapsulateAcceptInnerVlan types.Bool   `tfsdk:"decapsulate_accept_inner_vlan"`
 			EncapsulateInnerVlan       types.Bool   `tfsdk:"encapsulate_inner_vlan"`
 			IngressNodeReplication     types.Bool   `tfsdk:"ingress_node_replication"`
-			OvsdbManaged               types.Bool   `tfsdk:"ovsdb_managed"`
-			VNI                        types.Int64  `tfsdk:"vni"`
 			MulticastGroup             types.String `tfsdk:"multicast_group"`
+			OvsdbManaged               types.Bool   `tfsdk:"ovsdb_managed"`
 			UnreachableVtepAgingTimer  types.Int64  `tfsdk:"unreachable_vtep_aging_timer"`
 		} `tfsdk:"vxlan"`
 	}

--- a/internal/providerfwk/upgradestate_eventoptions_policy.go
+++ b/internal/providerfwk/upgradestate_eventoptions_policy.go
@@ -245,16 +245,16 @@ func upgradeEventoptionsPolicyV0toV1(
 		Events []types.String `tfsdk:"events"`
 		Then   []struct {
 			Ignore                   types.Bool   `tfsdk:"ignore"`
-			RaiseTrap                types.Bool   `tfsdk:"raise_trap"`
 			PriorityOverrideFacility types.String `tfsdk:"priority_override_facility"`
 			PriorityOverrideSeverity types.String `tfsdk:"priority_override_severity"`
+			RaiseTrap                types.Bool   `tfsdk:"raise_trap"`
 			ChangeConfiguration      []struct {
+				Commands                      []types.String `tfsdk:"commands"`
 				CommitOptionsCheck            types.Bool     `tfsdk:"commit_options_check"`
 				CommitOptionsCheckSynchronize types.Bool     `tfsdk:"commit_options_check_synchronize"`
 				CommitOptionsForce            types.Bool     `tfsdk:"commit_options_force"`
-				CommitOptionsSynchronize      types.Bool     `tfsdk:"commit_options_synchronize"`
-				Commands                      []types.String `tfsdk:"commands"`
 				CommitOptionsLog              types.String   `tfsdk:"commit_options_log"`
+				CommitOptionsSynchronize      types.Bool     `tfsdk:"commit_options_synchronize"`
 				RetryCount                    types.Int64    `tfsdk:"retry_count"`
 				RetryInterval                 types.Int64    `tfsdk:"retry_interval"`
 				Username                      types.String   `tfsdk:"user_name"`

--- a/internal/providerfwk/upgradestate_evpn.go
+++ b/internal/providerfwk/upgradestate_evpn.go
@@ -73,18 +73,18 @@ func upgradeEvpnV0toV1(
 	ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse,
 ) {
 	type modelV0 struct {
-		RoutingInstanceEvpn types.Bool   `tfsdk:"routing_instance_evpn"`
 		ID                  types.String `tfsdk:"id"`
 		RoutingInstance     types.String `tfsdk:"routing_instance"`
 		Encapsulation       types.String `tfsdk:"encapsulation"`
 		DefaultGateway      types.String `tfsdk:"default_gateway"`
 		MulticastMode       types.String `tfsdk:"multicast_mode"`
+		RoutingInstanceEvpn types.Bool   `tfsdk:"routing_instance_evpn"`
 		SwitchOrRIOptions   []struct {
-			VRFTargetAuto      types.Bool     `tfsdk:"vrf_target_auto"`
 			RouteDistinguisher types.String   `tfsdk:"route_distinguisher"`
 			VRFExport          []types.String `tfsdk:"vrf_export"`
 			VRFImport          []types.String `tfsdk:"vrf_import"`
 			VRFTarget          types.String   `tfsdk:"vrf_target"`
+			VRFTargetAuto      types.Bool     `tfsdk:"vrf_target_auto"`
 			VRFTargetExport    types.String   `tfsdk:"vrf_target_export"`
 			VRFTargetImport    types.String   `tfsdk:"vrf_target_import"`
 		} `tfsdk:"switch_or_ri_options"`

--- a/internal/providerfwk/upgradestate_firewall_filter.go
+++ b/internal/providerfwk/upgradestate_firewall_filter.go
@@ -210,17 +210,14 @@ func upgradeFirewallFilterStateV0toV1(
 	ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse,
 ) {
 	type modelV0 struct {
-		InterfaceSpecific types.Bool   `tfsdk:"interface_specific"`
 		ID                types.String `tfsdk:"id"`
 		Name              types.String `tfsdk:"name"`
 		Family            types.String `tfsdk:"family"`
+		InterfaceSpecific types.Bool   `tfsdk:"interface_specific"`
 		Term              []struct {
 			Name   types.String `tfsdk:"name"`
 			Filter types.String `tfsdk:"filter"`
 			From   []struct {
-				IsFragment                  types.Bool     `tfsdk:"is_fragment"`
-				TCPEstablished              types.Bool     `tfsdk:"tcp_established"`
-				TCPInitial                  types.Bool     `tfsdk:"tcp_initial"`
 				Address                     []types.String `tfsdk:"address"`
 				AddressExcept               []types.String `tfsdk:"address_except"`
 				DestinationAddress          []types.String `tfsdk:"destination_address"`
@@ -233,6 +230,7 @@ func upgradeFirewallFilterStateV0toV1(
 				IcmpCodeExcept              []types.String `tfsdk:"icmp_code_except"`
 				IcmpType                    []types.String `tfsdk:"icmp_type"`
 				IcmpTypeExcept              []types.String `tfsdk:"icmp_type_except"`
+				IsFragment                  types.Bool     `tfsdk:"is_fragment"`
 				NextHeader                  []types.String `tfsdk:"next_header"`
 				NextHeaderExcept            []types.String `tfsdk:"next_header_except"`
 				Port                        []types.String `tfsdk:"port"`
@@ -247,19 +245,21 @@ func upgradeFirewallFilterStateV0toV1(
 				SourcePortExcept            []types.String `tfsdk:"source_port_except"`
 				SourcePrefixList            []types.String `tfsdk:"source_prefix_list"`
 				SourcePrefixListExcept      []types.String `tfsdk:"source_prefix_list_except"`
+				TCPEstablished              types.Bool     `tfsdk:"tcp_established"`
 				TCPFlags                    types.String   `tfsdk:"tcp_flags"`
+				TCPInitial                  types.Bool     `tfsdk:"tcp_initial"`
 			} `tfsdk:"from"`
 			Then []struct {
+				Action            types.String `tfsdk:"action"`
+				Count             types.String `tfsdk:"count"`
 				Log               types.Bool   `tfsdk:"log"`
 				PacketMode        types.Bool   `tfsdk:"packet_mode"`
+				Policer           types.String `tfsdk:"policer"`
 				PortMirror        types.Bool   `tfsdk:"port_mirror"`
+				RoutingInstance   types.String `tfsdk:"routing_instance"`
 				Sample            types.Bool   `tfsdk:"sample"`
 				ServiceAccounting types.Bool   `tfsdk:"service_accounting"`
 				Syslog            types.Bool   `tfsdk:"syslog"`
-				Action            types.String `tfsdk:"action"`
-				Count             types.String `tfsdk:"count"`
-				Policer           types.String `tfsdk:"policer"`
-				RoutingInstance   types.String `tfsdk:"routing_instance"`
 			} `tfsdk:"then"`
 		} `tfsdk:"term"`
 	}

--- a/internal/providerfwk/upgradestate_firewall_policer.go
+++ b/internal/providerfwk/upgradestate_firewall_policer.go
@@ -68,9 +68,9 @@ func upgradeFirewallPolicerStateV0toV1(
 	ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse,
 ) {
 	type modelV0 struct {
-		FilterSpecific types.Bool   `tfsdk:"filter_specific"`
 		ID             types.String `tfsdk:"id"`
 		Name           types.String `tfsdk:"name"`
+		FilterSpecific types.Bool   `tfsdk:"filter_specific"`
 		IfExceeding    []struct {
 			BurstSizeLimit   types.String `tfsdk:"burst_size_limit"`
 			BandwidthPercent types.Int64  `tfsdk:"bandwidth_percent"`
@@ -78,9 +78,9 @@ func upgradeFirewallPolicerStateV0toV1(
 		} `tfsdk:"if_exceeding"`
 		Then []struct {
 			Discard         types.Bool   `tfsdk:"discard"`
-			OutOfProfile    types.Bool   `tfsdk:"out_of_profile"`
 			ForwardingClass types.String `tfsdk:"forwarding_class"`
 			LossPriority    types.String `tfsdk:"loss_priority"`
+			OutOfProfile    types.Bool   `tfsdk:"out_of_profile"`
 		} `tfsdk:"then"`
 	}
 

--- a/internal/providerfwk/upgradestate_forwardingoptions_sampling_instance.go
+++ b/internal/providerfwk/upgradestate_forwardingoptions_sampling_instance.go
@@ -376,9 +376,9 @@ func upgradeForwardingoptionsSamplingInstanceStateV0toV1(
 ) {
 	//nolint:lll
 	type modelV0 struct {
-		Disable         types.Bool   `tfsdk:"disable"`
 		ID              types.String `tfsdk:"id"`
 		Name            types.String `tfsdk:"name"`
+		Disable         types.Bool   `tfsdk:"disable"`
 		FamilyInetInput []struct {
 			MaxPacketsPerSecond types.Int64 `tfsdk:"max_packets_per_second"`
 			MaximumPacketLength types.Int64 `tfsdk:"maximum_packet_length"`
@@ -393,19 +393,19 @@ func upgradeForwardingoptionsSamplingInstanceStateV0toV1(
 			InlineJflowExportRate    types.Int64    `tfsdk:"inline_jflow_export_rate"`
 			InlineJflowSourceAddress types.String   `tfsdk:"inline_jflow_source_address"`
 			FlowServer               []struct {
+				Hostname                                         types.String `tfsdk:"hostname"`
+				Port                                             types.Int64  `tfsdk:"port"`
 				AggregationAutonomousSystem                      types.Bool   `tfsdk:"aggregation_autonomous_system"`
 				AggregationDestinationPrefix                     types.Bool   `tfsdk:"aggregation_destination_prefix"`
 				AggregationProtocolPort                          types.Bool   `tfsdk:"aggregation_protocol_port"`
 				AggregationSourceDestinationPrefix               types.Bool   `tfsdk:"aggregation_source_destination_prefix"`
 				AggregationSourceDestinationPrefixCaidaCompliant types.Bool   `tfsdk:"aggregation_source_destination_prefix_caida_compliant"`
 				AggregationSourcePrefix                          types.Bool   `tfsdk:"aggregation_source_prefix"`
-				LocalDump                                        types.Bool   `tfsdk:"local_dump"`
-				NoLocalDump                                      types.Bool   `tfsdk:"no_local_dump"`
-				Hostname                                         types.String `tfsdk:"hostname"`
-				Port                                             types.Int64  `tfsdk:"port"`
 				AutonomousSystemType                             types.String `tfsdk:"autonomous_system_type"`
 				Dscp                                             types.Int64  `tfsdk:"dscp"`
 				ForwardingClass                                  types.String `tfsdk:"forwarding_class"`
+				LocalDump                                        types.Bool   `tfsdk:"local_dump"`
+				NoLocalDump                                      types.Bool   `tfsdk:"no_local_dump"`
 				RoutingInstance                                  types.String `tfsdk:"routing_instance"`
 				SourceAddress                                    types.String `tfsdk:"source_address"`
 				Version                                          types.Int64  `tfsdk:"version"`
@@ -428,19 +428,19 @@ func upgradeForwardingoptionsSamplingInstanceStateV0toV1(
 			InlineJflowExportRate    types.Int64    `tfsdk:"inline_jflow_export_rate"`
 			InlineJflowSourceAddress types.String   `tfsdk:"inline_jflow_source_address"`
 			FlowServer               []struct {
+				Hostname                                         types.String `tfsdk:"hostname"`
+				Port                                             types.Int64  `tfsdk:"port"`
 				AggregationAutonomousSystem                      types.Bool   `tfsdk:"aggregation_autonomous_system"`
 				AggregationDestinationPrefix                     types.Bool   `tfsdk:"aggregation_destination_prefix"`
 				AggregationProtocolPort                          types.Bool   `tfsdk:"aggregation_protocol_port"`
 				AggregationSourceDestinationPrefix               types.Bool   `tfsdk:"aggregation_source_destination_prefix"`
 				AggregationSourceDestinationPrefixCaidaCompliant types.Bool   `tfsdk:"aggregation_source_destination_prefix_caida_compliant"`
 				AggregationSourcePrefix                          types.Bool   `tfsdk:"aggregation_source_prefix"`
-				LocalDump                                        types.Bool   `tfsdk:"local_dump"`
-				NoLocalDump                                      types.Bool   `tfsdk:"no_local_dump"`
-				Hostname                                         types.String `tfsdk:"hostname"`
-				Port                                             types.Int64  `tfsdk:"port"`
 				AutonomousSystemType                             types.String `tfsdk:"autonomous_system_type"`
 				Dscp                                             types.Int64  `tfsdk:"dscp"`
 				ForwardingClass                                  types.String `tfsdk:"forwarding_class"`
+				LocalDump                                        types.Bool   `tfsdk:"local_dump"`
+				NoLocalDump                                      types.Bool   `tfsdk:"no_local_dump"`
 				RoutingInstance                                  types.String `tfsdk:"routing_instance"`
 				SourceAddress                                    types.String `tfsdk:"source_address"`
 				Version9Template                                 types.String `tfsdk:"version9_template"`
@@ -461,19 +461,19 @@ func upgradeForwardingoptionsSamplingInstanceStateV0toV1(
 			InlineJflowExportRate    types.Int64  `tfsdk:"inline_jflow_export_rate"`
 			InlineJflowSourceAddress types.String `tfsdk:"inline_jflow_source_address"`
 			FlowServer               []struct {
+				Hostname                                         types.String `tfsdk:"hostname"`
+				Port                                             types.Int64  `tfsdk:"port"`
 				AggregationAutonomousSystem                      types.Bool   `tfsdk:"aggregation_autonomous_system"`
 				AggregationDestinationPrefix                     types.Bool   `tfsdk:"aggregation_destination_prefix"`
 				AggregationProtocolPort                          types.Bool   `tfsdk:"aggregation_protocol_port"`
 				AggregationSourceDestinationPrefix               types.Bool   `tfsdk:"aggregation_source_destination_prefix"`
 				AggregationSourceDestinationPrefixCaidaCompliant types.Bool   `tfsdk:"aggregation_source_destination_prefix_caida_compliant"`
 				AggregationSourcePrefix                          types.Bool   `tfsdk:"aggregation_source_prefix"`
-				LocalDump                                        types.Bool   `tfsdk:"local_dump"`
-				NoLocalDump                                      types.Bool   `tfsdk:"no_local_dump"`
-				Hostname                                         types.String `tfsdk:"hostname"`
-				Port                                             types.Int64  `tfsdk:"port"`
 				AutonomousSystemType                             types.String `tfsdk:"autonomous_system_type"`
 				Dscp                                             types.Int64  `tfsdk:"dscp"`
 				ForwardingClass                                  types.String `tfsdk:"forwarding_class"`
+				LocalDump                                        types.Bool   `tfsdk:"local_dump"`
+				NoLocalDump                                      types.Bool   `tfsdk:"no_local_dump"`
 				RoutingInstance                                  types.String `tfsdk:"routing_instance"`
 				SourceAddress                                    types.String `tfsdk:"source_address"`
 				Version9Template                                 types.String `tfsdk:"version9_template"`

--- a/internal/providerfwk/upgradestate_interface_logical.go
+++ b/internal/providerfwk/upgradestate_interface_logical.go
@@ -448,38 +448,38 @@ func upgradeInterfaceLogicalV0toV1(
 	ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse,
 ) {
 	type modelV0 struct {
-		St0AlsoOnDestroy         types.Bool     `tfsdk:"st0_also_on_destroy"`
-		VlanNoCompute            types.Bool     `tfsdk:"vlan_no_compute"`
-		Disable                  types.Bool     `tfsdk:"disable"`
 		ID                       types.String   `tfsdk:"id"`
 		Name                     types.String   `tfsdk:"name"`
+		St0AlsoOnDestroy         types.Bool     `tfsdk:"st0_also_on_destroy"`
+		Disable                  types.Bool     `tfsdk:"disable"`
 		Description              types.String   `tfsdk:"description"`
 		RoutingInstance          types.String   `tfsdk:"routing_instance"`
 		SecurityInboundProtocols []types.String `tfsdk:"security_inbound_protocols"`
 		SecurityInboundServices  []types.String `tfsdk:"security_inbound_services"`
 		SecurityZone             types.String   `tfsdk:"security_zone"`
 		VlanID                   types.Int64    `tfsdk:"vlan_id"`
+		VlanNoCompute            types.Bool     `tfsdk:"vlan_no_compute"`
 		FamilyInet               []struct {
-			SamplingInput  types.Bool   `tfsdk:"sampling_input"`
-			SamplingOutput types.Bool   `tfsdk:"sampling_output"`
 			FilterInput    types.String `tfsdk:"filter_input"`
 			FilterOutput   types.String `tfsdk:"filter_output"`
 			Mtu            types.Int64  `tfsdk:"mtu"`
+			SamplingInput  types.Bool   `tfsdk:"sampling_input"`
+			SamplingOutput types.Bool   `tfsdk:"sampling_output"`
 			Address        []struct {
+				CidrIP    types.String `tfsdk:"cidr_ip"`
 				Preferred types.Bool   `tfsdk:"preferred"`
 				Primary   types.Bool   `tfsdk:"primary"`
-				CidrIP    types.String `tfsdk:"cidr_ip"`
 				VRRPGroup []struct {
-					AcceptData              types.Bool     `tfsdk:"accept_data"`
-					NoAcceptData            types.Bool     `tfsdk:"no_accept_data"`
-					Preempt                 types.Bool     `tfsdk:"preempt"`
-					NoPreempt               types.Bool     `tfsdk:"no_preempt"`
 					Identifier              types.Int64    `tfsdk:"identifier"`
 					VirtualAddress          []types.String `tfsdk:"virtual_address"`
+					AcceptData              types.Bool     `tfsdk:"accept_data"`
+					NoAcceptData            types.Bool     `tfsdk:"no_accept_data"`
 					AdvertiseInterval       types.Int64    `tfsdk:"advertise_interval"`
 					AdvertisementsThreshold types.Int64    `tfsdk:"advertisements_threshold"`
 					AuthenticationKey       types.String   `tfsdk:"authentication_key"`
 					AuthenticationType      types.String   `tfsdk:"authentication_type"`
+					Preempt                 types.Bool     `tfsdk:"preempt"`
+					NoPreempt               types.Bool     `tfsdk:"no_preempt"`
 					Priority                types.Int64    `tfsdk:"priority"`
 					TrackInterface          []struct {
 						Interface    types.String `tfsdk:"interface"`
@@ -494,23 +494,23 @@ func upgradeInterfaceLogicalV0toV1(
 			} `tfsdk:"address"`
 			DHCP []struct {
 				SrxOldOptionName                          types.Bool   `tfsdk:"srx_old_option_name"`
-				ClientIdentifierPrefixHostname            types.Bool   `tfsdk:"client_identifier_prefix_hostname"`
-				ClientIdentifierPrefixRoutingInstanceName types.Bool   `tfsdk:"client_identifier_prefix_routing_instance_name"`
-				ForceDiscover                             types.Bool   `tfsdk:"force_discover"`
-				LeaseTimeInfinite                         types.Bool   `tfsdk:"lease_time_infinite"`
-				NoDNSInstall                              types.Bool   `tfsdk:"no_dns_install"`
-				OptionsNoHostname                         types.Bool   `tfsdk:"options_no_hostname"`
-				UpdateServer                              types.Bool   `tfsdk:"update_server"`
 				ClientIdentifierASCII                     types.String `tfsdk:"client_identifier_ascii"`
 				ClientIdentifierHexadecimal               types.String `tfsdk:"client_identifier_hexadecimal"`
+				ClientIdentifierPrefixHostname            types.Bool   `tfsdk:"client_identifier_prefix_hostname"`
+				ClientIdentifierPrefixRoutingInstanceName types.Bool   `tfsdk:"client_identifier_prefix_routing_instance_name"`
 				ClientIdentifierUseInterfaceDescription   types.String `tfsdk:"client_identifier_use_interface_description"`
 				ClientIdentifierUseridASCII               types.String `tfsdk:"client_identifier_userid_ascii"`
 				ClientIdentifierUseridHexadecimal         types.String `tfsdk:"client_identifier_userid_hexadecimal"`
+				ForceDiscover                             types.Bool   `tfsdk:"force_discover"`
 				LeaseTime                                 types.Int64  `tfsdk:"lease_time"`
+				LeaseTimeInfinite                         types.Bool   `tfsdk:"lease_time_infinite"`
 				Metric                                    types.Int64  `tfsdk:"metric"`
+				NoDNSInstall                              types.Bool   `tfsdk:"no_dns_install"`
+				OptionsNoHostname                         types.Bool   `tfsdk:"options_no_hostname"`
 				RetransmissionAttempt                     types.Int64  `tfsdk:"retransmission_attempt"`
 				RetransmissionInterval                    types.Int64  `tfsdk:"retransmission_interval"`
 				ServerAddress                             types.String `tfsdk:"server_address"`
+				UpdateServer                              types.Bool   `tfsdk:"update_server"`
 				VendorID                                  types.String `tfsdk:"vendor_id"`
 			} `tfsdk:"dhcp"`
 			RPFCheck []struct {
@@ -520,25 +520,25 @@ func upgradeInterfaceLogicalV0toV1(
 		} `tfsdk:"family_inet"`
 		FamilyInet6 []struct {
 			DadDisable     types.Bool   `tfsdk:"dad_disable"`
-			SamplingInput  types.Bool   `tfsdk:"sampling_input"`
-			SamplingOutput types.Bool   `tfsdk:"sampling_output"`
 			FilterInput    types.String `tfsdk:"filter_input"`
 			FilterOutput   types.String `tfsdk:"filter_output"`
 			Mtu            types.Int64  `tfsdk:"mtu"`
+			SamplingInput  types.Bool   `tfsdk:"sampling_input"`
+			SamplingOutput types.Bool   `tfsdk:"sampling_output"`
 			Address        []struct {
+				CidrIP    types.String `tfsdk:"cidr_ip"`
 				Preferred types.Bool   `tfsdk:"preferred"`
 				Primary   types.Bool   `tfsdk:"primary"`
-				CidrIP    types.String `tfsdk:"cidr_ip"`
 				VRRPGroup []struct {
-					AcceptData              types.Bool     `tfsdk:"accept_data"`
-					NoAcceptData            types.Bool     `tfsdk:"no_accept_data"`
-					Preempt                 types.Bool     `tfsdk:"preempt"`
-					NoPreempt               types.Bool     `tfsdk:"no_preempt"`
 					Identifier              types.Int64    `tfsdk:"identifier"`
 					VirtualAddress          []types.String `tfsdk:"virtual_address"`
 					VirutalLinkLocalAddress types.String   `tfsdk:"virtual_link_local_address"`
+					AcceptData              types.Bool     `tfsdk:"accept_data"`
+					NoAcceptData            types.Bool     `tfsdk:"no_accept_data"`
 					AdvertiseInterval       types.Int64    `tfsdk:"advertise_interval"`
 					AdvertisementsThreshold types.Int64    `tfsdk:"advertisements_threshold"`
+					Preempt                 types.Bool     `tfsdk:"preempt"`
+					NoPreempt               types.Bool     `tfsdk:"no_preempt"`
 					Priority                types.Int64    `tfsdk:"priority"`
 					TrackInterface          []struct {
 						Interface    types.String `tfsdk:"interface"`
@@ -552,14 +552,14 @@ func upgradeInterfaceLogicalV0toV1(
 				} `tfsdk:"vrrp_group"`
 			} `tfsdk:"address"`
 			DHCPv6Client []struct {
+				ClientIdentifierDuidType              types.String   `tfsdk:"client_identifier_duid_type"`
+				ClientType                            types.String   `tfsdk:"client_type"`
 				ClientIATypeNA                        types.Bool     `tfsdk:"client_ia_type_na"`
 				ClientIATypePD                        types.Bool     `tfsdk:"client_ia_type_pd"`
 				NoDNSInstall                          types.Bool     `tfsdk:"no_dns_install"`
-				RapidCommit                           types.Bool     `tfsdk:"rapid_commit"`
-				ClientIdentifierDuidType              types.String   `tfsdk:"client_identifier_duid_type"`
-				ClientType                            types.String   `tfsdk:"client_type"`
 				PrefixDelegatingPreferredPrefixLength types.Int64    `tfsdk:"prefix_delegating_preferred_prefix_length"`
 				PrefixDelegatingSubPrefixLength       types.Int64    `tfsdk:"prefix_delegating_sub_prefix_length"`
+				RapidCommit                           types.Bool     `tfsdk:"rapid_commit"`
 				ReqOption                             []types.String `tfsdk:"req_option"`
 				RetransmissionAttempt                 types.Int64    `tfsdk:"retransmission_attempt"`
 				UpdateRouterAdvertisementInterface    []types.String `tfsdk:"update_router_advertisement_interface"`
@@ -571,13 +571,13 @@ func upgradeInterfaceLogicalV0toV1(
 			} `tfsdk:"rpf_check"`
 		} `tfsdk:"family_inet6"`
 		Tunnel []struct {
-			AllowFragmentation         types.Bool   `tfsdk:"allow_fragmentation"`
-			DoNotFragment              types.Bool   `tfsdk:"do_not_fragment"`
-			PathMtuDiscovery           types.Bool   `tfsdk:"path_mtu_discovery"`
-			NoPathMtuDiscovery         types.Bool   `tfsdk:"no_path_mtu_discovery"`
 			Destination                types.String `tfsdk:"destination"`
 			Source                     types.String `tfsdk:"source"`
+			AllowFragmentation         types.Bool   `tfsdk:"allow_fragmentation"`
+			DoNotFragment              types.Bool   `tfsdk:"do_not_fragment"`
 			FlowLabel                  types.Int64  `tfsdk:"flow_label"`
+			PathMtuDiscovery           types.Bool   `tfsdk:"path_mtu_discovery"`
+			NoPathMtuDiscovery         types.Bool   `tfsdk:"no_path_mtu_discovery"`
 			RoutingInstanceDestination types.String `tfsdk:"routing_instance_destination"`
 			TrafficClass               types.Int64  `tfsdk:"traffic_class"`
 			TTL                        types.Int64  `tfsdk:"ttl"`

--- a/internal/providerfwk/upgradestate_interface_physical.go
+++ b/internal/providerfwk/upgradestate_interface_physical.go
@@ -249,41 +249,41 @@ func upgradeInterfacePhysicalV0toV1(
 	ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse,
 ) {
 	type modelV0 struct {
-		NoDisableOnDestroy types.Bool     `tfsdk:"no_disable_on_destroy"`
-		Disable            types.Bool     `tfsdk:"disable"`
-		Trunk              types.Bool     `tfsdk:"trunk"`
-		VlanTagging        types.Bool     `tfsdk:"vlan_tagging"`
 		ID                 types.String   `tfsdk:"id"`
 		Name               types.String   `tfsdk:"name"`
+		NoDisableOnDestroy types.Bool     `tfsdk:"no_disable_on_destroy"`
 		Description        types.String   `tfsdk:"description"`
+		Disable            types.Bool     `tfsdk:"disable"`
 		Mtu                types.Int64    `tfsdk:"mtu"`
+		Trunk              types.Bool     `tfsdk:"trunk"`
 		VlanMembers        []types.String `tfsdk:"vlan_members"`
 		VlanNative         types.Int64    `tfsdk:"vlan_native"`
+		VlanTagging        types.Bool     `tfsdk:"vlan_tagging"`
 		ESI                []struct {
-			AutoDeriveLACP types.Bool   `tfsdk:"auto_derive_lacp"`
 			Mode           types.String `tfsdk:"mode"`
+			AutoDeriveLACP types.Bool   `tfsdk:"auto_derive_lacp"`
 			DFElectionType types.String `tfsdk:"df_election_type"`
 			Identifier     types.String `tfsdk:"identifier"`
 			SourceBMAC     types.String `tfsdk:"source_bmac"`
 		} `tfsdk:"esi"`
 		EtherOpts []struct {
+			Ae8023ad          types.String `tfsdk:"ae_8023ad"`
 			AutoNegotiation   types.Bool   `tfsdk:"auto_negotiation"`
 			NoAutoNegotiation types.Bool   `tfsdk:"no_auto_negotiation"`
 			FlowControl       types.Bool   `tfsdk:"flow_control"`
 			NoFlowControl     types.Bool   `tfsdk:"no_flow_control"`
 			Loopback          types.Bool   `tfsdk:"loopback"`
 			NoLoopback        types.Bool   `tfsdk:"no_loopback"`
-			Ae8023ad          types.String `tfsdk:"ae_8023ad"`
 			RedundantParent   types.String `tfsdk:"redundant_parent"`
 		} `tfsdk:"ether_opts"`
 		GigetherOpts []struct {
+			Ae8023ad          types.String `tfsdk:"ae_8023ad"`
 			AutoNegotiation   types.Bool   `tfsdk:"auto_negotiation"`
 			NoAutoNegotiation types.Bool   `tfsdk:"no_auto_negotiation"`
 			FlowControl       types.Bool   `tfsdk:"flow_control"`
 			NoFlowControl     types.Bool   `tfsdk:"no_flow_control"`
 			Loopback          types.Bool   `tfsdk:"loopback"`
 			NoLoopback        types.Bool   `tfsdk:"no_loopback"`
-			Ae8023ad          types.String `tfsdk:"ae_8023ad"`
 			RedundantParent   types.String `tfsdk:"redundant_parent"`
 		} `tfsdk:"gigether_opts"`
 		ParentEtherOpts []struct {
@@ -291,17 +291,16 @@ func upgradeInterfacePhysicalV0toV1(
 			NoFlowControl        types.Bool     `tfsdk:"no_flow_control"`
 			Loopback             types.Bool     `tfsdk:"loopback"`
 			NoLoopback           types.Bool     `tfsdk:"no_loopback"`
-			SourceFiltering      types.Bool     `tfsdk:"source_filtering"`
 			LinkSpeed            types.String   `tfsdk:"link_speed"`
 			MinimumBandwidth     types.String   `tfsdk:"minimum_bandwidth"`
 			MinimumLinks         types.Int64    `tfsdk:"minimum_links"`
 			RedundancyGroup      types.Int64    `tfsdk:"redundancy_group"`
 			SourceAddressFilter  []types.String `tfsdk:"source_address_filter"`
+			SourceFiltering      types.Bool     `tfsdk:"source_filtering"`
 			BFDLivenessDetection []struct {
-				AuthenticationLooseCheck        types.Bool   `tfsdk:"authentication_loose_check"`
-				NoAdaptation                    types.Bool   `tfsdk:"no_adaptation"`
 				LocalAddress                    types.String `tfsdk:"local_address"`
 				AuthenticationAlgorithm         types.String `tfsdk:"authentication_algorithm"`
+				AuthenticationLooseCheck        types.Bool   `tfsdk:"authentication_loose_check"`
 				AuthenticationKeyChain          types.String `tfsdk:"authentication_key_chain"`
 				DetectionTimeThreshold          types.Int64  `tfsdk:"detection_time_threshold"`
 				HolddownInterval                types.Int64  `tfsdk:"holddown_interval"`
@@ -309,6 +308,7 @@ func upgradeInterfacePhysicalV0toV1(
 				MinimumReceiveInterval          types.Int64  `tfsdk:"minimum_receive_interval"`
 				Multiplier                      types.Int64  `tfsdk:"multiplier"`
 				Neighbor                        types.String `tfsdk:"neighbor"`
+				NoAdaptation                    types.Bool   `tfsdk:"no_adaptation"`
 				TransmitIntervalMinimumInterval types.Int64  `tfsdk:"transmit_interval_minimum_interval"`
 				TransmitIntervalThreshold       types.Int64  `tfsdk:"transmit_interval_threshold"`
 				Version                         types.String `tfsdk:"version"`

--- a/internal/providerfwk/upgradestate_policyoptions_policy_statement.go
+++ b/internal/providerfwk/upgradestate_policyoptions_policy_statement.go
@@ -228,9 +228,9 @@ func upgradePolicyoptionsPolicyStatementStateV0toV1(
 	ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse,
 ) {
 	type modelV0 struct {
-		AddItToForwardingTableExport types.Bool                              `tfsdk:"add_it_to_forwarding_table_export"`
 		ID                           types.String                            `tfsdk:"id"`
 		Name                         types.String                            `tfsdk:"name"`
+		AddItToForwardingTableExport types.Bool                              `tfsdk:"add_it_to_forwarding_table_export"`
 		From                         []policyoptionsPolicyStatementBlockFrom `tfsdk:"from"`
 		To                           []policyoptionsPolicyStatementBlockTo   `tfsdk:"to"`
 		Then                         []struct {

--- a/internal/providerfwk/upgradestate_security.go
+++ b/internal/providerfwk/upgradestate_security.go
@@ -400,10 +400,10 @@ func (rsc *security) UpgradeState(_ context.Context) map[int64]resource.StateUpg
 											"size": schema.Int64Attribute{
 												Optional: true,
 											},
-											"no_world_readable": schema.BoolAttribute{
+											"world_readable": schema.BoolAttribute{
 												Optional: true,
 											},
-											"world_readable": schema.BoolAttribute{
+											"no_world_readable": schema.BoolAttribute{
 												Optional: true,
 											},
 										},
@@ -560,8 +560,8 @@ func upgradeSecurityV0toV1(
 	ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse,
 ) {
 	type modelV0 struct {
-		CleanOnDestroy types.Bool   `tfsdk:"clean_on_destroy"`
 		ID             types.String `tfsdk:"id"`
+		CleanOnDestroy types.Bool   `tfsdk:"clean_on_destroy"`
 		Alg            []struct {
 			DNSDisable    types.Bool `tfsdk:"dns_disable"`
 			FtpDisable    types.Bool `tfsdk:"ftp_disable"`
@@ -586,11 +586,11 @@ func upgradeSecurityV0toV1(
 			ForceIPReassembly                types.Bool   `tfsdk:"force_ip_reassembly"`
 			IpsecPerformanceAcceleration     types.Bool   `tfsdk:"ipsec_performance_acceleration"`
 			McastBufferEnhance               types.Bool   `tfsdk:"mcast_buffer_enhance"`
-			PreserveIncomingFragmentSize     types.Bool   `tfsdk:"preserve_incoming_fragment_size"`
-			SyncIcmpSession                  types.Bool   `tfsdk:"sync_icmp_session"`
 			PendingSessQueueLength           types.String `tfsdk:"pending_sess_queue_length"`
+			PreserveIncomingFragmentSize     types.Bool   `tfsdk:"preserve_incoming_fragment_size"`
 			RouteChangeTimeout               types.Int64  `tfsdk:"route_change_timeout"`
 			SynFloodProtectionMode           types.String `tfsdk:"syn_flood_protection_mode"`
+			SyncIcmpSession                  types.Bool   `tfsdk:"sync_icmp_session"`
 			AdvancedOptions                  []struct {
 				DropMatchingLinkLocalAddress  types.Bool `tfsdk:"drop_matching_link_local_address"`
 				DropMatchingReservedIPAddress types.Bool `tfsdk:"drop_matching_reserved_ip_address"`
@@ -623,13 +623,13 @@ func upgradeSecurityV0toV1(
 			} `tfsdk:"tcp_mss"`
 			TCPSession []struct {
 				FinInvalidateSession types.Bool   `tfsdk:"fin_invalidate_session"`
+				MaximumWindow        types.String `tfsdk:"maximum_window"`
 				NoSequenceCheck      types.Bool   `tfsdk:"no_sequence_check"`
 				NoSynCheck           types.Bool   `tfsdk:"no_syn_check"`
 				NoSynCheckInTunnel   types.Bool   `tfsdk:"no_syn_check_in_tunnel"`
 				RstInvalidateSession types.Bool   `tfsdk:"rst_invalidate_session"`
 				RstSequenceCheck     types.Bool   `tfsdk:"rst_sequence_check"`
 				StrictSynCheck       types.Bool   `tfsdk:"strict_syn_check"`
-				MaximumWindow        types.String `tfsdk:"maximum_window"`
 				TCPInitialTimeout    types.Int64  `tfsdk:"tcp_initial_timeout"`
 				TimeWaitState        []struct {
 					ApplyToHalfCloseState types.Bool  `tfsdk:"apply_to_half_close_state"`
@@ -648,9 +648,9 @@ func upgradeSecurityV0toV1(
 		} `tfsdk:"forwarding_process"`
 		IdpSecurityPackage []struct {
 			AutomaticEnable           types.Bool   `tfsdk:"automatic_enable"`
-			InstallIgnoreVersionCheck types.Bool   `tfsdk:"install_ignore_version_check"`
 			AutomaticInterval         types.Int64  `tfsdk:"automatic_interval"`
 			AutomaticStartTime        types.String `tfsdk:"automatic_start_time"`
+			InstallIgnoreVersionCheck types.Bool   `tfsdk:"install_ignore_version_check"`
 			ProxyProfile              types.String `tfsdk:"proxy_profile"`
 			SourceAddress             types.String `tfsdk:"source_address"`
 			URL                       types.String `tfsdk:"url"`
@@ -680,26 +680,26 @@ func upgradeSecurityV0toV1(
 			NoRemoteTrace types.Bool     `tfsdk:"no_remote_trace"`
 			RateLimit     types.Int64    `tfsdk:"rate_limit"`
 			File          []struct {
-				NoWorldReadable types.Bool   `tfsdk:"no_world_readable"`
-				WorldReadable   types.Bool   `tfsdk:"world_readable"`
 				Name            types.String `tfsdk:"name"`
 				Files           types.Int64  `tfsdk:"files"`
 				Match           types.String `tfsdk:"match"`
 				Size            types.Int64  `tfsdk:"size"`
+				WorldReadable   types.Bool   `tfsdk:"world_readable"`
+				NoWorldReadable types.Bool   `tfsdk:"no_world_readable"`
 			} `tfsdk:"file"`
 		} `tfsdk:"ike_traceoptions"`
 		Log []struct {
 			Disable           types.Bool   `tfsdk:"disable"`
-			Report            types.Bool   `tfsdk:"report"`
-			UtcTimestamp      types.Bool   `tfsdk:"utc_timestamp"`
 			EventRate         types.Int64  `tfsdk:"event_rate"`
 			FacilityOverride  types.String `tfsdk:"facility_override"`
 			Format            types.String `tfsdk:"format"`
 			MaxDatabaseRecord types.Int64  `tfsdk:"max_database_record"`
 			Mode              types.String `tfsdk:"mode"`
 			RateCap           types.Int64  `tfsdk:"rate_cap"`
+			Report            types.Bool   `tfsdk:"report"`
 			SourceAddress     types.String `tfsdk:"source_address"`
 			SourceInterface   types.String `tfsdk:"source_interface"`
+			UtcTimestamp      types.Bool   `tfsdk:"utc_timestamp"`
 			File              []struct {
 				Files types.Int64  `tfsdk:"files"`
 				Name  types.String `tfsdk:"name"`

--- a/internal/providerfwk/upgradestate_security_global_policy.go
+++ b/internal/providerfwk/upgradestate_security_global_policy.go
@@ -147,38 +147,38 @@ func upgradeSecurityGlobalPolicyV0toV1(
 	type modelV0 struct {
 		ID     types.String `tfsdk:"id"`
 		Policy []struct {
-			Count                           types.Bool     `tfsdk:"count"`
-			LogInit                         types.Bool     `tfsdk:"log_init"`
-			LogClose                        types.Bool     `tfsdk:"log_close"`
-			MatchDestinationAddressExcluded types.Bool     `tfsdk:"match_destination_address_excluded"`
-			MatchSourceAddressExcluded      types.Bool     `tfsdk:"match_source_address_excluded"`
 			Name                            types.String   `tfsdk:"name"`
-			Then                            types.String   `tfsdk:"then"`
-			MatchSourceEndUserProfile       types.String   `tfsdk:"match_source_end_user_profile"`
 			MatchSourceAddress              []types.String `tfsdk:"match_source_address"`
 			MatchDestinationAddress         []types.String `tfsdk:"match_destination_address"`
 			MatchFromZone                   []types.String `tfsdk:"match_from_zone"`
 			MatchToZone                     []types.String `tfsdk:"match_to_zone"`
+			Then                            types.String   `tfsdk:"then"`
+			Count                           types.Bool     `tfsdk:"count"`
+			LogInit                         types.Bool     `tfsdk:"log_init"`
+			LogClose                        types.Bool     `tfsdk:"log_close"`
 			MatchApplication                []types.String `tfsdk:"match_application"`
+			MatchDestinationAddressExcluded types.Bool     `tfsdk:"match_destination_address_excluded"`
 			MatchDynamicApplication         []types.String `tfsdk:"match_dynamic_application"`
+			MatchSourceAddressExcluded      types.Bool     `tfsdk:"match_source_address_excluded"`
+			MatchSourceEndUserProfile       types.String   `tfsdk:"match_source_end_user_profile"`
 			PermitApplicationServices       []struct {
-				Idp                              types.Bool   `tfsdk:"idp"`
-				RedirectWx                       types.Bool   `tfsdk:"redirect_wx"`
-				ReverseRedirectWx                types.Bool   `tfsdk:"reverse_redirect_wx"`
 				AdvancedAntiMalwarePolicy        types.String `tfsdk:"advanced_anti_malware_policy"`
 				ApplicationFirewallRuleSet       types.String `tfsdk:"application_firewall_rule_set"`
 				ApplicationTrafficControlRuleSet types.String `tfsdk:"application_traffic_control_rule_set"`
 				GprsGtpProfile                   types.String `tfsdk:"gprs_gtp_profile"`
 				GprsSctpProfile                  types.String `tfsdk:"gprs_sctp_profile"`
+				Idp                              types.Bool   `tfsdk:"idp"`
 				IdpPolicy                        types.String `tfsdk:"idp_policy"`
+				RedirectWx                       types.Bool   `tfsdk:"redirect_wx"`
+				ReverseRedirectWx                types.Bool   `tfsdk:"reverse_redirect_wx"`
 				SecurityIntelligencePolicy       types.String `tfsdk:"security_intelligence_policy"`
+				UtmPolicy                        types.String `tfsdk:"utm_policy"`
 				SSLProxy                         []struct {
 					ProfileName types.String `tfsdk:"profile_name"`
 				} `tfsdk:"ssl_proxy"`
 				UacPolicy []struct {
 					CaptivePortal types.String `tfsdk:"captive_portal"`
 				} `tfsdk:"uac_policy"`
-				UtmPolicy types.String `tfsdk:"utm_policy"`
 			} `tfsdk:"permit_application_services"`
 		} `tfsdk:"policy"`
 	}

--- a/internal/providerfwk/upgradestate_security_ike_gateway.go
+++ b/internal/providerfwk/upgradestate_security_ike_gateway.go
@@ -150,26 +150,16 @@ func upgradeSecurityIkeGatewayV0toV1(
 	ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse,
 ) {
 	type modelV0 struct {
-		GeneralIkeID      types.Bool     `tfsdk:"general_ike_id"`
-		NoNatTraversal    types.Bool     `tfsdk:"no_nat_traversal"`
 		ID                types.String   `tfsdk:"id"`
 		Name              types.String   `tfsdk:"name"`
 		ExternalInterface types.String   `tfsdk:"external_interface"`
 		Policy            types.String   `tfsdk:"policy"`
 		Address           []types.String `tfsdk:"address"`
+		GeneralIkeID      types.Bool     `tfsdk:"general_ike_id"`
 		LocalAddress      types.String   `tfsdk:"local_address"`
+		NoNatTraversal    types.Bool     `tfsdk:"no_nat_traversal"`
 		Version           types.String   `tfsdk:"version"`
-		Aaa               []struct {
-			AccessProfile  types.String `tfsdk:"access_profile"`
-			ClientPassword types.String `tfsdk:"client_password"`
-			ClientUsername types.String `tfsdk:"client_username"`
-		} `tfsdk:"aaa"`
-		DeadPeerDetection []struct {
-			Interval  types.Int64  `tfsdk:"interval"`
-			SendMode  types.String `tfsdk:"send_mode"`
-			Threshold types.Int64  `tfsdk:"threshold"`
-		} `tfsdk:"dead_peer_detection"`
-		DynamicRemote []struct {
+		DynamicRemote     []struct {
 			ConnectionsLimit          types.Int64  `tfsdk:"connections_limit"`
 			Hostname                  types.String `tfsdk:"hostname"`
 			IkeUserType               types.String `tfsdk:"ike_user_type"`
@@ -182,6 +172,16 @@ func upgradeSecurityIkeGatewayV0toV1(
 				Wildcard  types.String `tfsdk:"wildcard"`
 			} `tfsdk:"distinguished_name"`
 		} `tfsdk:"dynamic_remote"`
+		Aaa []struct {
+			AccessProfile  types.String `tfsdk:"access_profile"`
+			ClientPassword types.String `tfsdk:"client_password"`
+			ClientUsername types.String `tfsdk:"client_username"`
+		} `tfsdk:"aaa"`
+		DeadPeerDetection []struct {
+			Interval  types.Int64  `tfsdk:"interval"`
+			SendMode  types.String `tfsdk:"send_mode"`
+			Threshold types.Int64  `tfsdk:"threshold"`
+		} `tfsdk:"dead_peer_detection"`
 		LocalIdentity []struct {
 			Type  types.String `tfsdk:"type"`
 			Value types.String `tfsdk:"value"`

--- a/internal/providerfwk/upgradestate_security_ipsec_vpn.go
+++ b/internal/providerfwk/upgradestate_security_ipsec_vpn.go
@@ -114,10 +114,10 @@ func upgradeSecurityIpsecVpnV0toV1(
 			RemoteIP types.String `tfsdk:"remote_ip"`
 		} `tfsdk:"traffic_selector"`
 		VpnMonitor []struct {
-			Optimized           types.Bool   `tfsdk:"optimized"`
-			SourceInterfaceAuto types.Bool   `tfsdk:"source_interface_auto"`
 			DestinationIP       types.String `tfsdk:"destination_ip"`
+			Optimized           types.Bool   `tfsdk:"optimized"`
 			SourceInterface     types.String `tfsdk:"source_interface"`
+			SourceInterfaceAuto types.Bool   `tfsdk:"source_interface_auto"`
 		} `tfsdk:"vpn_monitor"`
 	}
 

--- a/internal/providerfwk/upgradestate_security_nat_static.go
+++ b/internal/providerfwk/upgradestate_security_nat_static.go
@@ -107,9 +107,9 @@ func upgradeSecurityNatStaticV0toV1(
 	ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse,
 ) {
 	type modelV0 struct {
-		ConfigureRulesSingly types.Bool   `tfsdk:"configure_rules_singly"`
 		ID                   types.String `tfsdk:"id"`
 		Name                 types.String `tfsdk:"name"`
+		ConfigureRulesSingly types.Bool   `tfsdk:"configure_rules_singly"`
 		Description          types.String `tfsdk:"description"`
 		From                 []struct {
 			Type  types.String   `tfsdk:"type"`

--- a/internal/providerfwk/upgradestate_security_policy.go
+++ b/internal/providerfwk/upgradestate_security_policy.go
@@ -150,29 +150,29 @@ func upgradeSecurityPolicyV0toV1(
 		FromZone types.String `tfsdk:"from_zone"`
 		ToZone   types.String `tfsdk:"to_zone"`
 		Policy   []struct {
+			Name                            types.String   `tfsdk:"name"`
+			MatchSourceAddress              []types.String `tfsdk:"match_source_address"`
+			MatchDestinationAddress         []types.String `tfsdk:"match_destination_address"`
+			Then                            types.String   `tfsdk:"then"`
 			Count                           types.Bool     `tfsdk:"count"`
 			LogInit                         types.Bool     `tfsdk:"log_init"`
 			LogClose                        types.Bool     `tfsdk:"log_close"`
+			MatchApplication                []types.String `tfsdk:"match_application"`
 			MatchDestinationAddressExcluded types.Bool     `tfsdk:"match_destination_address_excluded"`
+			MatchDynamicApplication         []types.String `tfsdk:"match_dynamic_application"`
 			MatchSourceAddressExcluded      types.Bool     `tfsdk:"match_source_address_excluded"`
-			Name                            types.String   `tfsdk:"name"`
-			Then                            types.String   `tfsdk:"then"`
 			MatchSourceEndUserProfile       types.String   `tfsdk:"match_source_end_user_profile"`
 			PermitTunnelIpsecVpn            types.String   `tfsdk:"permit_tunnel_ipsec_vpn"`
-			MatchSourceAddress              []types.String `tfsdk:"match_source_address"`
-			MatchDestinationAddress         []types.String `tfsdk:"match_destination_address"`
-			MatchApplication                []types.String `tfsdk:"match_application"`
-			MatchDynamicApplication         []types.String `tfsdk:"match_dynamic_application"`
 			PermitApplicationServices       []struct {
-				Idp                              types.Bool   `tfsdk:"idp"`
-				RedirectWx                       types.Bool   `tfsdk:"redirect_wx"`
-				ReverseRedirectWx                types.Bool   `tfsdk:"reverse_redirect_wx"`
 				AdvancedAntiMalwarePolicy        types.String `tfsdk:"advanced_anti_malware_policy"`
 				ApplicationFirewallRuleSet       types.String `tfsdk:"application_firewall_rule_set"`
 				ApplicationTrafficControlRuleSet types.String `tfsdk:"application_traffic_control_rule_set"`
 				GprsGtpProfile                   types.String `tfsdk:"gprs_gtp_profile"`
 				GprsSctpProfile                  types.String `tfsdk:"gprs_sctp_profile"`
+				Idp                              types.Bool   `tfsdk:"idp"`
 				IdpPolicy                        types.String `tfsdk:"idp_policy"`
+				RedirectWx                       types.Bool   `tfsdk:"redirect_wx"`
+				ReverseRedirectWx                types.Bool   `tfsdk:"reverse_redirect_wx"`
 				SecurityIntelligencePolicy       types.String `tfsdk:"security_intelligence_policy"`
 				SSLProxy                         []struct {
 					ProfileName types.String `tfsdk:"profile_name"`

--- a/internal/providerfwk/upgradestate_services_flowmonitoring_vipfix_template.go
+++ b/internal/providerfwk/upgradestate_services_flowmonitoring_vipfix_template.go
@@ -84,21 +84,21 @@ func upgradeServicesFlowMonitoringVIPFixTemplateStateV0toV1(
 	ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse,
 ) {
 	type modelV0 struct {
-		FlowKeyFlowDirection      types.Bool     `tfsdk:"flow_key_flow_direction"`
-		FlowKeyVlanID             types.Bool     `tfsdk:"flow_key_vlan_id"`
-		NexthopLearningEnable     types.Bool     `tfsdk:"nexthop_learning_enable"`
-		NexthopLearningDisable    types.Bool     `tfsdk:"nexthop_learning_disable"`
-		TunnelObservationIPv4     types.Bool     `tfsdk:"tunnel_observation_ipv4"`
-		TunnelObservationIPv6     types.Bool     `tfsdk:"tunnel_observation_ipv6"`
 		ID                        types.String   `tfsdk:"id"`
 		Name                      types.String   `tfsdk:"name"`
 		Type                      types.String   `tfsdk:"type"`
 		FlowActiveTimeout         types.Int64    `tfsdk:"flow_active_timeout"`
 		FlowInactiveTimeout       types.Int64    `tfsdk:"flow_inactive_timeout"`
+		FlowKeyFlowDirection      types.Bool     `tfsdk:"flow_key_flow_direction"`
+		FlowKeyVlanID             types.Bool     `tfsdk:"flow_key_vlan_id"`
 		IPTemplateExportExtension []types.String `tfsdk:"ip_template_export_extension"`
+		NexthopLearningEnable     types.Bool     `tfsdk:"nexthop_learning_enable"`
+		NexthopLearningDisable    types.Bool     `tfsdk:"nexthop_learning_disable"`
 		ObservationDomainID       types.Int64    `tfsdk:"observation_domain_id"`
 		OptionTemplateID          types.Int64    `tfsdk:"option_template_id"`
 		TemplateID                types.Int64    `tfsdk:"template_id"`
+		TunnelObservationIPv4     types.Bool     `tfsdk:"tunnel_observation_ipv4"`
+		TunnelObservationIPv6     types.Bool     `tfsdk:"tunnel_observation_ipv6"`
 		OptionRefreshRate         []struct {
 			Packets types.Int64 `tfsdk:"packets"`
 			Seconds types.Int64 `tfsdk:"seconds"`

--- a/internal/providerfwk/upgradestate_snmp.go
+++ b/internal/providerfwk/upgradestate_snmp.go
@@ -101,24 +101,24 @@ func upgradeSnmpV0toV1(
 	ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse,
 ) {
 	type modelV0 struct {
+		ID                          types.String   `tfsdk:"id"`
 		CleanOnDestroy              types.Bool     `tfsdk:"clean_on_destroy"`
 		ARP                         types.Bool     `tfsdk:"arp"`
 		ARPHostNameResolution       types.Bool     `tfsdk:"arp_host_name_resolution"`
-		FilterDuplicates            types.Bool     `tfsdk:"filter_duplicates"`
-		FilterInternalInterfaces    types.Bool     `tfsdk:"filter_internal_interfaces"`
-		IfCountWithFilterInterfaces types.Bool     `tfsdk:"if_count_with_filter_interfaces"`
-		RoutingInstanceAccess       types.Bool     `tfsdk:"routing_instance_access"`
-		ID                          types.String   `tfsdk:"id"`
 		Contact                     types.String   `tfsdk:"contact"`
 		Description                 types.String   `tfsdk:"description"`
 		EngineID                    types.String   `tfsdk:"engine_id"`
+		FilterDuplicates            types.Bool     `tfsdk:"filter_duplicates"`
 		FilterInterfaces            []types.String `tfsdk:"filter_interfaces"`
+		FilterInternalInterfaces    types.Bool     `tfsdk:"filter_internal_interfaces"`
+		IfCountWithFilterInterfaces types.Bool     `tfsdk:"if_count_with_filter_interfaces"`
 		Interface                   []types.String `tfsdk:"interface"`
 		Location                    types.String   `tfsdk:"location"`
+		RoutingInstanceAccess       types.Bool     `tfsdk:"routing_instance_access"`
 		RoutingInstanceAccessList   []types.String `tfsdk:"routing_instance_access_list"`
 		HealthMonitor               []struct {
-			Idp                 types.Bool  `tfsdk:"idp"`
 			FallingThreshold    types.Int64 `tfsdk:"falling_threshold"`
+			Idp                 types.Bool  `tfsdk:"idp"`
 			IdpFallingThreshold types.Int64 `tfsdk:"idp_falling_threshold"`
 			IdpInterval         types.Int64 `tfsdk:"idp_interval"`
 			IdpRisingThreshold  types.Int64 `tfsdk:"idp_rising_threshold"`

--- a/internal/providerfwk/upgradestate_system.go
+++ b/internal/providerfwk/upgradestate_system.go
@@ -648,28 +648,28 @@ func upgradeSystemV0toV1(
 	ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse,
 ) {
 	type modelV0 struct {
-		AutoSnapshot                          types.Bool     `tfsdk:"auto_snapshot"`
-		DefaultAddressSelection               types.Bool     `tfsdk:"default_address_selection"`
-		NoMulticastEcho                       types.Bool     `tfsdk:"no_multicast_echo"`
-		NoPingRecordRoute                     types.Bool     `tfsdk:"no_ping_record_route"`
-		NoPingTimestamp                       types.Bool     `tfsdk:"no_ping_time_stamp"`
-		NoRedirects                           types.Bool     `tfsdk:"no_redirects"`
-		NoRedirectsIPv6                       types.Bool     `tfsdk:"no_redirects_ipv6"`
-		RadiusOptionsEnhancedAccounting       types.Bool     `tfsdk:"radius_options_enhanced_accounting"`
-		RadiusOptionsPasswordProtocolMschapv2 types.Bool     `tfsdk:"radius_options_password_protocol_mschapv2"`
 		ID                                    types.String   `tfsdk:"id"`
 		AuthenticationOrder                   []types.String `tfsdk:"authentication_order"`
+		AutoSnapshot                          types.Bool     `tfsdk:"auto_snapshot"`
+		DefaultAddressSelection               types.Bool     `tfsdk:"default_address_selection"`
 		DomainName                            types.String   `tfsdk:"domain_name"`
 		HostName                              types.String   `tfsdk:"host_name"`
 		MaxConfigurationRollbacks             types.Int64    `tfsdk:"max_configuration_rollbacks"`
 		MaxConfigurationsOnFlash              types.Int64    `tfsdk:"max_configurations_on_flash"`
 		NameServer                            []types.String `tfsdk:"name_server"`
+		NoMulticastEcho                       types.Bool     `tfsdk:"no_multicast_echo"`
+		NoPingRecordRoute                     types.Bool     `tfsdk:"no_ping_record_route"`
+		NoPingTimestamp                       types.Bool     `tfsdk:"no_ping_time_stamp"`
+		NoRedirects                           types.Bool     `tfsdk:"no_redirects"`
+		NoRedirectsIPv6                       types.Bool     `tfsdk:"no_redirects_ipv6"`
 		RadiusOptionsAttributesNasIpaddress   types.String   `tfsdk:"radius_options_attributes_nas_ipaddress"`
+		RadiusOptionsEnhancedAccounting       types.Bool     `tfsdk:"radius_options_enhanced_accounting"`
+		RadiusOptionsPasswordProtocolMschapv2 types.Bool     `tfsdk:"radius_options_password_protocol_mschapv2"`
 		TimeZone                              types.String   `tfsdk:"time_zone"`
 		TracingDestOverrideSyslogHost         types.String   `tfsdk:"tracing_dest_override_syslog_host"`
 		ArchivalConfiguration                 []struct {
-			TransferOnCommit types.Bool  `tfsdk:"transfer_on_commit"`
 			TransferInterval types.Int64 `tfsdk:"transfer_interval"`
+			TransferOnCommit types.Bool  `tfsdk:"transfer_on_commit"`
 			ArchiveSite      []struct {
 				URL      types.String `tfsdk:"url"`
 				Password types.String `tfsdk:"password"`
@@ -684,21 +684,21 @@ func upgradeSystemV0toV1(
 			NoGrePathMtuDiscovery               types.Bool   `tfsdk:"no_gre_path_mtu_discovery"`
 			IpipPathMtuDiscovery                types.Bool   `tfsdk:"ipip_path_mtu_discovery"`
 			NoIpipPathMtuDiscovery              types.Bool   `tfsdk:"no_ipip_path_mtu_discovery"`
+			IPv6DuplicateAddrDetectionTransmits types.Int64  `tfsdk:"ipv6_duplicate_addr_detection_transmits"`
 			IPv6PathMtuDiscovery                types.Bool   `tfsdk:"ipv6_path_mtu_discovery"`
 			NoIPv6PathMtuDiscovery              types.Bool   `tfsdk:"no_ipv6_path_mtu_discovery"`
+			IPv6PathMtuDiscoveryTimeout         types.Int64  `tfsdk:"ipv6_path_mtu_discovery_timeout"`
 			IPv6RejectZeroHopLimit              types.Bool   `tfsdk:"ipv6_reject_zero_hop_limit"`
 			NoIPv6RejectZeroHopLimit            types.Bool   `tfsdk:"no_ipv6_reject_zero_hop_limit"`
+			NoTCPReset                          types.String `tfsdk:"no_tcp_reset"`
 			NoTCPRFC1323                        types.Bool   `tfsdk:"no_tcp_rfc1323"`
 			NoTCPRFC1323Paws                    types.Bool   `tfsdk:"no_tcp_rfc1323_paws"`
 			PathMtuDiscovery                    types.Bool   `tfsdk:"path_mtu_discovery"`
 			NoPathMtuDiscovery                  types.Bool   `tfsdk:"no_path_mtu_discovery"`
+			SourcePortUpperLimit                types.Int64  `tfsdk:"source_port_upper_limit"`
 			SourceQuench                        types.Bool   `tfsdk:"source_quench"`
 			NoSourceQuench                      types.Bool   `tfsdk:"no_source_quench"`
 			TCPDropSynfinSet                    types.Bool   `tfsdk:"tcp_drop_synfin_set"`
-			IPv6DuplicateAddrDetectionTransmits types.Int64  `tfsdk:"ipv6_duplicate_addr_detection_transmits"`
-			IPv6PathMtuDiscoveryTimeout         types.Int64  `tfsdk:"ipv6_path_mtu_discovery_timeout"`
-			NoTCPReset                          types.String `tfsdk:"no_tcp_reset"`
-			SourcePortUpperLimit                types.Int64  `tfsdk:"source_port_upper_limit"`
 			TCPMss                              types.Int64  `tfsdk:"tcp_mss"`
 			IcmpV4RateLimit                     []struct {
 				BucketSize types.Int64 `tfsdk:"bucket_size"`
@@ -744,24 +744,24 @@ func upgradeSystemV0toV1(
 			} `tfsdk:"retry_options"`
 		} `tfsdk:"login"`
 		Ntp []struct {
-			BroadcastClient        types.Bool   `tfsdk:"broadcast_client"`
-			MulticastClient        types.Bool   `tfsdk:"multicast_client"`
 			BootServer             types.String `tfsdk:"boot_server"`
+			BroadcastClient        types.Bool   `tfsdk:"broadcast_client"`
 			IntervalRange          types.Int64  `tfsdk:"interval_range"`
+			MulticastClient        types.Bool   `tfsdk:"multicast_client"`
 			MulticastClientAddress types.String `tfsdk:"multicast_client_address"`
 			ThresholdAction        types.String `tfsdk:"threshold_action"`
 			ThresholdValue         types.Int64  `tfsdk:"threshold_value"`
 		} `tfsdk:"ntp"`
 		Ports []struct {
+			AuxiliaryAuthenticationOrder []types.String `tfsdk:"auxiliary_authentication_order"`
 			AuxiliaryDisable             types.Bool     `tfsdk:"auxiliary_disable"`
 			AuxiliaryInsecure            types.Bool     `tfsdk:"auxiliary_insecure"`
 			AuxiliaryLogoutOnDisconnect  types.Bool     `tfsdk:"auxiliary_logout_on_disconnect"`
+			AuxiliaryType                types.String   `tfsdk:"auxiliary_type"`
+			ConsoleAuthenticationOrder   []types.String `tfsdk:"console_authentication_order"`
 			ConsoleDisable               types.Bool     `tfsdk:"console_disable"`
 			ConsoleInsecure              types.Bool     `tfsdk:"console_insecure"`
 			ConsoleLogoutOnDisconnect    types.Bool     `tfsdk:"console_logout_on_disconnect"`
-			AuxiliaryAuthenticationOrder []types.String `tfsdk:"auxiliary_authentication_order"`
-			AuxiliaryType                types.String   `tfsdk:"auxiliary_type"`
-			ConsoleAuthenticationOrder   []types.String `tfsdk:"console_authentication_order"`
 			ConsoleType                  types.String   `tfsdk:"console_type"`
 		} `tfsdk:"ports"`
 		Services []struct {
@@ -772,22 +772,17 @@ func upgradeSystemV0toV1(
 				RateLimit           types.Int64 `tfsdk:"rate_limit"`
 			} `tfsdk:"netconf_ssh"`
 			NetconfTraceoptions []struct {
-				FileWorldReadable   types.Bool     `tfsdk:"file_world_readable"`
-				FileNoWorldReadable types.Bool     `tfsdk:"file_no_world_readable"`
-				NoRemoteTrace       types.Bool     `tfsdk:"no_remote_trace"`
-				OnDemand            types.Bool     `tfsdk:"on_demand"`
 				FileName            types.String   `tfsdk:"file_name"`
 				FileFiles           types.Int64    `tfsdk:"file_files"`
 				FileMatch           types.String   `tfsdk:"file_match"`
 				FileSize            types.Int64    `tfsdk:"file_size"`
+				FileWorldReadable   types.Bool     `tfsdk:"file_world_readable"`
+				FileNoWorldReadable types.Bool     `tfsdk:"file_no_world_readable"`
 				Flag                []types.String `tfsdk:"flag"`
+				NoRemoteTrace       types.Bool     `tfsdk:"no_remote_trace"`
+				OnDemand            types.Bool     `tfsdk:"on_demand"`
 			} `tfsdk:"netconf_traceoptions"`
 			SSH []struct {
-				LogKeyChanges               types.Bool     `tfsdk:"log_key_changes"`
-				NoPasswords                 types.Bool     `tfsdk:"no_passwords"`
-				NoPublicKeys                types.Bool     `tfsdk:"no_public_keys"`
-				TCPForwarding               types.Bool     `tfsdk:"tcp_forwarding"`
-				NoTCPForwarding             types.Bool     `tfsdk:"no_tcp_forwarding"`
 				AuthenticationOrder         []types.String `tfsdk:"authentication_order"`
 				Ciphers                     []types.String `tfsdk:"ciphers"`
 				ClientAliveCountMax         types.Int64    `tfsdk:"client_alive_count_max"`
@@ -796,38 +791,43 @@ func upgradeSystemV0toV1(
 				FingerprintHash             types.String   `tfsdk:"fingerprint_hash"`
 				HostkeyAlgorithm            []types.String `tfsdk:"hostkey_algorithm"`
 				KeyExchange                 []types.String `tfsdk:"key_exchange"`
+				LogKeyChanges               types.Bool     `tfsdk:"log_key_changes"`
 				Macs                        []types.String `tfsdk:"macs"`
 				MaxPreAuthenticationPackets types.Int64    `tfsdk:"max_pre_authentication_packets"`
 				MaxSessionsPerConnection    types.Int64    `tfsdk:"max_sessions_per_connection"`
+				NoPasswords                 types.Bool     `tfsdk:"no_passwords"`
+				NoPublicKeys                types.Bool     `tfsdk:"no_public_keys"`
 				Port                        types.Int64    `tfsdk:"port"`
 				ProtocolVersion             []types.String `tfsdk:"protocol_version"`
 				RateLimit                   types.Int64    `tfsdk:"rate_limit"`
 				RootLogin                   types.String   `tfsdk:"root_login"`
+				TCPForwarding               types.Bool     `tfsdk:"tcp_forwarding"`
+				NoTCPForwarding             types.Bool     `tfsdk:"no_tcp_forwarding"`
 			} `tfsdk:"ssh"`
 			WebManagementHTTP []struct {
 				Interface []types.String `tfsdk:"interface"`
 				Port      types.Int64    `tfsdk:"port"`
 			} `tfsdk:"web_management_http"`
 			WebManagementHTTPS []struct {
-				SystemGeneratedCertificate types.Bool     `tfsdk:"system_generated_certificate"`
 				Interface                  []types.String `tfsdk:"interface"`
 				LocalCertificate           types.String   `tfsdk:"local_certificate"`
 				PkiLocalCertificate        types.String   `tfsdk:"pki_local_certificate"`
 				Port                       types.Int64    `tfsdk:"port"`
+				SystemGeneratedCertificate types.Bool     `tfsdk:"system_generated_certificate"`
 			} `tfsdk:"web_management_https"`
 		} `tfsdk:"services"`
 		Syslog []struct {
-			TimeFormatMillisecond types.Bool   `tfsdk:"time_format_millisecond"`
-			TimeFormatYear        types.Bool   `tfsdk:"time_format_year"`
 			LogRotateFrequency    types.Int64  `tfsdk:"log_rotate_frequency"`
 			SourceAddress         types.String `tfsdk:"source_address"`
+			TimeFormatMillisecond types.Bool   `tfsdk:"time_format_millisecond"`
+			TimeFormatYear        types.Bool   `tfsdk:"time_format_year"`
 			Archive               []struct {
 				BinaryData      types.Bool  `tfsdk:"binary_data"`
 				NoBinaryData    types.Bool  `tfsdk:"no_binary_data"`
-				WorldReadable   types.Bool  `tfsdk:"world_readable"`
-				NoWorldReadable types.Bool  `tfsdk:"no_world_readable"`
 				Files           types.Int64 `tfsdk:"files"`
 				Size            types.Int64 `tfsdk:"size"`
+				WorldReadable   types.Bool  `tfsdk:"world_readable"`
+				NoWorldReadable types.Bool  `tfsdk:"no_world_readable"`
 			} `tfsdk:"archive"`
 			Console []struct {
 				AnySeverity                 types.String `tfsdk:"any_severity"`

--- a/internal/providerfwk/upgradestate_system_syslog_file.go
+++ b/internal/providerfwk/upgradestate_system_syslog_file.go
@@ -147,10 +147,10 @@ func upgradeSystemSyslogFileV0toV1(
 	ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse,
 ) {
 	type modelV0 struct {
-		AllowDuplicates             types.Bool     `tfsdk:"allow_duplicates"`
-		ExplicitPriority            types.Bool     `tfsdk:"explicit_priority"`
 		ID                          types.String   `tfsdk:"id"`
 		Filename                    types.String   `tfsdk:"filename"`
+		AllowDuplicates             types.Bool     `tfsdk:"allow_duplicates"`
+		ExplicitPriority            types.Bool     `tfsdk:"explicit_priority"`
 		Match                       types.String   `tfsdk:"match"`
 		MatchStrings                []types.String `tfsdk:"match_strings"`
 		AnySeverity                 types.String   `tfsdk:"any_severity"`
@@ -171,12 +171,12 @@ func upgradeSystemSyslogFileV0toV1(
 		Archive                     []struct {
 			BinaryData       types.Bool   `tfsdk:"binary_data"`
 			NoBinaryData     types.Bool   `tfsdk:"no_binary_data"`
-			WorldReadable    types.Bool   `tfsdk:"world_readable"`
-			NoWorldReadable  types.Bool   `tfsdk:"no_world_readable"`
 			Files            types.Int64  `tfsdk:"files"`
 			Size             types.Int64  `tfsdk:"size"`
 			StartTime        types.String `tfsdk:"start_time"`
 			TransferInterval types.Int64  `tfsdk:"transfer_interval"`
+			WorldReadable    types.Bool   `tfsdk:"world_readable"`
+			NoWorldReadable  types.Bool   `tfsdk:"no_world_readable"`
 			Sites            []struct {
 				URL             types.String `tfsdk:"url"`
 				Password        types.String `tfsdk:"password"`

--- a/internal/providerfwk/upgradestate_system_syslog_host.go
+++ b/internal/providerfwk/upgradestate_system_syslog_host.go
@@ -114,11 +114,11 @@ func upgradeSystemSyslogHostV0toV1(
 	ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse,
 ) {
 	type modelV0 struct {
+		ID                          types.String   `tfsdk:"id"`
+		Host                        types.String   `tfsdk:"host"`
 		AllowDuplicates             types.Bool     `tfsdk:"allow_duplicates"`
 		ExcludeHostname             types.Bool     `tfsdk:"exclude_hostname"`
 		ExplicitPriority            types.Bool     `tfsdk:"explicit_priority"`
-		ID                          types.String   `tfsdk:"id"`
-		Host                        types.String   `tfsdk:"host"`
 		FacilityOverride            types.String   `tfsdk:"facility_override"`
 		LogPrefix                   types.String   `tfsdk:"log_prefix"`
 		Match                       types.String   `tfsdk:"match"`

--- a/internal/tfdata/check_asblock.go
+++ b/internal/tfdata/check_asblock.go
@@ -25,8 +25,8 @@ func CheckBlockIsEmpty[B any](block B, excludeFields ...string) bool {
 			continue
 		}
 
-		if attr, ok := fieldValue.Interface().(attr.Value); ok {
-			if !attr.IsNull() {
+		if attrValue, ok := fieldValue.Interface().(attr.Value); ok {
+			if !attrValue.IsNull() {
 				return false
 			}
 
@@ -72,8 +72,8 @@ func CheckBlockHasKnownValue[B any](block B, excludeFields ...string) bool {
 			continue
 		}
 
-		if attr, ok := fieldValue.Interface().(attr.Value); ok {
-			if !attr.IsNull() && !attr.IsUnknown() {
+		if attrValue, ok := fieldValue.Interface().(attr.Value); ok {
+			if !attrValue.IsNull() && !attrValue.IsUnknown() {
 				return true
 			}
 

--- a/internal/tfvalidator/string_rune_exclusion.go
+++ b/internal/tfvalidator/string_rune_exclusion.go
@@ -19,10 +19,10 @@ type StringRuneExclusionValidator struct {
 }
 
 func StringRuneExclusion(runes ...rune) StringRuneExclusionValidator {
-	var validator StringRuneExclusionValidator
-	validator.runes = append(validator.runes, runes...)
+	var v StringRuneExclusionValidator
+	v.runes = append(v.runes, runes...)
 
-	return validator
+	return v
 }
 
 func StringDoubleQuoteExclusion() StringRuneExclusionValidator {


### PR DESCRIPTION
- tests: bump golangci-lint to v1.57 (reorder field of struct to align on schema order after disable maligned linter)
- tests: add additional rules with revive linter