### PR TITLE
r/system: add keys argument inside license block argument

### DIFF
--- a/.changes/issue-689.md
+++ b/.changes/issue-689.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable-file MD013 MD041 -->
+ENHANCEMENTS:
+
+* **resource/junos_system**: add `keys` argument inside `license` block argument (Fix [#689](https://github.com/jeremmfr/terraform-provider-junos/issues/689))

--- a/docs/resources/system.md
+++ b/docs/resources/system.md
@@ -86,6 +86,8 @@ The following arguments are supported:
   - **autoupdate_url** (Optional, String)  
     Url for autoupdate license keys from license servers.  
     `autoupdate` needs to be set.
+  - **keys** (Optional, Set of String)  
+    License keys.
   - **renew_before_expiration** (Optional, Number)  
     License renewal lead time before expiration, in days (0..60).  
     `renew_interval` needs to be set.

--- a/internal/providerfwk/resource_system_test.go
+++ b/internal/providerfwk/resource_system_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-// export TESTACC_INTERFACE=<inteface> for choose interface available else it's ge-0/0/3.
+// export TESTACC_LICENSE_KEY=<key> to test license keys attribute.
 func TestAccResourceSystem_basic(t *testing.T) {
 	if os.Getenv("TESTACC_SRX") != "" {
 		resource.Test(t, resource.TestCase{
@@ -183,6 +183,9 @@ func TestAccResourceSystem_basic(t *testing.T) {
 				},
 				{
 					ConfigDirectory: config.TestStepDirectory(),
+					ConfigVariables: map[string]config.Variable{
+						"license_key": config.StringVariable(os.Getenv("TESTACC_LICENSE_KEY")),
+					},
 					Check: resource.ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr("junos_system.testacc_system",
 							"internet_options.no_gre_path_mtu_discovery", "true"),
@@ -213,6 +216,9 @@ func TestAccResourceSystem_basic(t *testing.T) {
 					),
 				},
 				{
+					ConfigVariables: map[string]config.Variable{
+						"license_key": config.StringVariable(os.Getenv("TESTACC_LICENSE_KEY")),
+					},
 					ResourceName:      "junos_system.testacc_system",
 					ImportState:       true,
 					ImportStateVerify: true,

--- a/internal/providerfwk/testdata/TestAccResourceSystem_basic/3/main.tf
+++ b/internal/providerfwk/testdata/TestAccResourceSystem_basic/3/main.tf
@@ -63,6 +63,12 @@ resource "junos_system" "testacc_system" {
     no_tcp_rfc1323                = true
     no_tcp_rfc1323_paws           = true
   }
+  dynamic "license" {
+    for_each = var.license_key != "" ? [1] : []
+    content {
+      keys = [var.license_key]
+    }
+  }
   services {
     netconf_traceoptions {
       file_name              = "testacc_netconf"

--- a/internal/providerfwk/testdata/TestAccResourceSystem_basic/3/variables.tf
+++ b/internal/providerfwk/testdata/TestAccResourceSystem_basic/3/variables.tf
@@ -1,0 +1,3 @@
+variable "license_key" {
+  type = string
+}


### PR DESCRIPTION
ENHANCEMENTS:

* **resource/junos_system**: add `keys` argument inside `license` block argument (Fix #689)