### PR TITLE
r/forwardingoptions_dhcprelay: fix validation of attempts

### DIFF
--- a/.changes/fwd-dhcp-relay-fix-validate-config.md
+++ b/.changes/fwd-dhcp-relay-fix-validate-config.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable-file MD013 MD041 -->
+BUG FIXES:
+
+* **resource/junos_forwardingoptions_dhcprelay**: fix validation of `attempts` must be in range (1..10) when `version` = v6 in `bulk_leasequery` block

--- a/internal/providerfwk/resource_forwardingoptions_dhcprelay.go
+++ b/internal/providerfwk/resource_forwardingoptions_dhcprelay.go
@@ -989,7 +989,7 @@ func (rsc *forwardingoptionsDhcprelay) ValidateConfig( //nolint:gocognit,gocyclo
 			}
 		}
 		if config.BulkLeasequery != nil &&
-			config.BulkLeasequery.Attempts.IsNull() &&
+			!config.BulkLeasequery.Attempts.IsNull() &&
 			!config.BulkLeasequery.Attempts.IsUnknown() &&
 			config.BulkLeasequery.Attempts.ValueInt64() > 10 {
 			resp.Diagnostics.AddAttributeError(


### PR DESCRIPTION
BUG FIXES:

* **resource/junos_forwardingoptions_dhcprelay**: fix validation of `attempts` must be in range (1..10) when `version` = v6 in `bulk_leasequery` block