### PR TITLE
add applications, address-book ordered and policy unordered

### DIFF
--- a/.changes/issue-709.md
+++ b/.changes/issue-709.md
@@ -5,6 +5,8 @@ FEATURES:
 
 * add `junos_security_address_book_ordered` resource, copy of `junos_security_address_book` resource but with Block List instead of Block Set to have a workaround for the performance issue on Block Sets (workaround for [#498](https://github.com/jeremmfr/terraform-provider-junos/issues/498))
 
+* add `junos_security_global_policy_unordered` resource, copy of `junos_security_global_policy` resource but with Block Set instead of Block List to have a workaround for too complex plan output when the number of blocks on the resource changes
+
 * add `junos_security_zone_ordered` resource, copy of `junos_security_zone` resource but with Block List instead of Block Set to have a workaround for the performance issue on Block Sets
 
 ENHANCEMENTS:

--- a/.changes/issue-709.md
+++ b/.changes/issue-709.md
@@ -7,6 +7,8 @@ FEATURES:
 
 * add `junos_security_global_policy_unordered` resource, copy of `junos_security_global_policy` resource but with Block Set instead of Block List to have a workaround for too complex plan output when the number of blocks on the resource changes
 
+* add `junos_security_policy_unordered` resource, copy of `junos_security_policy` resource but with Block Set instead of Block List to have a workaround for too complex plan output when the number of blocks on the resource changes
+
 * add `junos_security_zone_ordered` resource, copy of `junos_security_zone` resource but with Block List instead of Block Set to have a workaround for the performance issue on Block Sets
 
 ENHANCEMENTS:

--- a/.changes/issue-709.md
+++ b/.changes/issue-709.md
@@ -5,6 +5,8 @@ FEATURES:
 
 * add `junos_security_address_book_ordered` resource, copy of `junos_security_address_book` resource but with Block List instead of Block Set to have a workaround for the performance issue on Block Sets (workaround for [#498](https://github.com/jeremmfr/terraform-provider-junos/issues/498))
 
+* add `junos_security_zone_ordered` resource, copy of `junos_security_zone` resource but with Block List instead of Block Set to have a workaround for the performance issue on Block Sets
+
 ENHANCEMENTS:
 
 BUG FIXES:

--- a/.changes/issue-709.md
+++ b/.changes/issue-709.md
@@ -1,0 +1,8 @@
+<!-- markdownlint-disable-file MD013 MD041 -->
+FEATURES:
+
+* add `junos_applications_ordered` resource, copy of `junos_applications` resource but with Block List instead of Block Set to have a workaround for the performance issue on Block Sets (workaround for [#709](https://github.com/jeremmfr/terraform-provider-junos/issues/709))
+
+ENHANCEMENTS:
+
+BUG FIXES:

--- a/.changes/issue-709.md
+++ b/.changes/issue-709.md
@@ -3,6 +3,8 @@ FEATURES:
 
 * add `junos_applications_ordered` resource, copy of `junos_applications` resource but with Block List instead of Block Set to have a workaround for the performance issue on Block Sets (workaround for [#709](https://github.com/jeremmfr/terraform-provider-junos/issues/709))
 
+* add `junos_security_address_book_ordered` resource, copy of `junos_security_address_book` resource but with Block List instead of Block Set to have a workaround for the performance issue on Block Sets (workaround for [#498](https://github.com/jeremmfr/terraform-provider-junos/issues/498))
+
 ENHANCEMENTS:
 
 BUG FIXES:

--- a/docs/resources/applications_ordered.md
+++ b/docs/resources/applications_ordered.md
@@ -1,0 +1,18 @@
+---
+page_title: "Junos: junos_applications_ordered"
+---
+
+# junos_applications_ordered
+
+It has the same functionality as the `junos_applications` resource
+but with `applications` and `application_set` arguments as Block List instead of Block Set.
+
+This provides a workaround for the performance issue on Terraform plan with many Block Sets
+(details in GitHub issue [#775](https://github.com/hashicorp/terraform-plugin-framework/issues/775))
+but Block List involves:
+
+- a change in the order of the blocks triggers a resource change.
+- Terraform plan output can be complex when the number of blocks on the resource changes.
+
+See the [junos_applications](applications) resource
+for more details on arguments or attributes.

--- a/docs/resources/security_address_book_ordered.md
+++ b/docs/resources/security_address_book_ordered.md
@@ -1,0 +1,19 @@
+---
+page_title: "Junos: junos_security_address_book_ordered"
+---
+
+# junos_security_address_book_ordered
+
+It has the same functionality as the `junos_security_address_book` resource
+but with `network_address`, `dns_name`, `range_address`, `wildcard_address` and `address_set`
+arguments as Block List instead of Block Set.
+
+This provides a workaround for the performance issue on Terraform plan with many Block Sets
+(details in GitHub issue [#775](https://github.com/hashicorp/terraform-plugin-framework/issues/775))
+but Block List involves:
+
+- a change in the order of the blocks triggers a resource change.
+- Terraform plan output can be complex when the number of blocks on the resource changes.
+
+See the [junos_security_address_book](security_address_book) resource
+for more details on arguments or attributes.

--- a/docs/resources/security_global_policy_unordered.md
+++ b/docs/resources/security_global_policy_unordered.md
@@ -1,0 +1,18 @@
+---
+page_title: "Junos: junos_security_global_policy_unordered"
+---
+
+# junos_security_global_policy_unordered
+
+It has the same functionality as the `junos_security_global_policy` resource
+but with `policy` argument as Block Set instead of Block List.
+
+This provides a workaround for too complex plan output when the number of blocks on the resource changes
+and if the `policy` order it's not important
+(by considering the action of the first policy that the traffic matches is applied to the packet).
+
+Block Set involves a performance issue on Terraform plan with many Block Sets
+(details in GitHub issue [#775](https://github.com/hashicorp/terraform-plugin-framework/issues/775)).
+
+See the [junos_security_global_policy](security_global_policy) resource
+for more details on arguments or attributes.

--- a/docs/resources/security_policy_unordered.md
+++ b/docs/resources/security_policy_unordered.md
@@ -1,0 +1,18 @@
+---
+page_title: "Junos: junos_security_policy_unordered"
+---
+
+# junos_security_policy_unordered
+
+It has the same functionality as the `junos_security_policy` resource
+but with `policy` argument as Block Set instead of Block List.
+
+This provides a workaround for too complex plan output when the number of blocks on the resource changes
+and if the `policy` order it's not important
+(by considering the action of the first policy that the traffic matches is applied to the packet).
+
+Block Set involves a performance issue on Terraform plan with many Block Sets
+(details in GitHub issue [#775](https://github.com/hashicorp/terraform-plugin-framework/issues/775)).
+
+See the [junos_security_policy](security_policy) resource
+for more details on arguments or attributes.

--- a/docs/resources/security_zone_ordered.md
+++ b/docs/resources/security_zone_ordered.md
@@ -1,0 +1,19 @@
+---
+page_title: "Junos: junos_security_zone_ordered"
+---
+
+# junos_security_zone_ordered
+
+It has the same functionality as the `junos_security_zone` resource
+but with `address_book`, `address_book_dns`, `address_book_range`, `address_book_set` and `address_book_wildcard`
+arguments as Block List instead of Block Set.
+
+This provides a workaround for the performance issue on Terraform plan with many Block Sets
+(details in GitHub issue [#775](https://github.com/hashicorp/terraform-plugin-framework/issues/775))
+but Block List involves:
+
+- a change in the order of the blocks triggers a resource change.
+- Terraform plan output can be complex when the number of blocks on the resource changes.
+
+See the [junos_security_zone](security_zone) resource
+for more details on arguments or attributes.

--- a/internal/providerfwk/provider.go
+++ b/internal/providerfwk/provider.go
@@ -237,6 +237,7 @@ func (p *junosProvider) Resources(_ context.Context) []func() resource.Resource 
 		newAggregateRouteResource,
 		newApplicationResource,
 		newApplicationsResource,
+		newApplicationsOrderedResource,
 		newApplicationSetResource,
 		newBgpGroupResource,
 		newBgpNeighborResource,

--- a/internal/providerfwk/provider.go
+++ b/internal/providerfwk/provider.go
@@ -295,6 +295,7 @@ func (p *junosProvider) Resources(_ context.Context) []func() resource.Resource 
 		newSecurityPolicyResource,
 		newSecurityPolicyTunnelPairPolicyResource,
 		newSecurityZoneResource,
+		newSecurityZoneOrderedResource,
 		newSecurityZoneBookAddressResource,
 		newSecurityZoneBookAddressSetResource,
 		newServicesFlowMonitoringV9TemplateResource,

--- a/internal/providerfwk/provider.go
+++ b/internal/providerfwk/provider.go
@@ -276,6 +276,7 @@ func (p *junosProvider) Resources(_ context.Context) []func() resource.Resource 
 		newRstpInterfaceResource,
 		newSecurityResource,
 		newSecurityAddressBookResource,
+		newSecurityAddressBookOrderedResource,
 		newSecurityAuthenticationKeyChainResource,
 		newSecurityGlobalPolicyResource,
 		newSecurityIkeGatewayResource,

--- a/internal/providerfwk/provider.go
+++ b/internal/providerfwk/provider.go
@@ -279,6 +279,7 @@ func (p *junosProvider) Resources(_ context.Context) []func() resource.Resource 
 		newSecurityAddressBookOrderedResource,
 		newSecurityAuthenticationKeyChainResource,
 		newSecurityGlobalPolicyResource,
+		newSecurityGlobalPolicyUnorderedResource,
 		newSecurityIkeGatewayResource,
 		newSecurityIkePolicyResource,
 		newSecurityIkeProposalResource,

--- a/internal/providerfwk/provider.go
+++ b/internal/providerfwk/provider.go
@@ -294,6 +294,7 @@ func (p *junosProvider) Resources(_ context.Context) []func() resource.Resource 
 		newSecurityNatStaticResource,
 		newSecurityNatStaticRuleResource,
 		newSecurityPolicyResource,
+		newSecurityPolicyUnorderedResource,
 		newSecurityPolicyTunnelPairPolicyResource,
 		newSecurityZoneResource,
 		newSecurityZoneOrderedResource,

--- a/internal/providerfwk/resource_application.go
+++ b/internal/providerfwk/resource_application.go
@@ -134,7 +134,7 @@ func (rscData *applicationAttrData) isEmpty() bool {
 	return tfdata.CheckBlockIsEmpty(rscData, "Name")
 }
 
-func (rscData applicationAttrData) attributesSchema() map[string]schema.Attribute {
+func (applicationAttrData) attributesSchema() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"name": schema.StringAttribute{
 			Required:    true,
@@ -276,7 +276,7 @@ func (rscData applicationAttrData) attributesSchema() map[string]schema.Attribut
 	}
 }
 
-func (rscData applicationAttrData) blocksSchema() map[string]schema.Block {
+func (applicationAttrData) blocksSchema() map[string]schema.Block {
 	return map[string]schema.Block{
 		"term": schema.ListNestedBlock{
 			Description: "For each name of term to declare.",

--- a/internal/providerfwk/resource_application_set.go
+++ b/internal/providerfwk/resource_application_set.go
@@ -116,7 +116,7 @@ func (rscData *applicationSetAttrData) isEmpty() bool {
 	return tfdata.CheckBlockIsEmpty(rscData, "Name")
 }
 
-func (rscData applicationSetAttrData) attributesSchema() map[string]schema.Attribute {
+func (applicationSetAttrData) attributesSchema() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"name": schema.StringAttribute{
 			Required:    true,

--- a/internal/providerfwk/resource_applications_ordered_test.go
+++ b/internal/providerfwk/resource_applications_ordered_test.go
@@ -1,0 +1,31 @@
+package providerfwk_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccResourceApplicationsOrdered_basic(t *testing.T) {
+	if os.Getenv("TESTACC_SRX") != "" {
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					ConfigDirectory: config.TestStepDirectory(),
+				},
+				{
+					ConfigDirectory: config.TestStepDirectory(),
+				},
+				{
+					ResourceName:      "junos_applications_ordered.testacc",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+			},
+		})
+	}
+}

--- a/internal/providerfwk/resource_forwardingoptions_sampling.go
+++ b/internal/providerfwk/resource_forwardingoptions_sampling.go
@@ -136,212 +136,7 @@ func (rsc *forwardingoptionsSampling) Schema(
 			"family_inet_output": schema.SingleNestedBlock{
 				Description: "Declare `family inet output` configuration.",
 				Attributes:  forwardingoptionsSamplingBlockFamilyInetOutput{}.attributesSchema(),
-				Blocks: map[string]schema.Block{
-					"file": schema.SingleNestedBlock{
-						Description: "Configure parameters for dumping sampled packets.",
-						Attributes: map[string]schema.Attribute{
-							"filename": schema.StringAttribute{
-								Required:    false, // true when SingleNestedBlock is specified
-								Optional:    true,
-								Description: "Name of file to contain sampled packet dumps.",
-								Validators: []validator.String{
-									stringvalidator.LengthAtLeast(1),
-									tfvalidator.StringDoubleQuoteExclusion(),
-									tfvalidator.StringSpaceExclusion(),
-									tfvalidator.StringRuneExclusion('/', '%'),
-								},
-							},
-							"disable": schema.BoolAttribute{
-								Optional:    true,
-								Description: "Disable sampled packet dumps.",
-								Validators: []validator.Bool{
-									tfvalidator.BoolTrue(),
-								},
-							},
-							"files": schema.Int64Attribute{
-								Optional:    true,
-								Description: "Maximum number of sampled packet dump files (2..10000).",
-								Validators: []validator.Int64{
-									int64validator.Between(2, 10000),
-								},
-							},
-							"size": schema.Int64Attribute{
-								Optional:    true,
-								Description: "Maximum sample dump file size (1024..104857600).",
-								Validators: []validator.Int64{
-									int64validator.Between(1024, 104857600),
-								},
-							},
-							"stamp": schema.BoolAttribute{
-								Optional:    true,
-								Description: "Timestamp every packet in the dump.",
-								Validators: []validator.Bool{
-									tfvalidator.BoolTrue(),
-								},
-							},
-							"no_stamp": schema.BoolAttribute{
-								Optional:    true,
-								Description: "Don't timestamp every packet in the dump.",
-								Validators: []validator.Bool{
-									tfvalidator.BoolTrue(),
-								},
-							},
-							"world_readable": schema.BoolAttribute{
-								Optional:    true,
-								Description: "Allow any user to read the sampled dump.",
-								Validators: []validator.Bool{
-									tfvalidator.BoolTrue(),
-								},
-							},
-							"no_world_readable": schema.BoolAttribute{
-								Optional:    true,
-								Description: "Don't allow any user to read the sampled dump.",
-								Validators: []validator.Bool{
-									tfvalidator.BoolTrue(),
-								},
-							},
-						},
-						PlanModifiers: []planmodifier.Object{
-							tfplanmodifier.BlockRemoveNull(),
-						},
-					},
-					"flow_server": schema.SetNestedBlock{
-						Description: "For each hostname, configure sending traffic aggregates in cflowd format.",
-						NestedObject: schema.NestedBlockObject{
-							Attributes: map[string]schema.Attribute{
-								"hostname": schema.StringAttribute{
-									Required:    true,
-									Description: "Name of host collecting cflowd packets.",
-									Validators: []validator.String{
-										tfvalidator.StringIPAddress(),
-									},
-								},
-								"port": schema.Int64Attribute{
-									Required:    true,
-									Description: "UDP port number on host collecting cflowd packets (1..65535).",
-									Validators: []validator.Int64{
-										int64validator.Between(1, 65535),
-									},
-								},
-								"aggregation_autonomous_system": schema.BoolAttribute{
-									Optional:    true,
-									Description: "Aggregate by autonomous system number.",
-									Validators: []validator.Bool{
-										tfvalidator.BoolTrue(),
-									},
-								},
-								"aggregation_destination_prefix": schema.BoolAttribute{
-									Optional:    true,
-									Description: "Aggregate by destination prefix.",
-									Validators: []validator.Bool{
-										tfvalidator.BoolTrue(),
-									},
-								},
-								"aggregation_protocol_port": schema.BoolAttribute{
-									Optional:    true,
-									Description: "Aggregate by protocol and port number.",
-									Validators: []validator.Bool{
-										tfvalidator.BoolTrue(),
-									},
-								},
-								"aggregation_source_destination_prefix": schema.BoolAttribute{
-									Optional:    true,
-									Description: "Aggregate by source and destination prefix.",
-									Validators: []validator.Bool{
-										tfvalidator.BoolTrue(),
-									},
-								},
-								"aggregation_source_destination_prefix_caida_compliant": schema.BoolAttribute{
-									Optional:    true,
-									Description: "Compatible with Caida record format for prefix aggregation (v8).",
-									Validators: []validator.Bool{
-										tfvalidator.BoolTrue(),
-									},
-								},
-								"aggregation_source_prefix": schema.BoolAttribute{
-									Optional:    true,
-									Description: "Aggregate by source prefix.",
-									Validators: []validator.Bool{
-										tfvalidator.BoolTrue(),
-									},
-								},
-								"autonomous_system_type": schema.StringAttribute{
-									Optional:    true,
-									Description: "Type of autonomous system number to export.",
-									Validators: []validator.String{
-										stringvalidator.OneOf("origin", "peer"),
-									},
-								},
-								"dscp": schema.Int64Attribute{
-									Optional:    true,
-									Description: "Numeric DSCP value in the range 0 to 63 (0..63).",
-									Validators: []validator.Int64{
-										int64validator.Between(0, 63),
-									},
-								},
-								"forwarding_class": schema.StringAttribute{
-									Optional:    true,
-									Description: "Forwarding-class for exported jflow packets, applicable only for inline-jflow.",
-									Validators: []validator.String{
-										stringvalidator.LengthBetween(1, 64),
-										tfvalidator.StringDoubleQuoteExclusion(),
-									},
-								},
-								"local_dump": schema.BoolAttribute{
-									Optional:    true,
-									Description: "Dump cflowd records to log file before exporting.",
-									Validators: []validator.Bool{
-										tfvalidator.BoolTrue(),
-									},
-								},
-								"no_local_dump": schema.BoolAttribute{
-									Optional:    true,
-									Description: "Don't dump cflowd records to log file before exporting.",
-									Validators: []validator.Bool{
-										tfvalidator.BoolTrue(),
-									},
-								},
-								"routing_instance": schema.StringAttribute{
-									Optional:    true,
-									Description: "Name of routing instance on which flow collector is reachable.",
-									Validators: []validator.String{
-										stringvalidator.LengthBetween(1, 63),
-										tfvalidator.StringFormat(tfvalidator.DefaultFormat),
-										stringvalidator.NoneOfCaseInsensitive(junos.DefaultW),
-									},
-								},
-								"source_address": schema.StringAttribute{
-									Optional:    true,
-									Description: "Source IPv4 address for cflowd packets.",
-									Validators: []validator.String{
-										tfvalidator.StringIPAddress().IPv4Only(),
-									},
-								},
-								"version": schema.Int64Attribute{
-									Optional:    true,
-									Description: "Format of exported cflowd aggregates.",
-									Validators: []validator.Int64{
-										int64validator.OneOf(5, 8, 500),
-									},
-								},
-								"version9_template": schema.StringAttribute{
-									Optional:    true,
-									Description: "Template to export data in version 9 format.",
-									Validators: []validator.String{
-										stringvalidator.LengthBetween(1, 250),
-										tfvalidator.StringDoubleQuoteExclusion(),
-									},
-								},
-							},
-						},
-					},
-					"interface": schema.ListNestedBlock{
-						Description: "For each name of interface, configure interfaces used to send monitored information.",
-						NestedObject: schema.NestedBlockObject{
-							Attributes: forwardingoptionsSamplingBlockOutputBlockInterface{}.attributesSchema(),
-						},
-					},
-				},
+				Blocks:      forwardingoptionsSamplingBlockFamilyInetOutput{}.blocksSchema(),
 				PlanModifiers: []planmodifier.Object{
 					tfplanmodifier.BlockRemoveNull(),
 				},
@@ -370,30 +165,8 @@ func (rsc *forwardingoptionsSampling) Schema(
 			},
 			"family_mpls_output": schema.SingleNestedBlock{
 				Description: "Declare `family mpls output` configuration.",
-				Attributes: map[string]schema.Attribute{
-					"aggregate_export_interval": schema.Int64Attribute{
-						Optional:    true,
-						Description: "Interval of exporting aggregate accounting information (90..1800 seconds).",
-						Validators: []validator.Int64{
-							int64validator.Between(90, 1800),
-						},
-					},
-					"flow_active_timeout": schema.Int64Attribute{
-						Optional:    true,
-						Description: "Interval after which an active flow is exported (60..1800 seconds).",
-						Validators: []validator.Int64{
-							int64validator.Between(60, 1800),
-						},
-					},
-					"flow_inactive_timeout": schema.Int64Attribute{
-						Optional:    true,
-						Description: "Interval of inactivity that marks a flow inactive (15..1800 seconds).",
-						Validators: []validator.Int64{
-							int64validator.Between(15, 1800),
-						},
-					},
-				},
-				Blocks: forwardingoptionsSamplingBlockFamilyMplsOutput{}.blocksSchema(),
+				Attributes:  forwardingoptionsSamplingBlockFamilyMplsOutput{}.attributesSchema(),
+				Blocks:      forwardingoptionsSamplingBlockFamilyMplsOutput{}.blocksSchema(),
 				PlanModifiers: []planmodifier.Object{
 					tfplanmodifier.BlockRemoveNull(),
 				},
@@ -552,6 +325,86 @@ func (forwardingoptionsSamplingBlockFamilyInetOutput) attributesSchema() map[str
 	}
 }
 
+func (forwardingoptionsSamplingBlockFamilyInetOutput) blocksSchema() map[string]schema.Block {
+	blocks := forwardingoptionsSamplingBlockFamilyInet6Output{}.blocksSchema()
+	blocks["file"] = schema.SingleNestedBlock{
+		Description: "Configure parameters for dumping sampled packets.",
+		Attributes: map[string]schema.Attribute{
+			"filename": schema.StringAttribute{
+				Required:    false, // true when SingleNestedBlock is specified
+				Optional:    true,
+				Description: "Name of file to contain sampled packet dumps.",
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+					tfvalidator.StringDoubleQuoteExclusion(),
+					tfvalidator.StringSpaceExclusion(),
+					tfvalidator.StringRuneExclusion('/', '%'),
+				},
+			},
+			"disable": schema.BoolAttribute{
+				Optional:    true,
+				Description: "Disable sampled packet dumps.",
+				Validators: []validator.Bool{
+					tfvalidator.BoolTrue(),
+				},
+			},
+			"files": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Maximum number of sampled packet dump files (2..10000).",
+				Validators: []validator.Int64{
+					int64validator.Between(2, 10000),
+				},
+			},
+			"size": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Maximum sample dump file size (1024..104857600).",
+				Validators: []validator.Int64{
+					int64validator.Between(1024, 104857600),
+				},
+			},
+			"stamp": schema.BoolAttribute{
+				Optional:    true,
+				Description: "Timestamp every packet in the dump.",
+				Validators: []validator.Bool{
+					tfvalidator.BoolTrue(),
+				},
+			},
+			"no_stamp": schema.BoolAttribute{
+				Optional:    true,
+				Description: "Don't timestamp every packet in the dump.",
+				Validators: []validator.Bool{
+					tfvalidator.BoolTrue(),
+				},
+			},
+			"world_readable": schema.BoolAttribute{
+				Optional:    true,
+				Description: "Allow any user to read the sampled dump.",
+				Validators: []validator.Bool{
+					tfvalidator.BoolTrue(),
+				},
+			},
+			"no_world_readable": schema.BoolAttribute{
+				Optional:    true,
+				Description: "Don't allow any user to read the sampled dump.",
+				Validators: []validator.Bool{
+					tfvalidator.BoolTrue(),
+				},
+			},
+		},
+		PlanModifiers: []planmodifier.Object{
+			tfplanmodifier.BlockRemoveNull(),
+		},
+	}
+	blocks["flow_server"] = schema.SetNestedBlock{
+		Description: "For each hostname, configure sending traffic aggregates in cflowd format.",
+		NestedObject: schema.NestedBlockObject{
+			Attributes: forwardingoptionsSamplingBlockFamilyInetOutputBlockFlowServer{}.attributesSchema(),
+		},
+	}
+
+	return blocks
+}
+
 type forwardingoptionsSamplingBlockFamilyInetOutputConfig struct {
 	AggregateExportInterval  types.Int64                                              `tfsdk:"aggregate_export_interval"`
 	ExtensionService         types.List                                               `tfsdk:"extension_service"`
@@ -600,6 +453,134 @@ type forwardingoptionsSamplingBlockFamilyInetOutputBlockFlowServer struct {
 	Version9Template                                 types.String `tfsdk:"version9_template"`
 }
 
+func (forwardingoptionsSamplingBlockFamilyInetOutputBlockFlowServer) attributesSchema() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"hostname": schema.StringAttribute{
+			Required:    true,
+			Description: "Name of host collecting cflowd packets.",
+			Validators: []validator.String{
+				tfvalidator.StringIPAddress(),
+			},
+		},
+		"port": schema.Int64Attribute{
+			Required:    true,
+			Description: "UDP port number on host collecting cflowd packets (1..65535).",
+			Validators: []validator.Int64{
+				int64validator.Between(1, 65535),
+			},
+		},
+		"aggregation_autonomous_system": schema.BoolAttribute{
+			Optional:    true,
+			Description: "Aggregate by autonomous system number.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+		"aggregation_destination_prefix": schema.BoolAttribute{
+			Optional:    true,
+			Description: "Aggregate by destination prefix.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+		"aggregation_protocol_port": schema.BoolAttribute{
+			Optional:    true,
+			Description: "Aggregate by protocol and port number.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+		"aggregation_source_destination_prefix": schema.BoolAttribute{
+			Optional:    true,
+			Description: "Aggregate by source and destination prefix.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+		"aggregation_source_destination_prefix_caida_compliant": schema.BoolAttribute{
+			Optional:    true,
+			Description: "Compatible with Caida record format for prefix aggregation (v8).",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+		"aggregation_source_prefix": schema.BoolAttribute{
+			Optional:    true,
+			Description: "Aggregate by source prefix.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+		"autonomous_system_type": schema.StringAttribute{
+			Optional:    true,
+			Description: "Type of autonomous system number to export.",
+			Validators: []validator.String{
+				stringvalidator.OneOf("origin", "peer"),
+			},
+		},
+		"dscp": schema.Int64Attribute{
+			Optional:    true,
+			Description: "Numeric DSCP value in the range 0 to 63 (0..63).",
+			Validators: []validator.Int64{
+				int64validator.Between(0, 63),
+			},
+		},
+		"forwarding_class": schema.StringAttribute{
+			Optional:    true,
+			Description: "Forwarding-class for exported jflow packets, applicable only for inline-jflow.",
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 64),
+				tfvalidator.StringDoubleQuoteExclusion(),
+			},
+		},
+		"local_dump": schema.BoolAttribute{
+			Optional:    true,
+			Description: "Dump cflowd records to log file before exporting.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+		"no_local_dump": schema.BoolAttribute{
+			Optional:    true,
+			Description: "Don't dump cflowd records to log file before exporting.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+		"routing_instance": schema.StringAttribute{
+			Optional:    true,
+			Description: "Name of routing instance on which flow collector is reachable.",
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 63),
+				tfvalidator.StringFormat(tfvalidator.DefaultFormat),
+				stringvalidator.NoneOfCaseInsensitive(junos.DefaultW),
+			},
+		},
+		"source_address": schema.StringAttribute{
+			Optional:    true,
+			Description: "Source IPv4 address for cflowd packets.",
+			Validators: []validator.String{
+				tfvalidator.StringIPAddress().IPv4Only(),
+			},
+		},
+		"version": schema.Int64Attribute{
+			Optional:    true,
+			Description: "Format of exported cflowd aggregates.",
+			Validators: []validator.Int64{
+				int64validator.OneOf(5, 8, 500),
+			},
+		},
+		"version9_template": schema.StringAttribute{
+			Optional:    true,
+			Description: "Template to export data in version 9 format.",
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 250),
+				tfvalidator.StringDoubleQuoteExclusion(),
+			},
+		},
+	}
+}
+
 type forwardingoptionsSamplingBlockFamilyInet6Output struct {
 	AggregateExportInterval  types.Int64                                           `tfsdk:"aggregate_export_interval"`
 	ExtensionService         []types.String                                        `tfsdk:"extension_service"`
@@ -620,124 +601,7 @@ func (forwardingoptionsSamplingBlockFamilyInet6Output) blocksSchema() map[string
 		"flow_server": schema.SetNestedBlock{
 			Description: "For each hostname, configure sending traffic aggregates in cflowd format.",
 			NestedObject: schema.NestedBlockObject{
-				Attributes: map[string]schema.Attribute{
-					"hostname": schema.StringAttribute{
-						Required:    true,
-						Description: "Name of host collecting cflowd packets.",
-						Validators: []validator.String{
-							tfvalidator.StringIPAddress(),
-						},
-					},
-					"port": schema.Int64Attribute{
-						Required:    true,
-						Description: "UDP port number on host collecting cflowd packets (1..65535).",
-						Validators: []validator.Int64{
-							int64validator.Between(1, 65535),
-						},
-					},
-					"aggregation_autonomous_system": schema.BoolAttribute{
-						Optional:    true,
-						Description: "Aggregate by autonomous system number.",
-						Validators: []validator.Bool{
-							tfvalidator.BoolTrue(),
-						},
-					},
-					"aggregation_destination_prefix": schema.BoolAttribute{
-						Optional:    true,
-						Description: "Aggregate by destination prefix.",
-						Validators: []validator.Bool{
-							tfvalidator.BoolTrue(),
-						},
-					},
-					"aggregation_protocol_port": schema.BoolAttribute{
-						Optional:    true,
-						Description: "Aggregate by protocol and port number.",
-						Validators: []validator.Bool{
-							tfvalidator.BoolTrue(),
-						},
-					},
-					"aggregation_source_destination_prefix": schema.BoolAttribute{
-						Optional:    true,
-						Description: "Aggregate by source and destination prefix.",
-						Validators: []validator.Bool{
-							tfvalidator.BoolTrue(),
-						},
-					},
-					"aggregation_source_destination_prefix_caida_compliant": schema.BoolAttribute{
-						Optional:    true,
-						Description: "Compatible with Caida record format for prefix aggregation (v8).",
-						Validators: []validator.Bool{
-							tfvalidator.BoolTrue(),
-						},
-					},
-					"aggregation_source_prefix": schema.BoolAttribute{
-						Optional:    true,
-						Description: "Aggregate by source prefix.",
-						Validators: []validator.Bool{
-							tfvalidator.BoolTrue(),
-						},
-					},
-					"autonomous_system_type": schema.StringAttribute{
-						Optional:    true,
-						Description: "Type of autonomous system number to export.",
-						Validators: []validator.String{
-							stringvalidator.OneOf("origin", "peer"),
-						},
-					},
-					"dscp": schema.Int64Attribute{
-						Optional:    true,
-						Description: "Numeric DSCP value in the range 0 to 63 (0..63).",
-						Validators: []validator.Int64{
-							int64validator.Between(0, 63),
-						},
-					},
-					"forwarding_class": schema.StringAttribute{
-						Optional:    true,
-						Description: "Forwarding-class for exported jflow packets, applicable only for inline-jflow.",
-						Validators: []validator.String{
-							stringvalidator.LengthBetween(1, 64),
-							tfvalidator.StringDoubleQuoteExclusion(),
-						},
-					},
-					"local_dump": schema.BoolAttribute{
-						Optional:    true,
-						Description: "Dump cflowd records to log file before exporting.",
-						Validators: []validator.Bool{
-							tfvalidator.BoolTrue(),
-						},
-					},
-					"no_local_dump": schema.BoolAttribute{
-						Optional:    true,
-						Description: "Don't dump cflowd records to log file before exporting.",
-						Validators: []validator.Bool{
-							tfvalidator.BoolTrue(),
-						},
-					},
-					"routing_instance": schema.StringAttribute{
-						Optional:    true,
-						Description: "Name of routing instance on which flow collector is reachable.",
-						Validators: []validator.String{
-							stringvalidator.LengthBetween(1, 63),
-							tfvalidator.StringFormat(tfvalidator.DefaultFormat),
-							stringvalidator.NoneOfCaseInsensitive(junos.DefaultW),
-						},
-					},
-					"source_address": schema.StringAttribute{
-						Optional:    true,
-						Description: "Source IPv4 address for cflowd packets",
-						Validators: []validator.String{
-							tfvalidator.StringIPAddress().IPv4Only(),
-						},
-					},
-					"version9_template": schema.StringAttribute{
-						Optional:    true,
-						Description: "Template to export data in version 9 format.",
-						Validators: []validator.String{
-							stringvalidator.LengthBetween(1, 250),
-							tfvalidator.StringDoubleQuoteExclusion(),
-						},
-					},
-				},
+				Attributes: forwardingoptionsSamplingBlockOutputBlockFlowServer{}.attributesSchema(),
 			},
 		},
 		"interface": schema.ListNestedBlock{
@@ -770,6 +634,15 @@ type forwardingoptionsSamplingBlockFamilyMplsOutput struct {
 	FlowInactiveTimeout     types.Int64                                           `tfsdk:"flow_inactive_timeout"`
 	FlowServer              []forwardingoptionsSamplingBlockOutputBlockFlowServer `tfsdk:"flow_server"`
 	Interface               []forwardingoptionsSamplingBlockOutputBlockInterface  `tfsdk:"interface"`
+}
+
+func (forwardingoptionsSamplingBlockFamilyMplsOutput) attributesSchema() map[string]schema.Attribute {
+	attributes := forwardingoptionsSamplingBlockFamilyInetOutput{}.attributesSchema()
+	delete(attributes, "extension_service")
+	delete(attributes, "inline_jflow_export_rate")
+	delete(attributes, "inline_jflow_source_address")
+
+	return attributes
 }
 
 func (forwardingoptionsSamplingBlockFamilyMplsOutput) blocksSchema() map[string]schema.Block {
@@ -806,6 +679,13 @@ type forwardingoptionsSamplingBlockOutputBlockFlowServer struct {
 	RoutingInstance                                  types.String `tfsdk:"routing_instance"`
 	SourceAddress                                    types.String `tfsdk:"source_address"`
 	Version9Template                                 types.String `tfsdk:"version9_template"`
+}
+
+func (forwardingoptionsSamplingBlockOutputBlockFlowServer) attributesSchema() map[string]schema.Attribute {
+	attributes := forwardingoptionsSamplingBlockFamilyInetOutputBlockFlowServer{}.attributesSchema()
+	delete(attributes, "version")
+
+	return attributes
 }
 
 type forwardingoptionsSamplingBlockOutputBlockInterface struct {

--- a/internal/providerfwk/resource_forwardingoptions_sampling.go
+++ b/internal/providerfwk/resource_forwardingoptions_sampling.go
@@ -128,14 +128,14 @@ func (rsc *forwardingoptionsSampling) Schema(
 		Blocks: map[string]schema.Block{
 			"family_inet_input": schema.SingleNestedBlock{
 				Description: "Declare `family inet input` configuration.",
-				Attributes:  rsc.schemaInputAttributes(),
+				Attributes:  forwardingoptionsSamplingBlockInput{}.attributesSchema(),
 				PlanModifiers: []planmodifier.Object{
 					tfplanmodifier.BlockRemoveNull(),
 				},
 			},
 			"family_inet_output": schema.SingleNestedBlock{
 				Description: "Declare `family inet output` configuration.",
-				Attributes:  rsc.schemaFamilyInetOutputAttributes(),
+				Attributes:  forwardingoptionsSamplingBlockFamilyInetOutput{}.attributesSchema(),
 				Blocks: map[string]schema.Block{
 					"file": schema.SingleNestedBlock{
 						Description: "Configure parameters for dumping sampled packets.",
@@ -338,7 +338,7 @@ func (rsc *forwardingoptionsSampling) Schema(
 					"interface": schema.ListNestedBlock{
 						Description: "For each name of interface, configure interfaces used to send monitored information.",
 						NestedObject: schema.NestedBlockObject{
-							Attributes: rsc.schemaOutputInterfaceAttributes(),
+							Attributes: forwardingoptionsSamplingBlockOutputBlockInterface{}.attributesSchema(),
 						},
 					},
 				},
@@ -348,22 +348,22 @@ func (rsc *forwardingoptionsSampling) Schema(
 			},
 			"family_inet6_input": schema.SingleNestedBlock{
 				Description: "Declare `family inet6 input` configuration.",
-				Attributes:  rsc.schemaInputAttributes(),
+				Attributes:  forwardingoptionsSamplingBlockInput{}.attributesSchema(),
 				PlanModifiers: []planmodifier.Object{
 					tfplanmodifier.BlockRemoveNull(),
 				},
 			},
 			"family_inet6_output": schema.SingleNestedBlock{
 				Description: "Declare `family inet6 output` configuration.",
-				Attributes:  rsc.schemaFamilyInetOutputAttributes(),
-				Blocks:      rsc.schemaOutputBlock(),
+				Attributes:  forwardingoptionsSamplingBlockFamilyInet6Output{}.attributesSchema(),
+				Blocks:      forwardingoptionsSamplingBlockFamilyInet6Output{}.blocksSchema(),
 				PlanModifiers: []planmodifier.Object{
 					tfplanmodifier.BlockRemoveNull(),
 				},
 			},
 			"family_mpls_input": schema.SingleNestedBlock{
 				Description: "Declare `family mpls input` configuration.",
-				Attributes:  rsc.schemaInputAttributes(),
+				Attributes:  forwardingoptionsSamplingBlockInput{}.attributesSchema(),
 				PlanModifiers: []planmodifier.Object{
 					tfplanmodifier.BlockRemoveNull(),
 				},
@@ -393,14 +393,14 @@ func (rsc *forwardingoptionsSampling) Schema(
 						},
 					},
 				},
-				Blocks: rsc.schemaOutputBlock(),
+				Blocks: forwardingoptionsSamplingBlockFamilyMplsOutput{}.blocksSchema(),
 				PlanModifiers: []planmodifier.Object{
 					tfplanmodifier.BlockRemoveNull(),
 				},
 			},
 			"input": schema.SingleNestedBlock{
 				Description: "Declare `input` configuration.",
-				Attributes:  rsc.schemaInputAttributes(),
+				Attributes:  forwardingoptionsSamplingBlockInput{}.attributesSchema(),
 				PlanModifiers: []planmodifier.Object{
 					tfplanmodifier.BlockRemoveNull(),
 				},
@@ -409,7 +409,44 @@ func (rsc *forwardingoptionsSampling) Schema(
 	}
 }
 
-func (rsc *forwardingoptionsSampling) schemaInputAttributes() map[string]schema.Attribute {
+type forwardingoptionsSamplingData struct {
+	ID                types.String                                     `tfsdk:"id"`
+	RoutingInstance   types.String                                     `tfsdk:"routing_instance"`
+	Disable           types.Bool                                       `tfsdk:"disable"`
+	PreRewriteTos     types.Bool                                       `tfsdk:"pre_rewrite_tos"`
+	SampleOnce        types.Bool                                       `tfsdk:"sample_once"`
+	FamilyInetInput   *forwardingoptionsSamplingBlockInput             `tfsdk:"family_inet_input"`
+	FamilyInetOutput  *forwardingoptionsSamplingBlockFamilyInetOutput  `tfsdk:"family_inet_output"`
+	FamilyInet6Input  *forwardingoptionsSamplingBlockInput             `tfsdk:"family_inet6_input"`
+	FamilyInet6Output *forwardingoptionsSamplingBlockFamilyInet6Output `tfsdk:"family_inet6_output"`
+	FamilyMplsInput   *forwardingoptionsSamplingBlockInput             `tfsdk:"family_mpls_input"`
+	FamilyMplsOutput  *forwardingoptionsSamplingBlockFamilyMplsOutput  `tfsdk:"family_mpls_output"`
+	Input             *forwardingoptionsSamplingBlockInput             `tfsdk:"input"`
+}
+
+type forwardingoptionsSamplingConfig struct {
+	ID                types.String                                           `tfsdk:"id"`
+	RoutingInstance   types.String                                           `tfsdk:"routing_instance"`
+	Disable           types.Bool                                             `tfsdk:"disable"`
+	PreRewriteTos     types.Bool                                             `tfsdk:"pre_rewrite_tos"`
+	SampleOnce        types.Bool                                             `tfsdk:"sample_once"`
+	FamilyInetInput   *forwardingoptionsSamplingBlockInput                   `tfsdk:"family_inet_input"`
+	FamilyInetOutput  *forwardingoptionsSamplingBlockFamilyInetOutputConfig  `tfsdk:"family_inet_output"`
+	FamilyInet6Input  *forwardingoptionsSamplingBlockInput                   `tfsdk:"family_inet6_input"`
+	FamilyInet6Output *forwardingoptionsSamplingBlockFamilyInet6OutputConfig `tfsdk:"family_inet6_output"`
+	FamilyMplsInput   *forwardingoptionsSamplingBlockInput                   `tfsdk:"family_mpls_input"`
+	FamilyMplsOutput  *forwardingoptionsSamplingBlockFamilyMplsOutputConfig  `tfsdk:"family_mpls_output"`
+	Input             *forwardingoptionsSamplingBlockInput                   `tfsdk:"input"`
+}
+
+type forwardingoptionsSamplingBlockInput struct {
+	MaxPacketsPerSecond types.Int64 `tfsdk:"max_packets_per_second"`
+	MaximumPacketLength types.Int64 `tfsdk:"maximum_packet_length"`
+	Rate                types.Int64 `tfsdk:"rate"`
+	RunLength           types.Int64 `tfsdk:"run_length"`
+}
+
+func (forwardingoptionsSamplingBlockInput) attributesSchema() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"max_packets_per_second": schema.Int64Attribute{
 			Optional:    true,
@@ -442,7 +479,28 @@ func (rsc *forwardingoptionsSampling) schemaInputAttributes() map[string]schema.
 	}
 }
 
-func (rsc *forwardingoptionsSampling) schemaFamilyInetOutputAttributes() map[string]schema.Attribute {
+func (block *forwardingoptionsSamplingBlockInput) isEmpty() bool {
+	return tfdata.CheckBlockIsEmpty(block)
+}
+
+func (block *forwardingoptionsSamplingBlockInput) hasKnownValue() bool {
+	return tfdata.CheckBlockHasKnownValue(block)
+}
+
+//nolint:lll
+type forwardingoptionsSamplingBlockFamilyInetOutput struct {
+	AggregateExportInterval  types.Int64                                                     `tfsdk:"aggregate_export_interval"`
+	ExtensionService         []types.String                                                  `tfsdk:"extension_service"`
+	File                     *forwardingoptionsSamplingBlockFamilyInetOutputBlockFile        `tfsdk:"file"`
+	FlowActiveTimeout        types.Int64                                                     `tfsdk:"flow_active_timeout"`
+	FlowInactiveTimeout      types.Int64                                                     `tfsdk:"flow_inactive_timeout"`
+	InlineJflowExportRate    types.Int64                                                     `tfsdk:"inline_jflow_export_rate"`
+	InlineJflowSourceAddress types.String                                                    `tfsdk:"inline_jflow_source_address"`
+	FlowServer               []forwardingoptionsSamplingBlockFamilyInetOutputBlockFlowServer `tfsdk:"flow_server"`
+	Interface                []forwardingoptionsSamplingBlockOutputBlockInterface            `tfsdk:"interface"`
+}
+
+func (forwardingoptionsSamplingBlockFamilyInetOutput) attributesSchema() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"aggregate_export_interval": schema.Int64Attribute{
 			Optional:    true,
@@ -494,7 +552,70 @@ func (rsc *forwardingoptionsSampling) schemaFamilyInetOutputAttributes() map[str
 	}
 }
 
-func (rsc *forwardingoptionsSampling) schemaOutputBlock() map[string]schema.Block {
+type forwardingoptionsSamplingBlockFamilyInetOutputConfig struct {
+	AggregateExportInterval  types.Int64                                              `tfsdk:"aggregate_export_interval"`
+	ExtensionService         types.List                                               `tfsdk:"extension_service"`
+	File                     *forwardingoptionsSamplingBlockFamilyInetOutputBlockFile `tfsdk:"file"`
+	FlowActiveTimeout        types.Int64                                              `tfsdk:"flow_active_timeout"`
+	FlowInactiveTimeout      types.Int64                                              `tfsdk:"flow_inactive_timeout"`
+	InlineJflowExportRate    types.Int64                                              `tfsdk:"inline_jflow_export_rate"`
+	InlineJflowSourceAddress types.String                                             `tfsdk:"inline_jflow_source_address"`
+	FlowServer               types.Set                                                `tfsdk:"flow_server"`
+	Interface                types.List                                               `tfsdk:"interface"`
+}
+
+func (block *forwardingoptionsSamplingBlockFamilyInetOutputConfig) isEmpty() bool {
+	return tfdata.CheckBlockIsEmpty(block)
+}
+
+type forwardingoptionsSamplingBlockFamilyInetOutputBlockFile struct {
+	Filename        types.String `tfsdk:"filename"`
+	Disable         types.Bool   `tfsdk:"disable"`
+	Files           types.Int64  `tfsdk:"files"`
+	Size            types.Int64  `tfsdk:"size"`
+	Stamp           types.Bool   `tfsdk:"stamp"`
+	NoStamp         types.Bool   `tfsdk:"no_stamp"`
+	WorldReadable   types.Bool   `tfsdk:"world_readable"`
+	NoWorldReadable types.Bool   `tfsdk:"no_world_readable"`
+}
+
+//nolint:lll
+type forwardingoptionsSamplingBlockFamilyInetOutputBlockFlowServer struct {
+	Hostname                                         types.String `tfsdk:"hostname"`
+	Port                                             types.Int64  `tfsdk:"port"`
+	AggregationAutonomousSystem                      types.Bool   `tfsdk:"aggregation_autonomous_system"`
+	AggregationDestinationPrefix                     types.Bool   `tfsdk:"aggregation_destination_prefix"`
+	AggregationProtocolPort                          types.Bool   `tfsdk:"aggregation_protocol_port"`
+	AggregationSourceDestinationPrefix               types.Bool   `tfsdk:"aggregation_source_destination_prefix"`
+	AggregationSourceDestinationPrefixCaidaCompliant types.Bool   `tfsdk:"aggregation_source_destination_prefix_caida_compliant"`
+	AggregationSourcePrefix                          types.Bool   `tfsdk:"aggregation_source_prefix"`
+	AutonomousSystemType                             types.String `tfsdk:"autonomous_system_type"`
+	Dscp                                             types.Int64  `tfsdk:"dscp"`
+	ForwardingClass                                  types.String `tfsdk:"forwarding_class"`
+	LocalDump                                        types.Bool   `tfsdk:"local_dump"`
+	NoLocalDump                                      types.Bool   `tfsdk:"no_local_dump"`
+	RoutingInstance                                  types.String `tfsdk:"routing_instance"`
+	SourceAddress                                    types.String `tfsdk:"source_address"`
+	Version                                          types.Int64  `tfsdk:"version"`
+	Version9Template                                 types.String `tfsdk:"version9_template"`
+}
+
+type forwardingoptionsSamplingBlockFamilyInet6Output struct {
+	AggregateExportInterval  types.Int64                                           `tfsdk:"aggregate_export_interval"`
+	ExtensionService         []types.String                                        `tfsdk:"extension_service"`
+	FlowActiveTimeout        types.Int64                                           `tfsdk:"flow_active_timeout"`
+	FlowInactiveTimeout      types.Int64                                           `tfsdk:"flow_inactive_timeout"`
+	InlineJflowExportRate    types.Int64                                           `tfsdk:"inline_jflow_export_rate"`
+	InlineJflowSourceAddress types.String                                          `tfsdk:"inline_jflow_source_address"`
+	FlowServer               []forwardingoptionsSamplingBlockOutputBlockFlowServer `tfsdk:"flow_server"`
+	Interface                []forwardingoptionsSamplingBlockOutputBlockInterface  `tfsdk:"interface"`
+}
+
+func (forwardingoptionsSamplingBlockFamilyInet6Output) attributesSchema() map[string]schema.Attribute {
+	return forwardingoptionsSamplingBlockFamilyInetOutput{}.attributesSchema()
+}
+
+func (forwardingoptionsSamplingBlockFamilyInet6Output) blocksSchema() map[string]schema.Block {
 	return map[string]schema.Block{
 		"flow_server": schema.SetNestedBlock{
 			Description: "For each hostname, configure sending traffic aggregates in cflowd format.",
@@ -622,161 +743,10 @@ func (rsc *forwardingoptionsSampling) schemaOutputBlock() map[string]schema.Bloc
 		"interface": schema.ListNestedBlock{
 			Description: "For each name of interface, configure interfaces used to send monitored information.",
 			NestedObject: schema.NestedBlockObject{
-				Attributes: rsc.schemaOutputInterfaceAttributes(),
+				Attributes: forwardingoptionsSamplingBlockOutputBlockInterface{}.attributesSchema(),
 			},
 		},
 	}
-}
-
-func (rsc *forwardingoptionsSampling) schemaOutputInterfaceAttributes() map[string]schema.Attribute {
-	return map[string]schema.Attribute{
-		"name": schema.StringAttribute{
-			Required:    true,
-			Description: "Name of interface.",
-			Validators: []validator.String{
-				stringvalidator.LengthAtLeast(1),
-				tfvalidator.StringFormat(tfvalidator.InterfaceFormat),
-			},
-		},
-		"engine_id": schema.Int64Attribute{
-			Optional:    true,
-			Description: "Identity (number) of this accounting interface (0..255).",
-			Validators: []validator.Int64{
-				int64validator.Between(0, 255),
-			},
-		},
-		"engine_type": schema.Int64Attribute{
-			Optional:    true,
-			Description: "Type (number) of this accounting interface (0..255).",
-			Validators: []validator.Int64{
-				int64validator.Between(0, 255),
-			},
-		},
-		"source_address": schema.StringAttribute{
-			Optional:    true,
-			Description: "Address to use for generating monitored packets.",
-			Validators: []validator.String{
-				tfvalidator.StringIPAddress(),
-			},
-		},
-	}
-}
-
-type forwardingoptionsSamplingData struct {
-	ID                types.String                                     `tfsdk:"id"`
-	RoutingInstance   types.String                                     `tfsdk:"routing_instance"`
-	Disable           types.Bool                                       `tfsdk:"disable"`
-	PreRewriteTos     types.Bool                                       `tfsdk:"pre_rewrite_tos"`
-	SampleOnce        types.Bool                                       `tfsdk:"sample_once"`
-	FamilyInetInput   *forwardingoptionsSamplingBlockInput             `tfsdk:"family_inet_input"`
-	FamilyInetOutput  *forwardingoptionsSamplingBlockFamilyInetOutput  `tfsdk:"family_inet_output"`
-	FamilyInet6Input  *forwardingoptionsSamplingBlockInput             `tfsdk:"family_inet6_input"`
-	FamilyInet6Output *forwardingoptionsSamplingBlockFamilyInet6Output `tfsdk:"family_inet6_output"`
-	FamilyMplsInput   *forwardingoptionsSamplingBlockInput             `tfsdk:"family_mpls_input"`
-	FamilyMplsOutput  *forwardingoptionsSamplingBlockFamilyMplsOutput  `tfsdk:"family_mpls_output"`
-	Input             *forwardingoptionsSamplingBlockInput             `tfsdk:"input"`
-}
-
-type forwardingoptionsSamplingConfig struct {
-	ID                types.String                                           `tfsdk:"id"`
-	RoutingInstance   types.String                                           `tfsdk:"routing_instance"`
-	Disable           types.Bool                                             `tfsdk:"disable"`
-	PreRewriteTos     types.Bool                                             `tfsdk:"pre_rewrite_tos"`
-	SampleOnce        types.Bool                                             `tfsdk:"sample_once"`
-	FamilyInetInput   *forwardingoptionsSamplingBlockInput                   `tfsdk:"family_inet_input"`
-	FamilyInetOutput  *forwardingoptionsSamplingBlockFamilyInetOutputConfig  `tfsdk:"family_inet_output"`
-	FamilyInet6Input  *forwardingoptionsSamplingBlockInput                   `tfsdk:"family_inet6_input"`
-	FamilyInet6Output *forwardingoptionsSamplingBlockFamilyInet6OutputConfig `tfsdk:"family_inet6_output"`
-	FamilyMplsInput   *forwardingoptionsSamplingBlockInput                   `tfsdk:"family_mpls_input"`
-	FamilyMplsOutput  *forwardingoptionsSamplingBlockFamilyMplsOutputConfig  `tfsdk:"family_mpls_output"`
-	Input             *forwardingoptionsSamplingBlockInput                   `tfsdk:"input"`
-}
-
-type forwardingoptionsSamplingBlockInput struct {
-	MaxPacketsPerSecond types.Int64 `tfsdk:"max_packets_per_second"`
-	MaximumPacketLength types.Int64 `tfsdk:"maximum_packet_length"`
-	Rate                types.Int64 `tfsdk:"rate"`
-	RunLength           types.Int64 `tfsdk:"run_length"`
-}
-
-func (block *forwardingoptionsSamplingBlockInput) isEmpty() bool {
-	return tfdata.CheckBlockIsEmpty(block)
-}
-
-func (block *forwardingoptionsSamplingBlockInput) hasKnownValue() bool {
-	return tfdata.CheckBlockHasKnownValue(block)
-}
-
-//nolint:lll
-type forwardingoptionsSamplingBlockFamilyInetOutput struct {
-	AggregateExportInterval  types.Int64                                                     `tfsdk:"aggregate_export_interval"`
-	ExtensionService         []types.String                                                  `tfsdk:"extension_service"`
-	File                     *forwardingoptionsSamplingBlockFamilyInetOutputBlockFile        `tfsdk:"file"`
-	FlowActiveTimeout        types.Int64                                                     `tfsdk:"flow_active_timeout"`
-	FlowInactiveTimeout      types.Int64                                                     `tfsdk:"flow_inactive_timeout"`
-	InlineJflowExportRate    types.Int64                                                     `tfsdk:"inline_jflow_export_rate"`
-	InlineJflowSourceAddress types.String                                                    `tfsdk:"inline_jflow_source_address"`
-	FlowServer               []forwardingoptionsSamplingBlockFamilyInetOutputBlockFlowServer `tfsdk:"flow_server"`
-	Interface                []forwardingoptionsSamplingBlockOutputBlockInterface            `tfsdk:"interface"`
-}
-
-type forwardingoptionsSamplingBlockFamilyInetOutputConfig struct {
-	AggregateExportInterval  types.Int64                                              `tfsdk:"aggregate_export_interval"`
-	ExtensionService         types.List                                               `tfsdk:"extension_service"`
-	File                     *forwardingoptionsSamplingBlockFamilyInetOutputBlockFile `tfsdk:"file"`
-	FlowActiveTimeout        types.Int64                                              `tfsdk:"flow_active_timeout"`
-	FlowInactiveTimeout      types.Int64                                              `tfsdk:"flow_inactive_timeout"`
-	InlineJflowExportRate    types.Int64                                              `tfsdk:"inline_jflow_export_rate"`
-	InlineJflowSourceAddress types.String                                             `tfsdk:"inline_jflow_source_address"`
-	FlowServer               types.Set                                                `tfsdk:"flow_server"`
-	Interface                types.List                                               `tfsdk:"interface"`
-}
-
-func (block *forwardingoptionsSamplingBlockFamilyInetOutputConfig) isEmpty() bool {
-	return tfdata.CheckBlockIsEmpty(block)
-}
-
-type forwardingoptionsSamplingBlockFamilyInetOutputBlockFile struct {
-	Filename        types.String `tfsdk:"filename"`
-	Disable         types.Bool   `tfsdk:"disable"`
-	Files           types.Int64  `tfsdk:"files"`
-	Size            types.Int64  `tfsdk:"size"`
-	Stamp           types.Bool   `tfsdk:"stamp"`
-	NoStamp         types.Bool   `tfsdk:"no_stamp"`
-	WorldReadable   types.Bool   `tfsdk:"world_readable"`
-	NoWorldReadable types.Bool   `tfsdk:"no_world_readable"`
-}
-
-//nolint:lll
-type forwardingoptionsSamplingBlockFamilyInetOutputBlockFlowServer struct {
-	Hostname                                         types.String `tfsdk:"hostname"`
-	Port                                             types.Int64  `tfsdk:"port"`
-	AggregationAutonomousSystem                      types.Bool   `tfsdk:"aggregation_autonomous_system"`
-	AggregationDestinationPrefix                     types.Bool   `tfsdk:"aggregation_destination_prefix"`
-	AggregationProtocolPort                          types.Bool   `tfsdk:"aggregation_protocol_port"`
-	AggregationSourceDestinationPrefix               types.Bool   `tfsdk:"aggregation_source_destination_prefix"`
-	AggregationSourceDestinationPrefixCaidaCompliant types.Bool   `tfsdk:"aggregation_source_destination_prefix_caida_compliant"`
-	AggregationSourcePrefix                          types.Bool   `tfsdk:"aggregation_source_prefix"`
-	AutonomousSystemType                             types.String `tfsdk:"autonomous_system_type"`
-	Dscp                                             types.Int64  `tfsdk:"dscp"`
-	ForwardingClass                                  types.String `tfsdk:"forwarding_class"`
-	LocalDump                                        types.Bool   `tfsdk:"local_dump"`
-	NoLocalDump                                      types.Bool   `tfsdk:"no_local_dump"`
-	RoutingInstance                                  types.String `tfsdk:"routing_instance"`
-	SourceAddress                                    types.String `tfsdk:"source_address"`
-	Version                                          types.Int64  `tfsdk:"version"`
-	Version9Template                                 types.String `tfsdk:"version9_template"`
-}
-
-type forwardingoptionsSamplingBlockFamilyInet6Output struct {
-	AggregateExportInterval  types.Int64                                           `tfsdk:"aggregate_export_interval"`
-	ExtensionService         []types.String                                        `tfsdk:"extension_service"`
-	FlowActiveTimeout        types.Int64                                           `tfsdk:"flow_active_timeout"`
-	FlowInactiveTimeout      types.Int64                                           `tfsdk:"flow_inactive_timeout"`
-	InlineJflowExportRate    types.Int64                                           `tfsdk:"inline_jflow_export_rate"`
-	InlineJflowSourceAddress types.String                                          `tfsdk:"inline_jflow_source_address"`
-	FlowServer               []forwardingoptionsSamplingBlockOutputBlockFlowServer `tfsdk:"flow_server"`
-	Interface                []forwardingoptionsSamplingBlockOutputBlockInterface  `tfsdk:"interface"`
 }
 
 type forwardingoptionsSamplingBlockFamilyInet6OutputConfig struct {
@@ -800,6 +770,10 @@ type forwardingoptionsSamplingBlockFamilyMplsOutput struct {
 	FlowInactiveTimeout     types.Int64                                           `tfsdk:"flow_inactive_timeout"`
 	FlowServer              []forwardingoptionsSamplingBlockOutputBlockFlowServer `tfsdk:"flow_server"`
 	Interface               []forwardingoptionsSamplingBlockOutputBlockInterface  `tfsdk:"interface"`
+}
+
+func (forwardingoptionsSamplingBlockFamilyMplsOutput) blocksSchema() map[string]schema.Block {
+	return forwardingoptionsSamplingBlockFamilyInet6Output{}.blocksSchema()
 }
 
 type forwardingoptionsSamplingBlockFamilyMplsOutputConfig struct {
@@ -839,6 +813,40 @@ type forwardingoptionsSamplingBlockOutputBlockInterface struct {
 	EngineID      types.Int64  `tfsdk:"engine_id"`
 	EngineType    types.Int64  `tfsdk:"engine_type"`
 	SourceAddress types.String `tfsdk:"source_address"`
+}
+
+func (forwardingoptionsSamplingBlockOutputBlockInterface) attributesSchema() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"name": schema.StringAttribute{
+			Required:    true,
+			Description: "Name of interface.",
+			Validators: []validator.String{
+				stringvalidator.LengthAtLeast(1),
+				tfvalidator.StringFormat(tfvalidator.InterfaceFormat),
+			},
+		},
+		"engine_id": schema.Int64Attribute{
+			Optional:    true,
+			Description: "Identity (number) of this accounting interface (0..255).",
+			Validators: []validator.Int64{
+				int64validator.Between(0, 255),
+			},
+		},
+		"engine_type": schema.Int64Attribute{
+			Optional:    true,
+			Description: "Type (number) of this accounting interface (0..255).",
+			Validators: []validator.Int64{
+				int64validator.Between(0, 255),
+			},
+		},
+		"source_address": schema.StringAttribute{
+			Optional:    true,
+			Description: "Address to use for generating monitored packets.",
+			Validators: []validator.String{
+				tfvalidator.StringIPAddress(),
+			},
+		},
+	}
 }
 
 func (rsc *forwardingoptionsSampling) ValidateConfig(

--- a/internal/providerfwk/resource_forwardingoptions_sampling_instance.go
+++ b/internal/providerfwk/resource_forwardingoptions_sampling_instance.go
@@ -127,14 +127,14 @@ func (rsc *forwardingoptionsSamplingInstance) Schema(
 		Blocks: map[string]schema.Block{
 			"family_inet_input": schema.SingleNestedBlock{
 				Description: "Declare `family inet input` configuration.",
-				Attributes:  rsc.schemaInputAttributes(),
+				Attributes:  forwardingoptionsSamplingInstanceBlockInput{}.attributesSchema(),
 				PlanModifiers: []planmodifier.Object{
 					tfplanmodifier.BlockRemoveNull(),
 				},
 			},
 			"family_inet_output": schema.SingleNestedBlock{
 				Description: "Declare `family inet output` configuration.",
-				Attributes:  rsc.schemaFamilyInetOutputAttributes(),
+				Attributes:  forwardingoptionsSamplingInstanceBlockFamilyInetOutput{}.attributesSchema(),
 				Blocks: map[string]schema.Block{
 					"flow_server": schema.SetNestedBlock{
 						Description: "For each hostname, configure sending traffic aggregates in cflowd format.",
@@ -277,7 +277,7 @@ func (rsc *forwardingoptionsSamplingInstance) Schema(
 					"interface": schema.ListNestedBlock{
 						Description: "For each name of interface, configure interfaces used to send monitored information.",
 						NestedObject: schema.NestedBlockObject{
-							Attributes: rsc.schemaOutputInterfaceAttributes(),
+							Attributes: forwardingoptionsSamplingInstanceBlockOutputBlockInterface{}.attributesSchema(),
 						},
 					},
 				},
@@ -287,22 +287,22 @@ func (rsc *forwardingoptionsSamplingInstance) Schema(
 			},
 			"family_inet6_input": schema.SingleNestedBlock{
 				Description: "Declare `family inet6 input` configuration.",
-				Attributes:  rsc.schemaInputAttributes(),
+				Attributes:  forwardingoptionsSamplingInstanceBlockInput{}.attributesSchema(),
 				PlanModifiers: []planmodifier.Object{
 					tfplanmodifier.BlockRemoveNull(),
 				},
 			},
 			"family_inet6_output": schema.SingleNestedBlock{
 				Description: "Declare `family inet6 output` configuration.",
-				Attributes:  rsc.schemaFamilyInetOutputAttributes(),
-				Blocks:      rsc.schemaOutputBlock(),
+				Attributes:  forwardingoptionsSamplingInstanceBlockFamilyInet6Output{}.attributesSchema(),
+				Blocks:      forwardingoptionsSamplingInstanceBlockFamilyInet6Output{}.blocksSchema(),
 				PlanModifiers: []planmodifier.Object{
 					tfplanmodifier.BlockRemoveNull(),
 				},
 			},
 			"family_mpls_input": schema.SingleNestedBlock{
 				Description: "Declare `family mpls input` configuration.",
-				Attributes:  rsc.schemaInputAttributes(),
+				Attributes:  forwardingoptionsSamplingInstanceBlockInput{}.attributesSchema(),
 				PlanModifiers: []planmodifier.Object{
 					tfplanmodifier.BlockRemoveNull(),
 				},
@@ -346,14 +346,14 @@ func (rsc *forwardingoptionsSamplingInstance) Schema(
 						},
 					},
 				},
-				Blocks: rsc.schemaOutputBlock(),
+				Blocks: forwardingoptionsSamplingInstanceBlockFamilyMplsOutput{}.blocksSchema(),
 				PlanModifiers: []planmodifier.Object{
 					tfplanmodifier.BlockRemoveNull(),
 				},
 			},
 			"input": schema.SingleNestedBlock{
 				Description: "Declare `input` configuration.",
-				Attributes:  rsc.schemaInputAttributes(),
+				Attributes:  forwardingoptionsSamplingInstanceBlockInput{}.attributesSchema(),
 				PlanModifiers: []planmodifier.Object{
 					tfplanmodifier.BlockRemoveNull(),
 				},
@@ -362,7 +362,42 @@ func (rsc *forwardingoptionsSamplingInstance) Schema(
 	}
 }
 
-func (rsc *forwardingoptionsSamplingInstance) schemaInputAttributes() map[string]schema.Attribute {
+type forwardingoptionsSamplingInstanceData struct {
+	ID                types.String                                             `tfsdk:"id"`
+	Name              types.String                                             `tfsdk:"name"`
+	RoutingInstance   types.String                                             `tfsdk:"routing_instance"`
+	Disable           types.Bool                                               `tfsdk:"disable"`
+	FamilyInetInput   *forwardingoptionsSamplingInstanceBlockInput             `tfsdk:"family_inet_input"`
+	FamilyInetOutput  *forwardingoptionsSamplingInstanceBlockFamilyInetOutput  `tfsdk:"family_inet_output"`
+	FamilyInet6Input  *forwardingoptionsSamplingInstanceBlockInput             `tfsdk:"family_inet6_input"`
+	FamilyInet6Output *forwardingoptionsSamplingInstanceBlockFamilyInet6Output `tfsdk:"family_inet6_output"`
+	FamilyMplsInput   *forwardingoptionsSamplingInstanceBlockInput             `tfsdk:"family_mpls_input"`
+	FamilyMplsOutput  *forwardingoptionsSamplingInstanceBlockFamilyMplsOutput  `tfsdk:"family_mpls_output"`
+	Input             *forwardingoptionsSamplingInstanceBlockInput             `tfsdk:"input"`
+}
+
+type forwardingoptionsSamplingInstanceConfig struct {
+	ID                types.String                                                  `tfsdk:"id"`
+	Name              types.String                                                  `tfsdk:"name"`
+	RoutingInstance   types.String                                                  `tfsdk:"routing_instance"`
+	Disable           types.Bool                                                    `tfsdk:"disable"`
+	FamilyInetInput   *forwardingoptionsSamplingInstanceBlockInput                  `tfsdk:"family_inet_input"`
+	FamilyInetOutput  *forwardingoptionsSamplingInstanceBlockFamilyInetOutputConfig `tfsdk:"family_inet_output"`
+	FamilyInet6Input  *forwardingoptionsSamplingInstanceBlockInput                  `tfsdk:"family_inet6_input"`
+	FamilyInet6Output *forwardingoptionsSamplingInstanceBlockFamilyInetOutputConfig `tfsdk:"family_inet6_output"`
+	FamilyMplsInput   *forwardingoptionsSamplingInstanceBlockInput                  `tfsdk:"family_mpls_input"`
+	FamilyMplsOutput  *forwardingoptionsSamplingInstanceBlockFamilyMplsOutputConfig `tfsdk:"family_mpls_output"`
+	Input             *forwardingoptionsSamplingInstanceBlockInput                  `tfsdk:"input"`
+}
+
+type forwardingoptionsSamplingInstanceBlockInput struct {
+	MaxPacketsPerSecond types.Int64 `tfsdk:"max_packets_per_second"`
+	MaximumPacketLength types.Int64 `tfsdk:"maximum_packet_length"`
+	Rate                types.Int64 `tfsdk:"rate"`
+	RunLength           types.Int64 `tfsdk:"run_length"`
+}
+
+func (forwardingoptionsSamplingInstanceBlockInput) attributesSchema() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"max_packets_per_second": schema.Int64Attribute{
 			Optional:    true,
@@ -395,7 +430,27 @@ func (rsc *forwardingoptionsSamplingInstance) schemaInputAttributes() map[string
 	}
 }
 
-func (rsc *forwardingoptionsSamplingInstance) schemaFamilyInetOutputAttributes() map[string]schema.Attribute {
+func (block *forwardingoptionsSamplingInstanceBlockInput) isEmpty() bool {
+	return tfdata.CheckBlockIsEmpty(block)
+}
+
+func (block *forwardingoptionsSamplingInstanceBlockInput) hasKnownValue() bool {
+	return tfdata.CheckBlockHasKnownValue(block)
+}
+
+//nolint:lll
+type forwardingoptionsSamplingInstanceBlockFamilyInetOutput struct {
+	AggregateExportInterval  types.Int64                                                             `tfsdk:"aggregate_export_interval"`
+	ExtensionService         []types.String                                                          `tfsdk:"extension_service"`
+	FlowActiveTimeout        types.Int64                                                             `tfsdk:"flow_active_timeout"`
+	FlowInactiveTimeout      types.Int64                                                             `tfsdk:"flow_inactive_timeout"`
+	InlineJflowExportRate    types.Int64                                                             `tfsdk:"inline_jflow_export_rate"`
+	InlineJflowSourceAddress types.String                                                            `tfsdk:"inline_jflow_source_address"`
+	FlowServer               []forwardingoptionsSamplingInstanceBlockFamilyInetOutputBlockFlowServer `tfsdk:"flow_server"`
+	Interface                []forwardingoptionsSamplingInstanceBlockOutputBlockInterface            `tfsdk:"interface"`
+}
+
+func (forwardingoptionsSamplingInstanceBlockFamilyInetOutput) attributesSchema() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"aggregate_export_interval": schema.Int64Attribute{
 			Optional:    true,
@@ -447,7 +502,60 @@ func (rsc *forwardingoptionsSamplingInstance) schemaFamilyInetOutputAttributes()
 	}
 }
 
-func (rsc *forwardingoptionsSamplingInstance) schemaOutputBlock() map[string]schema.Block {
+type forwardingoptionsSamplingInstanceBlockFamilyInetOutputConfig struct {
+	AggregateExportInterval  types.Int64  `tfsdk:"aggregate_export_interval"`
+	ExtensionService         types.List   `tfsdk:"extension_service"`
+	FlowActiveTimeout        types.Int64  `tfsdk:"flow_active_timeout"`
+	FlowInactiveTimeout      types.Int64  `tfsdk:"flow_inactive_timeout"`
+	InlineJflowExportRate    types.Int64  `tfsdk:"inline_jflow_export_rate"`
+	InlineJflowSourceAddress types.String `tfsdk:"inline_jflow_source_address"`
+	FlowServer               types.Set    `tfsdk:"flow_server"`
+	Interface                types.List   `tfsdk:"interface"`
+}
+
+func (block *forwardingoptionsSamplingInstanceBlockFamilyInetOutputConfig) isEmpty() bool {
+	return tfdata.CheckBlockIsEmpty(block)
+}
+
+//nolint:lll
+type forwardingoptionsSamplingInstanceBlockFamilyInetOutputBlockFlowServer struct {
+	Hostname                                         types.String `tfsdk:"hostname"`
+	Port                                             types.Int64  `tfsdk:"port"`
+	AggregationAutonomousSystem                      types.Bool   `tfsdk:"aggregation_autonomous_system"`
+	AggregationDestinationPrefix                     types.Bool   `tfsdk:"aggregation_destination_prefix"`
+	AggregationProtocolPort                          types.Bool   `tfsdk:"aggregation_protocol_port"`
+	AggregationSourceDestinationPrefix               types.Bool   `tfsdk:"aggregation_source_destination_prefix"`
+	AggregationSourceDestinationPrefixCaidaCompliant types.Bool   `tfsdk:"aggregation_source_destination_prefix_caida_compliant"`
+	AggregationSourcePrefix                          types.Bool   `tfsdk:"aggregation_source_prefix"`
+	AutonomousSystemType                             types.String `tfsdk:"autonomous_system_type"`
+	Dscp                                             types.Int64  `tfsdk:"dscp"`
+	ForwardingClass                                  types.String `tfsdk:"forwarding_class"`
+	LocalDump                                        types.Bool   `tfsdk:"local_dump"`
+	NoLocalDump                                      types.Bool   `tfsdk:"no_local_dump"`
+	RoutingInstance                                  types.String `tfsdk:"routing_instance"`
+	SourceAddress                                    types.String `tfsdk:"source_address"`
+	Version                                          types.Int64  `tfsdk:"version"`
+	Version9Template                                 types.String `tfsdk:"version9_template"`
+	VersionIPFixTemplate                             types.String `tfsdk:"version_ipfix_template"`
+}
+
+//nolint:lll
+type forwardingoptionsSamplingInstanceBlockFamilyInet6Output struct {
+	AggregateExportInterval  types.Int64                                                   `tfsdk:"aggregate_export_interval"`
+	ExtensionService         []types.String                                                `tfsdk:"extension_service"`
+	FlowActiveTimeout        types.Int64                                                   `tfsdk:"flow_active_timeout"`
+	FlowInactiveTimeout      types.Int64                                                   `tfsdk:"flow_inactive_timeout"`
+	InlineJflowExportRate    types.Int64                                                   `tfsdk:"inline_jflow_export_rate"`
+	InlineJflowSourceAddress types.String                                                  `tfsdk:"inline_jflow_source_address"`
+	FlowServer               []forwardingoptionsSamplingInstanceBlockOutputBlockFlowServer `tfsdk:"flow_server"`
+	Interface                []forwardingoptionsSamplingInstanceBlockOutputBlockInterface  `tfsdk:"interface"`
+}
+
+func (forwardingoptionsSamplingInstanceBlockFamilyInet6Output) attributesSchema() map[string]schema.Attribute {
+	return forwardingoptionsSamplingInstanceBlockFamilyInetOutput{}.attributesSchema()
+}
+
+func (forwardingoptionsSamplingInstanceBlockFamilyInet6Output) blocksSchema() map[string]schema.Block {
 	return map[string]schema.Block{
 		"flow_server": schema.SetNestedBlock{
 			Description: "For each hostname, configure sending traffic aggregates in cflowd format.",
@@ -583,148 +691,10 @@ func (rsc *forwardingoptionsSamplingInstance) schemaOutputBlock() map[string]sch
 		"interface": schema.ListNestedBlock{
 			Description: "For each name of interface, configure interfaces used to send monitored information.",
 			NestedObject: schema.NestedBlockObject{
-				Attributes: rsc.schemaOutputInterfaceAttributes(),
+				Attributes: forwardingoptionsSamplingInstanceBlockOutputBlockInterface{}.attributesSchema(),
 			},
 		},
 	}
-}
-
-func (rsc *forwardingoptionsSamplingInstance) schemaOutputInterfaceAttributes() map[string]schema.Attribute {
-	return map[string]schema.Attribute{
-		"name": schema.StringAttribute{
-			Required:    true,
-			Description: "Name of interface.",
-			Validators: []validator.String{
-				stringvalidator.LengthAtLeast(1),
-				tfvalidator.StringFormat(tfvalidator.InterfaceFormat),
-			},
-		},
-		"engine_id": schema.Int64Attribute{
-			Optional:    true,
-			Description: "Identity (number) of this accounting interface (0..255).",
-			Validators: []validator.Int64{
-				int64validator.Between(0, 255),
-			},
-		},
-		"engine_type": schema.Int64Attribute{
-			Optional:    true,
-			Description: "Type (number) of this accounting interface (0..255).",
-			Validators: []validator.Int64{
-				int64validator.Between(0, 255),
-			},
-		},
-		"source_address": schema.StringAttribute{
-			Optional:    true,
-			Description: "Address to use for generating monitored packets.",
-			Validators: []validator.String{
-				tfvalidator.StringIPAddress(),
-			},
-		},
-	}
-}
-
-type forwardingoptionsSamplingInstanceData struct {
-	ID                types.String                                             `tfsdk:"id"`
-	Name              types.String                                             `tfsdk:"name"`
-	RoutingInstance   types.String                                             `tfsdk:"routing_instance"`
-	Disable           types.Bool                                               `tfsdk:"disable"`
-	FamilyInetInput   *forwardingoptionsSamplingInstanceBlockInput             `tfsdk:"family_inet_input"`
-	FamilyInetOutput  *forwardingoptionsSamplingInstanceBlockFamilyInetOutput  `tfsdk:"family_inet_output"`
-	FamilyInet6Input  *forwardingoptionsSamplingInstanceBlockInput             `tfsdk:"family_inet6_input"`
-	FamilyInet6Output *forwardingoptionsSamplingInstanceBlockFamilyInet6Output `tfsdk:"family_inet6_output"`
-	FamilyMplsInput   *forwardingoptionsSamplingInstanceBlockInput             `tfsdk:"family_mpls_input"`
-	FamilyMplsOutput  *forwardingoptionsSamplingInstanceBlockFamilyMplsOutput  `tfsdk:"family_mpls_output"`
-	Input             *forwardingoptionsSamplingInstanceBlockInput             `tfsdk:"input"`
-}
-
-type forwardingoptionsSamplingInstanceConfig struct {
-	ID                types.String                                                  `tfsdk:"id"`
-	Name              types.String                                                  `tfsdk:"name"`
-	RoutingInstance   types.String                                                  `tfsdk:"routing_instance"`
-	Disable           types.Bool                                                    `tfsdk:"disable"`
-	FamilyInetInput   *forwardingoptionsSamplingInstanceBlockInput                  `tfsdk:"family_inet_input"`
-	FamilyInetOutput  *forwardingoptionsSamplingInstanceBlockFamilyInetOutputConfig `tfsdk:"family_inet_output"`
-	FamilyInet6Input  *forwardingoptionsSamplingInstanceBlockInput                  `tfsdk:"family_inet6_input"`
-	FamilyInet6Output *forwardingoptionsSamplingInstanceBlockFamilyInetOutputConfig `tfsdk:"family_inet6_output"`
-	FamilyMplsInput   *forwardingoptionsSamplingInstanceBlockInput                  `tfsdk:"family_mpls_input"`
-	FamilyMplsOutput  *forwardingoptionsSamplingInstanceBlockFamilyMplsOutputConfig `tfsdk:"family_mpls_output"`
-	Input             *forwardingoptionsSamplingInstanceBlockInput                  `tfsdk:"input"`
-}
-
-type forwardingoptionsSamplingInstanceBlockInput struct {
-	MaxPacketsPerSecond types.Int64 `tfsdk:"max_packets_per_second"`
-	MaximumPacketLength types.Int64 `tfsdk:"maximum_packet_length"`
-	Rate                types.Int64 `tfsdk:"rate"`
-	RunLength           types.Int64 `tfsdk:"run_length"`
-}
-
-func (block *forwardingoptionsSamplingInstanceBlockInput) isEmpty() bool {
-	return tfdata.CheckBlockIsEmpty(block)
-}
-
-func (block *forwardingoptionsSamplingInstanceBlockInput) hasKnownValue() bool {
-	return tfdata.CheckBlockHasKnownValue(block)
-}
-
-//nolint:lll
-type forwardingoptionsSamplingInstanceBlockFamilyInetOutput struct {
-	AggregateExportInterval  types.Int64                                                             `tfsdk:"aggregate_export_interval"`
-	ExtensionService         []types.String                                                          `tfsdk:"extension_service"`
-	FlowActiveTimeout        types.Int64                                                             `tfsdk:"flow_active_timeout"`
-	FlowInactiveTimeout      types.Int64                                                             `tfsdk:"flow_inactive_timeout"`
-	InlineJflowExportRate    types.Int64                                                             `tfsdk:"inline_jflow_export_rate"`
-	InlineJflowSourceAddress types.String                                                            `tfsdk:"inline_jflow_source_address"`
-	FlowServer               []forwardingoptionsSamplingInstanceBlockFamilyInetOutputBlockFlowServer `tfsdk:"flow_server"`
-	Interface                []forwardingoptionsSamplingInstanceBlockOutputBlockInterface            `tfsdk:"interface"`
-}
-
-type forwardingoptionsSamplingInstanceBlockFamilyInetOutputConfig struct {
-	AggregateExportInterval  types.Int64  `tfsdk:"aggregate_export_interval"`
-	ExtensionService         types.List   `tfsdk:"extension_service"`
-	FlowActiveTimeout        types.Int64  `tfsdk:"flow_active_timeout"`
-	FlowInactiveTimeout      types.Int64  `tfsdk:"flow_inactive_timeout"`
-	InlineJflowExportRate    types.Int64  `tfsdk:"inline_jflow_export_rate"`
-	InlineJflowSourceAddress types.String `tfsdk:"inline_jflow_source_address"`
-	FlowServer               types.Set    `tfsdk:"flow_server"`
-	Interface                types.List   `tfsdk:"interface"`
-}
-
-func (block *forwardingoptionsSamplingInstanceBlockFamilyInetOutputConfig) isEmpty() bool {
-	return tfdata.CheckBlockIsEmpty(block)
-}
-
-//nolint:lll
-type forwardingoptionsSamplingInstanceBlockFamilyInetOutputBlockFlowServer struct {
-	Hostname                                         types.String `tfsdk:"hostname"`
-	Port                                             types.Int64  `tfsdk:"port"`
-	AggregationAutonomousSystem                      types.Bool   `tfsdk:"aggregation_autonomous_system"`
-	AggregationDestinationPrefix                     types.Bool   `tfsdk:"aggregation_destination_prefix"`
-	AggregationProtocolPort                          types.Bool   `tfsdk:"aggregation_protocol_port"`
-	AggregationSourceDestinationPrefix               types.Bool   `tfsdk:"aggregation_source_destination_prefix"`
-	AggregationSourceDestinationPrefixCaidaCompliant types.Bool   `tfsdk:"aggregation_source_destination_prefix_caida_compliant"`
-	AggregationSourcePrefix                          types.Bool   `tfsdk:"aggregation_source_prefix"`
-	AutonomousSystemType                             types.String `tfsdk:"autonomous_system_type"`
-	Dscp                                             types.Int64  `tfsdk:"dscp"`
-	ForwardingClass                                  types.String `tfsdk:"forwarding_class"`
-	LocalDump                                        types.Bool   `tfsdk:"local_dump"`
-	NoLocalDump                                      types.Bool   `tfsdk:"no_local_dump"`
-	RoutingInstance                                  types.String `tfsdk:"routing_instance"`
-	SourceAddress                                    types.String `tfsdk:"source_address"`
-	Version                                          types.Int64  `tfsdk:"version"`
-	Version9Template                                 types.String `tfsdk:"version9_template"`
-	VersionIPFixTemplate                             types.String `tfsdk:"version_ipfix_template"`
-}
-
-//nolint:lll
-type forwardingoptionsSamplingInstanceBlockFamilyInet6Output struct {
-	AggregateExportInterval  types.Int64                                                   `tfsdk:"aggregate_export_interval"`
-	ExtensionService         []types.String                                                `tfsdk:"extension_service"`
-	FlowActiveTimeout        types.Int64                                                   `tfsdk:"flow_active_timeout"`
-	FlowInactiveTimeout      types.Int64                                                   `tfsdk:"flow_inactive_timeout"`
-	InlineJflowExportRate    types.Int64                                                   `tfsdk:"inline_jflow_export_rate"`
-	InlineJflowSourceAddress types.String                                                  `tfsdk:"inline_jflow_source_address"`
-	FlowServer               []forwardingoptionsSamplingInstanceBlockOutputBlockFlowServer `tfsdk:"flow_server"`
-	Interface                []forwardingoptionsSamplingInstanceBlockOutputBlockInterface  `tfsdk:"interface"`
 }
 
 //nolint:lll
@@ -736,6 +706,10 @@ type forwardingoptionsSamplingInstanceBlockFamilyMplsOutput struct {
 	InlineJflowSourceAddress types.String                                                  `tfsdk:"inline_jflow_source_address"`
 	FlowServer               []forwardingoptionsSamplingInstanceBlockOutputBlockFlowServer `tfsdk:"flow_server"`
 	Interface                []forwardingoptionsSamplingInstanceBlockOutputBlockInterface  `tfsdk:"interface"`
+}
+
+func (forwardingoptionsSamplingInstanceBlockFamilyMplsOutput) blocksSchema() map[string]schema.Block {
+	return forwardingoptionsSamplingInstanceBlockFamilyInet6Output{}.blocksSchema()
 }
 
 type forwardingoptionsSamplingInstanceBlockFamilyMplsOutputConfig struct {
@@ -778,6 +752,40 @@ type forwardingoptionsSamplingInstanceBlockOutputBlockInterface struct {
 	EngineID      types.Int64  `tfsdk:"engine_id"`
 	EngineType    types.Int64  `tfsdk:"engine_type"`
 	SourceAddress types.String `tfsdk:"source_address"`
+}
+
+func (forwardingoptionsSamplingInstanceBlockOutputBlockInterface) attributesSchema() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"name": schema.StringAttribute{
+			Required:    true,
+			Description: "Name of interface.",
+			Validators: []validator.String{
+				stringvalidator.LengthAtLeast(1),
+				tfvalidator.StringFormat(tfvalidator.InterfaceFormat),
+			},
+		},
+		"engine_id": schema.Int64Attribute{
+			Optional:    true,
+			Description: "Identity (number) of this accounting interface (0..255).",
+			Validators: []validator.Int64{
+				int64validator.Between(0, 255),
+			},
+		},
+		"engine_type": schema.Int64Attribute{
+			Optional:    true,
+			Description: "Type (number) of this accounting interface (0..255).",
+			Validators: []validator.Int64{
+				int64validator.Between(0, 255),
+			},
+		},
+		"source_address": schema.StringAttribute{
+			Optional:    true,
+			Description: "Address to use for generating monitored packets.",
+			Validators: []validator.String{
+				tfvalidator.StringIPAddress(),
+			},
+		},
+	}
 }
 
 func (rsc *forwardingoptionsSamplingInstance) ValidateConfig(

--- a/internal/providerfwk/resource_forwardingoptions_sampling_instance.go
+++ b/internal/providerfwk/resource_forwardingoptions_sampling_instance.go
@@ -135,152 +135,7 @@ func (rsc *forwardingoptionsSamplingInstance) Schema(
 			"family_inet_output": schema.SingleNestedBlock{
 				Description: "Declare `family inet output` configuration.",
 				Attributes:  forwardingoptionsSamplingInstanceBlockFamilyInetOutput{}.attributesSchema(),
-				Blocks: map[string]schema.Block{
-					"flow_server": schema.SetNestedBlock{
-						Description: "For each hostname, configure sending traffic aggregates in cflowd format.",
-						NestedObject: schema.NestedBlockObject{
-							Attributes: map[string]schema.Attribute{
-								"hostname": schema.StringAttribute{
-									Required:    true,
-									Description: "Name of host collecting cflowd packets.",
-									Validators: []validator.String{
-										tfvalidator.StringIPAddress(),
-									},
-								},
-								"port": schema.Int64Attribute{
-									Required:    true,
-									Description: "UDP port number on host collecting cflowd packets (1..65535).",
-									Validators: []validator.Int64{
-										int64validator.Between(1, 65535),
-									},
-								},
-								"aggregation_autonomous_system": schema.BoolAttribute{
-									Optional:    true,
-									Description: "Aggregate by autonomous system number.",
-									Validators: []validator.Bool{
-										tfvalidator.BoolTrue(),
-									},
-								},
-								"aggregation_destination_prefix": schema.BoolAttribute{
-									Optional:    true,
-									Description: "Aggregate by destination prefix.",
-									Validators: []validator.Bool{
-										tfvalidator.BoolTrue(),
-									},
-								},
-								"aggregation_protocol_port": schema.BoolAttribute{
-									Optional:    true,
-									Description: "Aggregate by protocol and port number.",
-									Validators: []validator.Bool{
-										tfvalidator.BoolTrue(),
-									},
-								},
-								"aggregation_source_destination_prefix": schema.BoolAttribute{
-									Optional:    true,
-									Description: "Aggregate by source and destination prefix.",
-									Validators: []validator.Bool{
-										tfvalidator.BoolTrue(),
-									},
-								},
-								"aggregation_source_destination_prefix_caida_compliant": schema.BoolAttribute{
-									Optional:    true,
-									Description: "Compatible with Caida record format for prefix aggregation (v8).",
-									Validators: []validator.Bool{
-										tfvalidator.BoolTrue(),
-									},
-								},
-								"aggregation_source_prefix": schema.BoolAttribute{
-									Optional:    true,
-									Description: "Aggregate by source prefix.",
-									Validators: []validator.Bool{
-										tfvalidator.BoolTrue(),
-									},
-								},
-								"autonomous_system_type": schema.StringAttribute{
-									Optional:    true,
-									Description: "Type of autonomous system number to export.",
-									Validators: []validator.String{
-										stringvalidator.OneOf("origin", "peer"),
-									},
-								},
-								"dscp": schema.Int64Attribute{
-									Optional:    true,
-									Description: "Numeric DSCP value in the range 0 to 63 (0..63).",
-									Validators: []validator.Int64{
-										int64validator.Between(0, 63),
-									},
-								},
-								"forwarding_class": schema.StringAttribute{
-									Optional:    true,
-									Description: "Forwarding-class for exported jflow packets, applicable only for inline-jflow.",
-									Validators: []validator.String{
-										stringvalidator.LengthBetween(1, 64),
-										tfvalidator.StringDoubleQuoteExclusion(),
-									},
-								},
-								"local_dump": schema.BoolAttribute{
-									Optional:    true,
-									Description: "Dump cflowd records to log file before exporting.",
-									Validators: []validator.Bool{
-										tfvalidator.BoolTrue(),
-									},
-								},
-								"no_local_dump": schema.BoolAttribute{
-									Optional:    true,
-									Description: "Don't dump cflowd records to log file before exporting.",
-									Validators: []validator.Bool{
-										tfvalidator.BoolTrue(),
-									},
-								},
-								"routing_instance": schema.StringAttribute{
-									Optional:    true,
-									Description: "Name of routing instance on which flow collector is reachable.",
-									Validators: []validator.String{
-										stringvalidator.LengthBetween(1, 63),
-										tfvalidator.StringFormat(tfvalidator.DefaultFormat),
-										stringvalidator.NoneOfCaseInsensitive(junos.DefaultW),
-									},
-								},
-								"source_address": schema.StringAttribute{
-									Optional:    true,
-									Description: "Source IPv4 address for cflowd packets.",
-									Validators: []validator.String{
-										tfvalidator.StringIPAddress().IPv4Only(),
-									},
-								},
-								"version": schema.Int64Attribute{
-									Optional:    true,
-									Description: "Format of exported cflowd aggregates.",
-									Validators: []validator.Int64{
-										int64validator.OneOf(5, 8),
-									},
-								},
-								"version9_template": schema.StringAttribute{
-									Optional:    true,
-									Description: "Template to export data in version 9 format.",
-									Validators: []validator.String{
-										stringvalidator.LengthBetween(1, 250),
-										tfvalidator.StringDoubleQuoteExclusion(),
-									},
-								},
-								"version_ipfix_template": schema.StringAttribute{
-									Optional:    true,
-									Description: "Template to export data in version ipfix format.",
-									Validators: []validator.String{
-										stringvalidator.LengthBetween(1, 250),
-										tfvalidator.StringDoubleQuoteExclusion(),
-									},
-								},
-							},
-						},
-					},
-					"interface": schema.ListNestedBlock{
-						Description: "For each name of interface, configure interfaces used to send monitored information.",
-						NestedObject: schema.NestedBlockObject{
-							Attributes: forwardingoptionsSamplingInstanceBlockOutputBlockInterface{}.attributesSchema(),
-						},
-					},
-				},
+				Blocks:      forwardingoptionsSamplingInstanceBlockFamilyInetOutput{}.blocksSchema(),
 				PlanModifiers: []planmodifier.Object{
 					tfplanmodifier.BlockRemoveNull(),
 				},
@@ -309,44 +164,8 @@ func (rsc *forwardingoptionsSamplingInstance) Schema(
 			},
 			"family_mpls_output": schema.SingleNestedBlock{
 				Description: "Declare `family mpls output` configuration.",
-				Attributes: map[string]schema.Attribute{
-					"aggregate_export_interval": schema.Int64Attribute{
-						Optional:    true,
-						Description: "Interval of exporting aggregate accounting information (90..1800 seconds).",
-						Validators: []validator.Int64{
-							int64validator.Between(90, 1800),
-						},
-					},
-					"flow_active_timeout": schema.Int64Attribute{
-						Optional:    true,
-						Description: "Interval after which an active flow is exported (60..1800 seconds).",
-						Validators: []validator.Int64{
-							int64validator.Between(60, 1800),
-						},
-					},
-					"flow_inactive_timeout": schema.Int64Attribute{
-						Optional:    true,
-						Description: "Interval of inactivity that marks a flow inactive (15..1800 seconds).",
-						Validators: []validator.Int64{
-							int64validator.Between(15, 1800),
-						},
-					},
-					"inline_jflow_export_rate": schema.Int64Attribute{
-						Optional:    true,
-						Description: "Inline processing of sampled packets with flow export rate of monitored packets in kpps (1..3200).",
-						Validators: []validator.Int64{
-							int64validator.Between(1, 3200),
-						},
-					},
-					"inline_jflow_source_address": schema.StringAttribute{
-						Optional:    true,
-						Description: "Inline processing of sampled packets with address to use for generating monitored packets.",
-						Validators: []validator.String{
-							tfvalidator.StringIPAddress(),
-						},
-					},
-				},
-				Blocks: forwardingoptionsSamplingInstanceBlockFamilyMplsOutput{}.blocksSchema(),
+				Attributes:  forwardingoptionsSamplingInstanceBlockFamilyMplsOutput{}.attributesSchema(),
+				Blocks:      forwardingoptionsSamplingInstanceBlockFamilyMplsOutput{}.blocksSchema(),
 				PlanModifiers: []planmodifier.Object{
 					tfplanmodifier.BlockRemoveNull(),
 				},
@@ -502,6 +321,18 @@ func (forwardingoptionsSamplingInstanceBlockFamilyInetOutput) attributesSchema()
 	}
 }
 
+func (forwardingoptionsSamplingInstanceBlockFamilyInetOutput) blocksSchema() map[string]schema.Block {
+	blocks := forwardingoptionsSamplingInstanceBlockFamilyInet6Output{}.blocksSchema()
+	blocks["flow_server"] = schema.SetNestedBlock{
+		Description: "For each hostname, configure sending traffic aggregates in cflowd format.",
+		NestedObject: schema.NestedBlockObject{
+			Attributes: forwardingoptionsSamplingInstanceBlockFamilyInetOutputBlockFlowServer{}.attributesSchema(),
+		},
+	}
+
+	return blocks
+}
+
 type forwardingoptionsSamplingInstanceBlockFamilyInetOutputConfig struct {
 	AggregateExportInterval  types.Int64  `tfsdk:"aggregate_export_interval"`
 	ExtensionService         types.List   `tfsdk:"extension_service"`
@@ -539,6 +370,142 @@ type forwardingoptionsSamplingInstanceBlockFamilyInetOutputBlockFlowServer struc
 	VersionIPFixTemplate                             types.String `tfsdk:"version_ipfix_template"`
 }
 
+func (forwardingoptionsSamplingInstanceBlockFamilyInetOutputBlockFlowServer) attributesSchema() map[string]schema.Attribute { //nolint:lll
+	return map[string]schema.Attribute{
+		"hostname": schema.StringAttribute{
+			Required:    true,
+			Description: "Name of host collecting cflowd packets.",
+			Validators: []validator.String{
+				tfvalidator.StringIPAddress(),
+			},
+		},
+		"port": schema.Int64Attribute{
+			Required:    true,
+			Description: "UDP port number on host collecting cflowd packets (1..65535).",
+			Validators: []validator.Int64{
+				int64validator.Between(1, 65535),
+			},
+		},
+		"aggregation_autonomous_system": schema.BoolAttribute{
+			Optional:    true,
+			Description: "Aggregate by autonomous system number.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+		"aggregation_destination_prefix": schema.BoolAttribute{
+			Optional:    true,
+			Description: "Aggregate by destination prefix.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+		"aggregation_protocol_port": schema.BoolAttribute{
+			Optional:    true,
+			Description: "Aggregate by protocol and port number.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+		"aggregation_source_destination_prefix": schema.BoolAttribute{
+			Optional:    true,
+			Description: "Aggregate by source and destination prefix.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+		"aggregation_source_destination_prefix_caida_compliant": schema.BoolAttribute{
+			Optional:    true,
+			Description: "Compatible with Caida record format for prefix aggregation (v8).",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+		"aggregation_source_prefix": schema.BoolAttribute{
+			Optional:    true,
+			Description: "Aggregate by source prefix.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+		"autonomous_system_type": schema.StringAttribute{
+			Optional:    true,
+			Description: "Type of autonomous system number to export.",
+			Validators: []validator.String{
+				stringvalidator.OneOf("origin", "peer"),
+			},
+		},
+		"dscp": schema.Int64Attribute{
+			Optional:    true,
+			Description: "Numeric DSCP value in the range 0 to 63 (0..63).",
+			Validators: []validator.Int64{
+				int64validator.Between(0, 63),
+			},
+		},
+		"forwarding_class": schema.StringAttribute{
+			Optional:    true,
+			Description: "Forwarding-class for exported jflow packets, applicable only for inline-jflow.",
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 64),
+				tfvalidator.StringDoubleQuoteExclusion(),
+			},
+		},
+		"local_dump": schema.BoolAttribute{
+			Optional:    true,
+			Description: "Dump cflowd records to log file before exporting.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+		"no_local_dump": schema.BoolAttribute{
+			Optional:    true,
+			Description: "Don't dump cflowd records to log file before exporting.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+		"routing_instance": schema.StringAttribute{
+			Optional:    true,
+			Description: "Name of routing instance on which flow collector is reachable.",
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 63),
+				tfvalidator.StringFormat(tfvalidator.DefaultFormat),
+				stringvalidator.NoneOfCaseInsensitive(junos.DefaultW),
+			},
+		},
+		"source_address": schema.StringAttribute{
+			Optional:    true,
+			Description: "Source IPv4 address for cflowd packets.",
+			Validators: []validator.String{
+				tfvalidator.StringIPAddress().IPv4Only(),
+			},
+		},
+		"version": schema.Int64Attribute{
+			Optional:    true,
+			Description: "Format of exported cflowd aggregates.",
+			Validators: []validator.Int64{
+				int64validator.OneOf(5, 8),
+			},
+		},
+		"version9_template": schema.StringAttribute{
+			Optional:    true,
+			Description: "Template to export data in version 9 format.",
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 250),
+				tfvalidator.StringDoubleQuoteExclusion(),
+			},
+		},
+		"version_ipfix_template": schema.StringAttribute{
+			Optional:    true,
+			Description: "Template to export data in version ipfix format.",
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 250),
+				tfvalidator.StringDoubleQuoteExclusion(),
+			},
+		},
+	}
+}
+
 //nolint:lll
 type forwardingoptionsSamplingInstanceBlockFamilyInet6Output struct {
 	AggregateExportInterval  types.Int64                                                   `tfsdk:"aggregate_export_interval"`
@@ -560,132 +527,7 @@ func (forwardingoptionsSamplingInstanceBlockFamilyInet6Output) blocksSchema() ma
 		"flow_server": schema.SetNestedBlock{
 			Description: "For each hostname, configure sending traffic aggregates in cflowd format.",
 			NestedObject: schema.NestedBlockObject{
-				Attributes: map[string]schema.Attribute{
-					"hostname": schema.StringAttribute{
-						Required:    true,
-						Description: "Name of host collecting cflowd packets.",
-						Validators: []validator.String{
-							tfvalidator.StringIPAddress(),
-						},
-					},
-					"port": schema.Int64Attribute{
-						Required:    true,
-						Description: "UDP port number on host collecting cflowd packets (1..65535).",
-						Validators: []validator.Int64{
-							int64validator.Between(1, 65535),
-						},
-					},
-					"aggregation_autonomous_system": schema.BoolAttribute{
-						Optional:    true,
-						Description: "Aggregate by autonomous system number.",
-						Validators: []validator.Bool{
-							tfvalidator.BoolTrue(),
-						},
-					},
-					"aggregation_destination_prefix": schema.BoolAttribute{
-						Optional:    true,
-						Description: "Aggregate by destination prefix.",
-						Validators: []validator.Bool{
-							tfvalidator.BoolTrue(),
-						},
-					},
-					"aggregation_protocol_port": schema.BoolAttribute{
-						Optional:    true,
-						Description: "Aggregate by protocol and port number.",
-						Validators: []validator.Bool{
-							tfvalidator.BoolTrue(),
-						},
-					},
-					"aggregation_source_destination_prefix": schema.BoolAttribute{
-						Optional:    true,
-						Description: "Aggregate by source and destination prefix.",
-						Validators: []validator.Bool{
-							tfvalidator.BoolTrue(),
-						},
-					},
-					"aggregation_source_destination_prefix_caida_compliant": schema.BoolAttribute{
-						Optional:    true,
-						Description: "Compatible with Caida record format for prefix aggregation (v8).",
-						Validators: []validator.Bool{
-							tfvalidator.BoolTrue(),
-						},
-					},
-					"aggregation_source_prefix": schema.BoolAttribute{
-						Optional:    true,
-						Description: "Aggregate by source prefix.",
-						Validators: []validator.Bool{
-							tfvalidator.BoolTrue(),
-						},
-					},
-					"autonomous_system_type": schema.StringAttribute{
-						Optional:    true,
-						Description: "Type of autonomous system number to export.",
-						Validators: []validator.String{
-							stringvalidator.OneOf("origin", "peer"),
-						},
-					},
-					"dscp": schema.Int64Attribute{
-						Optional:    true,
-						Description: "Numeric DSCP value in the range 0 to 63 (0..63).",
-						Validators: []validator.Int64{
-							int64validator.Between(0, 63),
-						},
-					},
-					"forwarding_class": schema.StringAttribute{
-						Optional:    true,
-						Description: "Forwarding-class for exported jflow packets, applicable only for inline-jflow.",
-						Validators: []validator.String{
-							stringvalidator.LengthBetween(1, 64),
-							tfvalidator.StringDoubleQuoteExclusion(),
-						},
-					},
-					"local_dump": schema.BoolAttribute{
-						Optional:    true,
-						Description: "Dump cflowd records to log file before exporting.",
-						Validators: []validator.Bool{
-							tfvalidator.BoolTrue(),
-						},
-					},
-					"no_local_dump": schema.BoolAttribute{
-						Optional:    true,
-						Description: "Don't dump cflowd records to log file before exporting.",
-						Validators: []validator.Bool{
-							tfvalidator.BoolTrue(),
-						},
-					},
-					"routing_instance": schema.StringAttribute{
-						Optional:    true,
-						Description: "Name of routing instance on which flow collector is reachable.",
-						Validators: []validator.String{
-							stringvalidator.LengthBetween(1, 63),
-							tfvalidator.StringFormat(tfvalidator.DefaultFormat),
-							stringvalidator.NoneOfCaseInsensitive(junos.DefaultW),
-						},
-					},
-					"source_address": schema.StringAttribute{
-						Optional:    true,
-						Description: "Source IPv4 address for cflowd packets",
-						Validators: []validator.String{
-							tfvalidator.StringIPAddress().IPv4Only(),
-						},
-					},
-					"version9_template": schema.StringAttribute{
-						Optional:    true,
-						Description: "Template to export data in version 9 format.",
-						Validators: []validator.String{
-							stringvalidator.LengthBetween(1, 250),
-							tfvalidator.StringDoubleQuoteExclusion(),
-						},
-					},
-					"version_ipfix_template": schema.StringAttribute{
-						Optional:    true,
-						Description: "Template to export data in version ipfix format.",
-						Validators: []validator.String{
-							stringvalidator.LengthBetween(1, 250),
-							tfvalidator.StringDoubleQuoteExclusion(),
-						},
-					},
-				},
+				Attributes: forwardingoptionsSamplingInstanceBlockOutputBlockFlowServer{}.attributesSchema(),
 			},
 		},
 		"interface": schema.ListNestedBlock{
@@ -706,6 +548,13 @@ type forwardingoptionsSamplingInstanceBlockFamilyMplsOutput struct {
 	InlineJflowSourceAddress types.String                                                  `tfsdk:"inline_jflow_source_address"`
 	FlowServer               []forwardingoptionsSamplingInstanceBlockOutputBlockFlowServer `tfsdk:"flow_server"`
 	Interface                []forwardingoptionsSamplingInstanceBlockOutputBlockInterface  `tfsdk:"interface"`
+}
+
+func (forwardingoptionsSamplingInstanceBlockFamilyMplsOutput) attributesSchema() map[string]schema.Attribute {
+	attributes := forwardingoptionsSamplingInstanceBlockFamilyInetOutput{}.attributesSchema()
+	delete(attributes, "extension_service")
+
+	return attributes
 }
 
 func (forwardingoptionsSamplingInstanceBlockFamilyMplsOutput) blocksSchema() map[string]schema.Block {
@@ -745,6 +594,13 @@ type forwardingoptionsSamplingInstanceBlockOutputBlockFlowServer struct {
 	SourceAddress                                    types.String `tfsdk:"source_address"`
 	Version9Template                                 types.String `tfsdk:"version9_template"`
 	VersionIPFixTemplate                             types.String `tfsdk:"version_ipfix_template"`
+}
+
+func (forwardingoptionsSamplingInstanceBlockOutputBlockFlowServer) attributesSchema() map[string]schema.Attribute {
+	attributes := forwardingoptionsSamplingInstanceBlockFamilyInetOutputBlockFlowServer{}.attributesSchema()
+	delete(attributes, "version")
+
+	return attributes
 }
 
 type forwardingoptionsSamplingInstanceBlockOutputBlockInterface struct {

--- a/internal/providerfwk/resource_interface_physical.go
+++ b/internal/providerfwk/resource_interface_physical.go
@@ -302,14 +302,14 @@ func (rsc *interfacePhysical) Schema(
 			},
 			"ether_opts": schema.SingleNestedBlock{
 				Description: "Declare `ether-options` configuration.",
-				Attributes:  rsc.schemaEtherOptsAttributes(),
+				Attributes:  interfacePhysicalBlockEtherOpts{}.attributesSchema(),
 				PlanModifiers: []planmodifier.Object{
 					tfplanmodifier.BlockRemoveNull(),
 				},
 			},
 			"gigether_opts": schema.SingleNestedBlock{
 				Description: "Declare `gigether-options` configuration.",
-				Attributes:  rsc.schemaEtherOptsAttributes(),
+				Attributes:  interfacePhysicalBlockEtherOpts{}.attributesSchema(),
 				PlanModifiers: []planmodifier.Object{
 					tfplanmodifier.BlockRemoveNull(),
 				},
@@ -672,71 +672,6 @@ func (rsc *interfacePhysical) Schema(
 	}
 }
 
-func (rsc *interfacePhysical) schemaEtherOptsAttributes() map[string]schema.Attribute {
-	return map[string]schema.Attribute{
-		"ae_8023ad": schema.StringAttribute{
-			Optional:    true,
-			Description: "Name of an aggregated Ethernet interface to join.",
-			Validators: []validator.String{
-				stringvalidator.RegexMatches(regexp.MustCompile(
-					`^ae\d+$`),
-					"must be an ae interface"),
-			},
-		},
-		"auto_negotiation": schema.BoolAttribute{
-			Optional:    true,
-			Description: "Enable auto-negotiation.",
-			Validators: []validator.Bool{
-				tfvalidator.BoolTrue(),
-			},
-		},
-		"no_auto_negotiation": schema.BoolAttribute{
-			Optional:    true,
-			Description: "Don't enable auto-negotiation.",
-			Validators: []validator.Bool{
-				tfvalidator.BoolTrue(),
-			},
-		},
-		"flow_control": schema.BoolAttribute{
-			Optional:    true,
-			Description: "Enable flow control.",
-			Validators: []validator.Bool{
-				tfvalidator.BoolTrue(),
-			},
-		},
-		"no_flow_control": schema.BoolAttribute{
-			Optional:    true,
-			Description: "Don't enable flow control.",
-			Validators: []validator.Bool{
-				tfvalidator.BoolTrue(),
-			},
-		},
-		"loopback": schema.BoolAttribute{
-			Optional:    true,
-			Description: "Enable loopback.",
-			Validators: []validator.Bool{
-				tfvalidator.BoolTrue(),
-			},
-		},
-		"no_loopback": schema.BoolAttribute{
-			Optional:    true,
-			Description: "Don't enable loopback.",
-			Validators: []validator.Bool{
-				tfvalidator.BoolTrue(),
-			},
-		},
-		"redundant_parent": schema.StringAttribute{
-			Optional:    true,
-			Description: "Name of a redundant ethernet interface to join.",
-			Validators: []validator.String{
-				stringvalidator.RegexMatches(regexp.MustCompile(
-					`^reth\d+$`),
-					"must be a reth interface"),
-			},
-		},
-	}
-}
-
 type interfacePhysicalData struct {
 	ID                     types.String                           `tfsdk:"id"`
 	Name                   types.String                           `tfsdk:"name"`
@@ -812,6 +747,71 @@ type interfacePhysicalBlockEtherOpts struct {
 	Loopback          types.Bool   `tfsdk:"loopback"`
 	NoLoopback        types.Bool   `tfsdk:"no_loopback"`
 	RedundantParent   types.String `tfsdk:"redundant_parent"`
+}
+
+func (interfacePhysicalBlockEtherOpts) attributesSchema() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"ae_8023ad": schema.StringAttribute{
+			Optional:    true,
+			Description: "Name of an aggregated Ethernet interface to join.",
+			Validators: []validator.String{
+				stringvalidator.RegexMatches(regexp.MustCompile(
+					`^ae\d+$`),
+					"must be an ae interface"),
+			},
+		},
+		"auto_negotiation": schema.BoolAttribute{
+			Optional:    true,
+			Description: "Enable auto-negotiation.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+		"no_auto_negotiation": schema.BoolAttribute{
+			Optional:    true,
+			Description: "Don't enable auto-negotiation.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+		"flow_control": schema.BoolAttribute{
+			Optional:    true,
+			Description: "Enable flow control.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+		"no_flow_control": schema.BoolAttribute{
+			Optional:    true,
+			Description: "Don't enable flow control.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+		"loopback": schema.BoolAttribute{
+			Optional:    true,
+			Description: "Enable loopback.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+		"no_loopback": schema.BoolAttribute{
+			Optional:    true,
+			Description: "Don't enable loopback.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+		"redundant_parent": schema.StringAttribute{
+			Optional:    true,
+			Description: "Name of a redundant ethernet interface to join.",
+			Validators: []validator.String{
+				stringvalidator.RegexMatches(regexp.MustCompile(
+					`^reth\d+$`),
+					"must be a reth interface"),
+			},
+		},
+	}
 }
 
 func (block *interfacePhysicalBlockEtherOpts) isEmpty() bool {

--- a/internal/providerfwk/resource_policyoptions_policy_statement.go
+++ b/internal/providerfwk/resource_policyoptions_policy_statement.go
@@ -122,23 +122,23 @@ func (rsc *policyoptionsPolicyStatement) Schema(
 		Blocks: map[string]schema.Block{
 			"from": schema.SingleNestedBlock{
 				Description: "Conditions to match the source of a route.",
-				Attributes:  rsc.schemaFromAttributes(),
-				Blocks:      rsc.schemaFromBlocks(),
+				Attributes:  policyoptionsPolicyStatementBlockFrom{}.attributesSchema(),
+				Blocks:      policyoptionsPolicyStatementBlockFrom{}.blocksSchema(),
 				PlanModifiers: []planmodifier.Object{
 					tfplanmodifier.BlockRemoveNull(),
 				},
 			},
 			"to": schema.SingleNestedBlock{
 				Description: "Conditions to match the destination of a route.",
-				Attributes:  rsc.schemaToAttributes(),
+				Attributes:  policyoptionsPolicyStatementBlockTo{}.attributesSchema(),
 				PlanModifiers: []planmodifier.Object{
 					tfplanmodifier.BlockRemoveNull(),
 				},
 			},
 			"then": schema.SingleNestedBlock{
 				Description: "Actions to take if 'from' and 'to' conditions match.",
-				Attributes:  rsc.schemaThenAttributes(),
-				Blocks:      rsc.schemaThenBlocks(),
+				Attributes:  policyoptionsPolicyStatementBlockThen{}.attributesSchema(),
+				Blocks:      policyoptionsPolicyStatementBlockThen{}.blocksSchema(),
 				PlanModifiers: []planmodifier.Object{
 					tfplanmodifier.BlockRemoveNull(),
 				},
@@ -159,23 +159,23 @@ func (rsc *policyoptionsPolicyStatement) Schema(
 					Blocks: map[string]schema.Block{
 						"from": schema.SingleNestedBlock{
 							Description: "Conditions to match the source of a route.",
-							Attributes:  rsc.schemaFromAttributes(),
-							Blocks:      rsc.schemaFromBlocks(),
+							Attributes:  policyoptionsPolicyStatementBlockFrom{}.attributesSchema(),
+							Blocks:      policyoptionsPolicyStatementBlockFrom{}.blocksSchema(),
 							PlanModifiers: []planmodifier.Object{
 								tfplanmodifier.BlockRemoveNull(),
 							},
 						},
 						"to": schema.SingleNestedBlock{
 							Description: "Conditions to match the destination of a route.",
-							Attributes:  rsc.schemaToAttributes(),
+							Attributes:  policyoptionsPolicyStatementBlockTo{}.attributesSchema(),
 							PlanModifiers: []planmodifier.Object{
 								tfplanmodifier.BlockRemoveNull(),
 							},
 						},
 						"then": schema.SingleNestedBlock{
 							Description: "Actions to take if 'from' and 'to' conditions match",
-							Attributes:  rsc.schemaThenAttributes(),
-							Blocks:      rsc.schemaThenBlocks(),
+							Attributes:  policyoptionsPolicyStatementBlockThen{}.attributesSchema(),
+							Blocks:      policyoptionsPolicyStatementBlockThen{}.blocksSchema(),
 							PlanModifiers: []planmodifier.Object{
 								tfplanmodifier.BlockRemoveNull(),
 							},
@@ -187,7 +187,87 @@ func (rsc *policyoptionsPolicyStatement) Schema(
 	}
 }
 
-func (rsc *policyoptionsPolicyStatement) schemaFromAttributes() map[string]schema.Attribute {
+type policyoptionsPolicyStatementData struct {
+	ID                           types.String                            `tfsdk:"id"`
+	Name                         types.String                            `tfsdk:"name"`
+	AddItToForwardingTableExport types.Bool                              `tfsdk:"add_it_to_forwarding_table_export"`
+	DynamicDB                    types.Bool                              `tfsdk:"dynamic_db"`
+	From                         *policyoptionsPolicyStatementBlockFrom  `tfsdk:"from"`
+	To                           *policyoptionsPolicyStatementBlockTo    `tfsdk:"to"`
+	Then                         *policyoptionsPolicyStatementBlockThen  `tfsdk:"then"`
+	Term                         []policyoptionsPolicyStatementBlockTerm `tfsdk:"term"`
+}
+
+type policyoptionsPolicyStatementConfig struct {
+	ID                           types.String                                 `tfsdk:"id"`
+	Name                         types.String                                 `tfsdk:"name"`
+	AddItToForwardingTableExport types.Bool                                   `tfsdk:"add_it_to_forwarding_table_export"`
+	DynamicDB                    types.Bool                                   `tfsdk:"dynamic_db"`
+	From                         *policyoptionsPolicyStatementBlockFromConfig `tfsdk:"from"`
+	To                           *policyoptionsPolicyStatementBlockToConfig   `tfsdk:"to"`
+	Then                         *policyoptionsPolicyStatementBlockThenConfig `tfsdk:"then"`
+	Term                         types.List                                   `tfsdk:"term"`
+}
+
+type policyoptionsPolicyStatementBlockTerm struct {
+	Name types.String                           `tfsdk:"name"`
+	From *policyoptionsPolicyStatementBlockFrom `tfsdk:"from"`
+	To   *policyoptionsPolicyStatementBlockTo   `tfsdk:"to"`
+	Then *policyoptionsPolicyStatementBlockThen `tfsdk:"then"`
+}
+
+func (block *policyoptionsPolicyStatementBlockTerm) isEmpty() bool {
+	return tfdata.CheckBlockIsEmpty(block, "Name")
+}
+
+type policyoptionsPolicyStatementBlockTermConfig struct {
+	Name types.String                                 `tfsdk:"name"`
+	From *policyoptionsPolicyStatementBlockFromConfig `tfsdk:"from"`
+	To   *policyoptionsPolicyStatementBlockToConfig   `tfsdk:"to"`
+	Then *policyoptionsPolicyStatementBlockThenConfig `tfsdk:"then"`
+}
+
+func (block *policyoptionsPolicyStatementBlockTermConfig) isEmpty() bool {
+	return tfdata.CheckBlockIsEmpty(block, "Name")
+}
+
+type policyoptionsPolicyStatementBlockFrom struct {
+	AggregateContributor types.Bool                                              `tfsdk:"aggregate_contributor"`
+	BgpASPath            []types.String                                          `tfsdk:"bgp_as_path"`
+	BgpASPathGroup       []types.String                                          `tfsdk:"bgp_as_path_group"`
+	BgpCommunity         []types.String                                          `tfsdk:"bgp_community"`
+	BgpOrigin            types.String                                            `tfsdk:"bgp_origin"`
+	BgpSrteDiscriminator types.Int64                                             `tfsdk:"bgp_srte_discriminator"`
+	Color                types.Int64                                             `tfsdk:"color"`
+	EvpnESI              []types.String                                          `tfsdk:"evpn_esi"`
+	EvpnMACRoute         types.String                                            `tfsdk:"evpn_mac_route"`
+	EvpnTag              []types.Int64                                           `tfsdk:"evpn_tag"`
+	Family               types.String                                            `tfsdk:"family"`
+	LocalPreference      types.Int64                                             `tfsdk:"local_preference"`
+	Interface            []types.String                                          `tfsdk:"interface"`
+	Metric               types.Int64                                             `tfsdk:"metric"`
+	Neighbor             []types.String                                          `tfsdk:"neighbor"`
+	NextHop              []types.String                                          `tfsdk:"next_hop"`
+	NextHopTypeMerged    types.Bool                                              `tfsdk:"next_hop_type_merged"`
+	OspfArea             types.String                                            `tfsdk:"ospf_area"`
+	Policy               []types.String                                          `tfsdk:"policy"`
+	Preference           types.Int64                                             `tfsdk:"preference"`
+	PrefixList           []types.String                                          `tfsdk:"prefix_list"`
+	Protocol             []types.String                                          `tfsdk:"protocol"`
+	RouteType            types.String                                            `tfsdk:"route_type"`
+	RoutingInstance      types.String                                            `tfsdk:"routing_instance"`
+	SrteColor            types.Int64                                             `tfsdk:"srte_color"`
+	State                types.String                                            `tfsdk:"state"`
+	TunnelType           []types.String                                          `tfsdk:"tunnel_type"`
+	ValidationDatabase   types.String                                            `tfsdk:"validation_database"`
+	BgpASPathCalcLength  []policyoptionsPolicyStatementBlockFromBlockCountMatch  `tfsdk:"bgp_as_path_calc_length"`
+	BgpASPathUniqueCount []policyoptionsPolicyStatementBlockFromBlockCountMatch  `tfsdk:"bgp_as_path_unique_count"`
+	BgpCommunityCount    []policyoptionsPolicyStatementBlockFromBlockCountMatch  `tfsdk:"bgp_community_count"`
+	NextHopWeight        []policyoptionsPolicyStatementBlockFromBlockMatchWeight `tfsdk:"next_hop_weight"`
+	RouteFilter          []policyoptionsPolicyStatementBlockFromBlockRouteFilter `tfsdk:"route_filter"`
+}
+
+func (policyoptionsPolicyStatementBlockFrom) attributesSchema() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"aggregate_contributor": schema.BoolAttribute{
 			Optional:    true,
@@ -452,7 +532,7 @@ func (rsc *policyoptionsPolicyStatement) schemaFromAttributes() map[string]schem
 	}
 }
 
-func (rsc *policyoptionsPolicyStatement) schemaFromBlocks() map[string]schema.Block {
+func (policyoptionsPolicyStatementBlockFrom) blocksSchema() map[string]schema.Block {
 	return map[string]schema.Block{
 		"bgp_as_path_calc_length": schema.SetNestedBlock{
 			Description: "Number of BGP ASes excluding confederations.",
@@ -573,7 +653,85 @@ func (rsc *policyoptionsPolicyStatement) schemaFromBlocks() map[string]schema.Bl
 	}
 }
 
-func (rsc *policyoptionsPolicyStatement) schemaToAttributes() map[string]schema.Attribute {
+func (block *policyoptionsPolicyStatementBlockFrom) isEmpty() bool {
+	return tfdata.CheckBlockIsEmpty(block)
+}
+
+type policyoptionsPolicyStatementBlockFromConfig struct {
+	AggregateContributor types.Bool   `tfsdk:"aggregate_contributor"`
+	BgpASPath            types.Set    `tfsdk:"bgp_as_path"`
+	BgpASPathGroup       types.Set    `tfsdk:"bgp_as_path_group"`
+	BgpCommunity         types.Set    `tfsdk:"bgp_community"`
+	BgpOrigin            types.String `tfsdk:"bgp_origin"`
+	BgpSrteDiscriminator types.Int64  `tfsdk:"bgp_srte_discriminator"`
+	Color                types.Int64  `tfsdk:"color"`
+	EvpnESI              types.Set    `tfsdk:"evpn_esi"`
+	EvpnMACRoute         types.String `tfsdk:"evpn_mac_route"`
+	EvpnTag              types.Set    `tfsdk:"evpn_tag"`
+	Family               types.String `tfsdk:"family"`
+	LocalPreference      types.Int64  `tfsdk:"local_preference"`
+	Interface            types.Set    `tfsdk:"interface"`
+	Metric               types.Int64  `tfsdk:"metric"`
+	Neighbor             types.Set    `tfsdk:"neighbor"`
+	NextHop              types.Set    `tfsdk:"next_hop"`
+	NextHopTypeMerged    types.Bool   `tfsdk:"next_hop_type_merged"`
+	OspfArea             types.String `tfsdk:"ospf_area"`
+	Policy               types.List   `tfsdk:"policy"`
+	Preference           types.Int64  `tfsdk:"preference"`
+	PrefixList           types.Set    `tfsdk:"prefix_list"`
+	Protocol             types.Set    `tfsdk:"protocol"`
+	RouteType            types.String `tfsdk:"route_type"`
+	RoutingInstance      types.String `tfsdk:"routing_instance"`
+	SrteColor            types.Int64  `tfsdk:"srte_color"`
+	State                types.String `tfsdk:"state"`
+	TunnelType           types.Set    `tfsdk:"tunnel_type"`
+	ValidationDatabase   types.String `tfsdk:"validation_database"`
+	BgpASPathCalcLength  types.Set    `tfsdk:"bgp_as_path_calc_length"`
+	BgpASPathUniqueCount types.Set    `tfsdk:"bgp_as_path_unique_count"`
+	BgpCommunityCount    types.Set    `tfsdk:"bgp_community_count"`
+	NextHopWeight        types.Set    `tfsdk:"next_hop_weight"`
+	RouteFilter          types.List   `tfsdk:"route_filter"`
+}
+
+func (block *policyoptionsPolicyStatementBlockFromConfig) isEmpty() bool {
+	return tfdata.CheckBlockIsEmpty(block)
+}
+
+type policyoptionsPolicyStatementBlockFromBlockCountMatch struct {
+	Count types.Int64  `tfsdk:"count"`
+	Match types.String `tfsdk:"match"`
+}
+
+type policyoptionsPolicyStatementBlockFromBlockMatchWeight struct {
+	Match  types.String `tfsdk:"match"`
+	Weight types.Int64  `tfsdk:"weight"`
+}
+
+type policyoptionsPolicyStatementBlockFromBlockRouteFilter struct {
+	Route       types.String `tfsdk:"route"`
+	Option      types.String `tfsdk:"option"`
+	OptionValue types.String `tfsdk:"option_value"`
+}
+
+type policyoptionsPolicyStatementBlockTo struct {
+	BgpASPath       []types.String `tfsdk:"bgp_as_path"`
+	BgpASPathGroup  []types.String `tfsdk:"bgp_as_path_group"`
+	BgpCommunity    []types.String `tfsdk:"bgp_community"`
+	BgpOrigin       types.String   `tfsdk:"bgp_origin"`
+	Family          types.String   `tfsdk:"family"`
+	LocalPreference types.Int64    `tfsdk:"local_preference"`
+	Interface       []types.String `tfsdk:"interface"`
+	Metric          types.Int64    `tfsdk:"metric"`
+	Neighbor        []types.String `tfsdk:"neighbor"`
+	NextHop         []types.String `tfsdk:"next_hop"`
+	OspfArea        types.String   `tfsdk:"ospf_area"`
+	Policy          []types.String `tfsdk:"policy"`
+	Preference      types.Int64    `tfsdk:"preference"`
+	Protocol        []types.String `tfsdk:"protocol"`
+	RoutingInstance types.String   `tfsdk:"routing_instance"`
+}
+
+func (policyoptionsPolicyStatementBlockTo) attributesSchema() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"bgp_as_path": schema.SetAttribute{
 			ElementType: types.StringType,
@@ -728,7 +886,48 @@ func (rsc *policyoptionsPolicyStatement) schemaToAttributes() map[string]schema.
 	}
 }
 
-func (rsc *policyoptionsPolicyStatement) schemaThenAttributes() map[string]schema.Attribute {
+func (block *policyoptionsPolicyStatementBlockTo) isEmpty() bool {
+	return tfdata.CheckBlockIsEmpty(block)
+}
+
+type policyoptionsPolicyStatementBlockToConfig struct {
+	BgpASPath       types.Set    `tfsdk:"bgp_as_path"`
+	BgpASPathGroup  types.Set    `tfsdk:"bgp_as_path_group"`
+	BgpCommunity    types.Set    `tfsdk:"bgp_community"`
+	BgpOrigin       types.String `tfsdk:"bgp_origin"`
+	Family          types.String `tfsdk:"family"`
+	LocalPreference types.Int64  `tfsdk:"local_preference"`
+	Interface       types.Set    `tfsdk:"interface"`
+	Metric          types.Int64  `tfsdk:"metric"`
+	Neighbor        types.Set    `tfsdk:"neighbor"`
+	NextHop         types.Set    `tfsdk:"next_hop"`
+	OspfArea        types.String `tfsdk:"ospf_area"`
+	Policy          types.List   `tfsdk:"policy"`
+	Preference      types.Int64  `tfsdk:"preference"`
+	Protocol        types.Set    `tfsdk:"protocol"`
+	RoutingInstance types.String `tfsdk:"routing_instance"`
+}
+
+func (block *policyoptionsPolicyStatementBlockToConfig) isEmpty() bool {
+	return tfdata.CheckBlockIsEmpty(block)
+}
+
+type policyoptionsPolicyStatementBlockThen struct {
+	Action          types.String                                                `tfsdk:"action"`
+	ASPathExpand    types.String                                                `tfsdk:"as_path_expand"`
+	ASPathPrepend   types.String                                                `tfsdk:"as_path_prepend"`
+	DefaultAction   types.String                                                `tfsdk:"default_action"`
+	LoadBalance     types.String                                                `tfsdk:"load_balance"`
+	Next            types.String                                                `tfsdk:"next"`
+	NextHop         types.String                                                `tfsdk:"next_hop"`
+	Origin          types.String                                                `tfsdk:"origin"`
+	Community       []policyoptionsPolicyStatementBlockThenBlockActionValue     `tfsdk:"community"`
+	LocalPreference *policyoptionsPolicyStatementBlockThenBlockActionValueInt64 `tfsdk:"local_preference"`
+	Metric          *policyoptionsPolicyStatementBlockThenBlockActionValueInt64 `tfsdk:"metric"`
+	Preference      *policyoptionsPolicyStatementBlockThenBlockActionValueInt64 `tfsdk:"preference"`
+}
+
+func (policyoptionsPolicyStatementBlockThen) attributesSchema() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"action": schema.StringAttribute{
 			Optional:    true,
@@ -795,7 +994,7 @@ func (rsc *policyoptionsPolicyStatement) schemaThenAttributes() map[string]schem
 	}
 }
 
-func (rsc *policyoptionsPolicyStatement) schemaThenBlocks() map[string]schema.Block {
+func (policyoptionsPolicyStatementBlockThen) blocksSchema() map[string]schema.Block {
 	return map[string]schema.Block{
 		"community": schema.ListNestedBlock{
 			Description: "For each community action.",
@@ -892,205 +1091,6 @@ func (rsc *policyoptionsPolicyStatement) schemaThenBlocks() map[string]schema.Bl
 			},
 		},
 	}
-}
-
-type policyoptionsPolicyStatementData struct {
-	ID                           types.String                            `tfsdk:"id"`
-	Name                         types.String                            `tfsdk:"name"`
-	AddItToForwardingTableExport types.Bool                              `tfsdk:"add_it_to_forwarding_table_export"`
-	DynamicDB                    types.Bool                              `tfsdk:"dynamic_db"`
-	From                         *policyoptionsPolicyStatementBlockFrom  `tfsdk:"from"`
-	To                           *policyoptionsPolicyStatementBlockTo    `tfsdk:"to"`
-	Then                         *policyoptionsPolicyStatementBlockThen  `tfsdk:"then"`
-	Term                         []policyoptionsPolicyStatementBlockTerm `tfsdk:"term"`
-}
-
-type policyoptionsPolicyStatementConfig struct {
-	ID                           types.String                                 `tfsdk:"id"`
-	Name                         types.String                                 `tfsdk:"name"`
-	AddItToForwardingTableExport types.Bool                                   `tfsdk:"add_it_to_forwarding_table_export"`
-	DynamicDB                    types.Bool                                   `tfsdk:"dynamic_db"`
-	From                         *policyoptionsPolicyStatementBlockFromConfig `tfsdk:"from"`
-	To                           *policyoptionsPolicyStatementBlockToConfig   `tfsdk:"to"`
-	Then                         *policyoptionsPolicyStatementBlockThenConfig `tfsdk:"then"`
-	Term                         types.List                                   `tfsdk:"term"`
-}
-
-type policyoptionsPolicyStatementBlockTerm struct {
-	Name types.String                           `tfsdk:"name"`
-	From *policyoptionsPolicyStatementBlockFrom `tfsdk:"from"`
-	To   *policyoptionsPolicyStatementBlockTo   `tfsdk:"to"`
-	Then *policyoptionsPolicyStatementBlockThen `tfsdk:"then"`
-}
-
-func (block *policyoptionsPolicyStatementBlockTerm) isEmpty() bool {
-	return tfdata.CheckBlockIsEmpty(block, "Name")
-}
-
-type policyoptionsPolicyStatementBlockTermConfig struct {
-	Name types.String                                 `tfsdk:"name"`
-	From *policyoptionsPolicyStatementBlockFromConfig `tfsdk:"from"`
-	To   *policyoptionsPolicyStatementBlockToConfig   `tfsdk:"to"`
-	Then *policyoptionsPolicyStatementBlockThenConfig `tfsdk:"then"`
-}
-
-func (block *policyoptionsPolicyStatementBlockTermConfig) isEmpty() bool {
-	return tfdata.CheckBlockIsEmpty(block, "Name")
-}
-
-type policyoptionsPolicyStatementBlockFrom struct {
-	AggregateContributor types.Bool                                              `tfsdk:"aggregate_contributor"`
-	BgpASPath            []types.String                                          `tfsdk:"bgp_as_path"`
-	BgpASPathGroup       []types.String                                          `tfsdk:"bgp_as_path_group"`
-	BgpCommunity         []types.String                                          `tfsdk:"bgp_community"`
-	BgpOrigin            types.String                                            `tfsdk:"bgp_origin"`
-	BgpSrteDiscriminator types.Int64                                             `tfsdk:"bgp_srte_discriminator"`
-	Color                types.Int64                                             `tfsdk:"color"`
-	EvpnESI              []types.String                                          `tfsdk:"evpn_esi"`
-	EvpnMACRoute         types.String                                            `tfsdk:"evpn_mac_route"`
-	EvpnTag              []types.Int64                                           `tfsdk:"evpn_tag"`
-	Family               types.String                                            `tfsdk:"family"`
-	LocalPreference      types.Int64                                             `tfsdk:"local_preference"`
-	Interface            []types.String                                          `tfsdk:"interface"`
-	Metric               types.Int64                                             `tfsdk:"metric"`
-	Neighbor             []types.String                                          `tfsdk:"neighbor"`
-	NextHop              []types.String                                          `tfsdk:"next_hop"`
-	NextHopTypeMerged    types.Bool                                              `tfsdk:"next_hop_type_merged"`
-	OspfArea             types.String                                            `tfsdk:"ospf_area"`
-	Policy               []types.String                                          `tfsdk:"policy"`
-	Preference           types.Int64                                             `tfsdk:"preference"`
-	PrefixList           []types.String                                          `tfsdk:"prefix_list"`
-	Protocol             []types.String                                          `tfsdk:"protocol"`
-	RouteType            types.String                                            `tfsdk:"route_type"`
-	RoutingInstance      types.String                                            `tfsdk:"routing_instance"`
-	SrteColor            types.Int64                                             `tfsdk:"srte_color"`
-	State                types.String                                            `tfsdk:"state"`
-	TunnelType           []types.String                                          `tfsdk:"tunnel_type"`
-	ValidationDatabase   types.String                                            `tfsdk:"validation_database"`
-	BgpASPathCalcLength  []policyoptionsPolicyStatementBlockFromBlockCountMatch  `tfsdk:"bgp_as_path_calc_length"`
-	BgpASPathUniqueCount []policyoptionsPolicyStatementBlockFromBlockCountMatch  `tfsdk:"bgp_as_path_unique_count"`
-	BgpCommunityCount    []policyoptionsPolicyStatementBlockFromBlockCountMatch  `tfsdk:"bgp_community_count"`
-	NextHopWeight        []policyoptionsPolicyStatementBlockFromBlockMatchWeight `tfsdk:"next_hop_weight"`
-	RouteFilter          []policyoptionsPolicyStatementBlockFromBlockRouteFilter `tfsdk:"route_filter"`
-}
-
-func (block *policyoptionsPolicyStatementBlockFrom) isEmpty() bool {
-	return tfdata.CheckBlockIsEmpty(block)
-}
-
-type policyoptionsPolicyStatementBlockFromConfig struct {
-	AggregateContributor types.Bool   `tfsdk:"aggregate_contributor"`
-	BgpASPath            types.Set    `tfsdk:"bgp_as_path"`
-	BgpASPathGroup       types.Set    `tfsdk:"bgp_as_path_group"`
-	BgpCommunity         types.Set    `tfsdk:"bgp_community"`
-	BgpOrigin            types.String `tfsdk:"bgp_origin"`
-	BgpSrteDiscriminator types.Int64  `tfsdk:"bgp_srte_discriminator"`
-	Color                types.Int64  `tfsdk:"color"`
-	EvpnESI              types.Set    `tfsdk:"evpn_esi"`
-	EvpnMACRoute         types.String `tfsdk:"evpn_mac_route"`
-	EvpnTag              types.Set    `tfsdk:"evpn_tag"`
-	Family               types.String `tfsdk:"family"`
-	LocalPreference      types.Int64  `tfsdk:"local_preference"`
-	Interface            types.Set    `tfsdk:"interface"`
-	Metric               types.Int64  `tfsdk:"metric"`
-	Neighbor             types.Set    `tfsdk:"neighbor"`
-	NextHop              types.Set    `tfsdk:"next_hop"`
-	NextHopTypeMerged    types.Bool   `tfsdk:"next_hop_type_merged"`
-	OspfArea             types.String `tfsdk:"ospf_area"`
-	Policy               types.List   `tfsdk:"policy"`
-	Preference           types.Int64  `tfsdk:"preference"`
-	PrefixList           types.Set    `tfsdk:"prefix_list"`
-	Protocol             types.Set    `tfsdk:"protocol"`
-	RouteType            types.String `tfsdk:"route_type"`
-	RoutingInstance      types.String `tfsdk:"routing_instance"`
-	SrteColor            types.Int64  `tfsdk:"srte_color"`
-	State                types.String `tfsdk:"state"`
-	TunnelType           types.Set    `tfsdk:"tunnel_type"`
-	ValidationDatabase   types.String `tfsdk:"validation_database"`
-	BgpASPathCalcLength  types.Set    `tfsdk:"bgp_as_path_calc_length"`
-	BgpASPathUniqueCount types.Set    `tfsdk:"bgp_as_path_unique_count"`
-	BgpCommunityCount    types.Set    `tfsdk:"bgp_community_count"`
-	NextHopWeight        types.Set    `tfsdk:"next_hop_weight"`
-	RouteFilter          types.List   `tfsdk:"route_filter"`
-}
-
-func (block *policyoptionsPolicyStatementBlockFromConfig) isEmpty() bool {
-	return tfdata.CheckBlockIsEmpty(block)
-}
-
-type policyoptionsPolicyStatementBlockFromBlockCountMatch struct {
-	Count types.Int64  `tfsdk:"count"`
-	Match types.String `tfsdk:"match"`
-}
-
-type policyoptionsPolicyStatementBlockFromBlockMatchWeight struct {
-	Match  types.String `tfsdk:"match"`
-	Weight types.Int64  `tfsdk:"weight"`
-}
-
-type policyoptionsPolicyStatementBlockFromBlockRouteFilter struct {
-	Route       types.String `tfsdk:"route"`
-	Option      types.String `tfsdk:"option"`
-	OptionValue types.String `tfsdk:"option_value"`
-}
-
-type policyoptionsPolicyStatementBlockTo struct {
-	BgpASPath       []types.String `tfsdk:"bgp_as_path"`
-	BgpASPathGroup  []types.String `tfsdk:"bgp_as_path_group"`
-	BgpCommunity    []types.String `tfsdk:"bgp_community"`
-	BgpOrigin       types.String   `tfsdk:"bgp_origin"`
-	Family          types.String   `tfsdk:"family"`
-	LocalPreference types.Int64    `tfsdk:"local_preference"`
-	Interface       []types.String `tfsdk:"interface"`
-	Metric          types.Int64    `tfsdk:"metric"`
-	Neighbor        []types.String `tfsdk:"neighbor"`
-	NextHop         []types.String `tfsdk:"next_hop"`
-	OspfArea        types.String   `tfsdk:"ospf_area"`
-	Policy          []types.String `tfsdk:"policy"`
-	Preference      types.Int64    `tfsdk:"preference"`
-	Protocol        []types.String `tfsdk:"protocol"`
-	RoutingInstance types.String   `tfsdk:"routing_instance"`
-}
-
-func (block *policyoptionsPolicyStatementBlockTo) isEmpty() bool {
-	return tfdata.CheckBlockIsEmpty(block)
-}
-
-type policyoptionsPolicyStatementBlockToConfig struct {
-	BgpASPath       types.Set    `tfsdk:"bgp_as_path"`
-	BgpASPathGroup  types.Set    `tfsdk:"bgp_as_path_group"`
-	BgpCommunity    types.Set    `tfsdk:"bgp_community"`
-	BgpOrigin       types.String `tfsdk:"bgp_origin"`
-	Family          types.String `tfsdk:"family"`
-	LocalPreference types.Int64  `tfsdk:"local_preference"`
-	Interface       types.Set    `tfsdk:"interface"`
-	Metric          types.Int64  `tfsdk:"metric"`
-	Neighbor        types.Set    `tfsdk:"neighbor"`
-	NextHop         types.Set    `tfsdk:"next_hop"`
-	OspfArea        types.String `tfsdk:"ospf_area"`
-	Policy          types.List   `tfsdk:"policy"`
-	Preference      types.Int64  `tfsdk:"preference"`
-	Protocol        types.Set    `tfsdk:"protocol"`
-	RoutingInstance types.String `tfsdk:"routing_instance"`
-}
-
-func (block *policyoptionsPolicyStatementBlockToConfig) isEmpty() bool {
-	return tfdata.CheckBlockIsEmpty(block)
-}
-
-type policyoptionsPolicyStatementBlockThen struct {
-	Action          types.String                                                `tfsdk:"action"`
-	ASPathExpand    types.String                                                `tfsdk:"as_path_expand"`
-	ASPathPrepend   types.String                                                `tfsdk:"as_path_prepend"`
-	DefaultAction   types.String                                                `tfsdk:"default_action"`
-	LoadBalance     types.String                                                `tfsdk:"load_balance"`
-	Next            types.String                                                `tfsdk:"next"`
-	NextHop         types.String                                                `tfsdk:"next_hop"`
-	Origin          types.String                                                `tfsdk:"origin"`
-	Community       []policyoptionsPolicyStatementBlockThenBlockActionValue     `tfsdk:"community"`
-	LocalPreference *policyoptionsPolicyStatementBlockThenBlockActionValueInt64 `tfsdk:"local_preference"`
-	Metric          *policyoptionsPolicyStatementBlockThenBlockActionValueInt64 `tfsdk:"metric"`
-	Preference      *policyoptionsPolicyStatementBlockThenBlockActionValueInt64 `tfsdk:"preference"`
 }
 
 func (block *policyoptionsPolicyStatementBlockThen) isEmpty() bool {

--- a/internal/providerfwk/resource_rip_group.go
+++ b/internal/providerfwk/resource_rip_group.go
@@ -196,7 +196,7 @@ func (rsc *ripGroup) Schema(
 			},
 		},
 		Blocks: map[string]schema.Block{
-			"bfd_liveness_detection": ripBlockBfdLivenessDetection{}.resourceSchema(),
+			"bfd_liveness_detection": ripBlockBfdLivenessDetection{}.schema(),
 		},
 	}
 }

--- a/internal/providerfwk/resource_rip_neighbor.go
+++ b/internal/providerfwk/resource_rip_neighbor.go
@@ -310,7 +310,7 @@ func (rsc *ripNeighbor) Schema(
 					},
 				},
 			},
-			"bfd_liveness_detection": ripBlockBfdLivenessDetection{}.resourceSchema(),
+			"bfd_liveness_detection": ripBlockBfdLivenessDetection{}.schema(),
 		},
 	}
 }

--- a/internal/providerfwk/resource_security_address_book.go
+++ b/internal/providerfwk/resource_security_address_book.go
@@ -80,236 +80,36 @@ func (rsc *securityAddressBook) Schema(
 ) {
 	resp.Schema = schema.Schema{
 		Description: defaultResourceSchemaDescription(rsc),
-		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{
-				Computed:    true,
-				Description: "An identifier for the resource with format `<name>`.",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
-			"name": schema.StringAttribute{
-				Optional:    true,
-				Computed:    true,
-				Default:     stringdefault.StaticString("global"),
-				Description: "The name of address book.",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
-				Validators: []validator.String{
-					stringvalidator.LengthBetween(1, 250),
-					tfvalidator.StringDoubleQuoteExclusion(),
-				},
-			},
-			"description": schema.StringAttribute{
-				Optional:    true,
-				Description: "The description of the address book.",
-				Validators: []validator.String{
-					stringvalidator.LengthBetween(1, 900),
-					tfvalidator.StringDoubleQuoteExclusion(),
-				},
-			},
-			"attach_zone": schema.ListAttribute{
-				ElementType: types.StringType,
-				Optional:    true,
-				Description: "List of zones to attach address book to.",
-				Validators: []validator.List{
-					listvalidator.SizeAtLeast(1),
-					listvalidator.ValueStringsAre(
-						stringvalidator.LengthBetween(1, 63),
-						tfvalidator.StringFormat(tfvalidator.DefaultFormat),
-					),
-				},
-			},
-		},
+		Attributes:  securityAddressBookData{}.attributesSchema(),
 		Blocks: map[string]schema.Block{
 			"network_address": schema.SetNestedBlock{
 				Description: "For each name of network address.",
 				NestedObject: schema.NestedBlockObject{
-					Attributes: map[string]schema.Attribute{
-						"name": schema.StringAttribute{
-							Required:    true,
-							Description: "Name of network address.",
-							Validators: []validator.String{
-								stringvalidator.LengthBetween(1, 63),
-								tfvalidator.StringFormat(tfvalidator.AddressNameFormat),
-							},
-						},
-						"value": schema.StringAttribute{
-							Required:    true,
-							Description: "CIDR value of network address (`192.0.0.0/24`).",
-							Validators: []validator.String{
-								tfvalidator.StringCIDRNetwork(),
-							},
-						},
-						"description": schema.StringAttribute{
-							Optional:    true,
-							Description: "Description of network address.",
-							Validators: []validator.String{
-								stringvalidator.LengthBetween(1, 900),
-								tfvalidator.StringDoubleQuoteExclusion(),
-							},
-						},
-					},
+					Attributes: securityAddressBookBlockNetworkAddress{}.attributesSchema(),
 				},
 			},
 			"dns_name": schema.SetNestedBlock{
 				Description: "For each name of dns name address.",
 				NestedObject: schema.NestedBlockObject{
-					Attributes: map[string]schema.Attribute{
-						"name": schema.StringAttribute{
-							Required:    true,
-							Description: "Name of dns name address.",
-							Validators: []validator.String{
-								stringvalidator.LengthBetween(1, 63),
-								tfvalidator.StringFormat(tfvalidator.AddressNameFormat),
-							},
-						},
-						"value": schema.StringAttribute{
-							Required:    true,
-							Description: "DNS name string value.",
-							Validators: []validator.String{
-								stringvalidator.LengthBetween(1, 253),
-								tfvalidator.StringFormat(tfvalidator.DNSNameFormat),
-							},
-						},
-						"description": schema.StringAttribute{
-							Optional:    true,
-							Description: "Description of dns name address.",
-							Validators: []validator.String{
-								stringvalidator.LengthBetween(1, 900),
-								tfvalidator.StringDoubleQuoteExclusion(),
-							},
-						},
-						"ipv4_only": schema.BoolAttribute{
-							Optional:    true,
-							Description: "IPv4 dns address.",
-							Validators: []validator.Bool{
-								tfvalidator.BoolTrue(),
-							},
-						},
-						"ipv6_only": schema.BoolAttribute{
-							Optional:    true,
-							Description: "IPv6 dns address.",
-							Validators: []validator.Bool{
-								tfvalidator.BoolTrue(),
-							},
-						},
-					},
+					Attributes: securityAddressBookBlockDNSName{}.attributesSchema(),
 				},
 			},
 			"range_address": schema.SetNestedBlock{
 				Description: "For each name of range address.",
 				NestedObject: schema.NestedBlockObject{
-					Attributes: map[string]schema.Attribute{
-						"name": schema.StringAttribute{
-							Required:    true,
-							Description: "Name of range address.",
-							Validators: []validator.String{
-								stringvalidator.LengthBetween(1, 63),
-								tfvalidator.StringFormat(tfvalidator.AddressNameFormat),
-							},
-						},
-						"from": schema.StringAttribute{
-							Required:    true,
-							Description: "IP address of start of range.",
-							Validators: []validator.String{
-								tfvalidator.StringIPAddress(),
-							},
-						},
-						"to": schema.StringAttribute{
-							Required:    true,
-							Description: "IP address of end of range.",
-							Validators: []validator.String{
-								tfvalidator.StringIPAddress(),
-							},
-						},
-						"description": schema.StringAttribute{
-							Optional:    true,
-							Description: "Description of range address.",
-							Validators: []validator.String{
-								stringvalidator.LengthBetween(1, 900),
-								tfvalidator.StringDoubleQuoteExclusion(),
-							},
-						},
-					},
+					Attributes: securityAddressBookBlockRangeAddress{}.attributesSchema(),
 				},
 			},
 			"wildcard_address": schema.SetNestedBlock{
 				Description: "For each name of wildcard address.",
 				NestedObject: schema.NestedBlockObject{
-					Attributes: map[string]schema.Attribute{
-						"name": schema.StringAttribute{
-							Required:    true,
-							Description: "Name of wildcard address.",
-							Validators: []validator.String{
-								stringvalidator.LengthBetween(1, 63),
-								tfvalidator.StringFormat(tfvalidator.AddressNameFormat),
-							},
-						},
-						"value": schema.StringAttribute{
-							Required:    true,
-							Description: "Network and mask of wildcard address (`192.0.0.0/255.255.0.255`).",
-							Validators: []validator.String{
-								tfvalidator.StringWildcardNetwork(),
-							},
-						},
-						"description": schema.StringAttribute{
-							Optional:    true,
-							Description: "Description of wildcard address.",
-							Validators: []validator.String{
-								stringvalidator.LengthBetween(1, 900),
-								tfvalidator.StringDoubleQuoteExclusion(),
-							},
-						},
-					},
+					Attributes: securityAddressBookBlockWildcardAddress{}.attributesSchema(),
 				},
 			},
 			"address_set": schema.SetNestedBlock{
 				Description: "For each name of address-set to declare.",
 				NestedObject: schema.NestedBlockObject{
-					Attributes: map[string]schema.Attribute{
-						"name": schema.StringAttribute{
-							Required:    true,
-							Description: "Name of address-set.",
-							Validators: []validator.String{
-								stringvalidator.LengthBetween(1, 63),
-								tfvalidator.StringFormat(tfvalidator.AddressNameFormat),
-							},
-						},
-						"address": schema.SetAttribute{
-							ElementType: types.StringType,
-							Optional:    true,
-							Description: "List of address names.",
-							Validators: []validator.Set{
-								setvalidator.SizeAtLeast(1),
-								setvalidator.ValueStringsAre(
-									stringvalidator.LengthBetween(1, 63),
-									tfvalidator.StringFormat(tfvalidator.AddressNameFormat),
-								),
-							},
-						},
-						"address_set": schema.SetAttribute{
-							ElementType: types.StringType,
-							Optional:    true,
-							Description: "List of address-set names.",
-							Validators: []validator.Set{
-								setvalidator.SizeAtLeast(1),
-								setvalidator.ValueStringsAre(
-									stringvalidator.LengthBetween(1, 63),
-									tfvalidator.StringFormat(tfvalidator.AddressNameFormat),
-								),
-							},
-						},
-						"description": schema.StringAttribute{
-							Optional:    true,
-							Description: "Description of address-set.",
-							Validators: []validator.String{
-								stringvalidator.LengthBetween(1, 900),
-								tfvalidator.StringDoubleQuoteExclusion(),
-							},
-						},
-					},
+					Attributes: securityAddressBookBlockAddressSet{}.attributesSchema(),
 				},
 			},
 		},
@@ -326,6 +126,51 @@ type securityAddressBookData struct {
 	RangeAddress    []securityAddressBookBlockRangeAddress    `tfsdk:"range_address"`
 	WildcardAddress []securityAddressBookBlockWildcardAddress `tfsdk:"wildcard_address"`
 	AddressSet      []securityAddressBookBlockAddressSet      `tfsdk:"address_set"`
+}
+
+func (securityAddressBookData) attributesSchema() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"id": schema.StringAttribute{
+			Computed:    true,
+			Description: "An identifier for the resource with format `<name>`.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
+		},
+		"name": schema.StringAttribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     stringdefault.StaticString("global"),
+			Description: "The name of address book.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.RequiresReplace(),
+			},
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 250),
+				tfvalidator.StringDoubleQuoteExclusion(),
+			},
+		},
+		"description": schema.StringAttribute{
+			Optional:    true,
+			Description: "The description of the address book.",
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 900),
+				tfvalidator.StringDoubleQuoteExclusion(),
+			},
+		},
+		"attach_zone": schema.ListAttribute{
+			ElementType: types.StringType,
+			Optional:    true,
+			Description: "List of zones to attach address book to.",
+			Validators: []validator.List{
+				listvalidator.SizeAtLeast(1),
+				listvalidator.ValueStringsAre(
+					stringvalidator.LengthBetween(1, 63),
+					tfvalidator.StringFormat(tfvalidator.DefaultFormat),
+				),
+			},
+		},
+	}
 }
 
 type securityAddressBookConfig struct {
@@ -346,12 +191,83 @@ type securityAddressBookBlockNetworkAddress struct {
 	Description types.String `tfsdk:"description"`
 }
 
+func (securityAddressBookBlockNetworkAddress) attributesSchema() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"name": schema.StringAttribute{
+			Required:    true,
+			Description: "Name of network address.",
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 63),
+				tfvalidator.StringFormat(tfvalidator.AddressNameFormat),
+			},
+		},
+		"value": schema.StringAttribute{
+			Required:    true,
+			Description: "CIDR value of network address (`192.0.0.0/24`).",
+			Validators: []validator.String{
+				tfvalidator.StringCIDRNetwork(),
+			},
+		},
+		"description": schema.StringAttribute{
+			Optional:    true,
+			Description: "Description of network address.",
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 900),
+				tfvalidator.StringDoubleQuoteExclusion(),
+			},
+		},
+	}
+}
+
 type securityAddressBookBlockDNSName struct {
 	Name        types.String `tfsdk:"name"`
 	Value       types.String `tfsdk:"value"`
 	Description types.String `tfsdk:"description"`
 	IPv4Only    types.Bool   `tfsdk:"ipv4_only"`
 	IPv6Only    types.Bool   `tfsdk:"ipv6_only"`
+}
+
+func (securityAddressBookBlockDNSName) attributesSchema() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"name": schema.StringAttribute{
+			Required:    true,
+			Description: "Name of dns name address.",
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 63),
+				tfvalidator.StringFormat(tfvalidator.AddressNameFormat),
+			},
+		},
+		"value": schema.StringAttribute{
+			Required:    true,
+			Description: "DNS name string value.",
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 253),
+				tfvalidator.StringFormat(tfvalidator.DNSNameFormat),
+			},
+		},
+		"description": schema.StringAttribute{
+			Optional:    true,
+			Description: "Description of dns name address.",
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 900),
+				tfvalidator.StringDoubleQuoteExclusion(),
+			},
+		},
+		"ipv4_only": schema.BoolAttribute{
+			Optional:    true,
+			Description: "IPv4 dns address.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+		"ipv6_only": schema.BoolAttribute{
+			Optional:    true,
+			Description: "IPv6 dns address.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+	}
 }
 
 type securityAddressBookBlockRangeAddress struct {
@@ -361,10 +277,73 @@ type securityAddressBookBlockRangeAddress struct {
 	Description types.String `tfsdk:"description"`
 }
 
+func (securityAddressBookBlockRangeAddress) attributesSchema() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"name": schema.StringAttribute{
+			Required:    true,
+			Description: "Name of range address.",
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 63),
+				tfvalidator.StringFormat(tfvalidator.AddressNameFormat),
+			},
+		},
+		"from": schema.StringAttribute{
+			Required:    true,
+			Description: "IP address of start of range.",
+			Validators: []validator.String{
+				tfvalidator.StringIPAddress(),
+			},
+		},
+		"to": schema.StringAttribute{
+			Required:    true,
+			Description: "IP address of end of range.",
+			Validators: []validator.String{
+				tfvalidator.StringIPAddress(),
+			},
+		},
+		"description": schema.StringAttribute{
+			Optional:    true,
+			Description: "Description of range address.",
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 900),
+				tfvalidator.StringDoubleQuoteExclusion(),
+			},
+		},
+	}
+}
+
 type securityAddressBookBlockWildcardAddress struct {
 	Name        types.String `tfsdk:"name"`
 	Value       types.String `tfsdk:"value"`
 	Description types.String `tfsdk:"description"`
+}
+
+func (securityAddressBookBlockWildcardAddress) attributesSchema() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"name": schema.StringAttribute{
+			Required:    true,
+			Description: "Name of wildcard address.",
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 63),
+				tfvalidator.StringFormat(tfvalidator.AddressNameFormat),
+			},
+		},
+		"value": schema.StringAttribute{
+			Required:    true,
+			Description: "Network and mask of wildcard address (`192.0.0.0/255.255.0.255`).",
+			Validators: []validator.String{
+				tfvalidator.StringWildcardNetwork(),
+			},
+		},
+		"description": schema.StringAttribute{
+			Optional:    true,
+			Description: "Description of wildcard address.",
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 900),
+				tfvalidator.StringDoubleQuoteExclusion(),
+			},
+		},
+	}
 }
 
 type securityAddressBookBlockAddressSet struct {
@@ -372,6 +351,51 @@ type securityAddressBookBlockAddressSet struct {
 	Address     []types.String `tfsdk:"address"`
 	AddressSet  []types.String `tfsdk:"address_set"`
 	Description types.String   `tfsdk:"description"`
+}
+
+func (securityAddressBookBlockAddressSet) attributesSchema() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"name": schema.StringAttribute{
+			Required:    true,
+			Description: "Name of address-set.",
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 63),
+				tfvalidator.StringFormat(tfvalidator.AddressNameFormat),
+			},
+		},
+		"address": schema.SetAttribute{
+			ElementType: types.StringType,
+			Optional:    true,
+			Description: "List of address names.",
+			Validators: []validator.Set{
+				setvalidator.SizeAtLeast(1),
+				setvalidator.ValueStringsAre(
+					stringvalidator.LengthBetween(1, 63),
+					tfvalidator.StringFormat(tfvalidator.AddressNameFormat),
+				),
+			},
+		},
+		"address_set": schema.SetAttribute{
+			ElementType: types.StringType,
+			Optional:    true,
+			Description: "List of address-set names.",
+			Validators: []validator.Set{
+				setvalidator.SizeAtLeast(1),
+				setvalidator.ValueStringsAre(
+					stringvalidator.LengthBetween(1, 63),
+					tfvalidator.StringFormat(tfvalidator.AddressNameFormat),
+				),
+			},
+		},
+		"description": schema.StringAttribute{
+			Optional:    true,
+			Description: "Description of address-set.",
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 900),
+				tfvalidator.StringDoubleQuoteExclusion(),
+			},
+		},
+	}
 }
 
 type securityAddressBookBlockAddressSetConfig struct {
@@ -741,10 +765,10 @@ func (rscData *securityAddressBookData) set(
 		configSet = append(configSet, setPrefix+"attach zone "+v.ValueString())
 	}
 	addressName := make(map[string]struct{})
-	for _, block := range rscData.NetworkAddress {
+	for i, block := range rscData.NetworkAddress {
 		name := block.Name.ValueString()
 		if _, ok := addressName[name]; ok {
-			return path.Root("network_address"),
+			return path.Root("network_address").AtListIndex(i).AtName("name"),
 				fmt.Errorf("multiple addresses with the same name %q", name)
 		}
 		addressName[name] = struct{}{}
@@ -755,10 +779,10 @@ func (rscData *securityAddressBookData) set(
 			configSet = append(configSet, setPrefixAddr+"description \""+v+"\"")
 		}
 	}
-	for _, block := range rscData.DNSName {
+	for i, block := range rscData.DNSName {
 		name := block.Name.ValueString()
 		if _, ok := addressName[name]; ok {
-			return path.Root("dns_name"),
+			return path.Root("dns_name").AtListIndex(i).AtName("name"),
 				fmt.Errorf("multiple addresses with the same name %q", name)
 		}
 		addressName[name] = struct{}{}
@@ -775,10 +799,10 @@ func (rscData *securityAddressBookData) set(
 			configSet = append(configSet, setPrefixAddr+"description \""+v+"\"")
 		}
 	}
-	for _, block := range rscData.RangeAddress {
+	for i, block := range rscData.RangeAddress {
 		name := block.Name.ValueString()
 		if _, ok := addressName[name]; ok {
-			return path.Root("range_address"),
+			return path.Root("range_address").AtListIndex(i).AtName("name"),
 				fmt.Errorf("multiple addresses with the same name %q", name)
 		}
 		addressName[name] = struct{}{}
@@ -789,10 +813,10 @@ func (rscData *securityAddressBookData) set(
 			configSet = append(configSet, setPrefixAddr+"description \""+v+"\"")
 		}
 	}
-	for _, block := range rscData.WildcardAddress {
+	for i, block := range rscData.WildcardAddress {
 		name := block.Name.ValueString()
 		if _, ok := addressName[name]; ok {
-			return path.Root("wildcard_address"),
+			return path.Root("wildcard_address").AtListIndex(i).AtName("name"),
 				fmt.Errorf("multiple addresses with the same name %q", name)
 		}
 		addressName[name] = struct{}{}
@@ -803,17 +827,17 @@ func (rscData *securityAddressBookData) set(
 			configSet = append(configSet, setPrefixAddr+"description \""+v+"\"")
 		}
 	}
-	for _, block := range rscData.AddressSet {
+	for i, block := range rscData.AddressSet {
 		name := block.Name.ValueString()
 		if _, ok := addressName[name]; ok {
-			return path.Root("address_set"),
+			return path.Root("address_set").AtListIndex(i).AtName("name"),
 				fmt.Errorf("multiple addresses or address-sets with the same name %q", name)
 		}
 		addressName[name] = struct{}{}
 
 		setPrefixAddrSet := setPrefix + "address-set " + name + " "
 		if len(block.Address) == 0 && len(block.AddressSet) == 0 {
-			return path.Root("address_set"),
+			return path.Root("address_set").AtListIndex(i).AtName("name"),
 				fmt.Errorf("at least one of address or address_set must be specified in address_set %q", name)
 		}
 		for _, v := range block.Address {

--- a/internal/providerfwk/resource_security_address_book_ordered.go
+++ b/internal/providerfwk/resource_security_address_book_ordered.go
@@ -1,0 +1,433 @@
+package providerfwk
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jeremmfr/terraform-provider-junos/internal/junos"
+	"github.com/jeremmfr/terraform-provider-junos/internal/tfdiag"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// Ensure the implementation satisfies the expected interfaces.
+var (
+	_ resource.Resource                   = &securityAddressBookOrdered{}
+	_ resource.ResourceWithConfigure      = &securityAddressBookOrdered{}
+	_ resource.ResourceWithValidateConfig = &securityAddressBookOrdered{}
+	_ resource.ResourceWithImportState    = &securityAddressBookOrdered{}
+)
+
+type securityAddressBookOrdered struct {
+	client *junos.Client
+}
+
+func newSecurityAddressBookOrderedResource() resource.Resource {
+	return &securityAddressBookOrdered{}
+}
+
+func (rsc *securityAddressBookOrdered) typeName() string {
+	return providerName + "_security_address_book_ordered"
+}
+
+func (rsc *securityAddressBookOrdered) junosName() string {
+	return "security address book"
+}
+
+func (rsc *securityAddressBookOrdered) junosClient() *junos.Client {
+	return rsc.client
+}
+
+func (rsc *securityAddressBookOrdered) Metadata(
+	_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse,
+) {
+	resp.TypeName = rsc.typeName()
+}
+
+func (rsc *securityAddressBookOrdered) Configure(
+	ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse,
+) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*junos.Client)
+	if !ok {
+		unexpectedResourceConfigureType(ctx, req, resp)
+
+		return
+	}
+	rsc.client = client
+}
+
+func (rsc *securityAddressBookOrdered) Schema(
+	_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse,
+) {
+	resp.Schema = schema.Schema{
+		Description: defaultResourceSchemaDescription(rsc),
+		Attributes:  securityAddressBookData{}.attributesSchema(),
+		Blocks: map[string]schema.Block{
+			"network_address": schema.ListNestedBlock{
+				Description: "For each name of network address.",
+				NestedObject: schema.NestedBlockObject{
+					Attributes: securityAddressBookBlockNetworkAddress{}.attributesSchema(),
+				},
+			},
+			"dns_name": schema.ListNestedBlock{
+				Description: "For each name of dns name address.",
+				NestedObject: schema.NestedBlockObject{
+					Attributes: securityAddressBookBlockDNSName{}.attributesSchema(),
+				},
+			},
+			"range_address": schema.ListNestedBlock{
+				Description: "For each name of range address.",
+				NestedObject: schema.NestedBlockObject{
+					Attributes: securityAddressBookBlockRangeAddress{}.attributesSchema(),
+				},
+			},
+			"wildcard_address": schema.ListNestedBlock{
+				Description: "For each name of wildcard address.",
+				NestedObject: schema.NestedBlockObject{
+					Attributes: securityAddressBookBlockWildcardAddress{}.attributesSchema(),
+				},
+			},
+			"address_set": schema.ListNestedBlock{
+				Description: "For each name of address-set to declare.",
+				NestedObject: schema.NestedBlockObject{
+					Attributes: securityAddressBookBlockAddressSet{}.attributesSchema(),
+				},
+			},
+		},
+	}
+}
+
+type securityAddressBookOrderedConfig struct {
+	ID              types.String `tfsdk:"id"`
+	Name            types.String `tfsdk:"name"`
+	Description     types.String `tfsdk:"description"`
+	AttachZone      types.List   `tfsdk:"attach_zone"`
+	NetworkAddress  types.List   `tfsdk:"network_address"`
+	DNSName         types.List   `tfsdk:"dns_name"`
+	RangeAddress    types.List   `tfsdk:"range_address"`
+	WildcardAddress types.List   `tfsdk:"wildcard_address"`
+	AddressSet      types.List   `tfsdk:"address_set"`
+}
+
+func (rsc *securityAddressBookOrdered) ValidateConfig(
+	ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse,
+) {
+	var config securityAddressBookOrderedConfig
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if (config.Name.IsNull() || config.Name.ValueString() == "global") &&
+		!config.AttachZone.IsNull() && !config.AttachZone.IsUnknown() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("attach_zone"),
+			tfdiag.ConflictConfigErrSummary,
+			"cannot attach global address book to a zone",
+		)
+	}
+
+	addressName := make(map[string]struct{})
+	if !config.NetworkAddress.IsNull() && !config.NetworkAddress.IsUnknown() {
+		var configNetworkAddress []securityAddressBookBlockNetworkAddress
+		asDiags := config.NetworkAddress.ElementsAs(ctx, &configNetworkAddress, false)
+		if asDiags.HasError() {
+			resp.Diagnostics.Append(asDiags...)
+
+			return
+		}
+		for i, block := range configNetworkAddress {
+			if block.Name.IsUnknown() {
+				continue
+			}
+			name := block.Name.ValueString()
+			if _, ok := addressName[name]; ok {
+				resp.Diagnostics.AddAttributeError(
+					path.Root("network_address").AtListIndex(i).AtName("name"),
+					tfdiag.DuplicateConfigErrSummary,
+					fmt.Sprintf("multiple addresses with the same name %q", name),
+				)
+			}
+			addressName[name] = struct{}{}
+		}
+	}
+	if !config.DNSName.IsNull() && !config.DNSName.IsUnknown() {
+		var configDNSName []securityAddressBookBlockDNSName
+		asDiags := config.DNSName.ElementsAs(ctx, &configDNSName, false)
+		if asDiags.HasError() {
+			resp.Diagnostics.Append(asDiags...)
+
+			return
+		}
+		for i, block := range configDNSName {
+			if !block.IPv4Only.IsNull() && !block.IPv4Only.IsUnknown() &&
+				!block.IPv6Only.IsNull() && !block.IPv6Only.IsUnknown() {
+				resp.Diagnostics.AddAttributeError(
+					path.Root("dns_name").AtListIndex(i).AtName("ipv4_only"),
+					tfdiag.ConflictConfigErrSummary,
+					fmt.Sprintf("ipv4_only and ipv6_only cannot be configured together in dns_name %q", block.Name.ValueString()),
+				)
+			}
+			if block.Name.IsUnknown() {
+				continue
+			}
+			name := block.Name.ValueString()
+			if _, ok := addressName[name]; ok {
+				resp.Diagnostics.AddAttributeError(
+					path.Root("dns_name").AtListIndex(i).AtName("name"),
+					tfdiag.DuplicateConfigErrSummary,
+					fmt.Sprintf("multiple addresses with the same name %q", name),
+				)
+			}
+			addressName[name] = struct{}{}
+		}
+	}
+	if !config.RangeAddress.IsNull() && !config.RangeAddress.IsUnknown() {
+		var configRangeAddress []securityAddressBookBlockRangeAddress
+		asDiags := config.RangeAddress.ElementsAs(ctx, &configRangeAddress, false)
+		if asDiags.HasError() {
+			resp.Diagnostics.Append(asDiags...)
+
+			return
+		}
+		for i, block := range configRangeAddress {
+			if block.Name.IsUnknown() {
+				continue
+			}
+			name := block.Name.ValueString()
+			if _, ok := addressName[block.Name.ValueString()]; ok {
+				resp.Diagnostics.AddAttributeError(
+					path.Root("range_address").AtListIndex(i).AtName("name"),
+					tfdiag.DuplicateConfigErrSummary,
+					fmt.Sprintf("multiple addresses with the same name %q", name),
+				)
+			}
+			addressName[name] = struct{}{}
+		}
+	}
+	if !config.WildcardAddress.IsNull() && !config.WildcardAddress.IsUnknown() {
+		var configWildcardAddress []securityAddressBookBlockWildcardAddress
+		asDiags := config.WildcardAddress.ElementsAs(ctx, &configWildcardAddress, false)
+		if asDiags.HasError() {
+			resp.Diagnostics.Append(asDiags...)
+
+			return
+		}
+		for i, block := range configWildcardAddress {
+			if block.Name.IsUnknown() {
+				continue
+			}
+			name := block.Name.ValueString()
+			if _, ok := addressName[name]; ok {
+				resp.Diagnostics.AddAttributeError(
+					path.Root("wildcard_address").AtListIndex(i).AtName("name"),
+					tfdiag.DuplicateConfigErrSummary,
+					fmt.Sprintf("multiple addresses with the same name %q", name),
+				)
+			}
+			addressName[name] = struct{}{}
+		}
+	}
+	if !config.AddressSet.IsNull() && !config.AddressSet.IsUnknown() {
+		var configAddressSet []securityAddressBookBlockAddressSetConfig
+		asDiags := config.AddressSet.ElementsAs(ctx, &configAddressSet, false)
+		if asDiags.HasError() {
+			resp.Diagnostics.Append(asDiags...)
+
+			return
+		}
+		for i, block := range configAddressSet {
+			if block.Address.IsNull() && block.AddressSet.IsNull() {
+				resp.Diagnostics.AddAttributeError(
+					path.Root("address_set").AtListIndex(i).AtName("name"),
+					tfdiag.MissingConfigErrSummary,
+					fmt.Sprintf("at least one of address or address_set must be specified in address_set %q",
+						block.Name.ValueString()),
+				)
+			}
+			if block.Name.IsUnknown() {
+				continue
+			}
+			name := block.Name.ValueString()
+			if _, ok := addressName[name]; ok {
+				resp.Diagnostics.AddAttributeError(
+					path.Root("address_set").AtListIndex(i).AtName("name"),
+					tfdiag.DuplicateConfigErrSummary,
+					fmt.Sprintf("multiple addresses or address-sets with the same name %q", name),
+				)
+			}
+			addressName[name] = struct{}{}
+		}
+	}
+
+	if config.Description.IsNull() &&
+		config.AttachZone.IsNull() &&
+		config.NetworkAddress.IsNull() &&
+		config.DNSName.IsNull() &&
+		config.RangeAddress.IsNull() &&
+		config.WildcardAddress.IsNull() &&
+		config.AddressSet.IsNull() {
+		if config.Name.IsNull() {
+			resp.Diagnostics.AddError(
+				tfdiag.MissingConfigErrSummary,
+				"resource without argument is not supported",
+			)
+		} else {
+			resp.Diagnostics.AddError(
+				tfdiag.MissingConfigErrSummary,
+				"resource with only the name argument is not supported",
+			)
+		}
+	}
+}
+
+func (rsc *securityAddressBookOrdered) Create(
+	ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse,
+) {
+	var plan securityAddressBookData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if plan.Name.ValueString() == "" {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("name"),
+			"Empty Name",
+			defaultResourceCouldNotCreateWithEmptyMessage(rsc, "name"),
+		)
+
+		return
+	}
+
+	defaultResourceCreate(
+		ctx,
+		rsc,
+		func(fnCtx context.Context, junSess *junos.Session) bool {
+			if !junSess.CheckCompatibilitySecurity() {
+				resp.Diagnostics.AddError(
+					tfdiag.CompatibilityErrSummary,
+					rsc.junosName()+junSess.SystemInformation.NotCompatibleMsg(),
+				)
+
+				return false
+			}
+			bookExists, err := checkSecurityAddressBookExists(fnCtx, plan.Name.ValueString(), junSess)
+			if err != nil {
+				resp.Diagnostics.AddError(tfdiag.PreCheckErrSummary, err.Error())
+
+				return false
+			}
+			if bookExists {
+				resp.Diagnostics.AddError(
+					tfdiag.DuplicateConfigErrSummary,
+					defaultResourceAlreadyExistsMessage(rsc, plan.Name),
+				)
+
+				return false
+			}
+
+			return true
+		},
+		func(fnCtx context.Context, junSess *junos.Session) bool {
+			bookExists, err := checkSecurityAddressBookExists(fnCtx, plan.Name.ValueString(), junSess)
+			if err != nil {
+				resp.Diagnostics.AddError(tfdiag.PostCheckErrSummary, err.Error())
+
+				return false
+			}
+			if !bookExists {
+				resp.Diagnostics.AddError(
+					tfdiag.NotFoundErrSummary,
+					defaultResourceDoesNotExistsAfterCommitMessage(rsc, plan.Name),
+				)
+
+				return false
+			}
+
+			return true
+		},
+		&plan,
+		resp,
+	)
+}
+
+func (rsc *securityAddressBookOrdered) Read(
+	ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse,
+) {
+	var state, data securityAddressBookData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var _ resourceDataReadFrom1String = &data
+	defaultResourceRead(
+		ctx,
+		rsc,
+		[]any{
+			state.Name.ValueString(),
+		},
+		&data,
+		nil,
+		resp,
+	)
+}
+
+func (rsc *securityAddressBookOrdered) Update(
+	ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse,
+) {
+	var plan, state securityAddressBookData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	defaultResourceUpdate(
+		ctx,
+		rsc,
+		&state,
+		&plan,
+		resp,
+	)
+}
+
+func (rsc *securityAddressBookOrdered) Delete(
+	ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse,
+) {
+	var state securityAddressBookData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	defaultResourceDelete(
+		ctx,
+		rsc,
+		&state,
+		resp,
+	)
+}
+
+func (rsc *securityAddressBookOrdered) ImportState(
+	ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse,
+) {
+	var data securityAddressBookData
+
+	var _ resourceDataReadFrom1String = &data
+	defaultResourceImportState(
+		ctx,
+		rsc,
+		&data,
+		req,
+		resp,
+		defaultResourceImportDontFindIDStrMessage(rsc, req.ID, "name"),
+	)
+}

--- a/internal/providerfwk/resource_security_address_book_ordered_test.go
+++ b/internal/providerfwk/resource_security_address_book_ordered_test.go
@@ -1,0 +1,31 @@
+package providerfwk_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccResourceSecurityAddressBookOrdered_basic(t *testing.T) {
+	if os.Getenv("TESTACC_SRX") != "" {
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					ConfigDirectory: config.TestStepDirectory(),
+				},
+				{
+					ConfigDirectory: config.TestStepDirectory(),
+				},
+				{
+					ResourceName:      "junos_security_address_book_ordered.testacc_securityGlobalAddressBook",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+			},
+		})
+	}
+}

