### PR TITLE
add junos_applications resource

### DIFF
--- a/.changes/issue-694.md
+++ b/.changes/issue-694.md
@@ -6,3 +6,6 @@ FEATURES:
 ENHANCEMENTS:
 
 * **resource/junos_application**: add `do_not_translate_a_query_to_aaaa_query`, `do_not_translate_aaaa_query_to_a_query`, `icmp_code`, `icmp_type`, `icmp6_code` and `icmp6_type` arguments
+* **data-source/junos_applications**:
+  * add `do_not_translate_a_query_to_aaaa_query`, `do_not_translate_aaaa_query_to_a_query`, `icmp_code`, `icmp_type`, `icmp6_code` and `icmp6_type` attributes in `applications` attribute
+  * add `do_not_translate_a_query_to_aaaa_query` and `do_not_translate_aaaa_query_to_a_query` arguments inside `match_options` block argument

--- a/.changes/issue-694.md
+++ b/.changes/issue-694.md
@@ -2,3 +2,7 @@
 FEATURES:
 
 * add **junos_applications** resource (Fix [#694](https://github.com/jeremmfr/terraform-provider-junos/issues/694))
+
+ENHANCEMENTS:
+
+* **resource/junos_application**: add `do_not_translate_a_query_to_aaaa_query`, `do_not_translate_aaaa_query_to_a_query`, `icmp_code`, `icmp_type`, `icmp6_code` and `icmp6_type` arguments

--- a/.changes/issue-694.md
+++ b/.changes/issue-694.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable-file MD013 MD041 -->
+FEATURES:
+
+* add **junos_applications** resource (Fix [#694](https://github.com/jeremmfr/terraform-provider-junos/issues/694))

--- a/docs/data-sources/applications.md
+++ b/docs/data-sources/applications.md
@@ -36,6 +36,10 @@ The following arguments are supported:
     Application protocol type.
   - **destination_port** (Optional, String)  
     Match TCP/UDP destination port.
+  - **do_not_translate_a_query_to_aaaa_query** (Optional, Boolean)  
+    Knob to control the translation of A query to AAAA query.
+  - **do_not_translate_aaaa_query_to_a_query** (Optional, Boolean)  
+    Knob to control the translation of AAAA query to A query.
   - **ether_type** (Optional, String)  
     Match ether type.
   - **icmp_code** (Optional, String)  
@@ -75,8 +79,20 @@ The following attributes are exported:
     Text description of application.
   - **destination_port** (String)  
     Port(s) destination used by application.
+  - **do_not_translate_a_query_to_aaaa_query** (Boolean)  
+    Knob to control the translation of A query to AAAA query.
+  - **do_not_translate_aaaa_query_to_a_query** (Boolean)  
+    Knob to control the translation of AAAA query to A query.
   - **ether_type** (String)  
     Match ether type.
+  - **icmp_code** (String)  
+    Match ICMP message code.
+  - **icmp_type** (String)  
+    Match ICMP message type.
+  - **icmp6_code** (String)  
+    Match ICMP6 message code.
+  - **icmp6_type** (String)  
+    Match ICMP6 message type.
   - **inactivity_timeout** (Number)  
     Application-specific inactivity timeout (4..86400 seconds).
   - **inactivity_timeout_never** (Boolean)  

--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -29,9 +29,21 @@ The following arguments are supported:
   Text description of application.
 - **destination_port** (Optional, String)  
   Match TCP/UDP destination port.
+- **do_not_translate_a_query_to_aaaa_query** (Optional, Boolean)  
+  Knob to control the translation of A query to AAAA query.
+- **do_not_translate_aaaa_query_to_a_query** (Optional, Boolean)  
+  Knob to control the translation of AAAA query to A query.
 - **ether_type** (Optional, String)  
   Match ether type.  
   Must be in hex (example: 0x8906).
+- **icmp_code** (Optional, String)  
+  Match ICMP message code.
+- **icmp_type** (Optional, String)  
+  Match ICMP message type.
+- **icmp6_code** (Optional, String)  
+  Match ICMP6 message code.
+- **icmp6_type** (Optional, String)  
+  Match ICMP6 message type.
 - **inactivity_timeout** (Optional, Number)  
   Application-specific inactivity timeout (4..86400 seconds).  
   Conflict with `inactivity_timeout_never`.

--- a/docs/resources/applications.md
+++ b/docs/resources/applications.md
@@ -1,0 +1,53 @@
+---
+page_title: "Junos: junos_applications"
+---
+
+# junos_applications
+
+~> **Note**
+  This resource should only be created **once**.  
+  It's used to configure entirely `applications` block.  
+
+!> **Warning**
+  Don't use `junos_application` or `junos_application_set` resources to avoid conflict with this resource.
+
+Configure entirely `applications` block.
+
+## Example Usage
+
+```hcl
+# Configure applications
+resource "junos_applications" "applications" {
+  application {
+    name                 = "customPort555"
+    application_protocol = "tcp"
+    destination_port     = 555
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- **application** (Optional, Block Set)  
+  For each name, define an application.  
+  See [arguments of application resource](application#argument-reference) for nested schema.
+- **application_set** (Optional, Block Set)  
+  For each name, define an applications set.  
+  See [arguments of application_set resource](application_set#argument-reference) for nested schema.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+- **id** (String)  
+  An identifier for the resource with value `applications`.
+
+## Import
+
+Junos applications can be imported using any id, e.g.
+
+```shell
+$ terraform import junos_applications.applications random
+```

--- a/internal/providerfwk/data_source_applications.go
+++ b/internal/providerfwk/data_source_applications.go
@@ -86,16 +86,22 @@ func (dsc *applicationsDataSource) Schema(
 				Computed:    true,
 				Description: "For each application found.",
 				ElementType: types.ObjectType{}.WithAttributeTypes(map[string]attr.Type{
-					"name":                     types.StringType,
-					"application_protocol":     types.StringType,
-					"description":              types.StringType,
-					"destination_port":         types.StringType,
-					"ether_type":               types.StringType,
-					"inactivity_timeout":       types.Int64Type,
-					"inactivity_timeout_never": types.BoolType,
-					"protocol":                 types.StringType,
-					"rpc_program_number":       types.StringType,
-					"source_port":              types.StringType,
+					"name":                                   types.StringType,
+					"application_protocol":                   types.StringType,
+					"description":                            types.StringType,
+					"destination_port":                       types.StringType,
+					"do_not_translate_a_query_to_aaaa_query": types.BoolType,
+					"do_not_translate_aaaa_query_to_a_query": types.BoolType,
+					"ether_type":                             types.StringType,
+					"icmp_code":                              types.StringType,
+					"icmp_type":                              types.StringType,
+					"icmp6_code":                             types.StringType,
+					"icmp6_type":                             types.StringType,
+					"inactivity_timeout":                     types.Int64Type,
+					"inactivity_timeout_never":               types.BoolType,
+					"protocol":                               types.StringType,
+					"rpc_program_number":                     types.StringType,
+					"source_port":                            types.StringType,
 					"term": types.ListType{}.WithElementType(types.ObjectType{}.WithAttributeTypes(map[string]attr.Type{
 						"name":                     types.StringType,
 						"alg":                      types.StringType,
@@ -131,6 +137,14 @@ func (dsc *applicationsDataSource) Schema(
 						"destination_port": schema.StringAttribute{
 							Optional:    true,
 							Description: "Match TCP/UDP destination port.",
+						},
+						"do_not_translate_a_query_to_aaaa_query": schema.BoolAttribute{
+							Optional:    true,
+							Description: "Knob to control the translation of A query to AAAA query.",
+						},
+						"do_not_translate_aaaa_query_to_a_query": schema.BoolAttribute{
+							Optional:    true,
+							Description: "Knob to control the translation of AAAA query to A query.",
 						},
 						"ether_type": schema.StringAttribute{
 							Optional:    true,
@@ -190,19 +204,26 @@ type applicationsDataSourceData struct {
 	MatchOptions []applicationsDataSourceBlockMatchOptions `tfsdk:"match_options"`
 }
 
+//nolint:lll
 type applicationsDataSourceBlockApplications struct {
-	Name                   types.String                                       `tfsdk:"name"`
-	ApplicationProtocol    types.String                                       `tfsdk:"application_protocol"`
-	Description            types.String                                       `tfsdk:"description"`
-	DestinationPort        types.String                                       `tfsdk:"destination_port"`
-	EtherType              types.String                                       `tfsdk:"ether_type"`
-	InactivityTimeout      types.Int64                                        `tfsdk:"inactivity_timeout"`
-	InactivityTimeoutNever types.Bool                                         `tfsdk:"inactivity_timeout_never"`
-	Protocol               types.String                                       `tfsdk:"protocol"`
-	RPCRrogramNumber       types.String                                       `tfsdk:"rpc_program_number"`
-	SourcePort             types.String                                       `tfsdk:"source_port"`
-	Term                   []applicationsDataSourceBlockApplicationsBlockTerm `tfsdk:"term"`
-	UUID                   types.String                                       `tfsdk:"uuid"`
+	Name                            types.String                                       `tfsdk:"name"`
+	ApplicationProtocol             types.String                                       `tfsdk:"application_protocol"`
+	Description                     types.String                                       `tfsdk:"description"`
+	DestinationPort                 types.String                                       `tfsdk:"destination_port"`
+	DoNotTranslateAQueryToAAAAQuery types.Bool                                         `tfsdk:"do_not_translate_a_query_to_aaaa_query"`
+	DoNotTranslateAAAAQueryToAQuery types.Bool                                         `tfsdk:"do_not_translate_aaaa_query_to_a_query"`
+	EtherType                       types.String                                       `tfsdk:"ether_type"`
+	IcmpCode                        types.String                                       `tfsdk:"icmp_code"`
+	IcmpType                        types.String                                       `tfsdk:"icmp_type"`
+	Icmp6Code                       types.String                                       `tfsdk:"icmp6_code"`
+	Icmp6Type                       types.String                                       `tfsdk:"icmp6_type"`
+	InactivityTimeout               types.Int64                                        `tfsdk:"inactivity_timeout"`
+	InactivityTimeoutNever          types.Bool                                         `tfsdk:"inactivity_timeout_never"`
+	Protocol                        types.String                                       `tfsdk:"protocol"`
+	RPCRrogramNumber                types.String                                       `tfsdk:"rpc_program_number"`
+	SourcePort                      types.String                                       `tfsdk:"source_port"`
+	Term                            []applicationsDataSourceBlockApplicationsBlockTerm `tfsdk:"term"`
+	UUID                            types.String                                       `tfsdk:"uuid"`
 }
 
 type applicationsDataSourceBlockApplicationsBlockTerm struct {
@@ -222,20 +243,22 @@ type applicationsDataSourceBlockApplicationsBlockTerm struct {
 }
 
 type applicationsDataSourceBlockMatchOptions struct {
-	Alg                    types.String `tfsdk:"alg"`
-	ApplicationProtocol    types.String `tfsdk:"application_protocol"`
-	DestinationPort        types.String `tfsdk:"destination_port"`
-	EtherType              types.String `tfsdk:"ether_type"`
-	IcmpCode               types.String `tfsdk:"icmp_code"`
-	IcmpType               types.String `tfsdk:"icmp_type"`
-	Icmp6Code              types.String `tfsdk:"icmp6_code"`
-	Icmp6Type              types.String `tfsdk:"icmp6_type"`
-	InactivityTimeout      types.Int64  `tfsdk:"inactivity_timeout"`
-	InactivityTimeoutNever types.Bool   `tfsdk:"inactivity_timeout_never"`
-	Protocol               types.String `tfsdk:"protocol"`
-	RPCRrogramNumber       types.String `tfsdk:"rpc_program_number"`
-	SourcePort             types.String `tfsdk:"source_port"`
-	UUID                   types.String `tfsdk:"uuid"`
+	Alg                             types.String `tfsdk:"alg"`
+	ApplicationProtocol             types.String `tfsdk:"application_protocol"`
+	DestinationPort                 types.String `tfsdk:"destination_port"`
+	DoNotTranslateAQueryToAAAAQuery types.Bool   `tfsdk:"do_not_translate_a_query_to_aaaa_query"`
+	DoNotTranslateAAAAQueryToAQuery types.Bool   `tfsdk:"do_not_translate_aaaa_query_to_a_query"`
+	EtherType                       types.String `tfsdk:"ether_type"`
+	IcmpCode                        types.String `tfsdk:"icmp_code"`
+	IcmpType                        types.String `tfsdk:"icmp_type"`
+	Icmp6Code                       types.String `tfsdk:"icmp6_code"`
+	Icmp6Type                       types.String `tfsdk:"icmp6_type"`
+	InactivityTimeout               types.Int64  `tfsdk:"inactivity_timeout"`
+	InactivityTimeoutNever          types.Bool   `tfsdk:"inactivity_timeout_never"`
+	Protocol                        types.String `tfsdk:"protocol"`
+	RPCRrogramNumber                types.String `tfsdk:"rpc_program_number"`
+	SourcePort                      types.String `tfsdk:"source_port"`
+	UUID                            types.String `tfsdk:"uuid"`
 }
 
 func (dsc *applicationsDataSource) Read(
@@ -333,8 +356,20 @@ func (block *applicationsDataSourceBlockApplications) read(itemTrim string) erro
 		block.Description = types.StringValue(strings.Trim(itemTrim, "\""))
 	case balt.CutPrefixInString(&itemTrim, "destination-port "):
 		block.DestinationPort = types.StringValue(strings.Trim(itemTrim, "\""))
+	case itemTrim == "do-not-translate-A-query-to-AAAA-query":
+		block.DoNotTranslateAQueryToAAAAQuery = types.BoolValue(true)
+	case itemTrim == "do-not-translate-AAAA-query-to-A-query":
+		block.DoNotTranslateAAAAQueryToAQuery = types.BoolValue(true)
 	case balt.CutPrefixInString(&itemTrim, "ether-type "):
 		block.EtherType = types.StringValue(itemTrim)
+	case balt.CutPrefixInString(&itemTrim, "icmp-code "):
+		block.IcmpCode = types.StringValue(itemTrim)
+	case balt.CutPrefixInString(&itemTrim, "icmp-type "):
+		block.IcmpType = types.StringValue(itemTrim)
+	case balt.CutPrefixInString(&itemTrim, "icmp6-code "):
+		block.Icmp6Code = types.StringValue(itemTrim)
+	case balt.CutPrefixInString(&itemTrim, "icmp6-type "):
+		block.Icmp6Type = types.StringValue(itemTrim)
 	case itemTrim == "inactivity-timeout never":
 		block.InactivityTimeoutNever = types.BoolValue(true)
 	case balt.CutPrefixInString(&itemTrim, "inactivity-timeout "):
@@ -403,7 +438,7 @@ func (block *applicationsDataSourceBlockApplicationsBlockTerm) read(itemTrim str
 	return nil
 }
 
-func (dscData *applicationsDataSourceData) filter(
+func (dscData *applicationsDataSourceData) filter( //nolint:gocognit
 	results map[string]applicationsDataSourceBlockApplications,
 ) error {
 	if v := dscData.MatchName.ValueString(); v != "" {
@@ -502,8 +537,44 @@ func (dscData *applicationsDataSourceData) filter(
 
 						break
 					}
+					if matchOption.DoNotTranslateAQueryToAAAAQuery.ValueBool() &&
+						!app.DoNotTranslateAQueryToAAAAQuery.ValueBool() {
+						matchOk = false
+
+						break
+					}
+					if matchOption.DoNotTranslateAAAAQueryToAQuery.ValueBool() &&
+						!app.DoNotTranslateAAAAQueryToAQuery.ValueBool() {
+						matchOk = false
+
+						break
+					}
 					if v := matchOption.EtherType.ValueString(); v != "" &&
 						v != app.EtherType.ValueString() {
+						matchOk = false
+
+						break
+					}
+					if v := matchOption.IcmpCode.ValueString(); v != "" &&
+						v != app.IcmpCode.ValueString() {
+						matchOk = false
+
+						break
+					}
+					if v := matchOption.IcmpType.ValueString(); v != "" &&
+						v != app.IcmpType.ValueString() {
+						matchOk = false
+
+						break
+					}
+					if v := matchOption.Icmp6Code.ValueString(); v != "" &&
+						v != app.Icmp6Code.ValueString() {
+						matchOk = false
+
+						break
+					}
+					if v := matchOption.Icmp6Type.ValueString(); v != "" &&
+						v != app.Icmp6Type.ValueString() {
 						matchOk = false
 
 						break

--- a/internal/providerfwk/provider.go
+++ b/internal/providerfwk/provider.go
@@ -228,8 +228,9 @@ func (p *junosProvider) DataSources(_ context.Context) []func() datasource.DataS
 func (p *junosProvider) Resources(_ context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
 		newAggregateRouteResource,
-		newApplicationSetResource,
 		newApplicationResource,
+		newApplicationsResource,
+		newApplicationSetResource,
 		newBgpGroupResource,
 		newBgpNeighborResource,
 		newBridgeDomainResource,

--- a/internal/providerfwk/resource_application.go
+++ b/internal/providerfwk/resource_application.go
@@ -2,7 +2,9 @@ package providerfwk
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"maps"
 	"regexp"
 	"strings"
 
@@ -77,230 +79,37 @@ func (rsc *application) Configure(
 func (rsc *application) Schema(
 	_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse,
 ) {
+	attributes := map[string]schema.Attribute{
+		"id": schema.StringAttribute{
+			Computed:    true,
+			Description: "An identifier for the resource with format `<name>`.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
+		},
+	}
+	maps.Copy(attributes, applicationAttrData{}.attributesSchema())
+	// add RequiresReplace on name to force replacement of application resource
+	// when value change (useless in applications resource)
+	nameAttribute := attributes["name"].(schema.StringAttribute)
+	nameAttribute.PlanModifiers = []planmodifier.String{
+		stringplanmodifier.RequiresReplace(),
+	}
+	attributes["name"] = nameAttribute
+
 	resp.Schema = schema.Schema{
 		Description: defaultResourceSchemaDescription(rsc),
-		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{
-				Computed:    true,
-				Description: "An identifier for the resource with format `<name>`.",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
-			"name": schema.StringAttribute{
-				Required:    true,
-				Description: "Application name.",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
-				Validators: []validator.String{
-					stringvalidator.LengthBetween(1, 63),
-					tfvalidator.StringFormat(tfvalidator.DefaultFormat),
-				},
-			},
-			"application_protocol": schema.StringAttribute{
-				Optional:    true,
-				Description: "Application protocol type.",
-				Validators: []validator.String{
-					stringvalidator.LengthAtLeast(1),
-					tfvalidator.StringFormat(tfvalidator.DefaultFormat),
-				},
-			},
-			"description": schema.StringAttribute{
-				Optional:    true,
-				Description: "Text description of application.",
-				Validators: []validator.String{
-					stringvalidator.LengthBetween(1, 900),
-					tfvalidator.StringDoubleQuoteExclusion(),
-				},
-			},
-			"destination_port": schema.StringAttribute{
-				Optional:    true,
-				Description: "Match TCP/UDP destination port.",
-				Validators: []validator.String{
-					stringvalidator.LengthAtLeast(1),
-					tfvalidator.StringDoubleQuoteExclusion(),
-				},
-			},
-			"ether_type": schema.StringAttribute{
-				Optional:    true,
-				Description: "Match ether type.",
-				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(
-						`^0[xX][0-9a-fA-F]{4}$`),
-						"must be in hex (example: 0x8906)",
-					),
-				},
-			},
-			"inactivity_timeout": schema.Int64Attribute{
-				Optional:    true,
-				Description: "Application-specific inactivity timeout.",
-				Validators: []validator.Int64{
-					int64validator.Between(4, 86400),
-				},
-			},
-			"inactivity_timeout_never": schema.BoolAttribute{
-				Optional:    true,
-				Description: "Disables inactivity timeout.",
-				Validators: []validator.Bool{
-					tfvalidator.BoolTrue(),
-				},
-			},
-			"protocol": schema.StringAttribute{
-				Optional:    true,
-				Description: "Match IP protocol type.",
-				Validators: []validator.String{
-					stringvalidator.LengthAtLeast(1),
-					tfvalidator.StringFormat(tfvalidator.DefaultFormat),
-				},
-			},
-			"rpc_program_number": schema.StringAttribute{
-				Optional:    true,
-				Description: "Match range of RPC program numbers.",
-				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(
-						`^\d+(-\d+)?$`),
-						"must be an integer or a range of integers"),
-				},
-			},
-			"source_port": schema.StringAttribute{
-				Optional:    true,
-				Description: "Match TCP/UDP source port.",
-				Validators: []validator.String{
-					stringvalidator.LengthAtLeast(1),
-					tfvalidator.StringDoubleQuoteExclusion(),
-				},
-			},
-			"uuid": schema.StringAttribute{
-				Optional:    true,
-				Description: "Match universal unique identifier for DCE RPC objects.",
-				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(
-						`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`),
-						"must be of the form xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-					),
-				},
-			},
-		},
-		Blocks: map[string]schema.Block{
-			"term": schema.ListNestedBlock{
-				Description: "For each name of term to declare.",
-				NestedObject: schema.NestedBlockObject{
-					Attributes: map[string]schema.Attribute{
-						"name": schema.StringAttribute{
-							Required:    true,
-							Description: "Term name.",
-							Validators: []validator.String{
-								stringvalidator.LengthBetween(1, 63),
-								tfvalidator.StringFormat(tfvalidator.DefaultFormat),
-							},
-						},
-						"protocol": schema.StringAttribute{
-							Required:    true,
-							Description: "Match IP protocol type.",
-							Validators: []validator.String{
-								stringvalidator.LengthAtLeast(1),
-								tfvalidator.StringFormat(tfvalidator.DefaultFormat),
-							},
-						},
-						"alg": schema.StringAttribute{
-							Optional:    true,
-							Description: "Application Layer Gateway.",
-							Validators: []validator.String{
-								stringvalidator.LengthAtLeast(1),
-								tfvalidator.StringFormat(tfvalidator.DefaultFormat),
-							},
-						},
-						"destination_port": schema.StringAttribute{
-							Optional:    true,
-							Description: "Match TCP/UDP destination port.",
-							Validators: []validator.String{
-								stringvalidator.LengthAtLeast(1),
-								tfvalidator.StringDoubleQuoteExclusion(),
-							},
-						},
-						"icmp_code": schema.StringAttribute{
-							Optional:    true,
-							Description: "Match ICMP message code.",
-							Validators: []validator.String{
-								stringvalidator.LengthAtLeast(1),
-								tfvalidator.StringFormat(tfvalidator.DefaultFormat),
-							},
-						},
-						"icmp_type": schema.StringAttribute{
-							Optional:    true,
-							Description: "Match ICMP message type.",
-							Validators: []validator.String{
-								stringvalidator.LengthAtLeast(1),
-								tfvalidator.StringFormat(tfvalidator.DefaultFormat),
-							},
-						},
-						"icmp6_code": schema.StringAttribute{
-							Optional:    true,
-							Description: "Match ICMP6 message code.",
-							Validators: []validator.String{
-								stringvalidator.LengthAtLeast(1),
-								tfvalidator.StringFormat(tfvalidator.DefaultFormat),
-							},
-						},
-						"icmp6_type": schema.StringAttribute{
-							Optional:    true,
-							Description: "Match ICMP6 message type.",
-							Validators: []validator.String{
-								stringvalidator.LengthAtLeast(1),
-								tfvalidator.StringFormat(tfvalidator.DefaultFormat),
-							},
-						},
-						"inactivity_timeout": schema.Int64Attribute{
-							Optional:    true,
-							Description: "Application-specific inactivity timeout.",
-							Validators: []validator.Int64{
-								int64validator.Between(4, 86400),
-							},
-						},
-						"inactivity_timeout_never": schema.BoolAttribute{
-							Optional:    true,
-							Description: "Disables inactivity timeout.",
-							Validators: []validator.Bool{
-								tfvalidator.BoolTrue(),
-							},
-						},
-						"rpc_program_number": schema.StringAttribute{
-							Optional:    true,
-							Description: "Match range of RPC program numbers.",
-							Validators: []validator.String{
-								stringvalidator.RegexMatches(regexp.MustCompile(
-									`^\d+(-\d+)?$`),
-									"must be an integer or a range of integers"),
-							},
-						},
-						"source_port": schema.StringAttribute{
-							Optional:    true,
-							Description: "Match TCP/UDP source port.",
-							Validators: []validator.String{
-								stringvalidator.LengthAtLeast(1),
-								tfvalidator.StringDoubleQuoteExclusion(),
-							},
-						},
-						"uuid": schema.StringAttribute{
-							Optional:    true,
-							Description: "Match universal unique identifier for DCE RPC objects.",
-							Validators: []validator.String{
-								stringvalidator.RegexMatches(regexp.MustCompile(
-									`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`),
-									"must be of the form xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-								),
-							},
-						},
-					},
-				},
-			},
-		},
+		Attributes:  attributes,
+		Blocks:      applicationAttrData{}.blocksSchema(),
 	}
 }
 
 type applicationData struct {
-	ID                     types.String           `tfsdk:"id"`
+	ID types.String `tfsdk:"id"`
+	applicationAttrData
+}
+
+type applicationAttrData struct {
 	Name                   types.String           `tfsdk:"name"`
 	ApplicationProtocol    types.String           `tfsdk:"application_protocol"`
 	Description            types.String           `tfsdk:"description"`
@@ -315,8 +124,229 @@ type applicationData struct {
 	Term                   []applicationBlockTerm `tfsdk:"term"`
 }
 
+func (rscData *applicationAttrData) isEmpty() bool {
+	return tfdata.CheckBlockIsEmpty(rscData, "Name")
+}
+
+func (rscData applicationAttrData) attributesSchema() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"name": schema.StringAttribute{
+			Required:    true,
+			Description: "Application name.",
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 63),
+				tfvalidator.StringFormat(tfvalidator.DefaultFormat),
+			},
+		},
+		"application_protocol": schema.StringAttribute{
+			Optional:    true,
+			Description: "Application protocol type.",
+			Validators: []validator.String{
+				stringvalidator.LengthAtLeast(1),
+				tfvalidator.StringFormat(tfvalidator.DefaultFormat),
+			},
+		},
+		"description": schema.StringAttribute{
+			Optional:    true,
+			Description: "Text description of application.",
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 900),
+				tfvalidator.StringDoubleQuoteExclusion(),
+			},
+		},
+		"destination_port": schema.StringAttribute{
+			Optional:    true,
+			Description: "Match TCP/UDP destination port.",
+			Validators: []validator.String{
+				stringvalidator.LengthAtLeast(1),
+				tfvalidator.StringDoubleQuoteExclusion(),
+			},
+		},
+		"ether_type": schema.StringAttribute{
+			Optional:    true,
+			Description: "Match ether type.",
+			Validators: []validator.String{
+				stringvalidator.RegexMatches(regexp.MustCompile(
+					`^0[xX][0-9a-fA-F]{4}$`),
+					"must be in hex (example: 0x8906)",
+				),
+			},
+		},
+		"inactivity_timeout": schema.Int64Attribute{
+			Optional:    true,
+			Description: "Application-specific inactivity timeout.",
+			Validators: []validator.Int64{
+				int64validator.Between(4, 86400),
+			},
+		},
+		"inactivity_timeout_never": schema.BoolAttribute{
+			Optional:    true,
+			Description: "Disables inactivity timeout.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+		"protocol": schema.StringAttribute{
+			Optional:    true,
+			Description: "Match IP protocol type.",
+			Validators: []validator.String{
+				stringvalidator.LengthAtLeast(1),
+				tfvalidator.StringFormat(tfvalidator.DefaultFormat),
+			},
+		},
+		"rpc_program_number": schema.StringAttribute{
+			Optional:    true,
+			Description: "Match range of RPC program numbers.",
+			Validators: []validator.String{
+				stringvalidator.RegexMatches(regexp.MustCompile(
+					`^\d+(-\d+)?$`),
+					"must be an integer or a range of integers"),
+			},
+		},
+		"source_port": schema.StringAttribute{
+			Optional:    true,
+			Description: "Match TCP/UDP source port.",
+			Validators: []validator.String{
+				stringvalidator.LengthAtLeast(1),
+				tfvalidator.StringDoubleQuoteExclusion(),
+			},
+		},
+		"uuid": schema.StringAttribute{
+			Optional:    true,
+			Description: "Match universal unique identifier for DCE RPC objects.",
+			Validators: []validator.String{
+				stringvalidator.RegexMatches(regexp.MustCompile(
+					`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`),
+					"must be of the form xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+				),
+			},
+		},
+	}
+}
+
+func (rscData applicationAttrData) blocksSchema() map[string]schema.Block {
+	return map[string]schema.Block{
+		"term": schema.ListNestedBlock{
+			Description: "For each name of term to declare.",
+			NestedObject: schema.NestedBlockObject{
+				Attributes: map[string]schema.Attribute{
+					"name": schema.StringAttribute{
+						Required:    true,
+						Description: "Term name.",
+						Validators: []validator.String{
+							stringvalidator.LengthBetween(1, 63),
+							tfvalidator.StringFormat(tfvalidator.DefaultFormat),
+						},
+					},
+					"protocol": schema.StringAttribute{
+						Required:    true,
+						Description: "Match IP protocol type.",
+						Validators: []validator.String{
+							stringvalidator.LengthAtLeast(1),
+							tfvalidator.StringFormat(tfvalidator.DefaultFormat),
+						},
+					},
+					"alg": schema.StringAttribute{
+						Optional:    true,
+						Description: "Application Layer Gateway.",
+						Validators: []validator.String{
+							stringvalidator.LengthAtLeast(1),
+							tfvalidator.StringFormat(tfvalidator.DefaultFormat),
+						},
+					},
+					"destination_port": schema.StringAttribute{
+						Optional:    true,
+						Description: "Match TCP/UDP destination port.",
+						Validators: []validator.String{
+							stringvalidator.LengthAtLeast(1),
+							tfvalidator.StringDoubleQuoteExclusion(),
+						},
+					},
+					"icmp_code": schema.StringAttribute{
+						Optional:    true,
+						Description: "Match ICMP message code.",
+						Validators: []validator.String{
+							stringvalidator.LengthAtLeast(1),
+							tfvalidator.StringFormat(tfvalidator.DefaultFormat),
+						},
+					},
+					"icmp_type": schema.StringAttribute{
+						Optional:    true,
+						Description: "Match ICMP message type.",
+						Validators: []validator.String{
+							stringvalidator.LengthAtLeast(1),
+							tfvalidator.StringFormat(tfvalidator.DefaultFormat),
+						},
+					},
+					"icmp6_code": schema.StringAttribute{
+						Optional:    true,
+						Description: "Match ICMP6 message code.",
+						Validators: []validator.String{
+							stringvalidator.LengthAtLeast(1),
+							tfvalidator.StringFormat(tfvalidator.DefaultFormat),
+						},
+					},
+					"icmp6_type": schema.StringAttribute{
+						Optional:    true,
+						Description: "Match ICMP6 message type.",
+						Validators: []validator.String{
+							stringvalidator.LengthAtLeast(1),
+							tfvalidator.StringFormat(tfvalidator.DefaultFormat),
+						},
+					},
+					"inactivity_timeout": schema.Int64Attribute{
+						Optional:    true,
+						Description: "Application-specific inactivity timeout.",
+						Validators: []validator.Int64{
+							int64validator.Between(4, 86400),
+						},
+					},
+					"inactivity_timeout_never": schema.BoolAttribute{
+						Optional:    true,
+						Description: "Disables inactivity timeout.",
+						Validators: []validator.Bool{
+							tfvalidator.BoolTrue(),
+						},
+					},
+					"rpc_program_number": schema.StringAttribute{
+						Optional:    true,
+						Description: "Match range of RPC program numbers.",
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(
+								`^\d+(-\d+)?$`),
+								"must be an integer or a range of integers"),
+						},
+					},
+					"source_port": schema.StringAttribute{
+						Optional:    true,
+						Description: "Match TCP/UDP source port.",
+						Validators: []validator.String{
+							stringvalidator.LengthAtLeast(1),
+							tfvalidator.StringDoubleQuoteExclusion(),
+						},
+					},
+					"uuid": schema.StringAttribute{
+						Optional:    true,
+						Description: "Match universal unique identifier for DCE RPC objects.",
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(
+								`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`),
+								"must be of the form xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+							),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 type applicationConfig struct {
-	ID                     types.String `tfsdk:"id"`
+	ID types.String `tfsdk:"id"`
+	applicationAttrConfig
+}
+
+type applicationAttrConfig struct {
 	Name                   types.String `tfsdk:"name"`
 	ApplicationProtocol    types.String `tfsdk:"application_protocol"`
 	Description            types.String `tfsdk:"description"`
@@ -329,6 +359,159 @@ type applicationConfig struct {
 	SourcePort             types.String `tfsdk:"source_port"`
 	UUID                   types.String `tfsdk:"uuid"`
 	Term                   types.List   `tfsdk:"term"`
+}
+
+func (config *applicationAttrConfig) isEmpty() bool {
+	return tfdata.CheckBlockIsEmpty(config, "Name")
+}
+
+func (config *applicationAttrConfig) validateConfig(
+	ctx context.Context, rootPath *path.Path, blockErrorSuffix string, resp *resource.ValidateConfigResponse,
+) {
+	if !config.InactivityTimeout.IsNull() && !config.InactivityTimeout.IsUnknown() &&
+		!config.InactivityTimeoutNever.IsNull() && !config.InactivityTimeoutNever.IsUnknown() {
+		errPath := path.Root("inactivity_timeout")
+		if rootPath != nil {
+			errPath = *rootPath
+		}
+		resp.Diagnostics.AddAttributeError(
+			errPath,
+			tfdiag.ConflictConfigErrSummary,
+			"inactivity_timeout and inactivity_timeout_never cannot be configured together"+blockErrorSuffix,
+		)
+	}
+
+	if !config.Term.IsNull() && !config.Term.IsUnknown() {
+		if !config.ApplicationProtocol.IsNull() && !config.ApplicationProtocol.IsUnknown() {
+			errPath := path.Root("application_protocol")
+			if rootPath != nil {
+				errPath = *rootPath
+			}
+			resp.Diagnostics.AddAttributeError(
+				errPath,
+				tfdiag.ConflictConfigErrSummary,
+				"application_protocol and term cannot be configured together"+blockErrorSuffix,
+			)
+		}
+		if !config.DestinationPort.IsNull() && !config.DestinationPort.IsUnknown() {
+			errPath := path.Root("destination_port")
+			if rootPath != nil {
+				errPath = *rootPath
+			}
+			resp.Diagnostics.AddAttributeError(
+				errPath,
+				tfdiag.ConflictConfigErrSummary,
+				"destination_port and term cannot be configured together"+blockErrorSuffix,
+			)
+		}
+		if !config.InactivityTimeout.IsNull() && !config.InactivityTimeout.IsUnknown() {
+			errPath := path.Root("inactivity_timeout")
+			if rootPath != nil {
+				errPath = *rootPath
+			}
+			resp.Diagnostics.AddAttributeError(
+				errPath,
+				tfdiag.ConflictConfigErrSummary,
+				"inactivity_timeout and term cannot be configured together"+blockErrorSuffix,
+			)
+		}
+		if !config.InactivityTimeoutNever.IsNull() && !config.InactivityTimeoutNever.IsUnknown() {
+			errPath := path.Root("inactivity_timeout_never")
+			if rootPath != nil {
+				errPath = *rootPath
+			}
+			resp.Diagnostics.AddAttributeError(
+				errPath,
+				tfdiag.ConflictConfigErrSummary,
+				"inactivity_timeout_never and term cannot be configured together"+blockErrorSuffix,
+			)
+		}
+		if !config.Protocol.IsNull() && !config.Protocol.IsUnknown() {
+			errPath := path.Root("protocol")
+			if rootPath != nil {
+				errPath = *rootPath
+			}
+			resp.Diagnostics.AddAttributeError(
+				errPath,
+				tfdiag.ConflictConfigErrSummary,
+				"protocol and term cannot be configured together"+blockErrorSuffix,
+			)
+		}
+		if !config.RPCProgramNumber.IsNull() && !config.RPCProgramNumber.IsUnknown() {
+			errPath := path.Root("rpc_program_number")
+			if rootPath != nil {
+				errPath = *rootPath
+			}
+			resp.Diagnostics.AddAttributeError(
+				errPath,
+				tfdiag.ConflictConfigErrSummary,
+				"rpc_program_number and term cannot be configured together"+blockErrorSuffix,
+			)
+		}
+		if !config.SourcePort.IsNull() && !config.SourcePort.IsUnknown() {
+			errPath := path.Root("source_port")
+			if rootPath != nil {
+				errPath = *rootPath
+			}
+			resp.Diagnostics.AddAttributeError(
+				errPath,
+				tfdiag.ConflictConfigErrSummary,
+				"source_port and term cannot be configured together"+blockErrorSuffix,
+			)
+		}
+		if !config.UUID.IsNull() && !config.UUID.IsUnknown() {
+			errPath := path.Root("uuid")
+			if rootPath != nil {
+				errPath = *rootPath
+			}
+			resp.Diagnostics.AddAttributeError(
+				errPath,
+				tfdiag.ConflictConfigErrSummary,
+				"uuid and term cannot be configured together"+blockErrorSuffix,
+			)
+		}
+
+		var term []applicationBlockTerm
+		asDiags := config.Term.ElementsAs(ctx, &term, false)
+		if asDiags.HasError() {
+			resp.Diagnostics.Append(asDiags...)
+
+			return
+		}
+
+		termName := make(map[string]struct{})
+		for i, block := range term {
+			if !block.Name.IsUnknown() {
+				name := block.Name.ValueString()
+				if _, ok := termName[name]; ok {
+					errPath := path.Root("term").AtListIndex(i).AtName("name")
+					if rootPath != nil {
+						errPath = *rootPath
+					}
+					resp.Diagnostics.AddAttributeError(
+						errPath,
+						tfdiag.DuplicateConfigErrSummary,
+						fmt.Sprintf("multiple term blocks with the same name %q"+blockErrorSuffix, name),
+					)
+				}
+				termName[name] = struct{}{}
+			}
+
+			if !block.InactivityTimeout.IsNull() && !block.InactivityTimeout.IsUnknown() &&
+				!block.InactivityTimeoutNever.IsNull() && !block.InactivityTimeoutNever.IsUnknown() {
+				errPath := path.Root("term").AtListIndex(i).AtName("inactivity_timeout")
+				if rootPath != nil {
+					errPath = *rootPath
+				}
+				resp.Diagnostics.AddAttributeError(
+					errPath,
+					tfdiag.ConflictConfigErrSummary,
+					fmt.Sprintf("inactivity_timeout and inactivity_timeout_never cannot be configured together"+
+						" in term block %q"+blockErrorSuffix, block.Name.ValueString()),
+				)
+			}
+		}
+	}
 }
 
 type applicationBlockTerm struct {
@@ -356,106 +539,15 @@ func (rsc *application) ValidateConfig(
 		return
 	}
 
-	if !config.InactivityTimeout.IsNull() && !config.InactivityTimeout.IsUnknown() &&
-		!config.InactivityTimeoutNever.IsNull() && !config.InactivityTimeoutNever.IsUnknown() {
+	if config.isEmpty() {
 		resp.Diagnostics.AddAttributeError(
-			path.Root("inactivity_timeout"),
-			tfdiag.ConflictConfigErrSummary,
-			"inactivity_timeout and inactivity_timeout_never cannot be configured together",
+			path.Root("name"),
+			tfdiag.MissingConfigErrSummary,
+			"at least one of arguments need to be set (in addition to `name`)",
 		)
 	}
 
-	if !config.Term.IsNull() && !config.Term.IsUnknown() {
-		if !config.ApplicationProtocol.IsNull() && !config.ApplicationProtocol.IsUnknown() {
-			resp.Diagnostics.AddAttributeError(
-				path.Root("application_protocol"),
-				tfdiag.ConflictConfigErrSummary,
-				"application_protocol and term cannot be configured together",
-			)
-		}
-		if !config.DestinationPort.IsNull() && !config.DestinationPort.IsUnknown() {
-			resp.Diagnostics.AddAttributeError(
-				path.Root("destination_port"),
-				tfdiag.ConflictConfigErrSummary,
-				"destination_port and term cannot be configured together",
-			)
-		}
-		if !config.InactivityTimeout.IsNull() && !config.InactivityTimeout.IsUnknown() {
-			resp.Diagnostics.AddAttributeError(
-				path.Root("inactivity_timeout"),
-				tfdiag.ConflictConfigErrSummary,
-				"inactivity_timeout and term cannot be configured together",
-			)
-		}
-		if !config.InactivityTimeoutNever.IsNull() && !config.InactivityTimeoutNever.IsUnknown() {
-			resp.Diagnostics.AddAttributeError(
-				path.Root("inactivity_timeout_never"),
-				tfdiag.ConflictConfigErrSummary,
-				"inactivity_timeout_never and term cannot be configured together",
-			)
-		}
-		if !config.Protocol.IsNull() && !config.Protocol.IsUnknown() {
-			resp.Diagnostics.AddAttributeError(
-				path.Root("protocol"),
-				tfdiag.ConflictConfigErrSummary,
-				"protocol and term cannot be configured together",
-			)
-		}
-		if !config.RPCProgramNumber.IsNull() && !config.RPCProgramNumber.IsUnknown() {
-			resp.Diagnostics.AddAttributeError(
-				path.Root("rpc_program_number"),
-				tfdiag.ConflictConfigErrSummary,
-				"rpc_program_number and term cannot be configured together",
-			)
-		}
-		if !config.SourcePort.IsNull() && !config.SourcePort.IsUnknown() {
-			resp.Diagnostics.AddAttributeError(
-				path.Root("source_port"),
-				tfdiag.ConflictConfigErrSummary,
-				"source_port and term cannot be configured together",
-			)
-		}
-		if !config.UUID.IsNull() && !config.UUID.IsUnknown() {
-			resp.Diagnostics.AddAttributeError(
-				path.Root("uuid"),
-				tfdiag.ConflictConfigErrSummary,
-				"uuid and term cannot be configured together",
-			)
-		}
-
-		var term []applicationBlockTerm
-		asDiags := config.Term.ElementsAs(ctx, &term, false)
-		if asDiags.HasError() {
-			resp.Diagnostics.Append(asDiags...)
-
-			return
-		}
-
-		termName := make(map[string]struct{})
-		for i, block := range term {
-			if !block.Name.IsUnknown() {
-				name := block.Name.ValueString()
-				if _, ok := termName[name]; ok {
-					resp.Diagnostics.AddAttributeError(
-						path.Root("term").AtListIndex(i).AtName("name"),
-						tfdiag.DuplicateConfigErrSummary,
-						fmt.Sprintf("multiple term blocks with the same name %q", name),
-					)
-				}
-				termName[name] = struct{}{}
-			}
-
-			if !block.InactivityTimeout.IsNull() && !block.InactivityTimeout.IsUnknown() &&
-				!block.InactivityTimeoutNever.IsNull() && !block.InactivityTimeoutNever.IsUnknown() {
-				resp.Diagnostics.AddAttributeError(
-					path.Root("term").AtListIndex(i).AtName("inactivity_timeout"),
-					tfdiag.ConflictConfigErrSummary,
-					fmt.Sprintf("inactivity_timeout and inactivity_timeout_never cannot be configured together"+
-						" in term block %q", block.Name.ValueString()),
-				)
-			}
-		}
-	}
+	config.applicationAttrConfig.validateConfig(ctx, nil, "", resp)
 }
 
 func (rsc *application) Create(
@@ -632,6 +724,20 @@ func (rscData *applicationData) set(
 ) (
 	path.Path, error,
 ) {
+	if rscData.applicationAttrData.isEmpty() {
+		return path.Root("name"),
+			errors.New("at least one of arguments need to be set (in addition to `name`)")
+	}
+
+	dataConfigSet, errPath, err := rscData.applicationAttrData.configSet("")
+	if err != nil {
+		return errPath, err
+	}
+
+	return path.Empty(), junSess.ConfigSet(dataConfigSet)
+}
+
+func (rscData applicationAttrData) configSet(blockErrorSuffix string) ([]string, path.Path, error) {
 	configSet := make([]string, 0)
 	setPrefix := "set applications application " + rscData.Name.ValueString() + " "
 
@@ -666,14 +772,14 @@ func (rscData *applicationData) set(
 	for i, block := range rscData.Term {
 		name := block.Name.ValueString()
 		if _, ok := termName[name]; ok {
-			return path.Root("term").AtListIndex(i).AtName("name"),
-				fmt.Errorf("multiple term blocks with the same name %q", name)
+			return configSet, path.Root("term").AtListIndex(i).AtName("name"),
+				fmt.Errorf("multiple term blocks with the same name %q"+blockErrorSuffix, name)
 		}
 		termName[name] = struct{}{}
 
-		blockSet, pathErr, err := block.configSet(setPrefix, path.Root("term").AtListIndex(i))
+		blockSet, pathErr, err := block.configSet(setPrefix, blockErrorSuffix, path.Root("term").AtListIndex(i))
 		if err != nil {
-			return pathErr, err
+			return configSet, pathErr, err
 		}
 		configSet = append(configSet, blockSet...)
 	}
@@ -681,11 +787,11 @@ func (rscData *applicationData) set(
 		configSet = append(configSet, setPrefix+"uuid "+v)
 	}
 
-	return path.Empty(), junSess.ConfigSet(configSet)
+	return configSet, path.Empty(), nil
 }
 
 func (block *applicationBlockTerm) configSet(
-	setPrefix string, pathRoot path.Path,
+	setPrefix, blockErrorSuffix string, pathRoot path.Path,
 ) (
 	[]string, // configSet
 	path.Path, // pathErr
@@ -723,7 +829,7 @@ func (block *applicationBlockTerm) configSet(
 			return configSet,
 				pathRoot.AtName("inactivity_timeout_never"),
 				fmt.Errorf("inactivity_timeout and inactivity_timeout_never cannot be configured together"+
-					" in term block %q", block.Name.ValueString())
+					" in term block %q"+blockErrorSuffix, block.Name.ValueString())
 		}
 	} else if block.InactivityTimeoutNever.ValueBool() {
 		configSet = append(configSet, setPrefix+"inactivity-timeout never")
@@ -760,44 +866,52 @@ func (rscData *applicationData) read(
 				break
 			}
 			itemTrim := strings.TrimPrefix(item, junos.SetLS)
-			switch {
-			case balt.CutPrefixInString(&itemTrim, "application-protocol "):
-				rscData.ApplicationProtocol = types.StringValue(itemTrim)
-			case balt.CutPrefixInString(&itemTrim, "description "):
-				rscData.Description = types.StringValue(strings.Trim(itemTrim, "\""))
-			case balt.CutPrefixInString(&itemTrim, "destination-port "):
-				rscData.DestinationPort = types.StringValue(strings.Trim(itemTrim, "\""))
-			case balt.CutPrefixInString(&itemTrim, "ether-type "):
-				rscData.EtherType = types.StringValue(itemTrim)
-			case itemTrim == "inactivity-timeout never":
-				rscData.InactivityTimeoutNever = types.BoolValue(true)
-			case balt.CutPrefixInString(&itemTrim, "inactivity-timeout "):
-				rscData.InactivityTimeout, err = tfdata.ConvAtoi64Value(itemTrim)
-				if err != nil {
-					return err
-				}
-			case balt.CutPrefixInString(&itemTrim, "protocol "):
-				rscData.Protocol = types.StringValue(itemTrim)
-			case balt.CutPrefixInString(&itemTrim, "rpc-program-number "):
-				rscData.RPCProgramNumber = types.StringValue(itemTrim)
-			case balt.CutPrefixInString(&itemTrim, "source-port "):
-				rscData.SourcePort = types.StringValue(strings.Trim(itemTrim, "\""))
-			case balt.CutPrefixInString(&itemTrim, "term "):
-				itemTrimFields := strings.Split(itemTrim, " ")
-				var term applicationBlockTerm
-				rscData.Term, term = tfdata.ExtractBlockWithTFTypesString(
-					rscData.Term, "Name", itemTrimFields[0],
-				)
-				term.Name = types.StringValue(itemTrimFields[0])
-				balt.CutPrefixInString(&itemTrim, itemTrimFields[0]+" ")
-				if err := term.read(strings.TrimPrefix(itemTrim, itemTrimFields[0]+" ")); err != nil {
-					return err
-				}
-				rscData.Term = append(rscData.Term, term)
-			case balt.CutPrefixInString(&itemTrim, "uuid "):
-				rscData.UUID = types.StringValue(itemTrim)
+			if err := rscData.applicationAttrData.read(itemTrim); err != nil {
+				return err
 			}
 		}
+	}
+
+	return nil
+}
+
+func (rscData *applicationAttrData) read(itemTrim string) (err error) {
+	switch {
+	case balt.CutPrefixInString(&itemTrim, "application-protocol "):
+		rscData.ApplicationProtocol = types.StringValue(itemTrim)
+	case balt.CutPrefixInString(&itemTrim, "description "):
+		rscData.Description = types.StringValue(strings.Trim(itemTrim, "\""))
+	case balt.CutPrefixInString(&itemTrim, "destination-port "):
+		rscData.DestinationPort = types.StringValue(strings.Trim(itemTrim, "\""))
+	case balt.CutPrefixInString(&itemTrim, "ether-type "):
+		rscData.EtherType = types.StringValue(itemTrim)
+	case itemTrim == "inactivity-timeout never":
+		rscData.InactivityTimeoutNever = types.BoolValue(true)
+	case balt.CutPrefixInString(&itemTrim, "inactivity-timeout "):
+		rscData.InactivityTimeout, err = tfdata.ConvAtoi64Value(itemTrim)
+		if err != nil {
+			return err
+		}
+	case balt.CutPrefixInString(&itemTrim, "protocol "):
+		rscData.Protocol = types.StringValue(itemTrim)
+	case balt.CutPrefixInString(&itemTrim, "rpc-program-number "):
+		rscData.RPCProgramNumber = types.StringValue(itemTrim)
+	case balt.CutPrefixInString(&itemTrim, "source-port "):
+		rscData.SourcePort = types.StringValue(strings.Trim(itemTrim, "\""))
+	case balt.CutPrefixInString(&itemTrim, "term "):
+		itemTrimFields := strings.Split(itemTrim, " ")
+		var term applicationBlockTerm
+		rscData.Term, term = tfdata.ExtractBlockWithTFTypesString(
+			rscData.Term, "Name", itemTrimFields[0],
+		)
+		term.Name = types.StringValue(itemTrimFields[0])
+		balt.CutPrefixInString(&itemTrim, itemTrimFields[0]+" ")
+		if err := term.read(itemTrim); err != nil {
+			return err
+		}
+		rscData.Term = append(rscData.Term, term)
+	case balt.CutPrefixInString(&itemTrim, "uuid "):
+		rscData.UUID = types.StringValue(itemTrim)
 	}
 
 	return nil

--- a/internal/providerfwk/resource_application.go
+++ b/internal/providerfwk/resource_application.go
@@ -110,18 +110,24 @@ type applicationData struct {
 }
 
 type applicationAttrData struct {
-	Name                   types.String           `tfsdk:"name"`
-	ApplicationProtocol    types.String           `tfsdk:"application_protocol"`
-	Description            types.String           `tfsdk:"description"`
-	DestinationPort        types.String           `tfsdk:"destination_port"`
-	EtherType              types.String           `tfsdk:"ether_type"`
-	InactivityTimeout      types.Int64            `tfsdk:"inactivity_timeout"`
-	InactivityTimeoutNever types.Bool             `tfsdk:"inactivity_timeout_never"`
-	Protocol               types.String           `tfsdk:"protocol"`
-	RPCProgramNumber       types.String           `tfsdk:"rpc_program_number"`
-	SourcePort             types.String           `tfsdk:"source_port"`
-	UUID                   types.String           `tfsdk:"uuid"`
-	Term                   []applicationBlockTerm `tfsdk:"term"`
+	Name                            types.String           `tfsdk:"name"`
+	ApplicationProtocol             types.String           `tfsdk:"application_protocol"`
+	Description                     types.String           `tfsdk:"description"`
+	DestinationPort                 types.String           `tfsdk:"destination_port"`
+	DoNotTranslateAQueryToAAAAQuery types.Bool             `tfsdk:"do_not_translate_a_query_to_aaaa_query"`
+	DoNotTranslateAAAAQueryToAQuery types.Bool             `tfsdk:"do_not_translate_aaaa_query_to_a_query"`
+	EtherType                       types.String           `tfsdk:"ether_type"`
+	IcmpCode                        types.String           `tfsdk:"icmp_code"`
+	IcmpType                        types.String           `tfsdk:"icmp_type"`
+	Icmp6Code                       types.String           `tfsdk:"icmp6_code"`
+	Icmp6Type                       types.String           `tfsdk:"icmp6_type"`
+	InactivityTimeout               types.Int64            `tfsdk:"inactivity_timeout"`
+	InactivityTimeoutNever          types.Bool             `tfsdk:"inactivity_timeout_never"`
+	Protocol                        types.String           `tfsdk:"protocol"`
+	RPCProgramNumber                types.String           `tfsdk:"rpc_program_number"`
+	SourcePort                      types.String           `tfsdk:"source_port"`
+	UUID                            types.String           `tfsdk:"uuid"`
+	Term                            []applicationBlockTerm `tfsdk:"term"`
 }
 
 func (rscData *applicationAttrData) isEmpty() bool {
@@ -162,6 +168,20 @@ func (rscData applicationAttrData) attributesSchema() map[string]schema.Attribut
 				tfvalidator.StringDoubleQuoteExclusion(),
 			},
 		},
+		"do_not_translate_a_query_to_aaaa_query": schema.BoolAttribute{
+			Optional:    true,
+			Description: "Knob to control the translation of A query to AAAA query.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+		"do_not_translate_aaaa_query_to_a_query": schema.BoolAttribute{
+			Optional:    true,
+			Description: "Knob to control the translation of AAAA query to A query.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
 		"ether_type": schema.StringAttribute{
 			Optional:    true,
 			Description: "Match ether type.",
@@ -170,6 +190,38 @@ func (rscData applicationAttrData) attributesSchema() map[string]schema.Attribut
 					`^0[xX][0-9a-fA-F]{4}$`),
 					"must be in hex (example: 0x8906)",
 				),
+			},
+		},
+		"icmp_code": schema.StringAttribute{
+			Optional:    true,
+			Description: "Match ICMP message code.",
+			Validators: []validator.String{
+				stringvalidator.LengthAtLeast(1),
+				tfvalidator.StringFormat(tfvalidator.DefaultFormat),
+			},
+		},
+		"icmp_type": schema.StringAttribute{
+			Optional:    true,
+			Description: "Match ICMP message type.",
+			Validators: []validator.String{
+				stringvalidator.LengthAtLeast(1),
+				tfvalidator.StringFormat(tfvalidator.DefaultFormat),
+			},
+		},
+		"icmp6_code": schema.StringAttribute{
+			Optional:    true,
+			Description: "Match ICMP6 message code.",
+			Validators: []validator.String{
+				stringvalidator.LengthAtLeast(1),
+				tfvalidator.StringFormat(tfvalidator.DefaultFormat),
+			},
+		},
+		"icmp6_type": schema.StringAttribute{
+			Optional:    true,
+			Description: "Match ICMP6 message type.",
+			Validators: []validator.String{
+				stringvalidator.LengthAtLeast(1),
+				tfvalidator.StringFormat(tfvalidator.DefaultFormat),
 			},
 		},
 		"inactivity_timeout": schema.Int64Attribute{
@@ -347,18 +399,24 @@ type applicationConfig struct {
 }
 
 type applicationAttrConfig struct {
-	Name                   types.String `tfsdk:"name"`
-	ApplicationProtocol    types.String `tfsdk:"application_protocol"`
-	Description            types.String `tfsdk:"description"`
-	DestinationPort        types.String `tfsdk:"destination_port"`
-	EtherType              types.String `tfsdk:"ether_type"`
-	InactivityTimeout      types.Int64  `tfsdk:"inactivity_timeout"`
-	InactivityTimeoutNever types.Bool   `tfsdk:"inactivity_timeout_never"`
-	Protocol               types.String `tfsdk:"protocol"`
-	RPCProgramNumber       types.String `tfsdk:"rpc_program_number"`
-	SourcePort             types.String `tfsdk:"source_port"`
-	UUID                   types.String `tfsdk:"uuid"`
-	Term                   types.List   `tfsdk:"term"`
+	Name                            types.String `tfsdk:"name"`
+	ApplicationProtocol             types.String `tfsdk:"application_protocol"`
+	Description                     types.String `tfsdk:"description"`
+	DestinationPort                 types.String `tfsdk:"destination_port"`
+	DoNotTranslateAQueryToAAAAQuery types.Bool   `tfsdk:"do_not_translate_a_query_to_aaaa_query"`
+	DoNotTranslateAAAAQueryToAQuery types.Bool   `tfsdk:"do_not_translate_aaaa_query_to_a_query"`
+	EtherType                       types.String `tfsdk:"ether_type"`
+	IcmpCode                        types.String `tfsdk:"icmp_code"`
+	IcmpType                        types.String `tfsdk:"icmp_type"`
+	Icmp6Code                       types.String `tfsdk:"icmp6_code"`
+	Icmp6Type                       types.String `tfsdk:"icmp6_type"`
+	InactivityTimeout               types.Int64  `tfsdk:"inactivity_timeout"`
+	InactivityTimeoutNever          types.Bool   `tfsdk:"inactivity_timeout_never"`
+	Protocol                        types.String `tfsdk:"protocol"`
+	RPCProgramNumber                types.String `tfsdk:"rpc_program_number"`
+	SourcePort                      types.String `tfsdk:"source_port"`
+	UUID                            types.String `tfsdk:"uuid"`
+	Term                            types.List   `tfsdk:"term"`
 }
 
 func (config *applicationAttrConfig) isEmpty() bool {
@@ -378,6 +436,19 @@ func (config *applicationAttrConfig) validateConfig(
 			errPath,
 			tfdiag.ConflictConfigErrSummary,
 			"inactivity_timeout and inactivity_timeout_never cannot be configured together"+blockErrorSuffix,
+		)
+	}
+	if !config.DoNotTranslateAQueryToAAAAQuery.IsNull() && !config.DoNotTranslateAQueryToAAAAQuery.IsUnknown() &&
+		!config.DoNotTranslateAAAAQueryToAQuery.IsNull() && !config.DoNotTranslateAAAAQueryToAQuery.IsUnknown() {
+		errPath := path.Root("do_not_translate_a_query_to_aaaa_query")
+		if rootPath != nil {
+			errPath = *rootPath
+		}
+		resp.Diagnostics.AddAttributeError(
+			errPath,
+			tfdiag.ConflictConfigErrSummary,
+			"do_not_translate_a_query_to_aaaa_query and do_not_translate_aaaa_query_to_a_query"+
+				" cannot be configured together"+blockErrorSuffix,
 		)
 	}
 
@@ -750,8 +821,26 @@ func (rscData applicationAttrData) configSet(blockErrorSuffix string) ([]string,
 	if v := rscData.DestinationPort.ValueString(); v != "" {
 		configSet = append(configSet, setPrefix+"destination-port \""+v+"\"")
 	}
+	if rscData.DoNotTranslateAQueryToAAAAQuery.ValueBool() {
+		configSet = append(configSet, setPrefix+"do-not-translate-A-query-to-AAAA-query")
+	}
+	if rscData.DoNotTranslateAAAAQueryToAQuery.ValueBool() {
+		configSet = append(configSet, setPrefix+"do-not-translate-AAAA-query-to-A-query")
+	}
 	if v := rscData.EtherType.ValueString(); v != "" {
 		configSet = append(configSet, setPrefix+"ether-type "+v)
+	}
+	if v := rscData.IcmpCode.ValueString(); v != "" {
+		configSet = append(configSet, setPrefix+"icmp-code "+v)
+	}
+	if v := rscData.IcmpType.ValueString(); v != "" {
+		configSet = append(configSet, setPrefix+"icmp-type "+v)
+	}
+	if v := rscData.Icmp6Code.ValueString(); v != "" {
+		configSet = append(configSet, setPrefix+"icmp6-code "+v)
+	}
+	if v := rscData.Icmp6Type.ValueString(); v != "" {
+		configSet = append(configSet, setPrefix+"icmp6-type "+v)
 	}
 	if !rscData.InactivityTimeout.IsNull() {
 		configSet = append(configSet, setPrefix+"inactivity-timeout "+
@@ -883,8 +972,20 @@ func (rscData *applicationAttrData) read(itemTrim string) (err error) {
 		rscData.Description = types.StringValue(strings.Trim(itemTrim, "\""))
 	case balt.CutPrefixInString(&itemTrim, "destination-port "):
 		rscData.DestinationPort = types.StringValue(strings.Trim(itemTrim, "\""))
+	case itemTrim == "do-not-translate-A-query-to-AAAA-query":
+		rscData.DoNotTranslateAQueryToAAAAQuery = types.BoolValue(true)
+	case itemTrim == "do-not-translate-AAAA-query-to-A-query":
+		rscData.DoNotTranslateAAAAQueryToAQuery = types.BoolValue(true)
 	case balt.CutPrefixInString(&itemTrim, "ether-type "):
 		rscData.EtherType = types.StringValue(itemTrim)
+	case balt.CutPrefixInString(&itemTrim, "icmp-code "):
+		rscData.IcmpCode = types.StringValue(itemTrim)
+	case balt.CutPrefixInString(&itemTrim, "icmp-type "):
+		rscData.IcmpType = types.StringValue(itemTrim)
+	case balt.CutPrefixInString(&itemTrim, "icmp6-code "):
+		rscData.Icmp6Code = types.StringValue(itemTrim)
+	case balt.CutPrefixInString(&itemTrim, "icmp6-type "):
+		rscData.Icmp6Type = types.StringValue(itemTrim)
 	case itemTrim == "inactivity-timeout never":
 		rscData.InactivityTimeoutNever = types.BoolValue(true)
 	case balt.CutPrefixInString(&itemTrim, "inactivity-timeout "):

--- a/internal/providerfwk/resource_applications.go
+++ b/internal/providerfwk/resource_applications.go
@@ -1,0 +1,433 @@
+package providerfwk
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/jeremmfr/terraform-provider-junos/internal/junos"
+	"github.com/jeremmfr/terraform-provider-junos/internal/tfdata"
+	"github.com/jeremmfr/terraform-provider-junos/internal/tfdiag"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	balt "github.com/jeremmfr/go-utils/basicalter"
+)
+
+// Ensure the implementation satisfies the expected interfaces.
+var (
+	_ resource.Resource                   = &applications{}
+	_ resource.ResourceWithConfigure      = &applications{}
+	_ resource.ResourceWithValidateConfig = &applications{}
+	_ resource.ResourceWithImportState    = &applications{}
+)
+
+type applications struct {
+	client *junos.Client
+}
+
+func newApplicationsResource() resource.Resource {
+	return &applications{}
+}
+
+func (rsc *applications) typeName() string {
+	return providerName + "_applications"
+}
+
+func (rsc *applications) junosName() string {
+	return "applications"
+}
+
+func (rsc *applications) junosClient() *junos.Client {
+	return rsc.client
+}
+
+func (rsc *applications) Metadata(
+	_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse,
+) {
+	resp.TypeName = rsc.typeName()
+}
+
+func (rsc *applications) Configure(
+	ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse,
+) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*junos.Client)
+	if !ok {
+		unexpectedResourceConfigureType(ctx, req, resp)
+
+		return
+	}
+	rsc.client = client
+}
+
+func (rsc *applications) Schema(
+	_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse,
+) {
+	resp.Schema = schema.Schema{
+		Description: "Configure entirely `" + rsc.junosName() + "` block",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "An identifier for the resource with value `applications`.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"application": schema.SetNestedBlock{
+				Description: "For each name, define an application.",
+				NestedObject: schema.NestedBlockObject{
+					Attributes: applicationAttrData{}.attributesSchema(),
+					Blocks:     applicationAttrData{}.blocksSchema(),
+				},
+			},
+			"application_set": schema.SetNestedBlock{
+				Description: "For each name, define an application set.",
+				NestedObject: schema.NestedBlockObject{
+					Attributes: applicationSetAttrData{}.attributesSchema(),
+				},
+			},
+		},
+	}
+}
+
+type applicationsData struct {
+	ID             types.String             `tfsdk:"id"`
+	Application    []applicationAttrData    `tfsdk:"application"`
+	ApplicationSet []applicationSetAttrData `tfsdk:"application_set"`
+}
+
+type applicationsConfig struct {
+	ID             types.String `tfsdk:"id"`
+	Application    types.Set    `tfsdk:"application"`
+	ApplicationSet types.Set    `tfsdk:"application_set"`
+}
+
+func (rsc *applications) ValidateConfig(
+	ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse,
+) {
+	var config applicationsConfig
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	applicationName := make(map[string]struct{})
+	if !config.Application.IsNull() &&
+		!config.Application.IsUnknown() {
+		var configApplication []applicationAttrConfig
+		asDiags := config.Application.ElementsAs(ctx, &configApplication, false)
+		if asDiags.HasError() {
+			resp.Diagnostics.Append(asDiags...)
+
+			return
+		}
+
+		for _, block := range configApplication {
+			if !block.Name.IsUnknown() {
+				name := block.Name.ValueString()
+				if _, ok := applicationName[name]; ok {
+					resp.Diagnostics.AddAttributeError(
+						path.Root("application"),
+						tfdiag.DuplicateConfigErrSummary,
+						fmt.Sprintf("multiple application blocks with the same name %q", name),
+					)
+				}
+				applicationName[name] = struct{}{}
+			}
+
+			if block.isEmpty() {
+				resp.Diagnostics.AddAttributeError(
+					path.Root("application"),
+					tfdiag.MissingConfigErrSummary,
+					fmt.Sprintf("at least one of arguments need to be set (in addition to `name`)"+
+						" in application block %q", block.Name.ValueString()),
+				)
+			}
+			rootPath := path.Root("application")
+			block.validateConfig(
+				ctx,
+				&rootPath,
+				fmt.Sprintf(" in application block %q", block.Name.ValueString()),
+				resp,
+			)
+		}
+	}
+
+	if !config.ApplicationSet.IsNull() &&
+		!config.ApplicationSet.IsUnknown() {
+		var configApplicationSet []applicationSetAttrConfig
+		asDiags := config.ApplicationSet.ElementsAs(ctx, &configApplicationSet, false)
+		if asDiags.HasError() {
+			resp.Diagnostics.Append(asDiags...)
+
+			return
+		}
+		applicationSetName := make(map[string]struct{})
+		for _, block := range configApplicationSet {
+			if !block.Name.IsUnknown() {
+				name := block.Name.ValueString()
+				if _, ok := applicationSetName[name]; ok {
+					resp.Diagnostics.AddAttributeError(
+						path.Root("application_set"),
+						tfdiag.DuplicateConfigErrSummary,
+						fmt.Sprintf("multiple application_set blocks with the same name %q", name),
+					)
+				}
+				applicationSetName[name] = struct{}{}
+				if _, ok := applicationName[name]; ok {
+					resp.Diagnostics.AddAttributeError(
+						path.Root("application"),
+						tfdiag.DuplicateConfigErrSummary,
+						fmt.Sprintf("application and application_set blocks with the same name %q", name),
+					)
+				}
+			}
+
+			if block.isEmpty() {
+				resp.Diagnostics.AddAttributeError(
+					path.Root("application_set"),
+					tfdiag.MissingConfigErrSummary,
+					fmt.Sprintf("at least one of applications, application_set or description must be specified"+
+						" in application_set block %q", block.Name.ValueString()),
+				)
+			}
+			rootPath := path.Root("application_set")
+			block.validateConfig(
+				ctx,
+				&rootPath,
+				fmt.Sprintf(" in application_set block %q", block.Name.ValueString()),
+				resp,
+			)
+		}
+	}
+}
+
+func (rsc *applications) Create(
+	ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse,
+) {
+	var plan applicationsData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	defaultResourceCreate(
+		ctx,
+		rsc,
+		nil,
+		nil,
+		&plan,
+		resp,
+	)
+}
+
+func (rsc *applications) Read(
+	ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse,
+) {
+	var state, data applicationsData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var _ resourceDataReadWithoutArg = &data
+	defaultResourceRead(
+		ctx,
+		rsc,
+		nil,
+		&data,
+		nil,
+		resp,
+	)
+}
+
+func (rsc *applications) Update(
+	ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse,
+) {
+	var plan, state applicationsData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	defaultResourceUpdate(
+		ctx,
+		rsc,
+		&state,
+		&plan,
+		resp,
+	)
+}
+
+func (rsc *applications) Delete(
+	ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse,
+) {
+	var state applicationsData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	defaultResourceDelete(
+		ctx,
+		rsc,
+		&state,
+		resp,
+	)
+}
+
+func (rsc *applications) ImportState(
+	ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse,
+) {
+	var data applicationsData
+
+	var _ resourceDataReadWithoutArg = &data
+	defaultResourceImportState(
+		ctx,
+		rsc,
+		&data,
+		req,
+		resp,
+		"",
+	)
+}
+
+func (rscData *applicationsData) fillID() {
+	rscData.ID = types.StringValue("applications")
+}
+
+func (rscData *applicationsData) nullID() bool {
+	return rscData.ID.IsNull()
+}
+
+func (rscData *applicationsData) set(
+	_ context.Context, junSess *junos.Session,
+) (
+	path.Path, error,
+) {
+	configSet := make([]string, 0, 100)
+
+	applicationName := make(map[string]struct{})
+	for _, block := range rscData.Application {
+		name := block.Name.ValueString()
+		if name == "" {
+			return path.Root("application"),
+				errors.New("name argument in application block is empty")
+		}
+		if _, ok := applicationName[name]; ok {
+			return path.Root("application"),
+				fmt.Errorf("multiple application blocks with the same name %q", name)
+		}
+		applicationName[name] = struct{}{}
+
+		blockErrorSuffix := fmt.Sprintf(" in application block %q", name)
+		if block.isEmpty() {
+			return path.Root("application"),
+				errors.New("at least one of arguments need to be set (in addition to `name`)" +
+					blockErrorSuffix)
+		}
+
+		dataConfigSet, _, err := block.configSet(blockErrorSuffix)
+		if err != nil {
+			return path.Root("application"), err
+		}
+		configSet = append(configSet, dataConfigSet...)
+	}
+	applicationSetName := make(map[string]struct{})
+	for _, block := range rscData.ApplicationSet {
+		name := block.Name.ValueString()
+		if name == "" {
+			return path.Root("application_set"),
+				errors.New("name argument in application_set block is empty")
+		}
+		if _, ok := applicationSetName[name]; ok {
+			return path.Root("application_set"),
+				fmt.Errorf("multiple application_set blocks with the same name %q", name)
+		}
+		if _, ok := applicationName[name]; ok {
+			return path.Root("application"),
+				fmt.Errorf("application and application_set blocks with the same name %q", name)
+		}
+		applicationSetName[name] = struct{}{}
+
+		if block.isEmpty() {
+			return path.Root("application_set"),
+				fmt.Errorf("at least one of applications, application_set or description must be specified"+
+					" in application_set block %q", name)
+		}
+
+		configSet = append(configSet, block.configSet()...)
+	}
+
+	return path.Empty(), junSess.ConfigSet(configSet)
+}
+
+func (rscData *applicationsData) read(
+	_ context.Context, junSess *junos.Session,
+) error {
+	showConfig, err := junSess.Command(junos.CmdShowConfig +
+		"applications " + junos.PipeDisplaySetRelative)
+	if err != nil {
+		return err
+	}
+	rscData.fillID()
+	if showConfig != junos.EmptyW {
+		for _, item := range strings.Split(showConfig, "\n") {
+			if strings.Contains(item, junos.XMLStartTagConfigOut) {
+				continue
+			}
+			if strings.Contains(item, junos.XMLEndTagConfigOut) {
+				break
+			}
+			itemTrim := strings.TrimPrefix(item, junos.SetLS)
+			switch {
+			case balt.CutPrefixInString(&itemTrim, "application "):
+				itemTrimFields := strings.Split(itemTrim, " ")
+				var application applicationAttrData
+				rscData.Application, application = tfdata.ExtractBlockWithTFTypesString(
+					rscData.Application, "Name", itemTrimFields[0],
+				)
+				application.Name = types.StringValue(itemTrimFields[0])
+				balt.CutPrefixInString(&itemTrim, itemTrimFields[0]+" ")
+				if err := application.read(itemTrim); err != nil {
+					return err
+				}
+				rscData.Application = append(rscData.Application, application)
+			case balt.CutPrefixInString(&itemTrim, "application-set "):
+				itemTrimFields := strings.Split(itemTrim, " ")
+				var applicationSet applicationSetAttrData
+				rscData.ApplicationSet, applicationSet = tfdata.ExtractBlockWithTFTypesString(
+					rscData.ApplicationSet, "Name", itemTrimFields[0],
+				)
+				applicationSet.Name = types.StringValue(itemTrimFields[0])
+				balt.CutPrefixInString(&itemTrim, itemTrimFields[0]+" ")
+				applicationSet.read(itemTrim)
+				rscData.ApplicationSet = append(rscData.ApplicationSet, applicationSet)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (rscData *applicationsData) del(
+	_ context.Context, junSess *junos.Session,
+) error {
+	configSet := []string{
+		"delete applications",
+	}
+
+	return junSess.ConfigSet(configSet)
+}

--- a/internal/providerfwk/resource_applications_test.go
+++ b/internal/providerfwk/resource_applications_test.go
@@ -1,0 +1,31 @@
+package providerfwk_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccResourceApplications_basic(t *testing.T) {
+	if os.Getenv("TESTACC_SRX") != "" {
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					ConfigDirectory: config.TestStepDirectory(),
+				},
+				{
+					ConfigDirectory: config.TestStepDirectory(),
+				},
+				{
+					ResourceName:      "junos_applications.testacc",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+			},
+		})
+	}
+}

--- a/internal/providerfwk/testdata/TestAccResourceApplications_basic/1/main.tf
+++ b/internal/providerfwk/testdata/TestAccResourceApplications_basic/1/main.tf
@@ -1,0 +1,19 @@
+resource "junos_applications" "testacc" {
+  application {
+    name             = "testacc_app"
+    protocol         = "tcp"
+    destination_port = 22
+  }
+  application {
+    name = "testacc_app3"
+    term {
+      name             = "term_B"
+      protocol         = "tcp"
+      destination_port = 22
+    }
+  }
+  application_set {
+    name         = "testacc_app_set"
+    applications = ["junos-ssh"]
+  }
+}

--- a/internal/providerfwk/testdata/TestAccResourceApplications_basic/2/main.tf
+++ b/internal/providerfwk/testdata/TestAccResourceApplications_basic/2/main.tf
@@ -56,6 +56,28 @@ resource "junos_applications" "testacc" {
       icmp6_type = "echo-reply"
     }
   }
+  application {
+    name      = "testacc_apps6"
+    protocol  = "icmp"
+    icmp_code = "1"
+    icmp_type = "echo-reply"
+  }
+  application {
+    name       = "testacc_apps7"
+    protocol   = "icmp6"
+    icmp6_code = "1"
+    icmp6_type = "echo-reply"
+  }
+  application {
+    name                                   = "testacc_apps8"
+    application_protocol                   = "dns"
+    do_not_translate_a_query_to_aaaa_query = true
+  }
+  application {
+    name                                   = "testacc_apps9"
+    application_protocol                   = "dns"
+    do_not_translate_aaaa_query_to_a_query = true
+  }
 
   application_set {
     name         = "testacc_apps_set1"

--- a/internal/providerfwk/testdata/TestAccResourceApplications_basic/2/main.tf
+++ b/internal/providerfwk/testdata/TestAccResourceApplications_basic/2/main.tf
@@ -1,0 +1,72 @@
+resource "junos_applications" "testacc" {
+  application {
+    name                 = "testacc_apps"
+    protocol             = "tcp"
+    destination_port     = "22"
+    application_protocol = "ssh"
+    description          = "ssh protocol"
+    inactivity_timeout   = 900
+    source_port          = "1024-65535"
+  }
+  application {
+    name                     = "testacc_apps2"
+    protocol                 = "tcp"
+    ether_type               = "0x0800"
+    rpc_program_number       = "0-0"
+    inactivity_timeout_never = true
+    uuid                     = "AAAAA0AA-B9B0-CCcc-DDDD-EEEffFFFAAAA"
+  }
+  application {
+    name = "testacc_apps3"
+    term {
+      name               = "term_B"
+      protocol           = "tcp"
+      destination_port   = 22
+      inactivity_timeout = 600
+      source_port        = "1024-65535"
+    }
+    term {
+      name     = "term_ALG"
+      protocol = "tcp"
+      alg      = "ssh"
+    }
+  }
+  application {
+    name = "testacc_apps4"
+    term {
+      name                     = "term_B"
+      protocol                 = "tcp"
+      rpc_program_number       = "1-1"
+      inactivity_timeout_never = true
+      uuid                     = "BBBAA0AA-B9B0-CCcc-DDDD-EEEffFFFAAAA"
+    }
+  }
+  application {
+    name = "testacc_apps5"
+    term {
+      name      = "term_I"
+      protocol  = "icmp"
+      icmp_code = "1"
+      icmp_type = "echo-reply"
+    }
+    term {
+      name       = "term_I6"
+      protocol   = "icmp6"
+      icmp6_code = "1"
+      icmp6_type = "echo-reply"
+    }
+  }
+
+  application_set {
+    name         = "testacc_apps_set1"
+    applications = ["junos-ssh", "junos-telnet"]
+    application_set = [
+      "testacc_apps_set2"
+    ]
+  }
+  application_set {
+    name         = "testacc_apps_set2"
+    applications = ["junos-ftp"]
+    description  = "testacc appsets2"
+  }
+}


### PR DESCRIPTION
FEATURES:

* add **junos_applications** resource (Fix #694)

ENHANCEMENTS:

* **resource/junos_application**: add `do_not_translate_a_query_to_aaaa_query`, `do_not_translate_aaaa_query_to_a_query`, `icmp_code`, `icmp_type`, `icmp6_code` and `icmp6_type` arguments
* **data-source/junos_applications**:
  * add `do_not_translate_a_query_to_aaaa_query`, `do_not_translate_aaaa_query_to_a_query`, `icmp_code`, `icmp_type`, `icmp6_code` and `icmp6_type` attributes in `applications` attribute
  * add `do_not_translate_a_query_to_aaaa_query` and `do_not_translate_aaaa_query_to_a_query` arguments inside `match_options` block argument
