### PR TITLE
deps: bump Go version to 1.26

### DIFF
--- a/.changes/golang-v1.26.md
+++ b/.changes/golang-v1.26.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable-file MD013 MD041 -->
+ENHANCEMENTS:
+
+* release now with Go 1.26

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,8 +8,8 @@ jobs:
     strategy:
       matrix:
         golang:
-          - '1.24'
           - '1.25'
+          - '1.26'
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go ${{ matrix.golang }}
@@ -33,8 +33,8 @@ jobs:
     strategy:
       matrix:
         golang:
-          - '1.24'
           - '1.25'
+          - '1.26'
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go ${{ matrix.golang }}

--- a/.github/workflows/go_analysis.yml
+++ b/.github/workflows/go_analysis.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Running govulncheck
         uses: Templum/govulncheck-action@v1.0.2
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           vulncheck-version: 'v1.1.4'
           package: ./...
           fail-on-vuln: false

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -7,10 +7,10 @@ jobs:
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.25
+      - name: Set up Go 1.26
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           check-latest: true
         id: go
       - name: Disable cgo
@@ -21,7 +21,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.8.0
+          version: v2.9.0
           args: -c .golangci.yml -v
 
   markdown-lint:
@@ -40,10 +40,10 @@ jobs:
     name: terrafmt
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.25
+      - name: Set up Go 1.26
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           check-latest: true
         id: go
       - name: Show version

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -41,10 +41,10 @@ jobs:
           - goos: windows
             goarch: arm64
     steps:
-      - name: Set up Go 1.25
+      - name: Set up Go 1.26
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
           check-latest: true
         id: go
       - name: Show version

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,30 +45,9 @@ linters:
         - fieldalignment
         - shadow
     revive:
+      enable-default-rules: true
       rules:
         # defaults
-        - name: blank-imports
-        - name: context-as-argument
-        - name: context-keys-type
-        - name: dot-imports
-        - name: empty-block
-        - name: error-naming
-        - name: error-return
-        - name: error-strings
-        - name: errorf
-        - name: exported
-        - name: increment-decrement
-        - name: indent-error-flow
-        - name: package-comments
-        - name: range
-        - name: receiver-naming
-        - name: redefines-builtin-id
-        - name: superfluous-else
-        - name: time-naming
-        - name: unexported-return
-        - name: unreachable-code
-        - name: unused-parameter
-        - name: var-declaration
         - name: var-naming
           arguments:
             - []
@@ -81,6 +60,7 @@ linters:
         - name: import-alias-naming
         - name: import-shadowing
         - name: unhandled-error
+        - name: use-slices-sort
     staticcheck:
       checks:
         - "all"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ for provider and resources documentation.
 
 ### In addition to develop
 
-- [Go](https://go.dev/doc/install) `v1.24` or `v1.25`
+- [Go](https://go.dev/doc/install) `v1.25` or `v1.26`
 
 ## Automatic install
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jeremmfr/terraform-provider-junos
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/hashicorp/go-version v1.8.0


### PR DESCRIPTION
- min version to v1.25
- release with v1.26
- workflows: go tests with both versions
- tests: bump golangci-lint to v2.9.0