--- a/internal/providerfwk/resource_security_global_policy.go
+++ b/internal/providerfwk/resource_security_global_policy.go
@@ -94,269 +94,8 @@ func (rsc *securityGlobalPolicy) Schema(
 			"policy": schema.ListNestedBlock{
 				Description: "For each policy name.",
 				NestedObject: schema.NestedBlockObject{
-					Attributes: map[string]schema.Attribute{
-						"name": schema.StringAttribute{
-							Required:    true,
-							Description: "Security policy name.",
-							Validators: []validator.String{
-								stringvalidator.LengthBetween(1, 63),
-								tfvalidator.StringFormat(tfvalidator.DefaultFormat),
-							},
-						},
-						"match_source_address": schema.SetAttribute{
-							ElementType: types.StringType,
-							Required:    true,
-							Description: "List of source address match.",
-							Validators: []validator.Set{
-								setvalidator.SizeAtLeast(1),
-								setvalidator.ValueStringsAre(
-									stringvalidator.LengthBetween(1, 250),
-									tfvalidator.StringDoubleQuoteExclusion(),
-								),
-							},
-						},
-						"match_destination_address": schema.SetAttribute{
-							ElementType: types.StringType,
-							Required:    true,
-							Description: "List of destination address match.",
-							Validators: []validator.Set{
-								setvalidator.SizeAtLeast(1),
-								setvalidator.ValueStringsAre(
-									stringvalidator.LengthBetween(1, 250),
-									tfvalidator.StringDoubleQuoteExclusion(),
-								),
-							},
-						},
-						"match_from_zone": schema.SetAttribute{
-							ElementType: types.StringType,
-							Required:    true,
-							Description: "Match multiple source zone.",
-							Validators: []validator.Set{
-								setvalidator.SizeAtLeast(1),
-								setvalidator.ValueStringsAre(
-									stringvalidator.LengthBetween(1, 63),
-									tfvalidator.StringFormat(tfvalidator.DefaultFormat),
-								),
-							},
-						},
-						"match_to_zone": schema.SetAttribute{
-							ElementType: types.StringType,
-							Required:    true,
-							Description: "Match multiple destination zone.",
-							Validators: []validator.Set{
-								setvalidator.SizeAtLeast(1),
-								setvalidator.ValueStringsAre(
-									stringvalidator.LengthBetween(1, 63),
-									tfvalidator.StringFormat(tfvalidator.DefaultFormat),
-								),
-							},
-						},
-						"then": schema.StringAttribute{
-							Optional:    true,
-							Computed:    true,
-							Default:     stringdefault.StaticString("permit"),
-							Description: "Action of policy.",
-							Validators: []validator.String{
-								stringvalidator.OneOf("permit", "reject", "deny"),
-							},
-						},
-						"count": schema.BoolAttribute{
-							Optional:    true,
-							Description: "Enable count.",
-							Validators: []validator.Bool{
-								tfvalidator.BoolTrue(),
-							},
-						},
-						"log_init": schema.BoolAttribute{
-							Optional:    true,
-							Description: "Log at session init time.",
-							Validators: []validator.Bool{
-								tfvalidator.BoolTrue(),
-							},
-						},
-						"log_close": schema.BoolAttribute{
-							Optional:    true,
-							Description: "Log at session close time.",
-							Validators: []validator.Bool{
-								tfvalidator.BoolTrue(),
-							},
-						},
-						"match_application": schema.SetAttribute{
-							ElementType: types.StringType,
-							Optional:    true,
-							Description: "List of applications match.",
-							Validators: []validator.Set{
-								setvalidator.SizeAtLeast(1),
-								setvalidator.ValueStringsAre(
-									stringvalidator.LengthBetween(1, 250),
-									tfvalidator.StringDoubleQuoteExclusion(),
-								),
-							},
-						},
-						"match_destination_address_excluded": schema.BoolAttribute{
-							Optional:    true,
-							Description: "Exclude destination addresses.",
-							Validators: []validator.Bool{
-								tfvalidator.BoolTrue(),
-							},
-						},
-						"match_dynamic_application": schema.SetAttribute{
-							ElementType: types.StringType,
-							Optional:    true,
-							Description: "List of dynamic application or group match.",
-							Validators: []validator.Set{
-								setvalidator.SizeAtLeast(1),
-								setvalidator.ValueStringsAre(
-									stringvalidator.LengthBetween(1, 250),
-									tfvalidator.StringDoubleQuoteExclusion(),
-								),
-							},
-						},
-						"match_source_address_excluded": schema.BoolAttribute{
-							Optional:    true,
-							Description: "Exclude source addresses.",
-							Validators: []validator.Bool{
-								tfvalidator.BoolTrue(),
-							},
-						},
-						"match_source_end_user_profile": schema.StringAttribute{
-							Optional:    true,
-							Description: "Match source end user profile (device identity profile).",
-							Validators: []validator.String{
-								stringvalidator.LengthAtLeast(1),
-								tfvalidator.StringDoubleQuoteExclusion(),
-							},
-						},
-					},
-					Blocks: map[string]schema.Block{
-						"permit_application_services": schema.SingleNestedBlock{
-							Description: "Declare `permit application-services` configuration.",
-							Attributes: map[string]schema.Attribute{
-								"advanced_anti_malware_policy": schema.StringAttribute{
-									Optional:    true,
-									Description: "Specify advanced-anti-malware policy name.",
-									Validators: []validator.String{
-										stringvalidator.LengthBetween(1, 250),
-										tfvalidator.StringDoubleQuoteExclusion(),
-									},
-								},
-								"application_firewall_rule_set": schema.StringAttribute{
-									Optional:    true,
-									Description: "Service rule-set name for Application firewall.",
-									Validators: []validator.String{
-										stringvalidator.LengthBetween(1, 250),
-										tfvalidator.StringDoubleQuoteExclusion(),
-									},
-								},
-								"application_traffic_control_rule_set": schema.StringAttribute{
-									Optional:    true,
-									Description: "Service rule-set name Application traffic control.",
-									Validators: []validator.String{
-										stringvalidator.LengthBetween(1, 250),
-										tfvalidator.StringDoubleQuoteExclusion(),
-									},
-								},
-								"gprs_gtp_profile": schema.StringAttribute{
-									Optional:    true,
-									Description: "Specify GPRS Tunneling Protocol profile name.",
-									Validators: []validator.String{
-										stringvalidator.LengthBetween(1, 250),
-										tfvalidator.StringDoubleQuoteExclusion(),
-									},
-								},
-								"gprs_sctp_profile": schema.StringAttribute{
-									Optional:    true,
-									Description: "Specify GPRS stream control protocol profile name.",
-									Validators: []validator.String{
-										stringvalidator.LengthBetween(1, 250),
-										tfvalidator.StringDoubleQuoteExclusion(),
-									},
-								},
-								"idp": schema.BoolAttribute{
-									Optional:    true,
-									Description: "Enable Intrusion detection and prevention.",
-									Validators: []validator.Bool{
-										tfvalidator.BoolTrue(),
-									},
-								},
-								"idp_policy": schema.StringAttribute{
-									Optional:    true,
-									Description: "Specify idp policy name.",
-									Validators: []validator.String{
-										stringvalidator.LengthBetween(1, 250),
-										tfvalidator.StringDoubleQuoteExclusion(),
-									},
-								},
-								"redirect_wx": schema.BoolAttribute{
-									Optional:    true,
-									Description: "Set WX redirection.",
-									Validators: []validator.Bool{
-										tfvalidator.BoolTrue(),
-									},
-								},
-								"reverse_redirect_wx": schema.BoolAttribute{
-									Optional:    true,
-									Description: "Set WX reverse redirection.",
-									Validators: []validator.Bool{
-										tfvalidator.BoolTrue(),
-									},
-								},
-								"security_intelligence_policy": schema.StringAttribute{
-									Optional:    true,
-									Description: "Specify security-intelligence policy name.",
-									Validators: []validator.String{
-										stringvalidator.LengthBetween(1, 250),
-										tfvalidator.StringDoubleQuoteExclusion(),
-									},
-								},
-								"utm_policy": schema.StringAttribute{
-									Optional:    true,
-									Description: "Specify utm policy name.",
-									Validators: []validator.String{
-										stringvalidator.LengthBetween(1, 250),
-										tfvalidator.StringDoubleQuoteExclusion(),
-									},
-								},
-							},
-							Blocks: map[string]schema.Block{
-								"ssl_proxy": schema.SingleNestedBlock{
-									Description: "Enable SSL Proxy.",
-									Attributes: map[string]schema.Attribute{
-										"profile_name": schema.StringAttribute{
-											Optional:    true,
-											Description: "Specify SSL proxy service profile name.",
-											Validators: []validator.String{
-												stringvalidator.LengthBetween(1, 250),
-												tfvalidator.StringDoubleQuoteExclusion(),
-											},
-										},
-									},
-									PlanModifiers: []planmodifier.Object{
-										tfplanmodifier.BlockRemoveNull(),
-									},
-								},
-								"uac_policy": schema.SingleNestedBlock{
-									Description: "Enable unified access control enforcement.",
-									Attributes: map[string]schema.Attribute{
-										"captive_portal": schema.StringAttribute{
-											Optional:    true,
-											Description: "Specify captive portal.",
-											Validators: []validator.String{
-												stringvalidator.LengthBetween(1, 250),
-												tfvalidator.StringDoubleQuoteExclusion(),
-											},
-										},
-									},
-									PlanModifiers: []planmodifier.Object{
-										tfplanmodifier.BlockRemoveNull(),
-									},
-								},
-							},
-							PlanModifiers: []planmodifier.Object{
-								tfplanmodifier.BlockRemoveNull(),
-							},
-						},
-					},
+					Attributes: securityGlobalPolicyBlockPolicy{}.attributesSchema(),
+					Blocks:     securityGlobalPolicyBlockPolicy{}.blocksSchema(),
 				},
 			},
 		},
