### PR TITLE
Add logical interface option `proxy-macip-advertisement`

### DIFF
--- a/docs/data-sources/interface_logical.md
+++ b/docs/data-sources/interface_logical.md
@@ -99,6 +99,8 @@ The following attributes are exported:
     Sample all packets input on this interface.
   - **sampling_output** (Boolean)  
     Sample all packets output on this interface.
+- **proxy_macip_advertisement** (Boolean)
+  Enable the proxy advertisement feature on a QFX Series switch that can function as a Layer 3 gateway.
 - **routing_instance** (String)  
   Routing_instance where the interface is (if not default instance).
 - **security_inbound_protocols** (Set of String)  

--- a/docs/resources/interface_logical.md
+++ b/docs/resources/interface_logical.md
@@ -101,6 +101,8 @@ The following arguments are supported:
     Sample all packets input on this interface.
   - **sampling_output** (Optional, Boolean)  
     Sample all packets output on this interface.
+- **proxy_macip_advertisement** (Optional, Boolean)
+  Enable the proxy advertisement feature on a QFX Series switch that can function as a Layer 3 gateway.
 - **routing_instance** (Optional, String)  
   Add this interface in routing_instance.  
   Need to be created before.

--- a/internal/provider/data_source_interface_logical.go
+++ b/internal/provider/data_source_interface_logical.go
@@ -266,6 +266,10 @@ func (dsc *interfaceLogicalDataSource) Schema(
 					}),
 				},
 			},
