### PR TITLE
r/forwardingoptions_dhcprelay_servergroup: ip_address argument is no longer ordered

### DIFF
--- a/.changes/forwardingoptions-dhcprelay-servergroup-ip-address-order.md
+++ b/.changes/forwardingoptions-dhcprelay-servergroup-ip-address-order.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable-file MD013 MD041 -->
+ENHANCEMENTS:
+
+* **resource/junos_forwardingoptions_dhcprelay_servergroup**: `ip_address` argument is no longer ordered

--- a/docs/resources/forwardingoptions_dhcprelay_servergroup.md
+++ b/docs/resources/forwardingoptions_dhcprelay_servergroup.md
@@ -31,7 +31,7 @@ The following arguments are supported:
 - **version** (Optional, String, Forces new resource)  
   Version for DHCP or DHCPv6.  
   Need to be `v4` or `v6`.
-- **ip_address** (Optional, List of String)  
+- **ip_address** (Optional, Set of String)  
   IP Addresses of DHCP servers.
 
 ## Attribute Reference

--- a/internal/providerfwk/resource_forwardingoptions_dhcprelay_servergroup.go
+++ b/internal/providerfwk/resource_forwardingoptions_dhcprelay_servergroup.go
@@ -9,7 +9,7 @@ import (
 	"github.com/jeremmfr/terraform-provider-junos/internal/tfdiag"
 	"github.com/jeremmfr/terraform-provider-junos/internal/tfvalidator"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -120,14 +120,14 @@ func (rsc *forwardingoptionsDhcprelayServergroup) Schema(
 					stringvalidator.OneOf("v4", "v6"),
 				},
 			},
-			"ip_address": schema.ListAttribute{
+			"ip_address": schema.SetAttribute{
 				ElementType: types.StringType,
 				Optional:    true,
 				Description: "IP Addresses of DHCP servers.",
-				Validators: []validator.List{
-					listvalidator.SizeAtLeast(1),
-					listvalidator.NoNullValues(),
-					listvalidator.ValueStringsAre(
+				Validators: []validator.Set{
+					setvalidator.SizeAtLeast(1),
+					setvalidator.NoNullValues(),
+					setvalidator.ValueStringsAre(
 						tfvalidator.StringIPAddress(),
 					),
 				},


### PR DESCRIPTION
ENHANCEMENTS:

* **resource/junos_forwardingoptions_dhcprelay_servergroup**: `ip_address` argument is no longer ordered