@@ -390,6 +129,275 @@ type securityGlobalPolicyBlockPolicy struct {
 	MatchSourceAddressExcluded      types.Bool                                               `tfsdk:"match_source_address_excluded"`
 	MatchSourceEndUserProfile       types.String                                             `tfsdk:"match_source_end_user_profile"`
 	PermitApplicationServices       *securityPolicyBlockPolicyBlockPermitApplicationServices `tfsdk:"permit_application_services"`
+}
+
+func (securityGlobalPolicyBlockPolicy) attributesSchema() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"name": schema.StringAttribute{
+			Required:    true,
+			Description: "Security policy name.",
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 63),
+				tfvalidator.StringFormat(tfvalidator.DefaultFormat),
+			},
+		},
+		"match_source_address": schema.SetAttribute{
+			ElementType: types.StringType,
+			Required:    true,
+			Description: "List of source address match.",
+			Validators: []validator.Set{
+				setvalidator.SizeAtLeast(1),
+				setvalidator.ValueStringsAre(
+					stringvalidator.LengthBetween(1, 250),
+					tfvalidator.StringDoubleQuoteExclusion(),
+				),
+			},
+		},
+		"match_destination_address": schema.SetAttribute{
+			ElementType: types.StringType,
+			Required:    true,
+			Description: "List of destination address match.",
+			Validators: []validator.Set{
+				setvalidator.SizeAtLeast(1),
+				setvalidator.ValueStringsAre(
+					stringvalidator.LengthBetween(1, 250),
+					tfvalidator.StringDoubleQuoteExclusion(),
+				),
+			},
+		},
+		"match_from_zone": schema.SetAttribute{
+			ElementType: types.StringType,
+			Required:    true,
+			Description: "Match multiple source zone.",
+			Validators: []validator.Set{
+				setvalidator.SizeAtLeast(1),
+				setvalidator.ValueStringsAre(
+					stringvalidator.LengthBetween(1, 63),
+					tfvalidator.StringFormat(tfvalidator.DefaultFormat),
+				),
+			},
+		},
+		"match_to_zone": schema.SetAttribute{
+			ElementType: types.StringType,
+			Required:    true,
+			Description: "Match multiple destination zone.",
+			Validators: []validator.Set{
+				setvalidator.SizeAtLeast(1),
+				setvalidator.ValueStringsAre(
+					stringvalidator.LengthBetween(1, 63),
+					tfvalidator.StringFormat(tfvalidator.DefaultFormat),
+				),
+			},
+		},
+		"then": schema.StringAttribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     stringdefault.StaticString("permit"),
+			Description: "Action of policy.",
+			Validators: []validator.String{
+				stringvalidator.OneOf("permit", "reject", "deny"),
+			},
+		},
+		"count": schema.BoolAttribute{
+			Optional:    true,
+			Description: "Enable count.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+		"log_init": schema.BoolAttribute{
+			Optional:    true,
+			Description: "Log at session init time.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+		"log_close": schema.BoolAttribute{
+			Optional:    true,
+			Description: "Log at session close time.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+		"match_application": schema.SetAttribute{
+			ElementType: types.StringType,
+			Optional:    true,
+			Description: "List of applications match.",
+			Validators: []validator.Set{
+				setvalidator.SizeAtLeast(1),
+				setvalidator.ValueStringsAre(
+					stringvalidator.LengthBetween(1, 250),
+					tfvalidator.StringDoubleQuoteExclusion(),
+				),
+			},
+		},
+		"match_destination_address_excluded": schema.BoolAttribute{
+			Optional:    true,
+			Description: "Exclude destination addresses.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+		"match_dynamic_application": schema.SetAttribute{
+			ElementType: types.StringType,
+			Optional:    true,
+			Description: "List of dynamic application or group match.",
+			Validators: []validator.Set{
+				setvalidator.SizeAtLeast(1),
+				setvalidator.ValueStringsAre(
+					stringvalidator.LengthBetween(1, 250),
+					tfvalidator.StringDoubleQuoteExclusion(),
+				),
+			},
+		},
+		"match_source_address_excluded": schema.BoolAttribute{
+			Optional:    true,
+			Description: "Exclude source addresses.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+		"match_source_end_user_profile": schema.StringAttribute{
+			Optional:    true,
+			Description: "Match source end user profile (device identity profile).",
+			Validators: []validator.String{
+				stringvalidator.LengthAtLeast(1),
+				tfvalidator.StringDoubleQuoteExclusion(),
+			},
+		},
+	}
+}
+
+func (securityGlobalPolicyBlockPolicy) blocksSchema() map[string]schema.Block {
+	return map[string]schema.Block{
+		"permit_application_services": schema.SingleNestedBlock{
+			Description: "Declare `permit application-services` configuration.",
+			Attributes: map[string]schema.Attribute{
+				"advanced_anti_malware_policy": schema.StringAttribute{
+					Optional:    true,
+					Description: "Specify advanced-anti-malware policy name.",
+					Validators: []validator.String{
+						stringvalidator.LengthBetween(1, 250),
+						tfvalidator.StringDoubleQuoteExclusion(),
+					},
+				},
+				"application_firewall_rule_set": schema.StringAttribute{
+					Optional:    true,
+					Description: "Service rule-set name for Application firewall.",
+					Validators: []validator.String{
+						stringvalidator.LengthBetween(1, 250),
+						tfvalidator.StringDoubleQuoteExclusion(),
+					},
+				},
+				"application_traffic_control_rule_set": schema.StringAttribute{
+					Optional:    true,
+					Description: "Service rule-set name Application traffic control.",
+					Validators: []validator.String{
+						stringvalidator.LengthBetween(1, 250),
+						tfvalidator.StringDoubleQuoteExclusion(),
+					},
+				},
+				"gprs_gtp_profile": schema.StringAttribute{
+					Optional:    true,
+					Description: "Specify GPRS Tunneling Protocol profile name.",
+					Validators: []validator.String{
+						stringvalidator.LengthBetween(1, 250),
+						tfvalidator.StringDoubleQuoteExclusion(),
+					},
+				},
+				"gprs_sctp_profile": schema.StringAttribute{
+					Optional:    true,
+					Description: "Specify GPRS stream control protocol profile name.",
+					Validators: []validator.String{
+						stringvalidator.LengthBetween(1, 250),
+						tfvalidator.StringDoubleQuoteExclusion(),
+					},
+				},
+				"idp": schema.BoolAttribute{
+					Optional:    true,
+					Description: "Enable Intrusion detection and prevention.",
+					Validators: []validator.Bool{
+						tfvalidator.BoolTrue(),
+					},
+				},
+				"idp_policy": schema.StringAttribute{
+					Optional:    true,
+					Description: "Specify idp policy name.",
+					Validators: []validator.String{
+						stringvalidator.LengthBetween(1, 250),
+						tfvalidator.StringDoubleQuoteExclusion(),
+					},
+				},
+				"redirect_wx": schema.BoolAttribute{
+					Optional:    true,
+					Description: "Set WX redirection.",
+					Validators: []validator.Bool{
+						tfvalidator.BoolTrue(),
+					},
+				},
+				"reverse_redirect_wx": schema.BoolAttribute{
+					Optional:    true,
+					Description: "Set WX reverse redirection.",
+					Validators: []validator.Bool{
+						tfvalidator.BoolTrue(),
+					},
+				},
+				"security_intelligence_policy": schema.StringAttribute{
+					Optional:    true,
+					Description: "Specify security-intelligence policy name.",
+					Validators: []validator.String{
+						stringvalidator.LengthBetween(1, 250),
+						tfvalidator.StringDoubleQuoteExclusion(),
+					},
+				},
+				"utm_policy": schema.StringAttribute{
+					Optional:    true,
+					Description: "Specify utm policy name.",
+					Validators: []validator.String{
+						stringvalidator.LengthBetween(1, 250),
+						tfvalidator.StringDoubleQuoteExclusion(),
+					},
+				},
+			},
+			Blocks: map[string]schema.Block{
+				"ssl_proxy": schema.SingleNestedBlock{
+					Description: "Enable SSL Proxy.",
+					Attributes: map[string]schema.Attribute{
+						"profile_name": schema.StringAttribute{
+							Optional:    true,
+							Description: "Specify SSL proxy service profile name.",
+							Validators: []validator.String{
+								stringvalidator.LengthBetween(1, 250),
+								tfvalidator.StringDoubleQuoteExclusion(),
+							},
+						},
+					},
+					PlanModifiers: []planmodifier.Object{
+						tfplanmodifier.BlockRemoveNull(),
+					},
+				},
+				"uac_policy": schema.SingleNestedBlock{
+					Description: "Enable unified access control enforcement.",
+					Attributes: map[string]schema.Attribute{
+						"captive_portal": schema.StringAttribute{
+							Optional:    true,
+							Description: "Specify captive portal.",
+							Validators: []validator.String{
+								stringvalidator.LengthBetween(1, 250),
+								tfvalidator.StringDoubleQuoteExclusion(),
+							},
+						},
+					},
+					PlanModifiers: []planmodifier.Object{
+						tfplanmodifier.BlockRemoveNull(),
+					},
+				},
+			},
+			PlanModifiers: []planmodifier.Object{
+				tfplanmodifier.BlockRemoveNull(),
+			},
+		},
+	}
 }
 
 //nolint:lll