+			"proxy_macip_advertisement": schema.BoolAttribute{
+				Computed:    true,
+				Description: "Enable the proxy advertisement feature on a QFX Series switch that can function as a Layer 3 gateway.",
+			},
 			"tunnel": schema.ObjectAttribute{
 				Computed:    true,
 				Description: "Tunnel parameters.",
@@ -304,6 +308,7 @@ type interfaceLogicalDataSourceData struct {
 	VlanID                   types.Int64                       `tfsdk:"vlan_id"`
 	FamilyInet               *interfaceLogicalBlockFamilyInet  `tfsdk:"family_inet"`
 	FamilyInet6              *interfaceLogicalBlockFamilyInet6 `tfsdk:"family_inet6"`
+	ProxyMacIPAdvertisement  types.Bool                        `tfsdk:"proxy_macip_advertisement"`
 	Tunnel                   *interfaceLogicalBlockTunnel      `tfsdk:"tunnel"`
 }
 
@@ -443,6 +448,7 @@ func (dscData *interfaceLogicalDataSourceData) copyFromResourceData(rscData inte
 	dscData.Encapsulation = rscData.Encapsulation
 	dscData.FamilyInet = rscData.FamilyInet
 	dscData.FamilyInet6 = rscData.FamilyInet6
+	dscData.ProxyMacIPAdvertisement = rscData.ProxyMacIPAdvertisement
 	dscData.RoutingInstance = rscData.RoutingInstance
 	dscData.SecurityInboundProtocols = rscData.SecurityInboundProtocols
 	dscData.SecurityInboundServices = rscData.SecurityInboundServices

--- a/internal/provider/resource_interface_logical.go
+++ b/internal/provider/resource_interface_logical.go
@@ -147,6 +147,13 @@ func (rsc *interfaceLogical) Schema(
 					stringvalidator.NoneOfCaseInsensitive(junos.DefaultW),
 				},
 			},
+			"proxy_macip_advertisement": schema.BoolAttribute{
+				Optional:    true,
+				Description: "Enable the proxy advertisement feature on a QFX Series switch that can function as a Layer 3 gateway.",
+				Validators: []validator.Bool{
+					tfvalidator.BoolTrue(),
+				},
+			},
 			"security_inbound_protocols": schema.SetAttribute{
 				ElementType: types.StringType,
 				Optional:    true,
@@ -1119,6 +1126,7 @@ type interfaceLogicalData struct {
 	Description              types.String                      `tfsdk:"description"`
 	Disable                  types.Bool                        `tfsdk:"disable"`
 	Encapsulation            types.String                      `tfsdk:"encapsulation"`
+	ProxyMacIPAdvertisement  types.Bool                        `tfsdk:"proxy_macip_advertisement"`
 	RoutingInstance          types.String                      `tfsdk:"routing_instance"`
 	SecurityInboundProtocols []types.String                    `tfsdk:"security_inbound_protocols"`
 	SecurityInboundServices  []types.String                    `tfsdk:"security_inbound_services"`
@@ -1140,6 +1148,7 @@ type interfaceLogicalConfig struct {
 	Description              types.String                            `tfsdk:"description"`
 	Disable                  types.Bool                              `tfsdk:"disable"`
 	Encapsulation            types.String                            `tfsdk:"encapsulation"`
+	ProxyMacIPAdvertisment   types.Bool                              `tfsdk:"proxy_macip_advertisement"`
 	RoutingInstance          types.String                            `tfsdk:"routing_instance"`
 	SecurityInboundProtocols types.Set                               `tfsdk:"security_inbound_protocols"`
 	SecurityInboundServices  types.Set                               `tfsdk:"security_inbound_services"`
@@ -2552,6 +2561,9 @@ func (rscData *interfaceLogicalData) set(
 	if v := rscData.Encapsulation.ValueString(); v != "" {
 		configSet = append(configSet, setPrefix+"encapsulation "+v)
 	}
+	if rscData.ProxyMacIPAdvertisement.ValueBool() {
+		configSet = append(configSet, setPrefix+"proxy-macip-advertisement")
+	}
 	if rscData.VirtualGatewayAcceptData.ValueBool() {
 		configSet = append(configSet, setPrefix+"virtual-gateway-accept-data")
 	}
@@ -3246,6 +3258,8 @@ func (rscData *interfaceLogicalData) read(
 				case itemTrim == " sampling output":
 					rscData.FamilyInet.SamplingOutput = types.BoolValue(true)
 				}
+			case itemTrim == "proxy-macip-advertisement":
+				rscData.ProxyMacIPAdvertisement = types.BoolValue(true)
 			case balt.CutPrefixInString(&itemTrim, "tunnel "):
 				if rscData.Tunnel == nil {
 					rscData.Tunnel = &interfaceLogicalBlockTunnel{}
@@ -3704,6 +3718,7 @@ func (rscData *interfaceLogicalData) delOpts(
 		delPrefix + "family inet",
 		delPrefix + "family inet6",
 		delPrefix + "tunnel",
+		delPrefix + "proxy-macip-advertisement",
 		delPrefix + "virtual-gateway-accept-data",
 		delPrefix + "virtual-gateway-v4-mac",
 		delPrefix + "virtual-gateway-v6-mac",

--- a/internal/provider/resource_interface_logical_test.go
+++ b/internal/provider/resource_interface_logical_test.go
@@ -50,6 +50,8 @@ func TestAccResourceInterfaceLogical_basic(t *testing.T) {
 						resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
 							"routing_instance", "testacc_interface_logical"),
 						resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
+							"proxy_macip_advertisement", "true"),
+						resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
 							"family_inet.mtu", "1400"),
 						resource.TestCheckResourceAttr("junos_interface_logical.testacc_interface_logical",
 							"family_inet.filter_input", "testacc_intlogicalInet"),

--- a/internal/provider/testdata/TestAccResourceInterfaceLogical_router/1/main.tf
+++ b/internal/provider/testdata/TestAccResourceInterfaceLogical_router/1/main.tf
@@ -10,6 +10,7 @@ resource "junos_interface_logical" "testacc_interface_logical" {
 resource "junos_interface_logical" "testacc_interface_logical3" {
   name                        = "irb.100"
   virtual_gateway_accept_data = true
+  proxy_macip_advertisement   = true
   virtual_gateway_v4_mac      = "00:aa:bb:cc:dd:ee"
   virtual_gateway_v6_mac      = "00:aa:bb:cc:dd:ff"
   family_inet {


### PR DESCRIPTION
Adds the config key `proxy-macip-advertisement` to the `interface_logical` resource, which is an [option available on QFX series switches](https://apps.juniper.net/cli-explorer/info/proxy-macip-advertisement-edit-interfaces/). 

Fixes #895 