### PR TITLE
action/commit_file: update tests with new Terraform version 

### DIFF
--- a/internal/provider/action_commit_file_test.go
+++ b/internal/provider/action_commit_file_test.go
@@ -23,8 +23,8 @@ func TestAccActionCommitFile_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			// tfversion.SkipBelow(tfversion.Version1_14_0),
-			tfversion.SkipBelow(version.Must(version.NewVersion("1.14.0"))),
+			// .1 due to a bug with lifecycle.action_trigger.events (see https://github.com/hashicorp/terraform/issues/37930)
+			tfversion.SkipBelow(version.Must(version.NewVersion("1.14.1"))),
 		},
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/action_load_config_test.go
+++ b/internal/provider/action_load_config_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
@@ -15,8 +14,7 @@ func TestAccActionLoadConfig_basic(t *testing.T) {
 		resource.Test(t, resource.TestCase{
 			PreCheck: func() { testAccPreCheck(t) },
 			TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-				// tfversion.SkipBelow(tfversion.Version1_14_0),
-				tfversion.SkipBelow(version.Must(version.NewVersion("1.14.0"))),
+				tfversion.SkipBelow(tfversion.Version1_14_0),
 			},
 			Steps: []resource.TestStep{
 				{

--- a/internal/provider/testdata/TestAccActionCommitFile_basic/1/main.tf
+++ b/internal/provider/testdata/TestAccActionCommitFile_basic/1/main.tf
@@ -4,15 +4,7 @@ resource "junos_interface_physical" "testacc_actioncommitfile" {
   name         = var.interface
   description  = "testacc_fakecreate"
   vlan_tagging = true
-}
 
-// a empty resource between junos resource(s) and action(s) due to
-// a bug with lifecycle.action_trigger.events (see https://github.com/hashicorp/terraform/issues/37930)
-resource "terraform_data" "setfile" {
-  depends_on = [
-    junos_interface_physical.testacc_actioncommitfile,
-  ]
-  triggers_replace = junos_interface_physical.testacc_actioncommitfile.description
   lifecycle {
     action_trigger {
       events  = [after_create, after_update]

--- a/internal/provider/testdata/TestAccActionCommitFile_basic/2/main.tf
+++ b/internal/provider/testdata/TestAccActionCommitFile_basic/2/main.tf
@@ -4,15 +4,7 @@ resource "junos_interface_physical" "testacc_actioncommitfile" {
   name         = var.interface
   description  = "testacc_fakeupdate"
   vlan_tagging = true
-}
 
-// a empty resource between junos resource(s) and action(s) due to
-// a bug with lifecycle.action_trigger.events (see https://github.com/hashicorp/terraform/issues/37930)
-resource "terraform_data" "setfile" {
-  depends_on = [
-    junos_interface_physical.testacc_actioncommitfile,
-  ]
-  triggers_replace = junos_interface_physical.testacc_actioncommitfile.description
   lifecycle {
     action_trigger {
       events  = [after_create, after_update]

--- a/internal/provider/testdata/TestAccActionCommitFile_basic/3/main.tf
+++ b/internal/provider/testdata/TestAccActionCommitFile_basic/3/main.tf
@@ -10,15 +10,7 @@ resource "local_file" "hostname" {
   ]
   content  = "set interfaces ${var.interface} description testacc_action"
   filename = var.file
-}
 
-// a empty resource between junos resource(s) and action(s) due to
-// a bug with lifecycle.action_trigger.events (see https://github.com/hashicorp/terraform/issues/37930)
-resource "terraform_data" "setfile" {
-  depends_on = [
-    local_file.hostname,
-  ]
-  triggers_replace = local_file.hostname.content
   lifecycle {
     action_trigger {
       events  = [after_create, after_update]


### PR DESCRIPTION
Update tests with the new Terraform version fixing lifecycle.action_trigger.events bug