--- a/internal/providerfwk/resource_security_global_policy_unordered.go
+++ b/internal/providerfwk/resource_security_global_policy_unordered.go
@@ -1,0 +1,276 @@
+package providerfwk
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jeremmfr/terraform-provider-junos/internal/junos"
+	"github.com/jeremmfr/terraform-provider-junos/internal/tfdiag"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// Ensure the implementation satisfies the expected interfaces.
+var (
+	_ resource.Resource                   = &securityGlobalPolicyUnordered{}
+	_ resource.ResourceWithConfigure      = &securityGlobalPolicyUnordered{}
+	_ resource.ResourceWithValidateConfig = &securityGlobalPolicyUnordered{}
+	_ resource.ResourceWithImportState    = &securityGlobalPolicyUnordered{}
+)
+
+type securityGlobalPolicyUnordered struct {
+	client *junos.Client
+}
+
+func newSecurityGlobalPolicyUnorderedResource() resource.Resource {
+	return &securityGlobalPolicyUnordered{}
+}
+
+func (rsc *securityGlobalPolicyUnordered) typeName() string {
+	return providerName + "_security_global_policy_unordered"
+}
+
+func (rsc *securityGlobalPolicyUnordered) junosName() string {
+	return "security policies global"
+}
+
+func (rsc *securityGlobalPolicyUnordered) junosClient() *junos.Client {
+	return rsc.client
+}
+
+func (rsc *securityGlobalPolicyUnordered) Metadata(
+	_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse,
+) {
+	resp.TypeName = rsc.typeName()
+}
+
+func (rsc *securityGlobalPolicyUnordered) Configure(
+	ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse,
+) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*junos.Client)
+	if !ok {
+		unexpectedResourceConfigureType(ctx, req, resp)
+
+		return
+	}
+	rsc.client = client
+}
+
+func (rsc *securityGlobalPolicyUnordered) Schema(
+	_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse,
+) {
+	resp.Schema = schema.Schema{
+		Description: "Configure static configuration in `" + rsc.junosName() + "` block",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "An identifier for the resource with value `security_global_policy`.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"policy": schema.SetNestedBlock{
+				Description: "For each policy name.",
+				NestedObject: schema.NestedBlockObject{
+					Attributes: securityGlobalPolicyBlockPolicy{}.attributesSchema(),
+					Blocks:     securityGlobalPolicyBlockPolicy{}.blocksSchema(),
+				},
+			},
+		},
+	}
+}
+
+type securityGlobalPolicyUnorderedConfig struct {
+	ID     types.String `tfsdk:"id"`
+	Policy types.Set    `tfsdk:"policy"`
+}
+
+func (rsc *securityGlobalPolicyUnordered) ValidateConfig(
+	ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse,
+) {
+	var config securityGlobalPolicyUnorderedConfig
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if config.Policy.IsNull() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("policy").AtName("name"),
+			tfdiag.MissingConfigErrSummary,
+			"at least one policy block must be specified",
+		)
+	} else if !config.Policy.IsUnknown() {
+		var configPolicy []securityGlobalPolicyBlockPolicyConfig
+		asDiags := config.Policy.ElementsAs(ctx, &configPolicy, false)
+		if asDiags.HasError() {
+			resp.Diagnostics.Append(asDiags...)
+
+			return
+		}
+		policyName := make(map[string]struct{})
+		for i, block := range configPolicy {
+			if !block.Name.IsUnknown() {
+				name := block.Name.ValueString()
+				if _, ok := policyName[name]; ok {
+					resp.Diagnostics.AddAttributeError(
+						path.Root("policy").AtListIndex(i).AtName("name"),
+						tfdiag.DuplicateConfigErrSummary,
+						fmt.Sprintf("multiple policy blocks with the same name %q", name),
+					)
+				}
+				policyName[name] = struct{}{}
+			}
+			if block.MatchApplication.IsNull() && block.MatchDynamicApplication.IsNull() {
+				resp.Diagnostics.AddAttributeError(
+					path.Root("policy").AtListIndex(i).AtName("name"),
+					tfdiag.MissingConfigErrSummary,
+					fmt.Sprintf("at least one of match_application or match_dynamic_application "+
+						"must be specified in policy %q", block.Name.ValueString()),
+				)
+			}
+			if block.PermitApplicationServices != nil {
+				if block.PermitApplicationServices.isEmpty() {
+					resp.Diagnostics.AddAttributeError(
+						path.Root("policy").AtListIndex(i).AtName("permit_application_services"),
+						tfdiag.MissingConfigErrSummary,
+						fmt.Sprintf("permit_application_services block is empty in policy %q", block.Name.ValueString()),
+					)
+				} else if block.PermitApplicationServices.hasKnownValue() &&
+					!block.Then.IsNull() && !block.Then.IsUnknown() && block.Then.ValueString() != junos.PermitW {
+					resp.Diagnostics.AddAttributeError(
+						path.Root("policy").AtListIndex(i).AtName("then"),
+						tfdiag.ConflictConfigErrSummary,
+						fmt.Sprintf("then is not %q (got %q) and permit_application_services is set in policy %q",
+							junos.PermitW, block.Then.ValueString(), block.Name.ValueString()),
+					)
+				}
+				if !block.PermitApplicationServices.RedirectWx.IsNull() &&
+					!block.PermitApplicationServices.RedirectWx.IsUnknown() &&
+					!block.PermitApplicationServices.ReverseRedirectWx.IsNull() &&
+					!block.PermitApplicationServices.ReverseRedirectWx.IsUnknown() {
+					resp.Diagnostics.AddAttributeError(
+						path.Root("policy").AtListIndex(i).AtName("redirect_wx"),
+						tfdiag.ConflictConfigErrSummary,
+						fmt.Sprintf("redirect_wx and reverse_redirect_wx enabled both in policy %q", block.Name.ValueString()),
+					)
+				}
+			}
+		}
+	}
+}
+
+func (rsc *securityGlobalPolicyUnordered) Create(
+	ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse,
+) {
+	var plan securityGlobalPolicyData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	defaultResourceCreate(
+		ctx,
+		rsc,
+		func(fnCtx context.Context, junSess *junos.Session) bool {
+			if !junSess.CheckCompatibilitySecurity() {
+				resp.Diagnostics.AddError(
+					tfdiag.CompatibilityErrSummary,
+					rsc.junosName()+junSess.SystemInformation.NotCompatibleMsg(),
+				)
+
+				return false
+			}
+			var check securityGlobalPolicyData
+			if err := check.read(fnCtx, junSess); err != nil {
+				resp.Diagnostics.AddError(tfdiag.PreCheckErrSummary, err.Error())
+
+				return false
+			}
+			if len(check.Policy) > 0 {
+				resp.Diagnostics.AddError(tfdiag.DuplicateConfigErrSummary, rsc.junosName()+" already exists")
+
+				return false
+			}
+
+			return true
+		},
+		nil,
+		&plan,
+		resp,
+	)
+}
+
+func (rsc *securityGlobalPolicyUnordered) Read(
+	ctx context.Context, _ resource.ReadRequest, resp *resource.ReadResponse,
+) {
+	var data securityGlobalPolicyData
+
+	var _ resourceDataReadWithoutArg = &data
+	defaultResourceRead(
+		ctx,
+		rsc,
+		nil,
+		&data,
+		nil,
+		resp,
+	)
+}
+
+func (rsc *securityGlobalPolicyUnordered) Update(
+	ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse,
+) {
+	var plan securityGlobalPolicyData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	defaultResourceUpdate(
+		ctx,
+		rsc,
+		&plan,
+		&plan,
+		resp,
+	)
+}
+
+func (rsc *securityGlobalPolicyUnordered) Delete(
+	ctx context.Context, _ resource.DeleteRequest, resp *resource.DeleteResponse,
+) {
+	var empty securityGlobalPolicyData
+
+	defaultResourceDelete(
+		ctx,
+		rsc,
+		&empty,
+		resp,
+	)
+}
+
+func (rsc *securityGlobalPolicyUnordered) ImportState(
+	ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse,
+) {
+	var data securityGlobalPolicyData
+
+	var _ resourceDataReadWithoutArg = &data
+	defaultResourceImportState(
+		ctx,
+		rsc,
+		&data,
+		req,
+		resp,
+		"",
+	)
+}

