### PR TITLE
tests: bump golangci-lint to v1.58.0

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -19,7 +19,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v5
         with:
-          version: 'v1.57.1'
+          version: 'v1.58.0'
           args: -c .golangci.yml -v
 
   markdown-lint:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,44 +1,49 @@
 run:
   timeout: 5m
+
 linters:
   enable-all: true
   disable:
-    - maligned # deprecated 1.38
-    - interfacer # deprecated 1.38
-    - scopelint # deprecated 1.39
-    - golint # deprecated 1.41
-    - exhaustivestruct # deprecated 1.46
-    - ifshort # deprecated 1.48
-    - deadcode # deprecated 1.49
-    - structcheck # deprecated 1.49
-    - varcheck # deprecated 1.49
-    - funlen
-    - dupl
-    - wsl
-    - gomnd
-    - goerr113 
-    - nestif
-    - exhaustruct
-    - paralleltest
+    # deprecated
+    - interfacer # deprecated 1.38.0
+    - maligned # deprecated 1.38.0
+    - scopelint # deprecated 1.39.0
+    - golint # deprecated 1.41.0
+    - exhaustivestruct # deprecated 1.46.0
+    - ifshort # deprecated 1.48.0
+    - deadcode # deprecated 1.49.0
+    - structcheck # deprecated 1.49.0
+    - varcheck # deprecated 1.49.0
+    - execinquery # deprecated 1.58.0
+    - gomnd # deprecated 1.58.0
+    # unwanted
     - cyclop
-    - forcetypeassert
-    - gomoddirectives
-    - varnamelen
-    - nonamedreturns
-    - maintidx
-    - execinquery
-    - nosnakecase
-    - musttag
     - depguard
+    - dupl
+    - err113
+    - exhaustruct
+    - forcetypeassert
+    - funlen
+    - gomoddirectives
     - gosec
     - inamedparam
     - ireturn
+    - maintidx
+    - mnd
+    - musttag
+    - nestif
+    - nonamedreturns
+    - nosnakecase
+    - paralleltest
+    - varnamelen
+    - wsl
+
 linters-settings:
   gci:
     custom-order: true
     sections:
       - standard
-      - prefix(github.com/jeremmfr/terraform-provider-junos/)
+      - localModule
       - default
   gocognit:
     # minimal code complexity to report, 30 by default
@@ -52,8 +57,6 @@ linters-settings:
     # minimal code complexity to report, 30 by default
     min-complexity: 100
   gofumpt:
-    module-path: github.com/jeremmfr/terraform-provider-junos
-    # Choose whether to use the extra rules.
     extra-rules: true
   govet:
     enable-all: true
@@ -91,6 +94,7 @@ linters-settings:
       - name: import-alias-naming
       - name: import-shadowing
       - name: unhandled-error
+
 issues:
   exclude-rules:
     - text: "github.com/jeremmfr/terraform-provider-junos/internal"


### PR DESCRIPTION
- bump golangci-lint to v1.58.0
- re-order disable linters (deprecated section with version order, alphabetical order for unwanted)
- gci: use localModule
- gofumpt: remove unnecessary module-path