### PR TITLE
r/bridge_doamin,routing_instance,switch_options,vlan: add `remote-vtep-list` arguments

### DIFF
--- a/.changes/issue-672-673.md
+++ b/.changes/issue-672-673.md
@@ -1,5 +1,6 @@
 <!-- markdownlint-disable-file MD013 MD041 -->
 ENHANCEMENTS:
 
+* **resource/junos_bridge_domain**:  add `static_remote_vtep_list` argument inside `vxlan` block argument (Fix [#672](https://github.com/jeremmfr/terraform-provider-junos/issues/672))
 * **resource/junos_routing_instance**:  add `remote_vtep_list` and `remote_vtep_v6_list` arguments (Fix [#673](https://github.com/jeremmfr/terraform-provider-junos/issues/673))
 * **resource/junos_switch_options**:  add `remote_vtep_list` and `remote_vtep_v6_list` arguments

--- a/.changes/issue-672-673.md
+++ b/.changes/issue-672-673.md
@@ -2,3 +2,4 @@
 ENHANCEMENTS:
 
 * **resource/junos_routing_instance**:  add `remote_vtep_list` and `remote_vtep_v6_list` arguments (Fix [#673](https://github.com/jeremmfr/terraform-provider-junos/issues/673))
+* **resource/junos_switch_options**:  add `remote_vtep_list` and `remote_vtep_v6_list` arguments

--- a/.changes/issue-672-673.md
+++ b/.changes/issue-672-673.md
@@ -4,3 +4,4 @@ ENHANCEMENTS:
 * **resource/junos_bridge_domain**:  add `static_remote_vtep_list` argument inside `vxlan` block argument (Fix [#672](https://github.com/jeremmfr/terraform-provider-junos/issues/672))
 * **resource/junos_routing_instance**:  add `remote_vtep_list` and `remote_vtep_v6_list` arguments (Fix [#673](https://github.com/jeremmfr/terraform-provider-junos/issues/673))
 * **resource/junos_switch_options**:  add `remote_vtep_list` and `remote_vtep_v6_list` arguments
+* **resource/junos_vlan**:  add `static_remote_vtep_list` argument inside `vxlan` block argument

--- a/.changes/issue-672-673.md
+++ b/.changes/issue-672-673.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable-file MD013 MD041 -->
+ENHANCEMENTS:
+
+* **resource/junos_routing_instance**:  add `remote_vtep_list` and `remote_vtep_v6_list` arguments (Fix [#673](https://github.com/jeremmfr/terraform-provider-junos/issues/673))

--- a/.changes/issue-672-673.md
+++ b/.changes/issue-672-673.md
@@ -3,5 +3,6 @@ ENHANCEMENTS:
 
 * **resource/junos_bridge_domain**:  add `static_remote_vtep_list` argument inside `vxlan` block argument (Fix [#672](https://github.com/jeremmfr/terraform-provider-junos/issues/672))
 * **resource/junos_routing_instance**:  add `remote_vtep_list` and `remote_vtep_v6_list` arguments (Fix [#673](https://github.com/jeremmfr/terraform-provider-junos/issues/673))
+* **data-source/junos_routing_instance**: add `remote_vtep_list` and `remote_vtep_v6_list` attributes like resource
 * **resource/junos_switch_options**:  add `remote_vtep_list` and `remote_vtep_v6_list` arguments
 * **resource/junos_vlan**:  add `static_remote_vtep_list` argument inside `vxlan` block argument

--- a/docs/data-sources/routing_instance.md
+++ b/docs/data-sources/routing_instance.md
@@ -40,6 +40,10 @@ The following attributes are exported:
   Import policy for instance RIBs.
 - **interface** (Set of String)  
   List of interfaces in routing instance.
+- **remote_vtep_list** (Set of String)  
+  Static remote VXLAN tunnel endpoints.
+- **remote_vtep_v6_list** (Set of String)  
+  Static ipv6 remote VXLAN tunnel endpoints.
 - **route_distinguisher** (String)  
   Route distinguisher for this instance.
 - **router_id** (String)  

--- a/docs/resources/bridge_domain.md
+++ b/docs/resources/bridge_domain.md
@@ -55,6 +55,8 @@ The following arguments are supported:
   Declare vxlan options.
   - **vni** (Required, Number)  
     VXLAN identifier (0..16777214).
+  - **vni_extend_evpn** (Optional, Boolean)  
+    Extend VNI to EVPN.
   - **decapsulate_accept_inner_vlan** (Optional, Boolean)  
     Accept VXLAN packets with inner VLAN.
   - **encapsulate_inner_vlan** (Optional, Boolean)  
@@ -65,10 +67,10 @@ The following arguments are supported:
     CIDR for Multicast group registered for VXLAN segment.
   - **ovsdb_managed** (Optional, Boolean)  
     Bridge-domain is managed remotely via VXLAN OVSDB Controller.
+  - **static_remote_vtep_list** (Optional, Set of String)  
+    Configure bridge domain specific static remote VXLAN tunnel endpoints.
   - **unreachable_vtep_aging_timer** (Optional, Number)  
     Unreachable VXLAN tunnel endpoint removal timer (300..1800 seconds).
-  - **vni_extend_evpn** (Optional, Boolean)  
-    Extend VNI to EVPN.
 
 ## Attribute Reference
 

--- a/docs/resources/routing_instance.md
+++ b/docs/resources/routing_instance.md
@@ -40,6 +40,10 @@ The following arguments are supported:
   Export policy for instance RIBs.
 - **instance_import** (Optional, List of String)  
   Import policy for instance RIBs.
+- **remote_vtep_list** (Optional, Set of String)  
+  Configure static remote VXLAN tunnel endpoints.
+- **remote_vtep_v6_list** (Optional, Set of String)  
+  Configure static ipv6 remote VXLAN tunnel endpoints.
 - **route_distinguisher** (Optional, String)  
   Route distinguisher for this instance.
 - **router_id** (Optional, String)  

--- a/docs/resources/switch_options.md
+++ b/docs/resources/switch_options.md
@@ -25,6 +25,10 @@ The following arguments are supported:
 
 - **clean_on_destroy** (Optional, Boolean)  
   Clean supported lines when destroy this resource.
+- **remote_vtep_list** (Optional, Set of String)  
+  Configure static remote VXLAN tunnel endpoints.
+- **remote_vtep_v6_list** (Optional, Set of String)  
+  Configure static ipv6 remote VXLAN tunnel endpoints.
 - **service_id** (Optional, Number)  
   Service ID required if multi-chassis AE is part of a bridge-domain (1..65535).
 - **vtep_source_interface** (Optional, String)  

--- a/docs/resources/vlan.md
+++ b/docs/resources/vlan.md
@@ -60,6 +60,8 @@ The following arguments are supported:
   Declare vxlan configuration.
   - **vni** (Required, Number)  
     VXLAN identifier (0..16777214).
+  - **vni_extend_evpn** (Optional, Boolean)  
+    Extend VNI to EVPN.
   - **encapsulate_inner_vlan** (Optional, Boolean)  
     Retain inner VLAN in the packet.
   - **ingress_node_replication** (Optional, Boolean)  
@@ -68,10 +70,10 @@ The following arguments are supported:
     Multicast group registered for VXLAN segment.
   - **ovsdb_managed** (Optional, Boolean)  
     Bridge-domain is managed remotely via VXLAN OVSDB Controller.
+  - **static_remote_vtep_list** (Optional, Set of String)  
+    Configure vlan specific static remote VXLAN tunnel endpoints.
   - **translation_vni** (Optional, Number)  
     Translated VXLAN identifier (1..16777214).
-  - **vni_extend_evpn** (Optional, Boolean)  
-    Extend VNI to EVPN.
   - **unreachable_vtep_aging_timer** (Optional, Number)  
     Unreachable VXLAN tunnel endpoint removal timer (300..1800 seconds).
 

--- a/internal/providerfwk/data_source_routing_instance.go
+++ b/internal/providerfwk/data_source_routing_instance.go
@@ -109,6 +109,16 @@ func (dsc *routingInstanceDataSource) Schema(
 				Computed:    true,
 				Description: "List of interfaces in routing instance.",
 			},
+			"remote_vtep_list": schema.SetAttribute{
+				ElementType: types.StringType,
+				Computed:    true,
+				Description: "Static remote VXLAN tunnel endpoints.",
+			},
+			"remote_vtep_v6_list": schema.SetAttribute{
+				ElementType: types.StringType,
+				Computed:    true,
+				Description: "Static ipv6 remote VXLAN tunnel endpoints.",
+			},
 			"route_distinguisher": schema.StringAttribute{
 				Computed:    true,
 				Description: "Route distinguisher for this instance.",
@@ -160,6 +170,8 @@ type routingInstanceDataSourceData struct {
 	InstanceExport      []types.String `tfsdk:"instance_export"`
 	InstanceImport      []types.String `tfsdk:"instance_import"`
 	Interface           []types.String `tfsdk:"interface"`
+	RemoteVtepList      []types.String `tfsdk:"remote_vtep_list"`
+	RemoteVtepV6List    []types.String `tfsdk:"remote_vtep_v6_list"`
 	RouteDistinguisher  types.String   `tfsdk:"route_distinguisher"`
 	RouterID            types.String   `tfsdk:"router_id"`
 	VRFExport           []types.String `tfsdk:"vrf_export"`
@@ -207,6 +219,8 @@ func (dscData *routingInstanceDataSourceData) copyFromResourceData(data any) {
 	dscData.InstanceExport = rscData.InstanceExport
 	dscData.InstanceImport = rscData.InstanceImport
 	dscData.Interface = rscData.Interface
+	dscData.RemoteVtepList = rscData.RemoteVtepList
+	dscData.RemoteVtepV6List = rscData.RemoteVtepV6List
 	dscData.RouteDistinguisher = rscData.RouteDistinguisher
 	dscData.RouterID = rscData.RouterID
 	dscData.VRFExport = rscData.VRFExport

--- a/internal/providerfwk/resource_bridge_domain.go
+++ b/internal/providerfwk/resource_bridge_domain.go
@@ -261,6 +261,17 @@ func (rsc *bridgeDomain) Schema(
 							tfvalidator.BoolTrue(),
 						},
 					},
+					"static_remote_vtep_list": schema.SetAttribute{
+						ElementType: types.StringType,
+						Optional:    true,
+						Description: "Configure bridge domain specific static remote VXLAN tunnel endpoints.",
+						Validators: []validator.Set{
+							setvalidator.SizeAtLeast(1),
+							setvalidator.ValueStringsAre(
+								tfvalidator.StringIPAddress().IPv4Only(),
+							),
+						},
+					},
 					"unreachable_vtep_aging_timer": schema.Int64Attribute{
 						Optional:    true,
 						Description: "Unreachable VXLAN tunnel endpoint removal timer.",
@@ -289,33 +300,45 @@ type bridgeDomainData struct {
 	IsolatedVLAN     types.Int64             `tfsdk:"isolated_vlan"`
 	RoutingInterface types.String            `tfsdk:"routing_interface"`
 	ServiceID        types.Int64             `tfsdk:"service_id"`
-	VLANID           types.Int64             `tfsdk:"vlan_id"`
-	VLANIDList       []types.String          `tfsdk:"vlan_id_list"`
-	VXLAN            *bridgeDomainBlockVXLAN `tfsdk:"vxlan"`
+	VlanID           types.Int64             `tfsdk:"vlan_id"`
+	VlanIDList       []types.String          `tfsdk:"vlan_id_list"`
+	Vxlan            *bridgeDomainBlockVxlan `tfsdk:"vxlan"`
 }
 
 type bridgeDomainConfig struct {
-	ID               types.String            `tfsdk:"id"`
-	Name             types.String            `tfsdk:"name"`
-	RoutingInstance  types.String            `tfsdk:"routing_instance"`
-	CommunityVlans   types.Set               `tfsdk:"community_vlans"`
-	Description      types.String            `tfsdk:"description"`
-	DomainID         types.Int64             `tfsdk:"domain_id"`
-	DomainTypeBridge types.Bool              `tfsdk:"domain_type_bridge"`
-	Interface        types.Set               `tfsdk:"interface"`
-	IsolatedVLAN     types.Int64             `tfsdk:"isolated_vlan"`
-	RoutingInterface types.String            `tfsdk:"routing_interface"`
-	ServiceID        types.Int64             `tfsdk:"service_id"`
-	VLANID           types.Int64             `tfsdk:"vlan_id"`
-	VLANIDList       types.Set               `tfsdk:"vlan_id_list"`
-	VXLAN            *bridgeDomainBlockVXLAN `tfsdk:"vxlan"`
+	ID               types.String                  `tfsdk:"id"`
+	Name             types.String                  `tfsdk:"name"`
+	RoutingInstance  types.String                  `tfsdk:"routing_instance"`
+	CommunityVlans   types.Set                     `tfsdk:"community_vlans"`
+	Description      types.String                  `tfsdk:"description"`
+	DomainID         types.Int64                   `tfsdk:"domain_id"`
+	DomainTypeBridge types.Bool                    `tfsdk:"domain_type_bridge"`
+	Interface        types.Set                     `tfsdk:"interface"`
+	IsolatedVLAN     types.Int64                   `tfsdk:"isolated_vlan"`
+	RoutingInterface types.String                  `tfsdk:"routing_interface"`
+	ServiceID        types.Int64                   `tfsdk:"service_id"`
+	VlanID           types.Int64                   `tfsdk:"vlan_id"`
+	VlanIDList       types.Set                     `tfsdk:"vlan_id_list"`
+	Vxlan            *bridgeDomainBlockVxlanConfig `tfsdk:"vxlan"`
 }
 
 func (rscConfig *bridgeDomainConfig) isEmpty() bool {
 	return tfdata.CheckBlockIsEmpty(rscConfig, "ID", "Name", "RoutingInstance")
 }
 
-type bridgeDomainBlockVXLAN struct {
+type bridgeDomainBlockVxlan struct {
+	Vni                        types.Int64    `tfsdk:"vni"`
+	VniExtendEvpn              types.Bool     `tfsdk:"vni_extend_evpn"`
+	DecapsulateAcceptInnerVlan types.Bool     `tfsdk:"decapsulate_accept_inner_vlan"`
+	EncapsulateInnerVlan       types.Bool     `tfsdk:"encapsulate_inner_vlan"`
+	IngressNodeReplication     types.Bool     `tfsdk:"ingress_node_replication"`
+	MulticastGroup             types.String   `tfsdk:"multicast_group"`
+	OvsdbManaged               types.Bool     `tfsdk:"ovsdb_managed"`
+	StaticRemoteVtepList       []types.String `tfsdk:"static_remote_vtep_list"`
+	UnreachableVtepAgingTimer  types.Int64    `tfsdk:"unreachable_vtep_aging_timer"`
+}
+
+type bridgeDomainBlockVxlanConfig struct {
 	Vni                        types.Int64  `tfsdk:"vni"`
 	VniExtendEvpn              types.Bool   `tfsdk:"vni_extend_evpn"`
 	DecapsulateAcceptInnerVlan types.Bool   `tfsdk:"decapsulate_accept_inner_vlan"`
@@ -323,6 +346,7 @@ type bridgeDomainBlockVXLAN struct {
 	IngressNodeReplication     types.Bool   `tfsdk:"ingress_node_replication"`
 	MulticastGroup             types.String `tfsdk:"multicast_group"`
 	OvsdbManaged               types.Bool   `tfsdk:"ovsdb_managed"`
+	StaticRemoteVtepList       types.Set    `tfsdk:"static_remote_vtep_list"`
 	UnreachableVtepAgingTimer  types.Int64  `tfsdk:"unreachable_vtep_aging_timer"`
 }
 
@@ -343,16 +367,16 @@ func (rsc *bridgeDomain) ValidateConfig(
 		)
 	}
 
-	if !config.VLANID.IsNull() && !config.VLANID.IsUnknown() &&
-		!config.VLANIDList.IsNull() && !config.VLANIDList.IsUnknown() {
+	if !config.VlanID.IsNull() && !config.VlanID.IsUnknown() &&
+		!config.VlanIDList.IsNull() && !config.VlanIDList.IsUnknown() {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("vlan_id"),
 			tfdiag.ConflictConfigErrSummary,
 			"vlan_id and vlan_id_list cannot be configured together",
 		)
 	}
-	if config.VXLAN != nil {
-		if config.VXLAN.Vni.IsNull() {
+	if config.Vxlan != nil {
+		if config.Vxlan.Vni.IsNull() {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("vxlan").AtName("vni"),
 				tfdiag.MissingConfigErrSummary,
@@ -624,39 +648,42 @@ func (rscData *bridgeDomainData) set(
 		configSet = append(configSet, setPrefix+"service-id "+
 			utils.ConvI64toa(rscData.ServiceID.ValueInt64()))
 	}
-	if !rscData.VLANID.IsNull() {
+	if !rscData.VlanID.IsNull() {
 		configSet = append(configSet, setPrefix+"vlan-id "+
-			utils.ConvI64toa(rscData.VLANID.ValueInt64()))
+			utils.ConvI64toa(rscData.VlanID.ValueInt64()))
 	}
-	for _, v := range rscData.VLANIDList {
+	for _, v := range rscData.VlanIDList {
 		configSet = append(configSet, setPrefix+"vlan-id-list "+v.ValueString())
 	}
-	if rscData.VXLAN != nil {
+	if rscData.Vxlan != nil {
 		configSet = append(configSet, setPrefix+"vxlan vni "+
-			utils.ConvI64toa(rscData.VXLAN.Vni.ValueInt64()))
+			utils.ConvI64toa(rscData.Vxlan.Vni.ValueInt64()))
 
-		if rscData.VXLAN.VniExtendEvpn.ValueBool() {
+		if rscData.Vxlan.VniExtendEvpn.ValueBool() {
 			configSet = append(configSet, setPrefixProtocolsEvpn+"extended-vni-list "+
-				utils.ConvI64toa(rscData.VXLAN.Vni.ValueInt64()))
+				utils.ConvI64toa(rscData.Vxlan.Vni.ValueInt64()))
 		}
-		if rscData.VXLAN.DecapsulateAcceptInnerVlan.ValueBool() {
+		if rscData.Vxlan.DecapsulateAcceptInnerVlan.ValueBool() {
 			configSet = append(configSet, setPrefix+"vxlan decapsulate-accept-inner-vlan")
 		}
-		if rscData.VXLAN.EncapsulateInnerVlan.ValueBool() {
+		if rscData.Vxlan.EncapsulateInnerVlan.ValueBool() {
 			configSet = append(configSet, setPrefix+"vxlan encapsulate-inner-vlan")
 		}
-		if rscData.VXLAN.IngressNodeReplication.ValueBool() {
+		if rscData.Vxlan.IngressNodeReplication.ValueBool() {
 			configSet = append(configSet, setPrefix+"vxlan ingress-node-replication")
 		}
-		if v := rscData.VXLAN.MulticastGroup.ValueString(); v != "" {
+		if v := rscData.Vxlan.MulticastGroup.ValueString(); v != "" {
 			configSet = append(configSet, setPrefix+"vxlan multicast-group "+v)
 		}
-		if rscData.VXLAN.OvsdbManaged.ValueBool() {
+		if rscData.Vxlan.OvsdbManaged.ValueBool() {
 			configSet = append(configSet, setPrefix+"vxlan ovsdb-managed")
 		}
-		if !rscData.VXLAN.UnreachableVtepAgingTimer.IsNull() {
+		for _, v := range rscData.Vxlan.StaticRemoteVtepList {
+			configSet = append(configSet, setPrefix+"vxlan static-remote-vtep-list "+v.ValueString())
+		}
+		if !rscData.Vxlan.UnreachableVtepAgingTimer.IsNull() {
 			configSet = append(configSet, setPrefix+"vxlan unreachable-vtep-aging-timer "+
-				utils.ConvI64toa(rscData.VXLAN.UnreachableVtepAgingTimer.ValueInt64()))
+				utils.ConvI64toa(rscData.Vxlan.UnreachableVtepAgingTimer.ValueInt64()))
 		}
 	}
 
@@ -718,19 +745,19 @@ func (rscData *bridgeDomainData) read(
 					return err
 				}
 			case balt.CutPrefixInString(&itemTrim, "vlan-id "):
-				rscData.VLANID, err = tfdata.ConvAtoi64Value(itemTrim)
+				rscData.VlanID, err = tfdata.ConvAtoi64Value(itemTrim)
 				if err != nil {
 					return err
 				}
 			case balt.CutPrefixInString(&itemTrim, "vlan-id-list "):
-				rscData.VLANIDList = append(rscData.VLANIDList, types.StringValue(itemTrim))
+				rscData.VlanIDList = append(rscData.VlanIDList, types.StringValue(itemTrim))
 			case balt.CutPrefixInString(&itemTrim, "vxlan "):
-				if rscData.VXLAN == nil {
-					rscData.VXLAN = &bridgeDomainBlockVXLAN{}
+				if rscData.Vxlan == nil {
+					rscData.Vxlan = &bridgeDomainBlockVxlan{}
 				}
 				switch {
 				case balt.CutPrefixInString(&itemTrim, "vni "):
-					rscData.VXLAN.Vni, err = tfdata.ConvAtoi64Value(itemTrim)
+					rscData.Vxlan.Vni, err = tfdata.ConvAtoi64Value(itemTrim)
 					if err != nil {
 						return err
 					}
@@ -747,24 +774,26 @@ func (rscData *bridgeDomainData) read(
 								break
 							}
 							if itemEvpn == junos.SetLS+"extended-vni-list "+itemTrim {
-								rscData.VXLAN.VniExtendEvpn = types.BoolValue(true)
+								rscData.Vxlan.VniExtendEvpn = types.BoolValue(true)
 
 								break
 							}
 						}
 					}
 				case itemTrim == "decapsulate-accept-inner-vlan":
-					rscData.VXLAN.DecapsulateAcceptInnerVlan = types.BoolValue(true)
+					rscData.Vxlan.DecapsulateAcceptInnerVlan = types.BoolValue(true)
 				case itemTrim == "encapsulate-inner-vlan":
-					rscData.VXLAN.EncapsulateInnerVlan = types.BoolValue(true)
+					rscData.Vxlan.EncapsulateInnerVlan = types.BoolValue(true)
 				case itemTrim == "ingress-node-replication":
-					rscData.VXLAN.IngressNodeReplication = types.BoolValue(true)
+					rscData.Vxlan.IngressNodeReplication = types.BoolValue(true)
 				case balt.CutPrefixInString(&itemTrim, "multicast-group "):
-					rscData.VXLAN.MulticastGroup = types.StringValue(itemTrim)
+					rscData.Vxlan.MulticastGroup = types.StringValue(itemTrim)
 				case itemTrim == "ovsdb-managed":
-					rscData.VXLAN.OvsdbManaged = types.BoolValue(true)
+					rscData.Vxlan.OvsdbManaged = types.BoolValue(true)
+				case balt.CutPrefixInString(&itemTrim, "static-remote-vtep-list "):
+					rscData.Vxlan.StaticRemoteVtepList = append(rscData.Vxlan.StaticRemoteVtepList, types.StringValue(itemTrim))
 				case balt.CutPrefixInString(&itemTrim, "unreachable-vtep-aging-timer "):
-					rscData.VXLAN.UnreachableVtepAgingTimer, err = tfdata.ConvAtoi64Value(itemTrim)
+					rscData.Vxlan.UnreachableVtepAgingTimer, err = tfdata.ConvAtoi64Value(itemTrim)
 					if err != nil {
 						return err
 					}
@@ -801,10 +830,10 @@ func (rscData *bridgeDomainData) delOpts(
 	for _, v := range rscData.Interface {
 		configSet = append(configSet, delPrefix+"interface "+v.ValueString())
 	}
-	if rscData.VXLAN != nil {
-		if rscData.VXLAN.VniExtendEvpn.ValueBool() {
+	if rscData.Vxlan != nil {
+		if rscData.Vxlan.VniExtendEvpn.ValueBool() {
 			configSet = append(configSet, delPrefixProtocolsEvpn+
-				"extended-vni-list "+utils.ConvI64toa(rscData.VXLAN.Vni.ValueInt64()))
+				"extended-vni-list "+utils.ConvI64toa(rscData.Vxlan.Vni.ValueInt64()))
 		}
 	}
 
@@ -822,10 +851,10 @@ func (rscData *bridgeDomainData) del(
 	configSet := []string{
 		delPrefix + "bridge-domains \"" + rscData.Name.ValueString() + "\"",
 	}
-	if rscData.VXLAN != nil {
-		if rscData.VXLAN.VniExtendEvpn.ValueBool() {
+	if rscData.Vxlan != nil {
+		if rscData.Vxlan.VniExtendEvpn.ValueBool() {
 			configSet = append(configSet, delPrefix+
-				"protocols evpn extended-vni-list "+utils.ConvI64toa(rscData.VXLAN.Vni.ValueInt64()))
+				"protocols evpn extended-vni-list "+utils.ConvI64toa(rscData.Vxlan.Vni.ValueInt64()))
 		}
 	}
 

--- a/internal/providerfwk/resource_vlan_test.go
+++ b/internal/providerfwk/resource_vlan_test.go
@@ -59,3 +59,20 @@ func TestAccResourceVlan_basic(t *testing.T) {
 		})
 	}
 }
+
+func TestAccResourceVlan_router(t *testing.T) {
+	if os.Getenv("TESTACC_ROUTER") != "" {
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					ConfigDirectory: config.TestStepDirectory(),
+				},
+				{
+					ConfigDirectory: config.TestStepDirectory(),
+				},
+			},
+		})
+	}
+}

--- a/internal/providerfwk/testdata/TestAccResourceBridgeDomain_basic/1/main.tf
+++ b/internal/providerfwk/testdata/TestAccResourceBridgeDomain_basic/1/main.tf
@@ -32,6 +32,7 @@ resource "junos_routing_instance" "testacc_bridge_ri" {
   route_distinguisher   = "10:11"
   vrf_target            = "target:1:200"
   vtep_source_interface = junos_interface_logical.testacc_bridge_ri.name
+  remote_vtep_list      = ["192.0.2.136", "192.0.2.36"]
 }
 resource "junos_evpn" "testacc_bridge_ri" {
   routing_instance = junos_routing_instance.testacc_bridge_ri.name

--- a/internal/providerfwk/testdata/TestAccResourceBridgeDomain_basic/4/main.tf
+++ b/internal/providerfwk/testdata/TestAccResourceBridgeDomain_basic/4/main.tf
@@ -27,6 +27,7 @@ resource "junos_routing_instance" "testacc_bridge_ri" {
   route_distinguisher   = "10:11"
   vrf_target            = "target:1:200"
   vtep_source_interface = junos_interface_logical.testacc_bridge_ri.name
+  remote_vtep_list      = ["192.0.2.136", "192.0.2.36"]
 }
 resource "junos_evpn" "testacc_bridge_ri" {
   routing_instance = junos_routing_instance.testacc_bridge_ri.name
@@ -48,6 +49,7 @@ resource "junos_bridge_domain" "testacc_bridge_ri" {
   service_id = 12
   vlan_id    = 13
   vxlan {
-    vni = 15
+    vni                     = 15
+    static_remote_vtep_list = ["192.0.2.136", "192.0.2.36"]
   }
 }

--- a/internal/providerfwk/testdata/TestAccResourceBridgeDomain_basic/5/main.tf
+++ b/internal/providerfwk/testdata/TestAccResourceBridgeDomain_basic/5/main.tf
@@ -27,6 +27,7 @@ resource "junos_routing_instance" "testacc_bridge_ri" {
   route_distinguisher   = "10:11"
   vrf_target            = "target:1:200"
   vtep_source_interface = junos_interface_logical.testacc_bridge_ri.name
+  remote_vtep_list      = ["192.0.2.136", "192.0.2.36"]
 }
 resource "junos_evpn" "testacc_bridge_ri" {
   routing_instance = junos_routing_instance.testacc_bridge_ri.name
@@ -47,6 +48,7 @@ resource "junos_bridge_domain" "testacc_bridge_ri" {
   service_id = 12
   vlan_id    = 13
   vxlan {
-    vni = 15
+    vni                     = 15
+    static_remote_vtep_list = ["192.0.2.36"]
   }
 }

--- a/internal/providerfwk/testdata/TestAccResourceRoutingInstance_router/1/main.tf
+++ b/internal/providerfwk/testdata/TestAccResourceRoutingInstance_router/1/main.tf
@@ -51,4 +51,6 @@ resource "junos_routing_instance" "testacc_routingInst4" {
   route_distinguisher = "8:9"
   vrf_export          = [junos_policyoptions_policy_statement.testacc_routingInst2.name]
   vrf_target_auto     = true
+  remote_vtep_list    = ["192.0.2.135", "192.0.2.35"]
+  remote_vtep_v6_list = ["fe80::34"]
 }

--- a/internal/providerfwk/testdata/TestAccResourceRoutingInstance_router/2/main.tf
+++ b/internal/providerfwk/testdata/TestAccResourceRoutingInstance_router/2/main.tf
@@ -74,4 +74,5 @@ resource "junos_routing_instance" "testacc_routingInst4" {
   route_distinguisher = "10:11"
   vrf_export          = [junos_policyoptions_policy_statement.testacc_routingInst2.name]
   vrf_target_auto     = true
+  remote_vtep_list    = ["192.0.2.35"]
 }

--- a/internal/providerfwk/testdata/TestAccResourceSwitchOptions_basic/1/main.tf
+++ b/internal/providerfwk/testdata/TestAccResourceSwitchOptions_basic/1/main.tf
@@ -10,6 +10,8 @@ resource "junos_interface_logical" "testacc_switchOpts" {
   }
 }
 resource "junos_switch_options" "testacc_switchOpts" {
+  remote_vtep_list      = ["192.0.2.134", "192.0.2.34"]
+  remote_vtep_v6_list   = ["fe80::34"]
   service_id            = 111
   vtep_source_interface = junos_interface_logical.testacc_switchOpts.name
 }

--- a/internal/providerfwk/testdata/TestAccResourceVlan_router/1/main.tf
+++ b/internal/providerfwk/testdata/TestAccResourceVlan_router/1/main.tf
@@ -1,0 +1,64 @@
+
+resource "junos_routing_options" "testacc_vlan_vxlan" {
+  clean_on_destroy = true
+  router_id        = "192.0.2.18"
+}
+resource "junos_interface_logical" "testacc_vlan_vxlan" {
+  depends_on = [
+    junos_routing_options.testacc_vlan_vxlan,
+  ]
+  name        = "lo0.0"
+  description = "testacc_vlan_vxlan"
+  family_inet {
+    address {
+      cidr_ip = "192.0.2.18/32"
+    }
+  }
+}
+resource "junos_switch_options" "testacc_vlan_vxlan" {
+  clean_on_destroy      = true
+  vtep_source_interface = junos_interface_logical.testacc_vlan_vxlan.name
+}
+resource "junos_policyoptions_community" "testacc_vlan_vxlan" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  name    = "testacc_vlan_vxlan"
+  members = ["target:65000:100"]
+}
+resource "junos_policyoptions_policy_statement" "testacc_vlan_vxlan" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  name = "testacc_vlan_vxlan"
+  from {
+    bgp_community = [junos_policyoptions_community.testacc_vlan_vxlan.name]
+  }
+  then {
+    action = "accept"
+  }
+}
+resource "junos_evpn" "testacc_vlan_vxlan" {
+  depends_on = [
+    junos_switch_options.testacc_vlan_vxlan,
+  ]
+  encapsulation = "vxlan"
+  switch_or_ri_options {
+    route_distinguisher = "20:1"
+    vrf_target          = "target:20:2"
+    vrf_import          = [junos_policyoptions_policy_statement.testacc_vlan_vxlan.name]
+    vrf_export          = [junos_policyoptions_policy_statement.testacc_vlan_vxlan.name]
+  }
+}
+
+resource "junos_vlan" "testacc_vlan_vxlan" {
+  depends_on = [
+    junos_evpn.testacc_vlan_vxlan,
+  ]
+  name    = "testacc_vlan_vxlan"
+  vlan_id = 1020
+  vxlan {
+    vni                     = 102010
+    static_remote_vtep_list = ["192.0.2.136", "192.0.2.36"]
+  }
+}

--- a/internal/providerfwk/testdata/TestAccResourceVlan_router/2/main.tf
+++ b/internal/providerfwk/testdata/TestAccResourceVlan_router/2/main.tf
@@ -1,0 +1,63 @@
+resource "junos_routing_options" "testacc_vlan_vxlan" {
+  clean_on_destroy = true
+  router_id        = "192.0.2.18"
+}
+resource "junos_interface_logical" "testacc_vlan_vxlan" {
+  depends_on = [
+    junos_routing_options.testacc_vlan_vxlan,
+  ]
+  name        = "lo0.0"
+  description = "testacc_vlan_vxlan"
+  family_inet {
+    address {
+      cidr_ip = "192.0.2.18/32"
+    }
+  }
+}
+resource "junos_switch_options" "testacc_vlan_vxlan" {
+  clean_on_destroy      = true
+  vtep_source_interface = junos_interface_logical.testacc_vlan_vxlan.name
+}
+resource "junos_policyoptions_community" "testacc_vlan_vxlan" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  name    = "testacc_vlan_vxlan"
+  members = ["target:65000:100"]
+}
+resource "junos_policyoptions_policy_statement" "testacc_vlan_vxlan" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  name = "testacc_vlan_vxlan"
+  from {
+    bgp_community = [junos_policyoptions_community.testacc_vlan_vxlan.name]
+  }
+  then {
+    action = "accept"
+  }
+}
+resource "junos_evpn" "testacc_vlan_vxlan" {
+  depends_on = [
+    junos_switch_options.testacc_vlan_vxlan,
+  ]
+  encapsulation = "vxlan"
+  switch_or_ri_options {
+    route_distinguisher = "20:1"
+    vrf_target          = "target:20:2"
+    vrf_import          = [junos_policyoptions_policy_statement.testacc_vlan_vxlan.name]
+    vrf_export          = [junos_policyoptions_policy_statement.testacc_vlan_vxlan.name]
+  }
+}
+
+resource "junos_vlan" "testacc_vlan_vxlan" {
+  depends_on = [
+    junos_evpn.testacc_vlan_vxlan,
+  ]
+  name    = "testacc_vlan_vxlan"
+  vlan_id = 1020
+  vxlan {
+    vni                     = 102010
+    static_remote_vtep_list = ["192.0.2.136"]
+  }
+}

--- a/internal/providerfwk/upgradestate_bridge_domain.go
+++ b/internal/providerfwk/upgradestate_bridge_domain.go
@@ -105,9 +105,9 @@ func upgradeBridgeDomainStateV0toV1(
 		IsolatedVLAN     types.Int64    `tfsdk:"isolated_vlan"`
 		RoutingInterface types.String   `tfsdk:"routing_interface"`
 		ServiceID        types.Int64    `tfsdk:"service_id"`
-		VLANID           types.Int64    `tfsdk:"vlan_id"`
-		VLANIDList       []types.String `tfsdk:"vlan_id_list"`
-		VXLAN            []struct {
+		VlanID           types.Int64    `tfsdk:"vlan_id"`
+		VlanIDList       []types.String `tfsdk:"vlan_id_list"`
+		Vxlan            []struct {
 			Vni                        types.Int64  `tfsdk:"vni"`
 			VniExtendEvpn              types.Bool   `tfsdk:"vni_extend_evpn"`
 			DecapsulateAcceptInnerVlan types.Bool   `tfsdk:"decapsulate_accept_inner_vlan"`
@@ -136,18 +136,18 @@ func upgradeBridgeDomainStateV0toV1(
 	dataV1.IsolatedVLAN = dataV0.IsolatedVLAN
 	dataV1.RoutingInterface = dataV0.RoutingInterface
 	dataV1.ServiceID = dataV0.ServiceID
-	dataV1.VLANID = dataV0.VLANID
-	dataV1.VLANIDList = dataV0.VLANIDList
-	if len(dataV0.VXLAN) > 0 {
-		dataV1.VXLAN = &bridgeDomainBlockVXLAN{
-			Vni:                        dataV0.VXLAN[0].Vni,
-			VniExtendEvpn:              dataV0.VXLAN[0].VniExtendEvpn,
-			DecapsulateAcceptInnerVlan: dataV0.VXLAN[0].DecapsulateAcceptInnerVlan,
-			EncapsulateInnerVlan:       dataV0.VXLAN[0].EncapsulateInnerVlan,
-			IngressNodeReplication:     dataV0.VXLAN[0].IngressNodeReplication,
-			OvsdbManaged:               dataV0.VXLAN[0].OvsdbManaged,
-			MulticastGroup:             dataV0.VXLAN[0].MulticastGroup,
-			UnreachableVtepAgingTimer:  dataV0.VXLAN[0].UnreachableVtepAgingTimer,
+	dataV1.VlanID = dataV0.VlanID
+	dataV1.VlanIDList = dataV0.VlanIDList
+	if len(dataV0.Vxlan) > 0 {
+		dataV1.Vxlan = &bridgeDomainBlockVxlan{
+			Vni:                        dataV0.Vxlan[0].Vni,
+			VniExtendEvpn:              dataV0.Vxlan[0].VniExtendEvpn,
+			DecapsulateAcceptInnerVlan: dataV0.Vxlan[0].DecapsulateAcceptInnerVlan,
+			EncapsulateInnerVlan:       dataV0.Vxlan[0].EncapsulateInnerVlan,
+			IngressNodeReplication:     dataV0.Vxlan[0].IngressNodeReplication,
+			OvsdbManaged:               dataV0.Vxlan[0].OvsdbManaged,
+			MulticastGroup:             dataV0.Vxlan[0].MulticastGroup,
+			UnreachableVtepAgingTimer:  dataV0.Vxlan[0].UnreachableVtepAgingTimer,
 		}
 	}
 


### PR DESCRIPTION
ENHANCEMENTS:

* **resource/junos_bridge_domain**:  add `static_remote_vtep_list` argument inside `vxlan` block argument (Fix #672)
* **resource/junos_routing_instance**:  add `remote_vtep_list` and `remote_vtep_v6_list` arguments (Fix #673)
* **data-source/junos_routing_instance**: add `remote_vtep_list` and `remote_vtep_v6_list` attributes like resource
* **resource/junos_switch_options**:  add `remote_vtep_list` and `remote_vtep_v6_list` arguments
* **resource/junos_vlan**:  add `static_remote_vtep_list` argument inside `vxlan` block argument