--- a/internal/providerfwk/resource_security_global_policy_unordered_test.go
+++ b/internal/providerfwk/resource_security_global_policy_unordered_test.go
@@ -1,0 +1,34 @@
+package providerfwk_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccResourceSecurityGlobalPolicyUnordered_basic(t *testing.T) {
+	if os.Getenv("TESTACC_SRX") != "" {
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					ConfigDirectory: config.TestStepDirectory(),
+				},
+				{
+					ConfigDirectory: config.TestStepDirectory(),
+				},
+				{
+					ResourceName:      "junos_security_global_policy_unordered.testacc_secglobpolicy",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+				{
+					ConfigDirectory: config.TestStepDirectory(),
+				},
+			},
+		})
+	}
+}

--- a/internal/providerfwk/resource_security_policy.go
+++ b/internal/providerfwk/resource_security_policy.go
@@ -82,288 +82,13 @@ func (rsc *securityPolicy) Schema(
 	resp.Schema = schema.Schema{
 		Version:     1,
 		Description: defaultResourceSchemaDescription(rsc),
-		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{
-				Computed:    true,
-				Description: "An identifier for the resource with format `<from_zone>" + junos.IDSeparator + "<to_zone>`.",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
-			"from_zone": schema.StringAttribute{
-				Required:    true,
-				Description: "The name of source zone.",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
-				Validators: []validator.String{
-					stringvalidator.LengthBetween(1, 63),
-					tfvalidator.StringFormat(tfvalidator.DefaultFormat),
-				},
-			},
-			"to_zone": schema.StringAttribute{
-				Required:    true,
-				Description: "The name of destination zone.",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
-				Validators: []validator.String{
-					stringvalidator.LengthBetween(1, 63),
-					tfvalidator.StringFormat(tfvalidator.DefaultFormat),
-				},
-			},
-		},
+		Attributes:  securityPolicyData{}.attributesSchema(),
 		Blocks: map[string]schema.Block{
 			"policy": schema.ListNestedBlock{
 				Description: "For each name of policy.",
 				NestedObject: schema.NestedBlockObject{
-					Attributes: map[string]schema.Attribute{
-						"name": schema.StringAttribute{
-							Required:    true,
-							Description: "The name of policy.",
-							Validators: []validator.String{
-								stringvalidator.LengthBetween(1, 63),
-								tfvalidator.StringFormat(tfvalidator.DefaultFormat),
-							},
-						},
-						"match_source_address": schema.SetAttribute{
-							ElementType: types.StringType,
-							Required:    true,
-							Description: "List of source address match.",
-							Validators: []validator.Set{
-								setvalidator.SizeAtLeast(1),
-								setvalidator.ValueStringsAre(
-									stringvalidator.LengthBetween(1, 250),
-									tfvalidator.StringDoubleQuoteExclusion(),
-								),
-							},
-						},
-						"match_destination_address": schema.SetAttribute{
-							ElementType: types.StringType,
-							Required:    true,
-							Description: "List of destination address match.",
-							Validators: []validator.Set{
-								setvalidator.SizeAtLeast(1),
-								setvalidator.ValueStringsAre(
-									stringvalidator.LengthBetween(1, 250),
-									tfvalidator.StringDoubleQuoteExclusion(),
-								),
-							},
-						},
-						"then": schema.StringAttribute{
-							Optional:    true,
-							Computed:    true,
-							Default:     stringdefault.StaticString("permit"),
-							Description: "Action of policy.",
-							Validators: []validator.String{
-								stringvalidator.OneOf("permit", "reject", "deny"),
-							},
-						},
-						"count": schema.BoolAttribute{
-							Optional:    true,
-							Description: "Enable count.",
-							Validators: []validator.Bool{
-								tfvalidator.BoolTrue(),
-							},
-						},
-						"log_init": schema.BoolAttribute{
-							Optional:    true,
-							Description: "Log at session init time.",
-							Validators: []validator.Bool{
-								tfvalidator.BoolTrue(),
-							},
-						},
-						"log_close": schema.BoolAttribute{
-							Optional:    true,
-							Description: "Log at session close time.",
-							Validators: []validator.Bool{
-								tfvalidator.BoolTrue(),
-							},
-						},
-						"match_application": schema.SetAttribute{
-							ElementType: types.StringType,
-							Optional:    true,
-							Description: "List of applications match.",
-							Validators: []validator.Set{
-								setvalidator.SizeAtLeast(1),
-								setvalidator.ValueStringsAre(
-									stringvalidator.LengthBetween(1, 250),
-									tfvalidator.StringDoubleQuoteExclusion(),
-								),
-							},
-						},
-						"match_destination_address_excluded": schema.BoolAttribute{
-							Optional:    true,
-							Description: "Exclude destination addresses.",
-							Validators: []validator.Bool{
-								tfvalidator.BoolTrue(),
-							},
-						},
-						"match_dynamic_application": schema.SetAttribute{
-							ElementType: types.StringType,
-							Optional:    true,
-							Description: "List of dynamic application or group match.",
-							Validators: []validator.Set{
-								setvalidator.SizeAtLeast(1),
-								setvalidator.ValueStringsAre(
-									stringvalidator.LengthBetween(1, 250),
-									tfvalidator.StringDoubleQuoteExclusion(),
-								),
-							},
-						},
-						"match_source_address_excluded": schema.BoolAttribute{
-							Optional:    true,
-							Description: "Exclude source addresses.",
-							Validators: []validator.Bool{
-								tfvalidator.BoolTrue(),
-							},
-						},
-						"match_source_end_user_profile": schema.StringAttribute{
-							Optional:    true,
-							Description: "Match source end user profile (device identity profile).",
-							Validators: []validator.String{
-								stringvalidator.LengthAtLeast(1),
-								tfvalidator.StringDoubleQuoteExclusion(),
-							},
-						},
-						"permit_tunnel_ipsec_vpn": schema.StringAttribute{
-							Optional:    true,
-							Description: "Name of vpn to permit with a tunnel ipsec.",
-							Validators: []validator.String{
-								stringvalidator.LengthBetween(1, 63),
-								tfvalidator.StringDoubleQuoteExclusion(),
-							},
-						},
-					},
-					Blocks: map[string]schema.Block{
-						"permit_application_services": schema.SingleNestedBlock{
-							Description: "Define application services for permit.",
-							Attributes: map[string]schema.Attribute{
-								"advanced_anti_malware_policy": schema.StringAttribute{
-									Optional:    true,
-									Description: "Specify advanced-anti-malware policy name.",
-									Validators: []validator.String{
-										stringvalidator.LengthBetween(1, 250),
-										tfvalidator.StringDoubleQuoteExclusion(),
-									},
-								},
-								"application_firewall_rule_set": schema.StringAttribute{
-									Optional:    true,
-									Description: "Service rule-set name for Application firewall.",
-									Validators: []validator.String{
-										stringvalidator.LengthBetween(1, 250),
-										tfvalidator.StringDoubleQuoteExclusion(),
-									},
-								},
-								"application_traffic_control_rule_set": schema.StringAttribute{
-									Optional:    true,
-									Description: "Service rule-set name Application traffic control.",
-									Validators: []validator.String{
-										stringvalidator.LengthBetween(1, 250),
-										tfvalidator.StringDoubleQuoteExclusion(),
-									},
-								},
-								"gprs_gtp_profile": schema.StringAttribute{
-									Optional:    true,
-									Description: "Specify GPRS Tunneling Protocol profile name.",
-									Validators: []validator.String{
-										stringvalidator.LengthBetween(1, 250),
-										tfvalidator.StringDoubleQuoteExclusion(),
-									},
-								},
-								"gprs_sctp_profile": schema.StringAttribute{
-									Optional:    true,
-									Description: "Specify GPRS stream control protocol profile name.",
-									Validators: []validator.String{
-										stringvalidator.LengthBetween(1, 250),
-										tfvalidator.StringDoubleQuoteExclusion(),
-									},
-								},
-								"idp": schema.BoolAttribute{
-									Optional:    true,
-									Description: "Enable Intrusion detection and prevention.",
-									Validators: []validator.Bool{
-										tfvalidator.BoolTrue(),
-									},
-								},
-								"idp_policy": schema.StringAttribute{
-									Optional:    true,
-									Description: "Specify idp policy name.",
-									Validators: []validator.String{
-										stringvalidator.LengthBetween(1, 250),
-										tfvalidator.StringDoubleQuoteExclusion(),
-									},
-								},
-								"redirect_wx": schema.BoolAttribute{
-									Optional:    true,
-									Description: "Set WX redirection.",
-									Validators: []validator.Bool{
-										tfvalidator.BoolTrue(),
-									},
-								},
-								"reverse_redirect_wx": schema.BoolAttribute{
-									Optional:    true,
-									Description: "Set WX reverse redirection.",
-									Validators: []validator.Bool{
-										tfvalidator.BoolTrue(),
-									},
-								},
-								"security_intelligence_policy": schema.StringAttribute{
-									Optional:    true,
-									Description: "Specify security-intelligence policy name.",
-									Validators: []validator.String{
-										stringvalidator.LengthBetween(1, 250),
-										tfvalidator.StringDoubleQuoteExclusion(),
-									},
-								},
-								"utm_policy": schema.StringAttribute{
-									Optional:    true,
-									Description: "Specify utm policy name.",
-									Validators: []validator.String{
-										stringvalidator.LengthBetween(1, 250),
-										tfvalidator.StringDoubleQuoteExclusion(),
-									},
-								},
-							},
-							Blocks: map[string]schema.Block{
-								"ssl_proxy": schema.SingleNestedBlock{
-									Description: "Enable SSL Proxy.",
-									Attributes: map[string]schema.Attribute{
-										"profile_name": schema.StringAttribute{
-											Optional:    true,
-											Description: "Specify SSL proxy service profile name.",
-											Validators: []validator.String{
-												stringvalidator.LengthBetween(1, 250),
-												tfvalidator.StringDoubleQuoteExclusion(),
-											},
-										},
-									},
-									PlanModifiers: []planmodifier.Object{
-										tfplanmodifier.BlockRemoveNull(),
-									},
-								},
-								"uac_policy": schema.SingleNestedBlock{
-									Description: "Enable unified access control enforcement.",
-									Attributes: map[string]schema.Attribute{
-										"captive_portal": schema.StringAttribute{
-											Optional:    true,
-											Description: "Specify captive portal.",
-											Validators: []validator.String{
-												stringvalidator.LengthBetween(1, 250),
-												tfvalidator.StringDoubleQuoteExclusion(),
-											},
-										},
-									},
-									PlanModifiers: []planmodifier.Object{
-										tfplanmodifier.BlockRemoveNull(),
-									},
-								},
-							},
-							PlanModifiers: []planmodifier.Object{
-								tfplanmodifier.BlockRemoveNull(),
-							},
-						},
-					},
+					Attributes: securityPolicyBlockPolicy{}.attributesSchema(),
+					Blocks:     securityPolicyBlockPolicy{}.blocksSchema(),
 				},
 			},
 		},
@@ -375,6 +100,40 @@ type securityPolicyData struct {
 	FromZone types.String                `tfsdk:"from_zone"`
 	ToZone   types.String                `tfsdk:"to_zone"`
 	Policy   []securityPolicyBlockPolicy `tfsdk:"policy"`
+}
+
+func (securityPolicyData) attributesSchema() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"id": schema.StringAttribute{
+			Computed:    true,
+			Description: "An identifier for the resource with format `<from_zone>" + junos.IDSeparator + "<to_zone>`.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
+		},
+		"from_zone": schema.StringAttribute{
+			Required:    true,
+			Description: "The name of source zone.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.RequiresReplace(),
+			},
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 63),
+				tfvalidator.StringFormat(tfvalidator.DefaultFormat),
+			},
+		},
+		"to_zone": schema.StringAttribute{
+			Required:    true,
+			Description: "The name of destination zone.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.RequiresReplace(),
+			},
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 63),
+				tfvalidator.StringFormat(tfvalidator.DefaultFormat),
+			},
+		},
+	}
 }
 
 type securityPolicyConfig struct {
@@ -400,6 +159,259 @@ type securityPolicyBlockPolicy struct {
 	MatchSourceEndUserProfile       types.String                                             `tfsdk:"match_source_end_user_profile"`
 	PermitTunnelIpsecVpn            types.String                                             `tfsdk:"permit_tunnel_ipsec_vpn"`
 	PermitApplicationServices       *securityPolicyBlockPolicyBlockPermitApplicationServices `tfsdk:"permit_application_services"`
+}
+
+func (securityPolicyBlockPolicy) attributesSchema() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"name": schema.StringAttribute{
+			Required:    true,
+			Description: "The name of policy.",
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 63),
+				tfvalidator.StringFormat(tfvalidator.DefaultFormat),
+			},
+		},
+		"match_source_address": schema.SetAttribute{
+			ElementType: types.StringType,
+			Required:    true,
+			Description: "List of source address match.",
+			Validators: []validator.Set{
+				setvalidator.SizeAtLeast(1),
+				setvalidator.ValueStringsAre(
+					stringvalidator.LengthBetween(1, 250),
+					tfvalidator.StringDoubleQuoteExclusion(),
+				),
+			},
+		},
+		"match_destination_address": schema.SetAttribute{
+			ElementType: types.StringType,
+			Required:    true,
+			Description: "List of destination address match.",
+			Validators: []validator.Set{
+				setvalidator.SizeAtLeast(1),
+				setvalidator.ValueStringsAre(
+					stringvalidator.LengthBetween(1, 250),
+					tfvalidator.StringDoubleQuoteExclusion(),
+				),
+			},
+		},
+		"then": schema.StringAttribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     stringdefault.StaticString("permit"),
+			Description: "Action of policy.",
+			Validators: []validator.String{
+				stringvalidator.OneOf("permit", "reject", "deny"),
+			},
+		},
+		"count": schema.BoolAttribute{
+			Optional:    true,
+			Description: "Enable count.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+		"log_init": schema.BoolAttribute{
+			Optional:    true,
+			Description: "Log at session init time.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+		"log_close": schema.BoolAttribute{
+			Optional:    true,
+			Description: "Log at session close time.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+		"match_application": schema.SetAttribute{
+			ElementType: types.StringType,
+			Optional:    true,
+			Description: "List of applications match.",
+			Validators: []validator.Set{
+				setvalidator.SizeAtLeast(1),
+				setvalidator.ValueStringsAre(
+					stringvalidator.LengthBetween(1, 250),
+					tfvalidator.StringDoubleQuoteExclusion(),
+				),
+			},
+		},
+		"match_destination_address_excluded": schema.BoolAttribute{
+			Optional:    true,
+			Description: "Exclude destination addresses.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+		"match_dynamic_application": schema.SetAttribute{
+			ElementType: types.StringType,
+			Optional:    true,
+			Description: "List of dynamic application or group match.",
+			Validators: []validator.Set{
+				setvalidator.SizeAtLeast(1),
+				setvalidator.ValueStringsAre(
+					stringvalidator.LengthBetween(1, 250),
+					tfvalidator.StringDoubleQuoteExclusion(),
+				),
+			},
+		},
+		"match_source_address_excluded": schema.BoolAttribute{
+			Optional:    true,
+			Description: "Exclude source addresses.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+		"match_source_end_user_profile": schema.StringAttribute{
+			Optional:    true,
+			Description: "Match source end user profile (device identity profile).",
+			Validators: []validator.String{
+				stringvalidator.LengthAtLeast(1),
+				tfvalidator.StringDoubleQuoteExclusion(),
+			},
+		},
+		"permit_tunnel_ipsec_vpn": schema.StringAttribute{
+			Optional:    true,
+			Description: "Name of vpn to permit with a tunnel ipsec.",
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 63),
+				tfvalidator.StringDoubleQuoteExclusion(),
+			},
+		},
+	}
+}
+
+func (securityPolicyBlockPolicy) blocksSchema() map[string]schema.Block {
+	return map[string]schema.Block{
+		"permit_application_services": schema.SingleNestedBlock{
+			Description: "Define application services for permit.",
+			Attributes: map[string]schema.Attribute{
+				"advanced_anti_malware_policy": schema.StringAttribute{
+					Optional:    true,
+					Description: "Specify advanced-anti-malware policy name.",
+					Validators: []validator.String{
+						stringvalidator.LengthBetween(1, 250),
+						tfvalidator.StringDoubleQuoteExclusion(),
+					},
+				},
+				"application_firewall_rule_set": schema.StringAttribute{
+					Optional:    true,
+					Description: "Service rule-set name for Application firewall.",
+					Validators: []validator.String{
+						stringvalidator.LengthBetween(1, 250),
+						tfvalidator.StringDoubleQuoteExclusion(),
+					},
+				},
+				"application_traffic_control_rule_set": schema.StringAttribute{
+					Optional:    true,
+					Description: "Service rule-set name Application traffic control.",
+					Validators: []validator.String{
+						stringvalidator.LengthBetween(1, 250),
+						tfvalidator.StringDoubleQuoteExclusion(),
+					},
+				},
+				"gprs_gtp_profile": schema.StringAttribute{
+					Optional:    true,
+					Description: "Specify GPRS Tunneling Protocol profile name.",
+					Validators: []validator.String{
+						stringvalidator.LengthBetween(1, 250),
+						tfvalidator.StringDoubleQuoteExclusion(),
+					},
+				},
+				"gprs_sctp_profile": schema.StringAttribute{
+					Optional:    true,
+					Description: "Specify GPRS stream control protocol profile name.",
+					Validators: []validator.String{
+						stringvalidator.LengthBetween(1, 250),
+						tfvalidator.StringDoubleQuoteExclusion(),
+					},
+				},
+				"idp": schema.BoolAttribute{
+					Optional:    true,
+					Description: "Enable Intrusion detection and prevention.",
+					Validators: []validator.Bool{
+						tfvalidator.BoolTrue(),
+					},
+				},
+				"idp_policy": schema.StringAttribute{
+					Optional:    true,
+					Description: "Specify idp policy name.",
+					Validators: []validator.String{
+						stringvalidator.LengthBetween(1, 250),
+						tfvalidator.StringDoubleQuoteExclusion(),
+					},
+				},
+				"redirect_wx": schema.BoolAttribute{
+					Optional:    true,
+					Description: "Set WX redirection.",
+					Validators: []validator.Bool{
+						tfvalidator.BoolTrue(),
+					},
+				},
+				"reverse_redirect_wx": schema.BoolAttribute{
+					Optional:    true,
+					Description: "Set WX reverse redirection.",
+					Validators: []validator.Bool{
+						tfvalidator.BoolTrue(),
+					},
+				},
+				"security_intelligence_policy": schema.StringAttribute{
+					Optional:    true,
+					Description: "Specify security-intelligence policy name.",
+					Validators: []validator.String{
+						stringvalidator.LengthBetween(1, 250),
+						tfvalidator.StringDoubleQuoteExclusion(),
+					},
+				},
+				"utm_policy": schema.StringAttribute{
+					Optional:    true,
+					Description: "Specify utm policy name.",
+					Validators: []validator.String{
+						stringvalidator.LengthBetween(1, 250),
+						tfvalidator.StringDoubleQuoteExclusion(),
+					},
+				},
+			},
+			Blocks: map[string]schema.Block{
+				"ssl_proxy": schema.SingleNestedBlock{
+					Description: "Enable SSL Proxy.",
+					Attributes: map[string]schema.Attribute{
+						"profile_name": schema.StringAttribute{
+							Optional:    true,
+							Description: "Specify SSL proxy service profile name.",
+							Validators: []validator.String{
+								stringvalidator.LengthBetween(1, 250),
+								tfvalidator.StringDoubleQuoteExclusion(),
+							},
+						},
+					},
+					PlanModifiers: []planmodifier.Object{
+						tfplanmodifier.BlockRemoveNull(),
+					},
+				},
+				"uac_policy": schema.SingleNestedBlock{
+					Description: "Enable unified access control enforcement.",
+					Attributes: map[string]schema.Attribute{
+						"captive_portal": schema.StringAttribute{
+							Optional:    true,
+							Description: "Specify captive portal.",
+							Validators: []validator.String{
+								stringvalidator.LengthBetween(1, 250),
+								tfvalidator.StringDoubleQuoteExclusion(),
+							},
+						},
+					},
+					PlanModifiers: []planmodifier.Object{
+						tfplanmodifier.BlockRemoveNull(),
+					},
+				},
+			},
+			PlanModifiers: []planmodifier.Object{
+				tfplanmodifier.BlockRemoveNull(),
+			},
+		},
+	}
 }
 
 //nolint:lll

