### PR TITLE
r/system_login_user, r/system_root_authentication: mark encrypted_password attribute as sensitive

### DIFF
--- a/.changes/encrypted-is-sensitive.md
+++ b/.changes/encrypted-is-sensitive.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable-file MD013 MD041 -->
+ENHANCEMENTS:
+
+* **resource/junos_system_login_user**, **resource/junos_system_root_authentication**: mark `encrypted_password` attribute as sensitive (to obscure the value in Terraform output) even if the data is encrypted

--- a/docs/resources/system_login_user.md
+++ b/docs/resources/system_login_user.md
@@ -31,7 +31,7 @@ The following arguments are supported:
   User identifier (uid) (100..64000).
 - **authentication** (Optional, Block)  
   Authentication method.
-  - **encrypted_password** (Optional, String)  
+  - **encrypted_password** (Optional, String, Sensitive)  
     Encrypted password string.  
     Conflict with `plain_text_password`.  
     If the encrypted password is present on Junos device and `plain_text_password` is used

--- a/docs/resources/system_root_authentication.md
+++ b/docs/resources/system_root_authentication.md
@@ -31,7 +31,7 @@ The following arguments are supported:
 -> **Note**
   One of `encrypted_password` or `plain_text_password` arguments is required.
 
-- **encrypted_password** (Optional, String)  
+- **encrypted_password** (Optional, String, Sensitive)  
   Encrypted password string.  
   If `plain_text_password` is used in Terraform config,
   the value of this argument is left blank to avoid conflict.

