### PR TITLE
bump golang version to v1.25

### DIFF
--- a/.changes/golang-1.25.md
+++ b/.changes/golang-1.25.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable-file MD013 MD041 -->
+ENHANCEMENTS:
+
+* release now with golang 1.25

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,34 +3,19 @@ on: [push, pull_request]
 permissions:
   contents: read
 jobs:
-  build-1_23:
-    name: Build 1.23
+  build:
+    name: Build
+    strategy:
+      matrix:
+        golang:
+          - '1.24'
+          - '1.25'
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.23
+      - name: Set up Go ${{ matrix.golang }}
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
-          check-latest: true
-        id: go
-      - name: Disable cgo
-        run: |
-          echo "CGO_ENABLED=0" >> $GITHUB_ENV
-      - name: Show version
-        run: go version
-      - name: Check out code
-        uses: actions/checkout@v5
-      - name: Build
-        run: go build -v .
-
-  build-1_24:
-    name: Build 1.24
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Go 1.24
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.24'
+          go-version: ${{ matrix.golang }}
           check-latest: true
         id: go
       - name: Disable cgo
@@ -45,12 +30,17 @@ jobs:
 
   test:
     name: Test
+    strategy:
+      matrix:
+        golang:
+          - '1.24'
+          - '1.25'
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.24
+      - name: Set up Go ${{ matrix.golang }}
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: ${{ matrix.golang }}
           check-latest: true
         id: go
       - name: Disable cgo

--- a/.github/workflows/go_analysis.yml
+++ b/.github/workflows/go_analysis.yml
@@ -16,7 +16,8 @@ jobs:
       - name: Running govulncheck
         uses: Templum/govulncheck-action@v1.0.2
         with:
-          go-version: '1.24'
+          go-version: '1.25'
+          vulncheck-version: 'v1.1.4'
           package: ./...
           fail-on-vuln: false
 

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -7,10 +7,10 @@ jobs:
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.24
+      - name: Set up Go 1.25
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           check-latest: true
         id: go
       - name: Disable cgo
@@ -40,10 +40,10 @@ jobs:
     name: terrafmt
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.24
+      - name: Set up Go 1.25
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           check-latest: true
         id: go
       - name: Show version

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -41,10 +41,10 @@ jobs:
           - goos: windows
             goarch: arm64
     steps:
-      - name: Set up Go 1.24
+      - name: Set up Go 1.25
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           check-latest: true
         id: go
       - name: Show version

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ for provider and resources documentation.
 
 ### In addition to develop
 
-- [Go](https://go.dev/doc/install) `v1.23` or `v1.24`
+- [Go](https://go.dev/doc/install) `v1.24` or `v1.25`
 
 ## Automatic install
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jeremmfr/terraform-provider-junos
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/hashicorp/terraform-plugin-framework v1.15.1


### PR DESCRIPTION
- min version to v1.24
- release with v1.25
- workflows: go tests with both versions