--- a/internal/providerfwk/resource_security_policy_unordered.go
+++ b/internal/providerfwk/resource_security_policy_unordered.go
@@ -1,0 +1,401 @@
+package providerfwk
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jeremmfr/terraform-provider-junos/internal/junos"
+	"github.com/jeremmfr/terraform-provider-junos/internal/tfdiag"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// Ensure the implementation satisfies the expected interfaces.
+var (
+	_ resource.Resource                   = &securityPolicyUnordered{}
+	_ resource.ResourceWithConfigure      = &securityPolicyUnordered{}
+	_ resource.ResourceWithValidateConfig = &securityPolicyUnordered{}
+	_ resource.ResourceWithImportState    = &securityPolicyUnordered{}
+)
+
+type securityPolicyUnordered struct {
+	client *junos.Client
+}
+
+func newSecurityPolicyUnorderedResource() resource.Resource {
+	return &securityPolicyUnordered{}
+}
+
+func (rsc *securityPolicyUnordered) typeName() string {
+	return providerName + "_security_policy_unordered"
+}
+
+func (rsc *securityPolicyUnordered) junosName() string {
+	return "security policy"
+}
+
+func (rsc *securityPolicyUnordered) junosClient() *junos.Client {
+	return rsc.client
+}
+
+func (rsc *securityPolicyUnordered) Metadata(
+	_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse,
+) {
+	resp.TypeName = rsc.typeName()
+}
+
+func (rsc *securityPolicyUnordered) Configure(
+	ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse,
+) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*junos.Client)
+	if !ok {
+		unexpectedResourceConfigureType(ctx, req, resp)
+
+		return
+	}
+	rsc.client = client
+}
+
+func (rsc *securityPolicyUnordered) Schema(
+	_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse,
+) {
+	resp.Schema = schema.Schema{
+		Description: defaultResourceSchemaDescription(rsc),
+		Attributes:  securityPolicyData{}.attributesSchema(),
+		Blocks: map[string]schema.Block{
+			"policy": schema.SetNestedBlock{
+				Description: "For each name of policy.",
+				NestedObject: schema.NestedBlockObject{
+					Attributes: securityPolicyBlockPolicy{}.attributesSchema(),
+					Blocks:     securityPolicyBlockPolicy{}.blocksSchema(),
+				},
+			},
+		},
+	}
+}
+
+type securityPolicyUnorderedConfig struct {
+	ID       types.String `tfsdk:"id"`
+	FromZone types.String `tfsdk:"from_zone"`
+	ToZone   types.String `tfsdk:"to_zone"`
+	Policy   types.Set    `tfsdk:"policy"`
+}
+
+func (rsc *securityPolicyUnordered) ValidateConfig(
+	ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse,
+) {
+	var config securityPolicyUnorderedConfig
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if config.Policy.IsNull() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("policy").AtName("name"),
+			tfdiag.MissingConfigErrSummary,
+			"at least one policy block must be specified",
+		)
+	} else if !config.Policy.IsUnknown() {
+		var configPolicy []securityPolicyBlockPolicyConfig
+		asDiags := config.Policy.ElementsAs(ctx, &configPolicy, false)
+		if asDiags.HasError() {
+			resp.Diagnostics.Append(asDiags...)
+
+			return
+		}
+		policyName := make(map[string]struct{})
+		for i, block := range configPolicy {
+			if !block.Name.IsUnknown() {
+				name := block.Name.ValueString()
+				if _, ok := policyName[name]; ok {
+					resp.Diagnostics.AddAttributeError(
+						path.Root("policy").AtListIndex(i).AtName("name"),
+						tfdiag.DuplicateConfigErrSummary,
+						fmt.Sprintf("multiple policy blocks with the same name %q", name),
+					)
+				}
+				policyName[name] = struct{}{}
+			}
+			if block.MatchApplication.IsNull() && block.MatchDynamicApplication.IsNull() {
+				resp.Diagnostics.AddAttributeError(
+					path.Root("policy").AtListIndex(i).AtName("name"),
+					tfdiag.MissingConfigErrSummary,
+					fmt.Sprintf("at least one of match_application or match_dynamic_application "+
+						"must be specified in policy %q", block.Name.ValueString()),
+				)
+			}
+			if !block.PermitTunnelIpsecVpn.IsNull() && !block.PermitTunnelIpsecVpn.IsUnknown() &&
+				!block.Then.IsNull() && !block.Then.IsUnknown() && block.Then.ValueString() != junos.PermitW {
+				resp.Diagnostics.AddAttributeError(
+					path.Root("policy").AtListIndex(i).AtName("then"),
+					tfdiag.ConflictConfigErrSummary,
+					fmt.Sprintf("then is not %q (got %q) and permit_tunnel_ipsec_vpn is set in policy %q",
+						junos.PermitW, block.Then.ValueString(), block.Name.ValueString()),
+				)
+			}
+			if block.PermitApplicationServices != nil {
+				if block.PermitApplicationServices.isEmpty() {
+					resp.Diagnostics.AddAttributeError(
+						path.Root("policy").AtListIndex(i).AtName("permit_application_services"),
+						tfdiag.MissingConfigErrSummary,
+						fmt.Sprintf("permit_application_services block is empty in policy %q", block.Name.ValueString()),
+					)
+				} else if block.PermitApplicationServices.hasKnownValue() &&
+					!block.Then.IsNull() && !block.Then.IsUnknown() && block.Then.ValueString() != junos.PermitW {
+					resp.Diagnostics.AddAttributeError(
+						path.Root("policy").AtListIndex(i).AtName("then"),
+						tfdiag.ConflictConfigErrSummary,
+						fmt.Sprintf("then is not %q (got %q) and permit_application_services is set in policy %q",
+							junos.PermitW, block.Then.ValueString(), block.Name.ValueString()),
+					)
+				}
+				if !block.PermitApplicationServices.RedirectWx.IsNull() &&
+					!block.PermitApplicationServices.RedirectWx.IsUnknown() &&
+					!block.PermitApplicationServices.ReverseRedirectWx.IsNull() &&
+					!block.PermitApplicationServices.ReverseRedirectWx.IsUnknown() {
+					resp.Diagnostics.AddAttributeError(
+						path.Root("policy").AtListIndex(i).AtName("redirect_wx"),
+						tfdiag.ConflictConfigErrSummary,
+						fmt.Sprintf("redirect_wx and reverse_redirect_wx enabled both in policy %q", block.Name.ValueString()),
+					)
+				}
+			}
+		}
+	}
+}
+
+func (rsc *securityPolicyUnordered) Create(
+	ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse,
+) {
+	var plan securityPolicyData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if plan.FromZone.ValueString() == "" || plan.ToZone.ValueString() == "" {
+		resp.Diagnostics.AddError(
+			"Empty Zone",
+			defaultResourceCouldNotCreateWithEmptyMessage(rsc, "from_zone or to_zone"),
+		)
+
+		return
+	}
+
+	defaultResourceCreate(
+		ctx,
+		rsc,
+		func(fnCtx context.Context, junSess *junos.Session) bool {
+			if !junSess.CheckCompatibilitySecurity() {
+				resp.Diagnostics.AddError(
+					tfdiag.CompatibilityErrSummary,
+					rsc.junosName()+junSess.SystemInformation.NotCompatibleMsg(),
+				)
+
+				return false
+			}
+			policyExists, err := checkSecurityPolicyExists(
+				fnCtx,
+				plan.FromZone.ValueString(),
+				plan.ToZone.ValueString(),
+				junSess,
+			)
+			if err != nil {
+				resp.Diagnostics.AddError(tfdiag.PreCheckErrSummary, err.Error())
+
+				return false
+			}
+			if policyExists {
+				resp.Diagnostics.AddError(
+					tfdiag.DuplicateConfigErrSummary,
+					fmt.Sprintf(rsc.junosName()+" from %q to %q already exists",
+						plan.FromZone.ValueString(), plan.ToZone.ValueString()),
+				)
+
+				return false
+			}
+
+			return true
+		},
+		func(fnCtx context.Context, junSess *junos.Session) bool {
+			policyExists, err := checkSecurityPolicyExists(
+				fnCtx,
+				plan.FromZone.ValueString(),
+				plan.ToZone.ValueString(),
+				junSess,
+			)
+			if err != nil {
+				resp.Diagnostics.AddError(tfdiag.PostCheckErrSummary, err.Error())
+
+				return false
+			}
+			if !policyExists {
+				resp.Diagnostics.AddError(
+					tfdiag.NotFoundErrSummary,
+					fmt.Sprintf(rsc.junosName()+" from %q to %q not exists after commit "+
+						"=> check your config", plan.FromZone.ValueString(), plan.ToZone.ValueString()),
+				)
+
+				return false
+			}
+
+			return true
+		},
+		&plan,
+		resp,
+	)
+}
+
+func (rsc *securityPolicyUnordered) Read(
+	ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse,
+) {
+	var state, data securityPolicyData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var _ resourceDataReadFrom2String = &data
+	defaultResourceRead(
+		ctx,
+		rsc,
+		[]any{
+			state.FromZone.ValueString(),
+			state.ToZone.ValueString(),
+		},
+		&data,
+		nil,
+		resp,
+	)
+}
+
+func (rsc *securityPolicyUnordered) Update(
+	ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse,
+) {
+	var plan, state securityPolicyData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if rsc.client.FakeUpdateAlso() {
+		junSess := rsc.client.NewSessionWithoutNetconf(ctx)
+
+		if err := state.del(ctx, junSess); err != nil {
+			resp.Diagnostics.AddError(tfdiag.ConfigDelErrSummary, err.Error())
+
+			return
+		}
+		if errPath, err := plan.set(ctx, junSess); err != nil {
+			if !errPath.Equal(path.Empty()) {
+				resp.Diagnostics.AddAttributeError(errPath, tfdiag.ConfigSetErrSummary, err.Error())
+			} else {
+				resp.Diagnostics.AddError(tfdiag.ConfigSetErrSummary, err.Error())
+			}
+
+			return
+		}
+
+		resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+
+		return
+	}
+
+	junSess, err := rsc.client.StartNewSession(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError(tfdiag.StartSessErrSummary, err.Error())
+
+		return
+	}
+	defer junSess.Close()
+	if err := junSess.ConfigLock(ctx); err != nil {
+		resp.Diagnostics.AddError(tfdiag.ConfigLockErrSummary, err.Error())
+
+		return
+	}
+	defer func() {
+		resp.Diagnostics.Append(tfdiag.Warns(tfdiag.ConfigUnlockWarnSummary, junSess.ConfigUnlock())...)
+	}()
+
+	listLinesToPairPolicy, err := readSecurityPolicyTunnelPairPolicyLines(
+		ctx,
+		state.FromZone.ValueString(),
+		state.ToZone.ValueString(),
+		junSess,
+	)
+	if err != nil {
+		resp.Diagnostics.AddError(tfdiag.ConfigReadErrSummary, err.Error())
+
+		return
+	}
+	if err := state.del(ctx, junSess); err != nil {
+		resp.Diagnostics.AddError(tfdiag.ConfigDelErrSummary, err.Error())
+
+		return
+	}
+	if errPath, err := plan.set(ctx, junSess); err != nil {
+		if !errPath.Equal(path.Empty()) {
+			resp.Diagnostics.AddAttributeError(errPath, tfdiag.ConfigSetErrSummary, err.Error())
+		} else {
+			resp.Diagnostics.AddError(tfdiag.ConfigSetErrSummary, err.Error())
+		}
+
+		return
+	}
+	if err := junSess.ConfigSet(listLinesToPairPolicy); err != nil {
+		resp.Diagnostics.AddError(tfdiag.ConfigSetErrSummary, err.Error())
+
+		return
+	}
+	warns, err := junSess.CommitConf(ctx, "update resource "+rsc.typeName())
+	resp.Diagnostics.Append(tfdiag.Warns(tfdiag.ConfigCommitWarnSummary, warns)...)
+	if err != nil {
+		resp.Diagnostics.AddError(tfdiag.ConfigCommitErrSummary, err.Error())
+
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (rsc *securityPolicyUnordered) Delete(
+	ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse,
+) {
+	var state securityPolicyData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	defaultResourceDelete(
+		ctx,
+		rsc,
+		&state,
+		resp,
+	)
+}
+
+func (rsc *securityPolicyUnordered) ImportState(
+	ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse,
+) {
+	var data securityPolicyData
+
+	var _ resourceDataReadFrom2String = &data
+	defaultResourceImportState(
+		ctx,
+		rsc,
+		&data,
+		req,
+		resp,
+		defaultResourceImportDontFindMessage(rsc, req.ID)+
+			" (id must be <zone>"+junos.IDSeparator+"<name>)",
+	)
+}

--- a/internal/providerfwk/resource_security_policy_unordered_test.go
+++ b/internal/providerfwk/resource_security_policy_unordered_test.go
@@ -1,0 +1,31 @@
+package providerfwk_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccResourceSecurityPolicyUnordered_basic(t *testing.T) {
+	if os.Getenv("TESTACC_SRX") != "" {
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					ConfigDirectory: config.TestStepDirectory(),
+				},
+				{
+					ConfigDirectory: config.TestStepDirectory(),
+				},
+				{
+					ResourceName:      "junos_security_policy_unordered.testacc_securityPolicy",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+			},
+		})
+	}
+}