--- a/internal/providerfwk/resource_system_login_user.go
+++ b/internal/providerfwk/resource_system_login_user.go
@@ -149,6 +149,7 @@ func (rsc *systemLoginUser) Schema(
 				Attributes: map[string]schema.Attribute{
 					"encrypted_password": schema.StringAttribute{
 						Optional:    true,
+						Sensitive:   true,
 						Description: "Encrypted password string.",
 						Validators: []validator.String{
 							stringvalidator.LengthBetween(1, 128),

--- a/internal/providerfwk/resource_system_login_user_test.go
+++ b/internal/providerfwk/resource_system_login_user_test.go
@@ -1,7 +1,6 @@
 package providerfwk_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
@@ -10,85 +9,83 @@ import (
 )
 
 func TestAccResourceSystemLoginUser_basic(t *testing.T) {
-	if os.Getenv("TESTACC_SWITCH") == "" {
-		resource.Test(t, resource.TestCase{
-			PreCheck: func() { testAccPreCheck(t) },
-			Steps: []resource.TestStep{
-				{
-					ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
-					ConfigDirectory:          config.TestStepDirectory(),
-					Check: resource.ComposeTestCheckFunc(
-						resource.TestCheckResourceAttr("junos_system_login_user.testacc",
-							"name", "testacc"),
-						resource.TestCheckResourceAttrSet("junos_system_login_user.testacc",
-							"uid"),
-					),
-				},
-				{
-					ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
-					ConfigDirectory:          config.TestStepDirectory(),
-					ConfigPlanChecks: resource.ConfigPlanChecks{
-						PreApply: []plancheck.PlanCheck{
-							plancheck.ExpectResourceAction(
-								"junos_system_login_user.testacc2",
-								plancheck.ResourceActionReplace,
-							),
-						},
-					},
-					Check: resource.ComposeTestCheckFunc(
-						resource.TestCheckResourceAttr("junos_system_login_user.testacc",
-							"name", "testacc"),
-						resource.TestCheckResourceAttrSet("junos_system_login_user.testacc",
-							"uid"),
-						resource.TestCheckResourceAttr("junos_system_login_user.testacc",
-							"authentication.ssh_public_keys.#", "1"),
-						resource.TestCheckResourceAttr("junos_system_login_user.testacc2",
-							"uid", "5000"),
-					),
-				},
-				{
-					ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
-					ResourceName:             "junos_system_login_user.testacc",
-					ImportState:              true,
-					ImportStateVerify:        true,
-				},
-				{
-					ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
-					ConfigDirectory:          config.TestStepDirectory(),
-					ExpectNonEmptyPlan:       true,
-					ConfigPlanChecks: resource.ConfigPlanChecks{
-						PostApplyPostRefresh: []plancheck.PlanCheck{
-							plancheck.ExpectNonEmptyPlan(),
-							plancheck.ExpectResourceAction(
-								"junos_system_login_user.testacc3",
-								plancheck.ResourceActionUpdate,
-							),
-							plancheck.ExpectResourceAction(
-								"junos_system_login_user.testacc3_copy",
-								plancheck.ResourceActionNoop,
-							),
-						},
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+				ConfigDirectory:          config.TestStepDirectory(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("junos_system_login_user.testacc",
+						"name", "testacc"),
+					resource.TestCheckResourceAttrSet("junos_system_login_user.testacc",
+						"uid"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+				ConfigDirectory:          config.TestStepDirectory(),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(
+							"junos_system_login_user.testacc2",
+							plancheck.ResourceActionReplace,
+						),
 					},
 				},
-				{
-					ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
-					ConfigDirectory:          config.TestStepDirectory(),
-					ExpectNonEmptyPlan:       true,
-					ConfigPlanChecks: resource.ConfigPlanChecks{
-						PostApplyPostRefresh: []plancheck.PlanCheck{
-							plancheck.ExpectNonEmptyPlan(),
-							plancheck.ExpectResourceAction(
-								"junos_system_login_user.testacc3",
-								plancheck.ResourceActionNoop,
-							),
-							plancheck.ExpectResourceAction(
-								"junos_system_login_user.testacc3_copy",
-								plancheck.ResourceActionUpdate,
-							),
-						},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("junos_system_login_user.testacc",
+						"name", "testacc"),
+					resource.TestCheckResourceAttrSet("junos_system_login_user.testacc",
+						"uid"),
+					resource.TestCheckResourceAttr("junos_system_login_user.testacc",
+						"authentication.ssh_public_keys.#", "1"),
+					resource.TestCheckResourceAttr("junos_system_login_user.testacc2",
+						"uid", "5000"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+				ResourceName:             "junos_system_login_user.testacc",
+				ImportState:              true,
+				ImportStateVerify:        true,
+			},
+			{
+				ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+				ConfigDirectory:          config.TestStepDirectory(),
+				ExpectNonEmptyPlan:       true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+						plancheck.ExpectResourceAction(
+							"junos_system_login_user.testacc3",
+							plancheck.ResourceActionUpdate,
+						),
+						plancheck.ExpectResourceAction(
+							"junos_system_login_user.testacc3_copy",
+							plancheck.ResourceActionNoop,
+						),
 					},
 				},
 			},
-		})
-	}
+			{
+				ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+				ConfigDirectory:          config.TestStepDirectory(),
+				ExpectNonEmptyPlan:       true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+						plancheck.ExpectResourceAction(
+							"junos_system_login_user.testacc3",
+							plancheck.ResourceActionNoop,
+						),
+						plancheck.ExpectResourceAction(
+							"junos_system_login_user.testacc3_copy",
+							plancheck.ResourceActionUpdate,
+						),
+					},
+				},
+			},
+		},
+	})
 }

--- a/internal/providerfwk/resource_system_root_authentication.go
+++ b/internal/providerfwk/resource_system_root_authentication.go
@@ -89,6 +89,7 @@ func (rsc *systemRootAuthentication) Schema(
 			},
 			"encrypted_password": schema.StringAttribute{
 				Optional:    true,
+				Sensitive:   true,
 				Description: "Encrypted password string.",
 				Validators: []validator.String{
 					stringvalidator.LengthBetween(1, 128),


### PR DESCRIPTION
ENHANCEMENTS:

* **resource/junos_system_login_user**, **resource/junos_system_root_authentication**: mark `encrypted_password` attribute as sensitive (to obscure the value in Terraform output) even if the data is encrypted