### PR TITLE
Add config option `vpn_apply_export`

### DIFF
--- a/docs/resources/bgp_group.md
+++ b/docs/resources/bgp_group.md
@@ -178,7 +178,8 @@ The following arguments are supported:
   Remove well-known private AS numbers.
 - **tcp_aggressive_transmission** (Optional, Boolean)  
   Enable aggressive transmission of pure TCP ACKs and retransmissions
-
+- **vpn_apply_export** (Optional, Boolean)
+  Apply both the VRF export and BGP group or neighbor export policies before routes from the vrf or l2vpn routing tables are advertised to other PE routers.
 ---
 
 ### bfd_liveness_detection arguments

--- a/internal/provider/resource_bgp_group.go
+++ b/internal/provider/resource_bgp_group.go
@@ -121,6 +121,13 @@ func (rsc *bgpGroup) Schema(
 				stringvalidator.OneOf("internal", "external"),
 			},
 		},
+		"vpn_apply_export": schema.BoolAttribute{
+			Optional:    true,
+			Description: "Apply both the VRF export and BGP group or neighbor export policies (VRF first, then BGP) before routes from the vrf or l2vpn routing tables are advertised to other PE routers.",
+			Validators: []validator.Bool{
+				tfvalidator.BoolTrue(),
+			},
+		},
 	}
 	maps.Copy(attributes, bgpAttrData{}.attributesSchema())
 
@@ -139,6 +146,7 @@ type bgpGroupData struct {
 	Name            types.String `tfsdk:"name"`
 	RoutingInstance types.String `tfsdk:"routing_instance"`
 	Type            types.String `tfsdk:"type"`
+	VpnApplyExport  types.Bool   `tfsdk:"vpn_apply_export"`
 }
 
 type bgpGroupConfig struct {
@@ -148,6 +156,7 @@ type bgpGroupConfig struct {
 	Name            types.String `tfsdk:"name"`
 	RoutingInstance types.String `tfsdk:"routing_instance"`
 	Type            types.String `tfsdk:"type"`
+	VpnApplyExport  types.Bool   `tfsdk:"vpn_apply_export"`
 }
 
 func (rsc *bgpGroup) ValidateConfig(
@@ -456,6 +465,9 @@ func (rscData *bgpGroupData) set(
 	if err != nil {
 		return errPath, err
 	}
+	if rscData.VpnApplyExport.ValueBool() {
+		configSet = append(configSet, setPrefix+"vpn-apply-export")
+	}
 	configSet = append(configSet, dataConfigSet...)
 
 	return path.Empty(), junSess.ConfigSet(ctx, configSet)
@@ -492,6 +504,8 @@ func (rscData *bgpGroupData) read(
 			switch {
 			case balt.CutPrefixInString(&itemTrim, "type "):
 				rscData.Type = types.StringValue(itemTrim)
+			case itemTrim == "vpn-apply-export":
+				rscData.VpnApplyExport = types.BoolValue(true)
 			default:
 				if err := rscData.bgpAttrData.read(itemTrim, junSess); err != nil {
 					return err


### PR DESCRIPTION
Adds a config option `vpn_apply_export` to the `bgp_group` resource like [documented here](https://apps.juniper.net/cli-explorer/info/vpn-apply-export-edit-protocols-bgp-vp/).