--- a/internal/providerfwk/resource_security_zone.go
+++ b/internal/providerfwk/resource_security_zone.go
@@ -77,298 +77,36 @@ func (rsc *securityZone) Schema(
 ) {
 	resp.Schema = schema.Schema{
 		Description: defaultResourceSchemaDescription(rsc),
-		Attributes: map[string]schema.Attribute{
-			"id": schema.StringAttribute{
-				Computed:    true,
-				Description: "An identifier for the resource with format `<name>`.",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
-			"name": schema.StringAttribute{
-				Required:    true,
-				Description: "The name of security zone.",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
-				Validators: []validator.String{
-					stringvalidator.LengthBetween(1, 63),
-					tfvalidator.StringFormat(tfvalidator.DefaultFormat),
-				},
-			},
-			"address_book_configure_singly": schema.BoolAttribute{
-				Optional: true,
-				Description: "Disable management of address-book in this resource " +
-					"to be able to manage them with specific resources.",
-				Validators: []validator.Bool{
-					tfvalidator.BoolTrue(),
-				},
-			},
-			"advance_policy_based_routing_profile": schema.StringAttribute{
-				Optional:    true,
-				Description: "Enable Advance Policy Based Routing on this zone with a profile.",
-				Validators: []validator.String{
-					stringvalidator.LengthBetween(1, 63),
-					tfvalidator.StringDoubleQuoteExclusion(),
-				},
-			},
-			"application_tracking": schema.BoolAttribute{
-				Optional:    true,
-				Description: "Enable Application tracking support for this zone.",
-				Validators: []validator.Bool{
-					tfvalidator.BoolTrue(),
-				},
-			},
-			"description": schema.StringAttribute{
-				Optional:    true,
-				Description: "Text description of zone.",
-				Validators: []validator.String{
-					stringvalidator.LengthBetween(1, 900),
-					tfvalidator.StringDoubleQuoteExclusion(),
-				},
-			},
-			"inbound_protocols": schema.SetAttribute{
-				ElementType: types.StringType,
-				Optional:    true,
-				Description: "The inbound protocols allowed.",
-				Validators: []validator.Set{
-					setvalidator.SizeAtLeast(1),
-					setvalidator.ValueStringsAre(
-						stringvalidator.LengthBetween(1, 32),
-						tfvalidator.StringDoubleQuoteExclusion(),
-					),
-				},
-			},
-			"inbound_services": schema.SetAttribute{
-				ElementType: types.StringType,
-				Optional:    true,
-				Description: "The inbound services allowed.",
-				Validators: []validator.Set{
-					setvalidator.SizeAtLeast(1),
-					setvalidator.ValueStringsAre(
-						stringvalidator.LengthBetween(1, 32),
-						tfvalidator.StringDoubleQuoteExclusion(),
-					),
-				},
-			},
-			"reverse_reroute": schema.BoolAttribute{
-				Optional:    true,
-				Description: "Enable Reverse route lookup when there is change in ingress interface.",
-				Validators: []validator.Bool{
-					tfvalidator.BoolTrue(),
-				},
-			},
-			"screen": schema.StringAttribute{
-				Optional:    true,
-				Description: "Name of ids option object (screen) applied to the zone.",
-				Validators: []validator.String{
-					stringvalidator.LengthBetween(1, 32),
-					tfvalidator.StringDoubleQuoteExclusion(),
-				},
-			},
-			"source_identity_log": schema.BoolAttribute{
-				Optional:    true,
-				Description: "Show user and group info in session log for this zone.",
-				Validators: []validator.Bool{
-					tfvalidator.BoolTrue(),
-				},
-			},
-			"tcp_rst": schema.BoolAttribute{
-				Optional:    true,
-				Description: "Send RST for NON-SYN packet not matching TCP session.",
-				Validators: []validator.Bool{
-					tfvalidator.BoolTrue(),
-				},
-			},
-		},
+		Attributes:  securityZoneData{}.attributesSchema(),
 		Blocks: map[string]schema.Block{
 			"address_book": schema.SetNestedBlock{
 				Description: "For each name of network address to declare.",
 				NestedObject: schema.NestedBlockObject{
-					Attributes: map[string]schema.Attribute{
-						"name": schema.StringAttribute{
-							Required:    true,
-							Description: "Name of network address.",
-							Validators: []validator.String{
-								stringvalidator.LengthBetween(1, 63),
-								tfvalidator.StringFormat(tfvalidator.AddressNameFormat),
-							},
-						},
-						"network": schema.StringAttribute{
-							Required:    true,
-							Description: "CIDR value of network address (`192.0.0.0/24`).",
-							Validators: []validator.String{
-								tfvalidator.StringCIDRNetwork(),
-							},
-						},
-						"description": schema.StringAttribute{
-							Optional:    true,
-							Description: "Description of network address.",
-							Validators: []validator.String{
-								stringvalidator.LengthBetween(1, 900),
-								tfvalidator.StringDoubleQuoteExclusion(),
-							},
-						},
-					},
+					Attributes: securityZoneBlockAddressBook{}.attributesSchema(),
 				},
 			},
 			"address_book_dns": schema.SetNestedBlock{
 				Description: "For each name of dns-name address to declare.",
 				NestedObject: schema.NestedBlockObject{
-					Attributes: map[string]schema.Attribute{
-						"name": schema.StringAttribute{
-							Required:    true,
-							Description: "Name of dns name address.",
-							Validators: []validator.String{
-								stringvalidator.LengthBetween(1, 63),
-								tfvalidator.StringFormat(tfvalidator.AddressNameFormat),
-							},
-						},
-						"fqdn": schema.StringAttribute{
-							Required:    true,
-							Description: "Fully qualified domain name.",
-							Validators: []validator.String{
-								stringvalidator.LengthBetween(1, 253),
-								tfvalidator.StringFormat(tfvalidator.DNSNameFormat),
-							},
-						},
-						"description": schema.StringAttribute{
-							Optional:    true,
-							Description: "Description of dns name address.",
-							Validators: []validator.String{
-								stringvalidator.LengthBetween(1, 900),
-								tfvalidator.StringDoubleQuoteExclusion(),
-							},
-						},
-						"ipv4_only": schema.BoolAttribute{
-							Optional:    true,
-							Description: "IPv4 dns address.",
-							Validators: []validator.Bool{
-								tfvalidator.BoolTrue(),
-							},
-						},
-						"ipv6_only": schema.BoolAttribute{
-							Optional:    true,
-							Description: "IPv6 dns address.",
-							Validators: []validator.Bool{
-								tfvalidator.BoolTrue(),
-							},
-						},
-					},
+					Attributes: securityZoneBlockAddressBookDNS{}.attributesSchema(),
 				},
 			},
 			"address_book_range": schema.SetNestedBlock{
 				Description: "For each name of range-address to declare.",
 				NestedObject: schema.NestedBlockObject{
-					Attributes: map[string]schema.Attribute{
-						"name": schema.StringAttribute{
-							Required:    true,
-							Description: "Name of range address.",
-							Validators: []validator.String{
-								stringvalidator.LengthBetween(1, 63),
-								tfvalidator.StringFormat(tfvalidator.AddressNameFormat),
-							},
-						},
-						"from": schema.StringAttribute{
-							Required:    true,
-							Description: "Lower limit of address range.",
-							Validators: []validator.String{
-								tfvalidator.StringIPAddress(),
-							},
-						},
-						"to": schema.StringAttribute{
-							Required:    true,
-							Description: "Upper limit of address range.",
-							Validators: []validator.String{
-								tfvalidator.StringIPAddress(),
-							},
-						},
-						"description": schema.StringAttribute{
-							Optional:    true,
-							Description: "Description of range address.",
-							Validators: []validator.String{
-								stringvalidator.LengthBetween(1, 900),
-								tfvalidator.StringDoubleQuoteExclusion(),
-							},
-						},
-					},
+					Attributes: securityZoneBlockAddressBookRange{}.attributesSchema(),
 				},
 			},
 			"address_book_set": schema.SetNestedBlock{
 				Description: "For each name of address-set to declare.",
 				NestedObject: schema.NestedBlockObject{
-					Attributes: map[string]schema.Attribute{
-						"name": schema.StringAttribute{
-							Required:    true,
-							Description: "Name of address-set.",
-							Validators: []validator.String{
-								stringvalidator.LengthBetween(1, 63),
-								tfvalidator.StringFormat(tfvalidator.AddressNameFormat),
-							},
-						},
-						"address": schema.SetAttribute{
-							ElementType: types.StringType,
-							Optional:    true,
-							Description: "List of address names.",
-							Validators: []validator.Set{
-								setvalidator.SizeAtLeast(1),
-								setvalidator.ValueStringsAre(
-									stringvalidator.LengthBetween(1, 63),
-									tfvalidator.StringFormat(tfvalidator.AddressNameFormat),
-								),
-							},
-						},
-						"address_set": schema.SetAttribute{
-							ElementType: types.StringType,
-							Optional:    true,
-							Description: "List of address-set names.",
-							Validators: []validator.Set{
-								setvalidator.SizeAtLeast(1),
-								setvalidator.ValueStringsAre(
-									stringvalidator.LengthBetween(1, 63),
-									tfvalidator.StringFormat(tfvalidator.AddressNameFormat),
-								),
-							},
-						},
-						"description": schema.StringAttribute{
-							Optional:    true,
-							Description: "Description of address-set.",
-							Validators: []validator.String{
-								stringvalidator.LengthBetween(1, 900),
-								tfvalidator.StringDoubleQuoteExclusion(),
-							},
-						},
-					},
+					Attributes: securityZoneBlockAddressBookSet{}.attributesSchema(),
 				},
 			},
 			"address_book_wildcard": schema.SetNestedBlock{
 				Description: "For each name of wildcard-address to declare.",
 				NestedObject: schema.NestedBlockObject{
-					Attributes: map[string]schema.Attribute{
-						"name": schema.StringAttribute{
-							Required:    true,
-							Description: "Name of wildcard address.",
-							Validators: []validator.String{
-								stringvalidator.LengthBetween(1, 63),
-								tfvalidator.StringFormat(tfvalidator.AddressNameFormat),
-							},
-						},
-						"network": schema.StringAttribute{
-							Required:    true,
-							Description: "Numeric IPv4 wildcard address with in the form of a.d.d.r/netmask.",
-							Validators: []validator.String{
-								tfvalidator.StringWildcardNetwork(),
-							},
-						},
-						"description": schema.StringAttribute{
-							Optional:    true,
-							Description: "Description of wildcard address.",
-							Validators: []validator.String{
-								stringvalidator.LengthBetween(1, 900),
-								tfvalidator.StringDoubleQuoteExclusion(),
-							},
-						},
-					},
+					Attributes: securityZoneBlockAddressBookWildcard{}.attributesSchema(),
 				},
 			},
 		},
@@ -394,6 +132,113 @@ type securityZoneData struct {
 	AddressBookSet                   []securityZoneBlockAddressBookSet      `tfsdk:"address_book_set"`
 	AddressBookWildcard              []securityZoneBlockAddressBookWildcard `tfsdk:"address_book_wildcard"`
 	Interface                        []securityZoneDataSourceBlockInterface `tfsdk:"-"` // to data source
+}
+
+func (securityZoneData) attributesSchema() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"id": schema.StringAttribute{
+			Computed:    true,
+			Description: "An identifier for the resource with format `<name>`.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
+		},
+		"name": schema.StringAttribute{
+			Required:    true,
+			Description: "The name of security zone.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.RequiresReplace(),
+			},
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 63),
+				tfvalidator.StringFormat(tfvalidator.DefaultFormat),
+			},
+		},
+		"address_book_configure_singly": schema.BoolAttribute{
+			Optional: true,
+			Description: "Disable management of address-book in this resource " +
+				"to be able to manage them with specific resources.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+		"advance_policy_based_routing_profile": schema.StringAttribute{
+			Optional:    true,
+			Description: "Enable Advance Policy Based Routing on this zone with a profile.",
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 63),
+				tfvalidator.StringDoubleQuoteExclusion(),
+			},
+		},
+		"application_tracking": schema.BoolAttribute{
+			Optional:    true,
+			Description: "Enable Application tracking support for this zone.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+		"description": schema.StringAttribute{
+			Optional:    true,
+			Description: "Text description of zone.",
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 900),
+				tfvalidator.StringDoubleQuoteExclusion(),
+			},
+		},
+		"inbound_protocols": schema.SetAttribute{
+			ElementType: types.StringType,
+			Optional:    true,
+			Description: "The inbound protocols allowed.",
+			Validators: []validator.Set{
+				setvalidator.SizeAtLeast(1),
+				setvalidator.ValueStringsAre(
+					stringvalidator.LengthBetween(1, 32),
+					tfvalidator.StringDoubleQuoteExclusion(),
+				),
+			},
+		},
+		"inbound_services": schema.SetAttribute{
+			ElementType: types.StringType,
+			Optional:    true,
+			Description: "The inbound services allowed.",
+			Validators: []validator.Set{
+				setvalidator.SizeAtLeast(1),
+				setvalidator.ValueStringsAre(
+					stringvalidator.LengthBetween(1, 32),
+					tfvalidator.StringDoubleQuoteExclusion(),
+				),
+			},
+		},
+		"reverse_reroute": schema.BoolAttribute{
+			Optional:    true,
+			Description: "Enable Reverse route lookup when there is change in ingress interface.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+		"screen": schema.StringAttribute{
+			Optional:    true,
+			Description: "Name of ids option object (screen) applied to the zone.",
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 32),
+				tfvalidator.StringDoubleQuoteExclusion(),
+			},
+		},
+		"source_identity_log": schema.BoolAttribute{
+			Optional:    true,
+			Description: "Show user and group info in session log for this zone.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+		"tcp_rst": schema.BoolAttribute{
+			Optional:    true,
+			Description: "Send RST for NON-SYN packet not matching TCP session.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+	}
 }
 
 type securityZoneConfig struct {
@@ -422,12 +267,83 @@ type securityZoneBlockAddressBook struct {
 	Description types.String `tfsdk:"description"`
 }
 
+func (securityZoneBlockAddressBook) attributesSchema() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"name": schema.StringAttribute{
+			Required:    true,
+			Description: "Name of network address.",
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 63),
+				tfvalidator.StringFormat(tfvalidator.AddressNameFormat),
+			},
+		},
+		"network": schema.StringAttribute{
+			Required:    true,
+			Description: "CIDR value of network address (`192.0.0.0/24`).",
+			Validators: []validator.String{
+				tfvalidator.StringCIDRNetwork(),
+			},
+		},
+		"description": schema.StringAttribute{
+			Optional:    true,
+			Description: "Description of network address.",
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 900),
+				tfvalidator.StringDoubleQuoteExclusion(),
+			},
+		},
+	}
+}
+
 type securityZoneBlockAddressBookDNS struct {
 	Name        types.String `tfsdk:"name"`
 	FQDN        types.String `tfsdk:"fqdn"`
 	Description types.String `tfsdk:"description"`
 	IPv4Only    types.Bool   `tfsdk:"ipv4_only"`
 	IPv6Only    types.Bool   `tfsdk:"ipv6_only"`
+}
+
+func (securityZoneBlockAddressBookDNS) attributesSchema() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"name": schema.StringAttribute{
+			Required:    true,
+			Description: "Name of dns name address.",
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 63),
+				tfvalidator.StringFormat(tfvalidator.AddressNameFormat),
+			},
+		},
+		"fqdn": schema.StringAttribute{
+			Required:    true,
+			Description: "Fully qualified domain name.",
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 253),
+				tfvalidator.StringFormat(tfvalidator.DNSNameFormat),
+			},
+		},
+		"description": schema.StringAttribute{
+			Optional:    true,
+			Description: "Description of dns name address.",
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 900),
+				tfvalidator.StringDoubleQuoteExclusion(),
+			},
+		},
+		"ipv4_only": schema.BoolAttribute{
+			Optional:    true,
+			Description: "IPv4 dns address.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+		"ipv6_only": schema.BoolAttribute{
+			Optional:    true,
+			Description: "IPv6 dns address.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
+	}
 }
 
 type securityZoneBlockAddressBookRange struct {
@@ -437,11 +353,91 @@ type securityZoneBlockAddressBookRange struct {
 	Description types.String `tfsdk:"description"`
 }
 
+func (securityZoneBlockAddressBookRange) attributesSchema() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"name": schema.StringAttribute{
+			Required:    true,
+			Description: "Name of range address.",
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 63),
+				tfvalidator.StringFormat(tfvalidator.AddressNameFormat),
+			},
+		},
+		"from": schema.StringAttribute{
+			Required:    true,
+			Description: "Lower limit of address range.",
+			Validators: []validator.String{
+				tfvalidator.StringIPAddress(),
+			},
+		},
+		"to": schema.StringAttribute{
+			Required:    true,
+			Description: "Upper limit of address range.",
+			Validators: []validator.String{
+				tfvalidator.StringIPAddress(),
+			},
+		},
+		"description": schema.StringAttribute{
+			Optional:    true,
+			Description: "Description of range address.",
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 900),
+				tfvalidator.StringDoubleQuoteExclusion(),
+			},
+		},
+	}
+}
+
 type securityZoneBlockAddressBookSet struct {
 	Name        types.String   `tfsdk:"name"`
 	Address     []types.String `tfsdk:"address"`
 	AddressSet  []types.String `tfsdk:"address_set"`
 	Description types.String   `tfsdk:"description"`
+}
+
+func (securityZoneBlockAddressBookSet) attributesSchema() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"name": schema.StringAttribute{
+			Required:    true,
+			Description: "Name of address-set.",
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 63),
+				tfvalidator.StringFormat(tfvalidator.AddressNameFormat),
+			},
+		},
+		"address": schema.SetAttribute{
+			ElementType: types.StringType,
+			Optional:    true,
+			Description: "List of address names.",
+			Validators: []validator.Set{
+				setvalidator.SizeAtLeast(1),
+				setvalidator.ValueStringsAre(
+					stringvalidator.LengthBetween(1, 63),
+					tfvalidator.StringFormat(tfvalidator.AddressNameFormat),
+				),
+			},
+		},
+		"address_set": schema.SetAttribute{
+			ElementType: types.StringType,
+			Optional:    true,
+			Description: "List of address-set names.",
+			Validators: []validator.Set{
+				setvalidator.SizeAtLeast(1),
+				setvalidator.ValueStringsAre(
+					stringvalidator.LengthBetween(1, 63),
+					tfvalidator.StringFormat(tfvalidator.AddressNameFormat),
+				),
+			},
+		},
+		"description": schema.StringAttribute{
+			Optional:    true,
+			Description: "Description of address-set.",
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 900),
+				tfvalidator.StringDoubleQuoteExclusion(),
+			},
+		},
+	}
 }
 
 type securityZoneBlockAddressBookSetConfig struct {
@@ -455,6 +451,34 @@ type securityZoneBlockAddressBookWildcard struct {
 	Name        types.String `tfsdk:"name"`
 	Network     types.String `tfsdk:"network"`
 	Description types.String `tfsdk:"description"`
+}
+
+func (securityZoneBlockAddressBookWildcard) attributesSchema() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"name": schema.StringAttribute{
+			Required:    true,
+			Description: "Name of wildcard address.",
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 63),
+				tfvalidator.StringFormat(tfvalidator.AddressNameFormat),
+			},
+		},
+		"network": schema.StringAttribute{
+			Required:    true,
+			Description: "Numeric IPv4 wildcard address with in the form of a.d.d.r/netmask.",
+			Validators: []validator.String{
+				tfvalidator.StringWildcardNetwork(),
+			},
+		},
+		"description": schema.StringAttribute{
+			Optional:    true,
+			Description: "Description of wildcard address.",
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 900),
+				tfvalidator.StringDoubleQuoteExclusion(),
+			},
+		},
+	}
 }
 
 func (rsc *securityZone) ValidateConfig(
@@ -876,10 +900,10 @@ func (rscData *securityZoneData) set(
 	configSet = append(configSet, setPrefix)
 	if !rscData.AddressBookConfigureSingly.ValueBool() {
 		addressName := make(map[string]struct{})
-		for _, block := range rscData.AddressBook {
+		for i, block := range rscData.AddressBook {
 			name := block.Name.ValueString()
 			if _, ok := addressName[name]; ok {
-				return path.Root("address_book"),
+				return path.Root("address_book").AtListIndex(i).AtName("name"),
 					fmt.Errorf("multiple addresses with the same name %q", name)
 			}
 			addressName[name] = struct{}{}
@@ -889,10 +913,10 @@ func (rscData *securityZoneData) set(
 				configSet = append(configSet, setPrefix+"address-book address "+name+" description \""+v+"\"")
 			}
 		}
-		for _, block := range rscData.AddressBookDNS {
+		for i, block := range rscData.AddressBookDNS {
 			name := block.Name.ValueString()
 			if _, ok := addressName[name]; ok {
-				return path.Root("address_book_dns"),
+				return path.Root("address_book_dns").AtListIndex(i).AtName("name"),
 					fmt.Errorf("multiple addresses with the same name %q", name)
 			}
 			addressName[name] = struct{}{}
@@ -909,10 +933,10 @@ func (rscData *securityZoneData) set(
 				configSet = append(configSet, setPrefix+"address-book address "+name+" description \""+v+"\"")
 			}
 		}
-		for _, block := range rscData.AddressBookRange {
+		for i, block := range rscData.AddressBookRange {
 			name := block.Name.ValueString()
 			if _, ok := addressName[name]; ok {
-				return path.Root("address_book_range"),
+				return path.Root("address_book_range").AtListIndex(i).AtName("name"),
 					fmt.Errorf("multiple addresses with the same name %q", name)
 			}
 			addressName[name] = struct{}{}
@@ -924,17 +948,17 @@ func (rscData *securityZoneData) set(
 				configSet = append(configSet, setPrefix+"address-book address "+name+" description \""+v+"\"")
 			}
 		}
-		for _, block := range rscData.AddressBookSet {
+		for i, block := range rscData.AddressBookSet {
 			name := block.Name.ValueString()
 			if _, ok := addressName[name]; ok {
-				return path.Root("address_book_set"),
+				return path.Root("address_book_set").AtListIndex(i).AtName("name"),
 					fmt.Errorf("multiple addresses or address-sets with the same name %q", name)
 			}
 			addressName[name] = struct{}{}
 
 			if len(block.Address) == 0 &&
 				len(block.AddressSet) == 0 {
-				return path.Root("address_book_set"),
+				return path.Root("address_book_set").AtListIndex(i).AtName("name"),
 					fmt.Errorf("at least one of address or address_set must be specified in address_set %q", name)
 			}
 			for _, v := range block.Address {
@@ -947,10 +971,10 @@ func (rscData *securityZoneData) set(
 				configSet = append(configSet, setPrefix+"address-book address-set "+name+" description \""+v+"\"")
 			}
 		}
-		for _, block := range rscData.AddressBookWildcard {
+		for i, block := range rscData.AddressBookWildcard {
 			name := block.Name.ValueString()
 			if _, ok := addressName[name]; ok {
-				return path.Root("address_book_wildcard"),
+				return path.Root("address_book_wildcard").AtListIndex(i).AtName("name"),
 					fmt.Errorf("multiple addresses with the same name %q", name)
 			}
 			addressName[name] = struct{}{}

--- a/internal/providerfwk/resource_security_zone_ordered.go
+++ b/internal/providerfwk/resource_security_zone_ordered.go
@@ -1,0 +1,508 @@
+package providerfwk
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jeremmfr/terraform-provider-junos/internal/junos"
+	"github.com/jeremmfr/terraform-provider-junos/internal/tfdiag"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// Ensure the implementation satisfies the expected interfaces.
+var (
+	_ resource.Resource                   = &securityZoneOrdered{}
+	_ resource.ResourceWithConfigure      = &securityZoneOrdered{}
+	_ resource.ResourceWithValidateConfig = &securityZoneOrdered{}
+	_ resource.ResourceWithImportState    = &securityZoneOrdered{}
+)
+
+type securityZoneOrdered struct {
+	client *junos.Client
+}
+
+func newSecurityZoneOrderedResource() resource.Resource {
+	return &securityZoneOrdered{}
+}
+
+func (rsc *securityZoneOrdered) typeName() string {
+	return providerName + "_security_zone_ordered"
+}
+
+func (rsc *securityZoneOrdered) junosName() string {
+	return "security zone"
+}
+
+func (rsc *securityZoneOrdered) junosClient() *junos.Client {
+	return rsc.client
+}
+
+func (rsc *securityZoneOrdered) Metadata(
+	_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse,
+) {
+	resp.TypeName = rsc.typeName()
+}
+
+func (rsc *securityZoneOrdered) Configure(
+	ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse,
+) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(*junos.Client)
+	if !ok {
+		unexpectedResourceConfigureType(ctx, req, resp)
+
+		return
+	}
+	rsc.client = client
+}
+
+func (rsc *securityZoneOrdered) Schema(
+	_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse,
+) {
+	resp.Schema = schema.Schema{
+		Description: defaultResourceSchemaDescription(rsc),
+		Attributes:  securityZoneData{}.attributesSchema(),
+		Blocks: map[string]schema.Block{
+			"address_book": schema.ListNestedBlock{
+				Description: "For each name of network address to declare.",
+				NestedObject: schema.NestedBlockObject{
+					Attributes: securityZoneBlockAddressBook{}.attributesSchema(),
+				},
+			},
+			"address_book_dns": schema.ListNestedBlock{
+				Description: "For each name of dns-name address to declare.",
+				NestedObject: schema.NestedBlockObject{
+					Attributes: securityZoneBlockAddressBookDNS{}.attributesSchema(),
+				},
+			},
+			"address_book_range": schema.ListNestedBlock{
+				Description: "For each name of range-address to declare.",
+				NestedObject: schema.NestedBlockObject{
+					Attributes: securityZoneBlockAddressBookRange{}.attributesSchema(),
+				},
+			},
+			"address_book_set": schema.ListNestedBlock{
+				Description: "For each name of address-set to declare.",
+				NestedObject: schema.NestedBlockObject{
+					Attributes: securityZoneBlockAddressBookSet{}.attributesSchema(),
+				},
+			},
+			"address_book_wildcard": schema.ListNestedBlock{
+				Description: "For each name of wildcard-address to declare.",
+				NestedObject: schema.NestedBlockObject{
+					Attributes: securityZoneBlockAddressBookWildcard{}.attributesSchema(),
+				},
+			},
+		},
+	}
+}
+
+type securityZoneOrderedConfig struct {
+	ID                               types.String `tfsdk:"id"`
+	Name                             types.String `tfsdk:"name"`
+	AddressBookConfigureSingly       types.Bool   `tfsdk:"address_book_configure_singly"`
+	AdvancePolicyBasedRoutingProfile types.String `tfsdk:"advance_policy_based_routing_profile"`
+	ApplicationTracking              types.Bool   `tfsdk:"application_tracking"`
+	Description                      types.String `tfsdk:"description"`
+	InboundProtocols                 types.Set    `tfsdk:"inbound_protocols"`
+	InboundServices                  types.Set    `tfsdk:"inbound_services"`
+	ReverseReroute                   types.Bool   `tfsdk:"reverse_reroute"`
+	Screen                           types.String `tfsdk:"screen"`
+	SourceIdentityLog                types.Bool   `tfsdk:"source_identity_log"`
+	TCPRst                           types.Bool   `tfsdk:"tcp_rst"`
+	AddressBook                      types.List   `tfsdk:"address_book"`
+	AddressBookDNS                   types.List   `tfsdk:"address_book_dns"`
+	AddressBookRange                 types.List   `tfsdk:"address_book_range"`
+	AddressBookSet                   types.List   `tfsdk:"address_book_set"`
+	AddressBookWildcard              types.List   `tfsdk:"address_book_wildcard"`
+}
+
+func (rsc *securityZoneOrdered) ValidateConfig(
+	ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse,
+) {
+	var config securityZoneOrderedConfig
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if config.AddressBookConfigureSingly.ValueBool() &&
+		((!config.AddressBook.IsNull() && !config.AddressBook.IsUnknown()) ||
+			(!config.AddressBookDNS.IsNull() && !config.AddressBookDNS.IsUnknown()) ||
+			(!config.AddressBookRange.IsNull() && !config.AddressBookRange.IsUnknown()) ||
+			(!config.AddressBookSet.IsNull() && !config.AddressBookSet.IsUnknown()) ||
+			(!config.AddressBookWildcard.IsNull() && !config.AddressBookWildcard.IsUnknown())) {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("address_book_configure_singly"),
+			tfdiag.ConflictConfigErrSummary,
+			"cannot have address_book_configure_singly and want to configure address book at the same time",
+		)
+	}
+
+	addressName := make(map[string]struct{})
+	if !config.AddressBook.IsNull() && !config.AddressBook.IsUnknown() {
+		var configAddressBook []securityZoneBlockAddressBook
+		asDiags := config.AddressBook.ElementsAs(ctx, &configAddressBook, false)
+		if asDiags.HasError() {
+			resp.Diagnostics.Append(asDiags...)
+
+			return
+		}
+		for i, block := range configAddressBook {
+			if block.Name.IsUnknown() {
+				continue
+			}
+			name := block.Name.ValueString()
+			if _, ok := addressName[name]; ok {
+				resp.Diagnostics.AddAttributeError(
+					path.Root("address_book").AtListIndex(i).AtName("name"),
+					tfdiag.DuplicateConfigErrSummary,
+					fmt.Sprintf("multiple addresses with the same name %q", name),
+				)
+			}
+			addressName[name] = struct{}{}
+		}
+	}
+	if !config.AddressBookDNS.IsNull() && !config.AddressBookDNS.IsUnknown() {
+		var configAddressBookDNS []securityZoneBlockAddressBookDNS
+		asDiags := config.AddressBookDNS.ElementsAs(ctx, &configAddressBookDNS, false)
+		if asDiags.HasError() {
+			resp.Diagnostics.Append(asDiags...)
+
+			return
+		}
+		for i, block := range configAddressBookDNS {
+			if block.IPv4Only.ValueBool() && block.IPv6Only.ValueBool() {
+				resp.Diagnostics.AddAttributeError(
+					path.Root("address_book_dns").AtListIndex(i).AtName("ipv4_only"),
+					tfdiag.ConflictConfigErrSummary,
+					fmt.Sprintf("ipv4_only and ipv6_only cannot be configured together in address_book_dns %q",
+						block.Name.ValueString()),
+				)
+			}
+			if block.Name.IsUnknown() {
+				continue
+			}
+			name := block.Name.ValueString()
+			if _, ok := addressName[name]; ok {
+				resp.Diagnostics.AddAttributeError(
+					path.Root("address_book_dns").AtListIndex(i).AtName("name"),
+					tfdiag.DuplicateConfigErrSummary,
+					fmt.Sprintf("multiple addresses with the same name %q", name),
+				)
+			}
+			addressName[name] = struct{}{}
+		}
+	}
+	if !config.AddressBookRange.IsNull() && !config.AddressBookRange.IsUnknown() {
+		var configAddressBookRange []securityZoneBlockAddressBookRange
+		asDiags := config.AddressBookRange.ElementsAs(ctx, &configAddressBookRange, false)
+		if asDiags.HasError() {
+			resp.Diagnostics.Append(asDiags...)
+
+			return
+		}
+		for i, block := range configAddressBookRange {
+			if block.Name.IsUnknown() {
+				continue
+			}
+			name := block.Name.ValueString()
+			if _, ok := addressName[name]; ok {
+				resp.Diagnostics.AddAttributeError(
+					path.Root("address_book_range").AtListIndex(i).AtName("name"),
+					tfdiag.DuplicateConfigErrSummary,
+					fmt.Sprintf("multiple addresses with the same name %q", name),
+				)
+			}
+			addressName[name] = struct{}{}
+		}
+	}
+	if !config.AddressBookSet.IsNull() && !config.AddressBookSet.IsUnknown() {
+		var configAddressBookSet []securityZoneBlockAddressBookSetConfig
+		asDiags := config.AddressBookSet.ElementsAs(ctx, &configAddressBookSet, false)
+		if asDiags.HasError() {
+			resp.Diagnostics.Append(asDiags...)
+
+			return
+		}
+		for i, block := range configAddressBookSet {
+			if block.Address.IsNull() && block.AddressSet.IsNull() {
+				resp.Diagnostics.AddAttributeError(
+					path.Root("address_book_set").AtListIndex(i).AtName("name"),
+					tfdiag.MissingConfigErrSummary,
+					fmt.Sprintf("at least one of address or address_set must be specified in address_book_set %q",
+						block.Name.ValueString()),
+				)
+			}
+			if block.Name.IsUnknown() {
+				continue
+			}
+			name := block.Name.ValueString()
+			if _, ok := addressName[name]; ok {
+				resp.Diagnostics.AddAttributeError(
+					path.Root("address_book_set").AtListIndex(i).AtName("name"),
+					tfdiag.DuplicateConfigErrSummary,
+					fmt.Sprintf("multiple addresses or address-sets with the same name %q", name),
+				)
+			}
+			addressName[name] = struct{}{}
+		}
+	}
+	if !config.AddressBookWildcard.IsNull() && !config.AddressBookWildcard.IsUnknown() {
+		var configAddressBookWildcard []securityZoneBlockAddressBookWildcard
+		asDiags := config.AddressBookWildcard.ElementsAs(ctx, &configAddressBookWildcard, false)
+		if asDiags.HasError() {
+			resp.Diagnostics.Append(asDiags...)
+
+			return
+		}
+		for i, block := range configAddressBookWildcard {
+			if block.Name.IsUnknown() {
+				continue
+			}
+			name := block.Name.ValueString()
+			if _, ok := addressName[name]; ok {
+				resp.Diagnostics.AddAttributeError(
+					path.Root("address_book_wildcard").AtListIndex(i).AtName("name"),
+					tfdiag.DuplicateConfigErrSummary,
+					fmt.Sprintf("multiple addresses with the same name %q", name),
+				)
+			}
+			addressName[name] = struct{}{}
+		}
+	}
+}
+
+func (rsc *securityZoneOrdered) Create(
+	ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse,
+) {
+	var plan securityZoneData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if plan.Name.ValueString() == "" {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("name"),
+			"Empty Name",
+			defaultResourceCouldNotCreateWithEmptyMessage(rsc, "name"),
+		)
+
+		return
+	}
+
+	defaultResourceCreate(
+		ctx,
+		rsc,
+		func(fnCtx context.Context, junSess *junos.Session) bool {
+			if !junSess.CheckCompatibilitySecurity() {
+				resp.Diagnostics.AddError(
+					tfdiag.CompatibilityErrSummary,
+					rsc.junosName()+junSess.SystemInformation.NotCompatibleMsg(),
+				)
+
+				return false
+			}
+			zoneExists, err := checkSecurityZonesExists(fnCtx, plan.Name.ValueString(), junSess)
+			if err != nil {
+				resp.Diagnostics.AddError(tfdiag.PreCheckErrSummary, err.Error())
+
+				return false
+			}
+			if zoneExists {
+				resp.Diagnostics.AddError(
+					tfdiag.DuplicateConfigErrSummary,
+					defaultResourceAlreadyExistsMessage(rsc, plan.Name),
+				)
+
+				return false
+			}
+
+			return true
+		},
+		func(fnCtx context.Context, junSess *junos.Session) bool {
+			zoneExists, err := checkSecurityZonesExists(fnCtx, plan.Name.ValueString(), junSess)
+			if err != nil {
+				resp.Diagnostics.AddError(tfdiag.PostCheckErrSummary, err.Error())
+
+				return false
+			}
+			if !zoneExists {
+				resp.Diagnostics.AddError(
+					tfdiag.NotFoundErrSummary,
+					defaultResourceDoesNotExistsAfterCommitMessage(rsc, plan.Name),
+				)
+
+				return false
+			}
+
+			return true
+		},
+		&plan,
+		resp,
+	)
+}
+
+func (rsc *securityZoneOrdered) Read(
+	ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse,
+) {
+	var state, data securityZoneData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var _ resourceDataReadFrom1String = &data
+	defaultResourceRead(
+		ctx,
+		rsc,
+		[]any{
+			state.Name.ValueString(),
+		},
+		&data,
+		func() {
+			data.AddressBookConfigureSingly = state.AddressBookConfigureSingly
+			if data.AddressBookConfigureSingly.ValueBool() {
+				data.AddressBook = nil
+				data.AddressBookDNS = nil
+				data.AddressBookRange = nil
+				data.AddressBookSet = nil
+				data.AddressBookWildcard = nil
+			}
+		},
+		resp,
+	)
+}
+
+func (rsc *securityZoneOrdered) Update(
+	ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse,
+) {
+	var plan, state securityZoneData
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	addressBookConfiguredSingly := plan.AddressBookConfigureSingly.ValueBool()
+	if !plan.AddressBookConfigureSingly.Equal(state.AddressBookConfigureSingly) {
+		if state.AddressBookConfigureSingly.ValueBool() {
+			addressBookConfiguredSingly = state.AddressBookConfigureSingly.ValueBool()
+			resp.Diagnostics.AddAttributeWarning(
+				path.Root("address_book_configure_singly"),
+				"Disable address_book_configure_singly on resource already created",
+				"It's doesn't delete addresses and address-sets already configured. "+
+					"So refresh resource after apply to detect address-book entries that need to be deleted",
+			)
+		} else {
+			resp.Diagnostics.AddAttributeWarning(
+				path.Root("address_book_configure_singly"),
+				"Enable address_book_configure_singly on resource already created",
+				"It's doesn't delete addresses and address-sets already configured. "+
+					"So import address-book entries in dedicated resource(s) to be able to manage them",
+			)
+		}
+	}
+
+	if rsc.client.FakeUpdateAlso() {
+		junSess := rsc.client.NewSessionWithoutNetconf(ctx)
+
+		if err := state.delOpts(ctx, addressBookConfiguredSingly, junSess); err != nil {
+			resp.Diagnostics.AddError(tfdiag.ConfigDelErrSummary, err.Error())
+
+			return
+		}
+		if errPath, err := plan.set(ctx, junSess); err != nil {
+			if !errPath.Equal(path.Empty()) {
+				resp.Diagnostics.AddAttributeError(errPath, tfdiag.ConfigSetErrSummary, err.Error())
+			} else {
+				resp.Diagnostics.AddError(tfdiag.ConfigSetErrSummary, err.Error())
+			}
+
+			return
+		}
+
+		resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+
+		return
+	}
+
+	junSess, err := rsc.client.StartNewSession(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError(tfdiag.StartSessErrSummary, err.Error())
+
+		return
+	}
+	defer junSess.Close()
+	if err := junSess.ConfigLock(ctx); err != nil {
+		resp.Diagnostics.AddError(tfdiag.ConfigLockErrSummary, err.Error())
+
+		return
+	}
+	defer func() {
+		resp.Diagnostics.Append(tfdiag.Warns(tfdiag.ConfigUnlockWarnSummary, junSess.ConfigUnlock())...)
+	}()
+
+	if err := state.delOpts(ctx, addressBookConfiguredSingly, junSess); err != nil {
+		resp.Diagnostics.AddError(tfdiag.ConfigDelErrSummary, err.Error())
+
+		return
+	}
+	if errPath, err := plan.set(ctx, junSess); err != nil {
+		if !errPath.Equal(path.Empty()) {
+			resp.Diagnostics.AddAttributeError(errPath, tfdiag.ConfigSetErrSummary, err.Error())
+		} else {
+			resp.Diagnostics.AddError(tfdiag.ConfigSetErrSummary, err.Error())
+		}
+
+		return
+	}
+	warns, err := junSess.CommitConf(ctx, "update resource "+rsc.typeName())
+	resp.Diagnostics.Append(tfdiag.Warns(tfdiag.ConfigCommitWarnSummary, warns)...)
+	if err != nil {
+		resp.Diagnostics.AddError(tfdiag.ConfigCommitErrSummary, err.Error())
+
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (rsc *securityZoneOrdered) Delete(
+	ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse,
+) {
+	var state securityZoneData
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	defaultResourceDelete(
+		ctx,
+		rsc,
+		&state,
+		resp,
+	)
+}
+
+func (rsc *securityZoneOrdered) ImportState(
+	ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse,
+) {
+	var data securityZoneData
+
+	var _ resourceDataReadFrom1String = &data
+	defaultResourceImportState(
+		ctx,
+		rsc,
+		&data,
+		req,
+		resp,
+		defaultResourceImportDontFindIDStrMessage(rsc, req.ID, "name"),
+	)
+}

--- a/internal/providerfwk/resource_security_zone_ordered_test.go
+++ b/internal/providerfwk/resource_security_zone_ordered_test.go
@@ -1,0 +1,41 @@
+package providerfwk_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/jeremmfr/terraform-provider-junos/internal/junos"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// export TESTACC_INTERFACE=<inteface> to choose interface available else it's ge-0/0/3.
+func TestAccResourceSecurityZoneOrdered_basic(t *testing.T) {
+	testaccInterface := junos.DefaultInterfaceTestAcc
+	if iface := os.Getenv("TESTACC_INTERFACE"); iface != "" {
+		testaccInterface = iface
+	}
+	if os.Getenv("TESTACC_SRX") != "" {
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					ConfigDirectory: config.TestStepDirectory(),
+				},
+				{
+					ResourceName:      "junos_security_zone_ordered.testacc_securityZone",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+				{
+					ConfigDirectory: config.TestStepDirectory(),
+					ConfigVariables: map[string]config.Variable{
+						"interface": config.StringVariable(testaccInterface),
+					},
+				},
+			},
+		})
+	}
+}

--- a/internal/providerfwk/resourceattr_bgp.go
+++ b/internal/providerfwk/resourceattr_bgp.go
@@ -76,7 +76,7 @@ type bgpAttrData struct {
 	GracefulRestart              *bgpBlockGracefulRestart      `tfsdk:"graceful_restart"`
 }
 
-func (rscData bgpAttrData) attributesSchema() map[string]schema.Attribute {
+func (bgpAttrData) attributesSchema() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"accept_remote_nexthop": schema.BoolAttribute{
 			Optional:    true,
@@ -399,15 +399,15 @@ func (rscData bgpAttrData) attributesSchema() map[string]schema.Attribute {
 	}
 }
 
-func (rscData bgpAttrData) blocksSchema() map[string]schema.Block {
+func (bgpAttrData) blocksSchema() map[string]schema.Block {
 	return map[string]schema.Block{
-		"bfd_liveness_detection": bgpBlockBfdLivenessDetection{}.resourceSchema(),
-		"bgp_error_tolerance":    bgpBlockBgpErrorTolerance{}.resourceSchema(),
-		"bgp_multipath":          bgpBlockBgpMultipath{}.resourceSchema(),
-		"family_evpn":            bgpBlockFamily{}.resourceSchema("EVPN"),
-		"family_inet":            bgpBlockFamily{}.resourceSchema("IPv4"),
-		"family_inet6":           bgpBlockFamily{}.resourceSchema("IPv6"),
-		"graceful_restart":       bgpBlockGracefulRestart{}.resourceSchema(),
+		"bfd_liveness_detection": bgpBlockBfdLivenessDetection{}.schema(),
+		"bgp_error_tolerance":    bgpBlockBgpErrorTolerance{}.schema(),
+		"bgp_multipath":          bgpBlockBgpMultipath{}.schema(),
+		"family_evpn":            bgpBlockFamily{}.schema("EVPN"),
+		"family_inet":            bgpBlockFamily{}.schema("IPv4"),
+		"family_inet6":           bgpBlockFamily{}.schema("IPv6"),
+		"graceful_restart":       bgpBlockGracefulRestart{}.schema(),
 	}
 }
 

--- a/internal/providerfwk/resourceattr_vstp_vlan.go
+++ b/internal/providerfwk/resourceattr_vstp_vlan.go
@@ -29,7 +29,7 @@ type vstpVlanAttrData struct {
 	SystemIdentifier     types.String `tfsdk:"system_identifier"`
 }
 
-func (rscData vstpVlanAttrData) attributesSchema() map[string]schema.Attribute {
+func (vstpVlanAttrData) attributesSchema() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"backup_bridge_priority": schema.StringAttribute{
 			Optional:    true,

--- a/internal/providerfwk/resourceblock_bgp.go
+++ b/internal/providerfwk/resourceblock_bgp.go
@@ -40,7 +40,7 @@ func (block *bgpBlockBfdLivenessDetection) isEmpty() bool {
 	return tfdata.CheckBlockIsEmpty(block)
 }
 
-func (bgpBlockBfdLivenessDetection) resourceSchema() schema.SingleNestedBlock {
+func (bgpBlockBfdLivenessDetection) schema() schema.SingleNestedBlock {
 	return schema.SingleNestedBlock{
 		Description: "Define Bidirectional Forwarding Detection (BFD) options.",
 		Attributes: map[string]schema.Attribute{
@@ -246,7 +246,7 @@ type bgpBlockBgpErrorTolerance struct {
 	MalformedUpdateLogInterval types.Int64 `tfsdk:"malformed_update_log_interval"`
 }
 
-func (bgpBlockBgpErrorTolerance) resourceSchema() schema.SingleNestedBlock {
+func (bgpBlockBgpErrorTolerance) schema() schema.SingleNestedBlock {
 	return schema.SingleNestedBlock{
 		Description: "Handle BGP malformed updates softly.",
 		Attributes: map[string]schema.Attribute{
@@ -325,7 +325,7 @@ type bgpBlockBgpMultipath struct {
 	MultipleAS      types.Bool `tfsdk:"multiple_as"`
 }
 
-func (bgpBlockBgpMultipath) resourceSchema() schema.SingleNestedBlock {
+func (bgpBlockBgpMultipath) schema() schema.SingleNestedBlock {
 	return schema.SingleNestedBlock{
 		Description: "Allow load sharing among multiple BGP paths.",
 		Attributes: map[string]schema.Attribute{
@@ -394,7 +394,7 @@ type bgpBlockFamily struct {
 	PrefixLimit         *bgpBlockFamilyBlockPrefixLimit `tfsdk:"prefix_limit"`
 }
 
-func (bgpBlockFamily) resourceSchema(family string) schema.ListNestedBlock {
+func (bgpBlockFamily) schema(family string) schema.ListNestedBlock {
 	attributes := map[string]schema.Attribute{
 		"nlri_type": schema.StringAttribute{
 			Required:    true,
@@ -423,8 +423,8 @@ func (bgpBlockFamily) resourceSchema(family string) schema.ListNestedBlock {
 		NestedObject: schema.NestedBlockObject{
 			Attributes: attributes,
 			Blocks: map[string]schema.Block{
-				"accepted_prefix_limit": bgpBlockFamilyBlockPrefixLimit{}.resourceSchema(true),
-				"prefix_limit":          bgpBlockFamilyBlockPrefixLimit{}.resourceSchema(false),
+				"accepted_prefix_limit": bgpBlockFamilyBlockPrefixLimit{}.schema(true),
+				"prefix_limit":          bgpBlockFamilyBlockPrefixLimit{}.schema(false),
 			},
 		},
 	}
@@ -437,7 +437,7 @@ type bgpBlockFamilyBlockPrefixLimit struct {
 	TeardownIdleTimeoutForever types.Bool  `tfsdk:"teardown_idle_timeout_forever"`
 }
 
-func (block bgpBlockFamilyBlockPrefixLimit) resourceSchema(accepted bool) schema.SingleNestedBlock {
+func (block bgpBlockFamilyBlockPrefixLimit) schema(accepted bool) schema.SingleNestedBlock {
 	description := "Define maximum number of prefixes from a peer."
 	if accepted {
 		description = "Define maximum number of prefixes accepted from a peer."
@@ -445,14 +445,14 @@ func (block bgpBlockFamilyBlockPrefixLimit) resourceSchema(accepted bool) schema
 
 	return schema.SingleNestedBlock{
 		Description: description,
-		Attributes:  block.resourceSchemaAttributes(),
+		Attributes:  block.attributesSchema(),
 		PlanModifiers: []planmodifier.Object{
 			tfplanmodifier.BlockRemoveNull(),
 		},
 	}
 }
 
-func (bgpBlockFamilyBlockPrefixLimit) resourceSchemaAttributes() map[string]schema.Attribute {
+func (bgpBlockFamilyBlockPrefixLimit) attributesSchema() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"maximum": schema.Int64Attribute{
 			Required:    false, // true when SingleNestedBlock is specified
@@ -610,7 +610,7 @@ type bgpBlockGracefulRestart struct {
 	StaleRouteTime types.Int64 `tfsdk:"stale_route_time"`
 }
 
-func (bgpBlockGracefulRestart) resourceSchema() schema.SingleNestedBlock {
+func (bgpBlockGracefulRestart) schema() schema.SingleNestedBlock {
 	return schema.SingleNestedBlock{
 		Description: "Define BGP graceful restart options.",
 		Attributes: map[string]schema.Attribute{

--- a/internal/providerfwk/resourceblock_rip.go
+++ b/internal/providerfwk/resourceblock_rip.go
@@ -31,7 +31,7 @@ type ripBlockBfdLivenessDetection struct {
 	Version                         types.String `tfsdk:"version"`
 }
 
-func (ripBlockBfdLivenessDetection) resourceSchema() schema.SingleNestedBlock {
+func (ripBlockBfdLivenessDetection) schema() schema.SingleNestedBlock {
 	return schema.SingleNestedBlock{
 		Description: "Define Bidirectional Forwarding Detection (BFD) options.",
 		Attributes: map[string]schema.Attribute{

--- a/internal/providerfwk/testdata/TestAccResourceApplicationsOrdered_basic/1/main.tf
+++ b/internal/providerfwk/testdata/TestAccResourceApplicationsOrdered_basic/1/main.tf
@@ -1,0 +1,19 @@
+resource "junos_applications_ordered" "testacc" {
+  application {
+    name             = "testacc_app4"
+    protocol         = "tcp"
+    destination_port = 22
+  }
+  application {
+    name = "testacc_app3"
+    term {
+      name             = "term_B"
+      protocol         = "tcp"
+      destination_port = 22
+    }
+  }
+  application_set {
+    name         = "testacc_app_set"
+    applications = ["junos-ssh"]
+  }
+}

--- a/internal/providerfwk/testdata/TestAccResourceApplicationsOrdered_basic/2/main.tf
+++ b/internal/providerfwk/testdata/TestAccResourceApplicationsOrdered_basic/2/main.tf
@@ -1,0 +1,94 @@
+resource "junos_applications_ordered" "testacc" {
+  application {
+    name                 = "testacc_apps4"
+    protocol             = "tcp"
+    destination_port     = "22"
+    application_protocol = "ssh"
+    description          = "ssh protocol"
+    inactivity_timeout   = 900
+    source_port          = "1024-65535"
+  }
+  application {
+    name                     = "testacc_apps2"
+    protocol                 = "tcp"
+    ether_type               = "0x0800"
+    rpc_program_number       = "0-0"
+    inactivity_timeout_never = true
+    uuid                     = "AAAAA0AA-B9B0-CCcc-DDDD-EEEffFFFAAAA"
+  }
+  application {
+    name = "testacc_apps3"
+    term {
+      name               = "term_B"
+      protocol           = "tcp"
+      destination_port   = 22
+      inactivity_timeout = 600
+      source_port        = "1024-65535"
+    }
+    term {
+      name     = "term_ALG"
+      protocol = "tcp"
+      alg      = "ssh"
+    }
+  }
+  application {
+    name = "testacc_apps0"
+    term {
+      name                     = "term_B"
+      protocol                 = "tcp"
+      rpc_program_number       = "1-1"
+      inactivity_timeout_never = true
+      uuid                     = "BBBAA0AA-B9B0-CCcc-DDDD-EEEffFFFAAAA"
+    }
+  }
+  application {
+    name = "testacc_apps5"
+    term {
+      name      = "term_I"
+      protocol  = "icmp"
+      icmp_code = "1"
+      icmp_type = "echo-reply"
+    }
+    term {
+      name       = "term_I6"
+      protocol   = "icmp6"
+      icmp6_code = "1"
+      icmp6_type = "echo-reply"
+    }
+  }
+  application {
+    name      = "testacc_apps6"
+    protocol  = "icmp"
+    icmp_code = "1"
+    icmp_type = "echo-reply"
+  }
+  application {
+    name       = "testacc_apps7"
+    protocol   = "icmp6"
+    icmp6_code = "1"
+    icmp6_type = "echo-reply"
+  }
+  application {
+    name                                   = "testacc_apps8"
+    application_protocol                   = "dns"
+    do_not_translate_a_query_to_aaaa_query = true
+  }
+  application {
+    name                                   = "testacc_apps9"
+    application_protocol                   = "dns"
+    do_not_translate_aaaa_query_to_a_query = true
+  }
+
+  application_set {
+    name         = "testacc_apps_set1"
+    applications = ["junos-ssh", "junos-telnet"]
+    application_set = [
+      "testacc_apps_set2"
+    ]
+  }
+  application_set {
+    name         = "testacc_apps_set2"
+    applications = ["junos-ftp"]
+    description  = "testacc appsets2"
+  }
+}

--- a/internal/providerfwk/testdata/TestAccResourceSecurityAddressBookOrdered_basic/1/main.tf
+++ b/internal/providerfwk/testdata/TestAccResourceSecurityAddressBookOrdered_basic/1/main.tf
@@ -1,0 +1,54 @@
+resource "junos_security_zone" "testacc_secZoneAddr1" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  name = "testacc_secZoneAddr1"
+}
+resource "junos_security_zone" "testacc_secZoneAddr2" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  name = "testacc_secZoneAddr2"
+}
+
+resource "junos_security_address_book_ordered" "testacc_securityGlobalAddressBook" {
+  description = "testacc global description"
+  network_address {
+    name        = "testacc_networkB"
+    description = "testacc_network description"
+    value       = "10.0.0.0/24"
+  }
+  wildcard_address {
+    name        = "testacc_wildcard"
+    description = "testacc_wildcard description"
+    value       = "10.0.0.0/255.255.0.255"
+  }
+  network_address {
+    name        = "testacc_networkA"
+    description = "testacc_network description2"
+    value       = "10.1.0.0/24"
+  }
+  range_address {
+    name        = "testacc_range"
+    description = "testacc_range description"
+    from        = "10.1.1.1"
+    to          = "10.1.1.5"
+  }
+  dns_name {
+    name  = "testacc_dns"
+    value = "google.com"
+  }
+  address_set {
+    name    = "testacc_addressSet"
+    address = ["testacc_networkB", "testacc_wildcard", "testacc_networkA"]
+  }
+}
+
+resource "junos_security_address_book_ordered" "testacc_securityNamedAddressBook" {
+  name        = "testacc_secAddrBook"
+  attach_zone = [junos_security_zone.testacc_secZoneAddr1.name, junos_security_zone.testacc_secZoneAddr2.name]
+  network_address {
+    name  = "testacc_network"
+    value = "10.1.2.3/32"
+  }
+}

--- a/internal/providerfwk/testdata/TestAccResourceSecurityAddressBookOrdered_basic/2/main.tf
+++ b/internal/providerfwk/testdata/TestAccResourceSecurityAddressBookOrdered_basic/2/main.tf
@@ -1,0 +1,37 @@
+resource "junos_security_address_book_ordered" "testacc_securityGlobalAddressBook" {
+  description = "testacc global description"
+  network_address {
+    name        = "testacc_network"
+    description = "testacc_network description"
+    value       = "10.1.0.0/24"
+  }
+  dns_name {
+    name        = "testacc_dns"
+    description = "testacc_dns description"
+    value       = "google.com"
+    ipv4_only   = true
+  }
+  dns_name {
+    name      = "testacc_dns6"
+    value     = "google.com"
+    ipv6_only = true
+  }
+  address_set {
+    name        = "testacc_addressSet2"
+    description = "testacc_addressSet description"
+    address     = ["testacc_network", "testacc_dns"]
+  }
+  address_set {
+    name        = "testacc_addressSet1"
+    address     = ["testacc_dns"]
+    address_set = ["testacc_addressSet2"]
+  }
+}
+
+resource "junos_security_address_book_ordered" "testacc_securityNamedAddressBook" {
+  name = "testacc_secAddrBook"
+  network_address {
+    name  = "testacc_network"
+    value = "10.1.2.4/32"
+  }
+}

--- a/internal/providerfwk/testdata/TestAccResourceSecurityGlobalPolicyUnordered_basic/1/main.tf
+++ b/internal/providerfwk/testdata/TestAccResourceSecurityGlobalPolicyUnordered_basic/1/main.tf
@@ -1,0 +1,46 @@
+resource "junos_security_zone" "testacc_secglobpolicy1" {
+  name = "testacc_secglobpolicy1"
+}
+resource "junos_security_zone" "testacc_secglobpolicy2" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  name = "testacc_secglobpolicy2"
+}
+resource "junos_security_address_book" "testacc_secglobpolicy" {
+  network_address {
+    name  = "blue"
+    value = "192.0.2.1/32"
+  }
+  network_address {
+    name  = "green"
+    value = "192.0.2.2/32"
+  }
+}
+resource "junos_services_user_identification_device_identity_profile" "profile" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  name   = "testacc_secglobpolicy"
+  domain = "testacc_secglobpolicy"
+  attribute {
+    name  = "device-identity"
+    value = ["testacc_secglobpolicy"]
+  }
+}
+resource "junos_security_global_policy_unordered" "testacc_secglobpolicy" {
+  depends_on = [
+    junos_security_address_book.testacc_secglobpolicy
+  ]
+  policy {
+    name                               = "test"
+    match_source_address               = ["blue"]
+    match_destination_address          = ["green"]
+    match_destination_address_excluded = true
+    match_application                  = ["any"]
+    match_dynamic_application          = ["any"]
+    match_source_end_user_profile      = junos_services_user_identification_device_identity_profile.profile.name
+    match_from_zone                    = [junos_security_zone.testacc_secglobpolicy1.name]
+    match_to_zone                      = [junos_security_zone.testacc_secglobpolicy2.name]
+  }
+}

--- a/internal/providerfwk/testdata/TestAccResourceSecurityGlobalPolicyUnordered_basic/2/main.tf
+++ b/internal/providerfwk/testdata/TestAccResourceSecurityGlobalPolicyUnordered_basic/2/main.tf
@@ -1,0 +1,60 @@
+resource "junos_security_zone" "testacc_secglobpolicy1" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  name = "testacc_secglobpolicy1"
+}
+resource "junos_security_address_book" "testacc_secglobpolicy" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  network_address {
+    name  = "blue"
+    value = "192.0.2.1/32"
+  }
+  network_address {
+    name  = "green"
+    value = "192.0.2.2/32"
+  }
+}
+resource "junos_services_advanced_anti_malware_policy" "testacc_secglobpolicy" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  name                     = "testacc_secglobpolicy"
+  verdict_threshold        = "recommended"
+  default_notification_log = true
+}
+resource "junos_security_global_policy_unordered" "testacc_secglobpolicy" {
+  depends_on = [
+    junos_security_address_book.testacc_secglobpolicy
+  ]
+  policy {
+    name                      = "test"
+    match_source_address      = ["blue"]
+    match_destination_address = ["any"]
+    match_application         = ["any"]
+    match_from_zone           = [junos_security_zone.testacc_secglobpolicy1.name]
+    match_to_zone             = [junos_security_zone.testacc_secglobpolicy1.name]
+    count                     = true
+    log_init                  = true
+    log_close                 = true
+    permit_application_services {
+      advanced_anti_malware_policy = junos_services_advanced_anti_malware_policy.testacc_secglobpolicy.name
+      idp                          = true
+      redirect_wx                  = true
+      ssl_proxy {}
+      uac_policy {}
+    }
+  }
+  policy {
+    name                          = "drop"
+    match_source_address          = ["blue"]
+    match_destination_address     = ["any"]
+    match_application             = ["any"]
+    match_from_zone               = ["any"]
+    match_to_zone                 = ["any"]
+    match_source_address_excluded = true
+    then                          = "deny"
+  }
+}

--- a/internal/providerfwk/testdata/TestAccResourceSecurityGlobalPolicyUnordered_basic/4/main.tf
+++ b/internal/providerfwk/testdata/TestAccResourceSecurityGlobalPolicyUnordered_basic/4/main.tf
@@ -1,0 +1,45 @@
+
+resource "junos_security_zone" "testacc_secglobpolicy1" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  name = "testacc_secglobpolicy1"
+}
+resource "junos_security_idp_policy" "testacc_secglobpolicy" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  name = "testacc_secglobpolicy"
+}
+resource "junos_security_address_book" "testacc_secglobpolicy" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  network_address {
+    name  = "blue"
+    value = "192.0.2.1/32"
+  }
+  network_address {
+    name  = "green"
+    value = "192.0.2.2/32"
+  }
+}
+resource "junos_security_global_policy_unordered" "testacc_secglobpolicy" {
+  depends_on = [
+    junos_security_address_book.testacc_secglobpolicy
+  ]
+  policy {
+    name                      = "test"
+    match_source_address      = ["blue"]
+    match_destination_address = ["any"]
+    match_application         = ["any"]
+    match_from_zone           = [junos_security_zone.testacc_secglobpolicy1.name]
+    match_to_zone             = [junos_security_zone.testacc_secglobpolicy1.name]
+    count                     = true
+    log_init                  = true
+    log_close                 = true
+    permit_application_services {
+      idp_policy = junos_security_idp_policy.testacc_secglobpolicy.name
+    }
+  }
+}

--- a/internal/providerfwk/testdata/TestAccResourceSecurityPolicyUnordered_basic/1/main.tf
+++ b/internal/providerfwk/testdata/TestAccResourceSecurityPolicyUnordered_basic/1/main.tf
@@ -1,0 +1,34 @@
+resource "junos_services_user_identification_device_identity_profile" "profile" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  name   = "testacc_securityPolicy"
+  domain = "testacc_securityPolicy"
+  attribute {
+    name  = "device-identity"
+    value = ["testacc_securityPolicy"]
+  }
+}
+resource "junos_security_policy_unordered" "testacc_securityPolicy" {
+  from_zone = junos_security_zone.testacc_seczonePolicy1.name
+  to_zone   = junos_security_zone.testacc_seczonePolicy1.name
+  policy {
+    name                          = "testacc_Policy_1"
+    match_source_address          = ["testacc_address1"]
+    match_destination_address     = ["any"]
+    match_application             = ["junos-ssh"]
+    match_dynamic_application     = ["any"]
+    match_source_end_user_profile = junos_services_user_identification_device_identity_profile.profile.name
+    log_init                      = true
+    log_close                     = true
+    count                         = true
+  }
+}
+
+resource "junos_security_zone" "testacc_seczonePolicy1" {
+  name = "testacc_seczonePolicy1"
+  address_book {
+    name    = "testacc_address1"
+    network = "192.0.2.0/25"
+  }
+}

--- a/internal/providerfwk/testdata/TestAccResourceSecurityPolicyUnordered_basic/2/main.tf
+++ b/internal/providerfwk/testdata/TestAccResourceSecurityPolicyUnordered_basic/2/main.tf
@@ -1,0 +1,45 @@
+resource "junos_services_advanced_anti_malware_policy" "testacc_securityPolicy" {
+  name                     = "testacc_securityPolicy"
+  verdict_threshold        = "recommended"
+  default_notification_log = true
+}
+resource "junos_security_idp_policy" "testacc_securityPolicy" {
+  name = "testacc_securityPolicy"
+}
+resource "junos_security_policy_unordered" "testacc_securityPolicy" {
+  from_zone = junos_security_zone.testacc_seczonePolicy1.name
+  to_zone   = junos_security_zone.testacc_seczonePolicy1.name
+  policy {
+    name                          = "testacc_Policy_1"
+    match_source_address          = ["testacc_address1"]
+    match_destination_address     = ["any"]
+    match_application             = ["junos-ssh"]
+    match_source_address_excluded = true
+    log_init                      = true
+    log_close                     = true
+    count                         = true
+    permit_application_services {
+      advanced_anti_malware_policy = junos_services_advanced_anti_malware_policy.testacc_securityPolicy.name
+      idp_policy                   = junos_security_idp_policy.testacc_securityPolicy.name
+      redirect_wx                  = true
+      ssl_proxy {}
+      uac_policy {}
+    }
+  }
+  policy {
+    name                               = "testacc_Policy_2"
+    match_source_address               = ["testacc_address1"]
+    match_destination_address          = ["testacc_address1"]
+    match_destination_address_excluded = true
+    match_application                  = ["any"]
+    then                               = "reject"
+  }
+}
+
+resource "junos_security_zone" "testacc_seczonePolicy1" {
+  name = "testacc_seczonePolicy1"
+  address_book {
+    name    = "testacc_address1"
+    network = "192.0.2.0/25"
+  }
+}

--- a/internal/providerfwk/testdata/TestAccResourceSecurityZoneOrdered_basic/1/main.tf
+++ b/internal/providerfwk/testdata/TestAccResourceSecurityZoneOrdered_basic/1/main.tf
@@ -1,0 +1,62 @@
+resource "junos_security_screen" "testaccZone" {
+  lifecycle {
+    create_before_destroy = true
+  }
+  name        = "testaccZone"
+  description = "testaccZone"
+}
+resource "junos_security_zone_ordered" "testacc_securityZone" {
+  name = "testacc_securityZone"
+  address_book {
+    name        = "testacc_zone1"
+    description = "testacc_zone 1"
+    network     = "192.0.2.0/25"
+  }
+  address_book_dns {
+    name        = "testacc_zone2"
+    description = "testacc_zone 2"
+    fqdn        = "test.com"
+  }
+  address_book_dns {
+    name        = "testacc_zone2c"
+    description = "testacc_zone 2c"
+    fqdn        = "test.com"
+    ipv6_only   = true
+  }
+  address_book_dns {
+    name        = "testacc_zone2b"
+    description = "testacc_zone 2b"
+    fqdn        = "test.com"
+    ipv4_only   = true
+  }
+  address_book_range {
+    name        = "testacc_zone3"
+    description = "testacc_zone 3"
+    from        = "192.0.2.10"
+    to          = "192.0.2.12"
+  }
+  address_book_set {
+    name        = "testacc_zoneSet2"
+    description = "testacc_zone Set2"
+    address     = ["testacc_zone2c"]
+    address_set = ["testacc_zoneSet1"]
+  }
+  address_book_set {
+    name        = "testacc_zoneSet1"
+    description = "testacc_zone Set"
+    address     = ["testacc_zone1"]
+  }
+
+  address_book_wildcard {
+    name        = "testacc_zone4"
+    description = "testacc_zone 4"
+    network     = "192.0.2.0/255.0.255.255"
+  }
+  application_tracking = true
+  inbound_protocols    = ["bgp"]
+  description          = "testacc securityZone"
+  reverse_reroute      = true
+  screen               = junos_security_screen.testaccZone.id
+  source_identity_log  = true
+  tcp_rst              = true
+}

--- a/internal/providerfwk/testdata/TestAccResourceSecurityZoneOrdered_basic/3/main.tf
+++ b/internal/providerfwk/testdata/TestAccResourceSecurityZoneOrdered_basic/3/main.tf
@@ -1,0 +1,23 @@
+resource "junos_security_zone_ordered" "testacc_securityZone" {
+  name = "testacc_securityZone"
+  address_book {
+    name    = "testacc_zone2"
+    network = "192.0.2.128/25"
+  }
+  address_book {
+    name    = "testacc_zone1"
+    network = "192.0.2.0/25"
+  }
+  address_book_set {
+    name    = "testacc_zoneSet"
+    address = ["testacc_zone1", "testacc_zone2"]
+  }
+  inbound_protocols = ["bgp"]
+  inbound_services  = ["ssh"]
+}
+resource "junos_interface_logical" "testacc_securityZone" {
+  name                       = "${var.interface}.0"
+  security_zone              = junos_security_zone_ordered.testacc_securityZone.name
+  security_inbound_protocols = ["bgp"]
+  security_inbound_services  = ["ssh"]
+}

--- a/internal/providerfwk/testdata/TestAccResourceSecurityZoneOrdered_basic/3/variables.tf
+++ b/internal/providerfwk/testdata/TestAccResourceSecurityZoneOrdered_basic/3/variables.tf
@@ -1,0 +1,3 @@
+variable "interface" {
+  type = string
+}

--- a/internal/providerfwk/upgradestate_bgp_group.go
+++ b/internal/providerfwk/upgradestate_bgp_group.go
@@ -220,12 +220,12 @@ func (rsc *bgpGroup) UpgradeState(_ context.Context) map[int64]resource.StateUpg
 							Blocks: map[string]schema.Block{
 								"accepted_prefix_limit": schema.ListNestedBlock{
 									NestedObject: schema.NestedBlockObject{
-										Attributes: bgpBlockFamilyBlockPrefixLimit{}.resourceSchemaAttributes(),
+										Attributes: bgpBlockFamilyBlockPrefixLimit{}.attributesSchema(),
 									},
 								},
 								"prefix_limit": schema.ListNestedBlock{
 									NestedObject: schema.NestedBlockObject{
-										Attributes: bgpBlockFamilyBlockPrefixLimit{}.resourceSchemaAttributes(),
+										Attributes: bgpBlockFamilyBlockPrefixLimit{}.attributesSchema(),
 									},
 								},
 							},
@@ -241,12 +241,12 @@ func (rsc *bgpGroup) UpgradeState(_ context.Context) map[int64]resource.StateUpg
 							Blocks: map[string]schema.Block{
 								"accepted_prefix_limit": schema.ListNestedBlock{
 									NestedObject: schema.NestedBlockObject{
-										Attributes: bgpBlockFamilyBlockPrefixLimit{}.resourceSchemaAttributes(),
+										Attributes: bgpBlockFamilyBlockPrefixLimit{}.attributesSchema(),
 									},
 								},
 								"prefix_limit": schema.ListNestedBlock{
 									NestedObject: schema.NestedBlockObject{
-										Attributes: bgpBlockFamilyBlockPrefixLimit{}.resourceSchemaAttributes(),
+										Attributes: bgpBlockFamilyBlockPrefixLimit{}.attributesSchema(),
 									},
 								},
 							},
@@ -262,12 +262,12 @@ func (rsc *bgpGroup) UpgradeState(_ context.Context) map[int64]resource.StateUpg
 							Blocks: map[string]schema.Block{
 								"accepted_prefix_limit": schema.ListNestedBlock{
 									NestedObject: schema.NestedBlockObject{
-										Attributes: bgpBlockFamilyBlockPrefixLimit{}.resourceSchemaAttributes(),
+										Attributes: bgpBlockFamilyBlockPrefixLimit{}.attributesSchema(),
 									},
 								},
 								"prefix_limit": schema.ListNestedBlock{
 									NestedObject: schema.NestedBlockObject{
-										Attributes: bgpBlockFamilyBlockPrefixLimit{}.resourceSchemaAttributes(),
+										Attributes: bgpBlockFamilyBlockPrefixLimit{}.attributesSchema(),
 									},
 								},
 							},

--- a/internal/providerfwk/upgradestate_bgp_neighbor.go
+++ b/internal/providerfwk/upgradestate_bgp_neighbor.go
@@ -219,12 +219,12 @@ func (rsc *bgpNeighbor) UpgradeState(_ context.Context) map[int64]resource.State
 							Blocks: map[string]schema.Block{
 								"accepted_prefix_limit": schema.ListNestedBlock{
 									NestedObject: schema.NestedBlockObject{
-										Attributes: bgpBlockFamilyBlockPrefixLimit{}.resourceSchemaAttributes(),
+										Attributes: bgpBlockFamilyBlockPrefixLimit{}.attributesSchema(),
 									},
 								},
 								"prefix_limit": schema.ListNestedBlock{
 									NestedObject: schema.NestedBlockObject{
-										Attributes: bgpBlockFamilyBlockPrefixLimit{}.resourceSchemaAttributes(),
+										Attributes: bgpBlockFamilyBlockPrefixLimit{}.attributesSchema(),
 									},
 								},
 							},
@@ -240,12 +240,12 @@ func (rsc *bgpNeighbor) UpgradeState(_ context.Context) map[int64]resource.State
 							Blocks: map[string]schema.Block{
 								"accepted_prefix_limit": schema.ListNestedBlock{
 									NestedObject: schema.NestedBlockObject{
-										Attributes: bgpBlockFamilyBlockPrefixLimit{}.resourceSchemaAttributes(),
+										Attributes: bgpBlockFamilyBlockPrefixLimit{}.attributesSchema(),
 									},
 								},
 								"prefix_limit": schema.ListNestedBlock{
 									NestedObject: schema.NestedBlockObject{
-										Attributes: bgpBlockFamilyBlockPrefixLimit{}.resourceSchemaAttributes(),
+										Attributes: bgpBlockFamilyBlockPrefixLimit{}.attributesSchema(),
 									},
 								},
 							},
@@ -261,12 +261,12 @@ func (rsc *bgpNeighbor) UpgradeState(_ context.Context) map[int64]resource.State
 							Blocks: map[string]schema.Block{
 								"accepted_prefix_limit": schema.ListNestedBlock{
 									NestedObject: schema.NestedBlockObject{
-										Attributes: bgpBlockFamilyBlockPrefixLimit{}.resourceSchemaAttributes(),
+										Attributes: bgpBlockFamilyBlockPrefixLimit{}.attributesSchema(),
 									},
 								},
 								"prefix_limit": schema.ListNestedBlock{
 									NestedObject: schema.NestedBlockObject{
-										Attributes: bgpBlockFamilyBlockPrefixLimit{}.resourceSchemaAttributes(),
+										Attributes: bgpBlockFamilyBlockPrefixLimit{}.attributesSchema(),
 									},
 								},
 							},

--- a/internal/providerfwk/upgradestate_forwardingoptions_sampling_instance.go
+++ b/internal/providerfwk/upgradestate_forwardingoptions_sampling_instance.go
@@ -130,7 +130,7 @@ func (rsc *forwardingoptionsSamplingInstance) UpgradeState(_ context.Context) ma
 								},
 								"interface": schema.ListNestedBlock{
 									NestedObject: schema.NestedBlockObject{
-										Attributes: rsc.schemaOutputInterfaceAttributes(),
+										Attributes: forwardingoptionsSamplingBlockOutputBlockInterface{}.attributesSchema(),
 									},
 								},
 							},
@@ -237,7 +237,7 @@ func (rsc *forwardingoptionsSamplingInstance) UpgradeState(_ context.Context) ma
 								},
 								"interface": schema.ListNestedBlock{
 									NestedObject: schema.NestedBlockObject{
-										Attributes: rsc.schemaOutputInterfaceAttributes(),
+										Attributes: forwardingoptionsSamplingBlockOutputBlockInterface{}.attributesSchema(),
 									},
 								},
 							},
@@ -340,7 +340,7 @@ func (rsc *forwardingoptionsSamplingInstance) UpgradeState(_ context.Context) ma
 								},
 								"interface": schema.ListNestedBlock{
 									NestedObject: schema.NestedBlockObject{
-										Attributes: rsc.schemaOutputInterfaceAttributes(),
+										Attributes: forwardingoptionsSamplingBlockOutputBlockInterface{}.attributesSchema(),
 									},
 								},
 							},

--- a/internal/providerfwk/upgradestate_policyoptions_policy_statement.go
+++ b/internal/providerfwk/upgradestate_policyoptions_policy_statement.go
@@ -26,13 +26,13 @@ func (rsc *policyoptionsPolicyStatement) UpgradeState(_ context.Context) map[int
 				Blocks: map[string]schema.Block{
 					"from": schema.ListNestedBlock{
 						NestedObject: schema.NestedBlockObject{
-							Attributes: rsc.schemaFromAttributes(),
-							Blocks:     rsc.schemaFromBlocks(),
+							Attributes: policyoptionsPolicyStatementBlockFrom{}.attributesSchema(),
+							Blocks:     policyoptionsPolicyStatementBlockFrom{}.blocksSchema(),
 						},
 					},
 					"to": schema.ListNestedBlock{
 						NestedObject: schema.NestedBlockObject{
-							Attributes: rsc.schemaToAttributes(),
+							Attributes: policyoptionsPolicyStatementBlockTo{}.attributesSchema(),
 						},
 					},
 					"then": schema.ListNestedBlock{
@@ -125,13 +125,13 @@ func (rsc *policyoptionsPolicyStatement) UpgradeState(_ context.Context) map[int
 							Blocks: map[string]schema.Block{
 								"from": schema.ListNestedBlock{
 									NestedObject: schema.NestedBlockObject{
-										Attributes: rsc.schemaFromAttributes(),
-										Blocks:     rsc.schemaFromBlocks(),
+										Attributes: policyoptionsPolicyStatementBlockFrom{}.attributesSchema(),
+										Blocks:     policyoptionsPolicyStatementBlockFrom{}.blocksSchema(),
 									},
 								},
 								"to": schema.ListNestedBlock{
 									NestedObject: schema.NestedBlockObject{
-										Attributes: rsc.schemaToAttributes(),
+										Attributes: policyoptionsPolicyStatementBlockTo{}.attributesSchema(),
 									},
 								},
 								"then": schema.ListNestedBlock{


### PR DESCRIPTION
FEATURES:

* add `junos_applications_ordered` resource, copy of `junos_applications` resource but with Block List instead of Block Set to have a workaround for the performance issue on Block Sets (workaround for [#709](https://github.com/jeremmfr/terraform-provider-junos/issues/709))
* add `junos_security_address_book_ordered` resource, copy of `junos_security_address_book` resource but with Block List instead of Block Set to have a workaround for the performance issue on Block Sets (workaround for [#498](https://github.com/jeremmfr/terraform-provider-junos/issues/498))
* add `junos_security_global_policy_unordered` resource, copy of `junos_security_global_policy` resource but with Block Set instead of Block List to have a workaround for too complex plan output when the number of blocks on the resource changes
* add `junos_security_policy_unordered` resource, copy of `junos_security_policy` resource but with Block Set instead of Block List to have a workaround for too complex plan output when the number of blocks on the resource changes
* add `junos_security_zone_ordered` resource, copy of `junos_security_zone` resource but with Block List instead of Block Set to have a workaround for the performance issue on Block Sets