### PR TITLE
r&d/interface_logical: add proxy_macip_advertisement argument

### DIFF
--- a/.changes/issue-895.md
+++ b/.changes/issue-895.md
@@ -1,0 +1,5 @@
+<!-- markdownlint-disable-file MD013 MD041 -->
+ENHANCEMENTS:
+
+* **resource/junos_interface_logical**: add `proxy_macip_advertisement` argument (Fix [#895](https://github.com/jeremmfr/terraform-provider-junos/issues/895))
+* **data-source/junos_interface_logical**: add `proxy_macip_advertisement` attribute like resource

--- a/docs/data-sources/interface_logical.md
+++ b/docs/data-sources/interface_logical.md
@@ -99,6 +99,8 @@ The following attributes are exported:
     Sample all packets input on this interface.
   - **sampling_output** (Boolean)  
     Sample all packets output on this interface.
+- **proxy_macip_advertisement** (Boolean)  
+  Proxy advertisement of type 2 MAC+IP route for EVPN.
 - **routing_instance** (String)  
   Routing_instance where the interface is (if not default instance).
 - **security_inbound_protocols** (Set of String)  

--- a/docs/resources/interface_logical.md
+++ b/docs/resources/interface_logical.md
@@ -101,6 +101,8 @@ The following arguments are supported:
     Sample all packets input on this interface.
   - **sampling_output** (Optional, Boolean)  
     Sample all packets output on this interface.
+- **proxy_macip_advertisement** (Optional, Boolean)  
+  Proxy advertisement of type 2 MAC+IP route for EVPN.
 - **routing_instance** (Optional, String)  
   Add this interface in routing_instance.  
   Need to be created before.

--- a/internal/provider/data_source_interface_logical.go
+++ b/internal/provider/data_source_interface_logical.go
@@ -107,6 +107,10 @@ func (dsc *interfaceLogicalDataSource) Schema(
 				Computed:    true,
 				Description: "Logical link-layer encapsulation.",
 			},
+			"proxy_macip_advertisement": schema.BoolAttribute{
+				Computed:    true,
+				Description: "Proxy advertisement of type 2 MAC+IP route for EVPN.",
+			},
 			"routing_instance": schema.StringAttribute{
 				Computed:    true,
 				Description: "Routing_instance where the interface is.",
@@ -294,6 +298,7 @@ type interfaceLogicalDataSourceData struct {
 	Description              types.String                      `tfsdk:"description"`
 	Disable                  types.Bool                        `tfsdk:"disable"`
 	Encapsulation            types.String                      `tfsdk:"encapsulation"`
+	ProxyMacipAdvertisement  types.Bool                        `tfsdk:"proxy_macip_advertisement"`
 	RoutingInstance          types.String                      `tfsdk:"routing_instance"`
 	SecurityInboundProtocols []types.String                    `tfsdk:"security_inbound_protocols"`
 	SecurityInboundServices  []types.String                    `tfsdk:"security_inbound_services"`
@@ -443,6 +448,7 @@ func (dscData *interfaceLogicalDataSourceData) copyFromResourceData(rscData inte
 	dscData.Encapsulation = rscData.Encapsulation
 	dscData.FamilyInet = rscData.FamilyInet
 	dscData.FamilyInet6 = rscData.FamilyInet6
+	dscData.ProxyMacipAdvertisement = rscData.ProxyMacipAdvertisement
 	dscData.RoutingInstance = rscData.RoutingInstance
 	dscData.SecurityInboundProtocols = rscData.SecurityInboundProtocols
 	dscData.SecurityInboundServices = rscData.SecurityInboundServices

--- a/internal/provider/resource_interface_logical.go
+++ b/internal/provider/resource_interface_logical.go
@@ -138,6 +138,13 @@ func (rsc *interfaceLogical) Schema(
 					tfvalidator.StringFormat(tfvalidator.DefaultFormat),
 				},
 			},
+			"proxy_macip_advertisement": schema.BoolAttribute{
+				Optional:    true,
+				Description: "Proxy advertisement of type 2 MAC+IP route for EVPN.",
+				Validators: []validator.Bool{
+					tfvalidator.BoolTrue(),
+				},
+			},
 			"routing_instance": schema.StringAttribute{
 				Optional:    true,
 				Description: "Add this interface in routing_instance.",
@@ -1119,6 +1126,7 @@ type interfaceLogicalData struct {
 	Description              types.String                      `tfsdk:"description"`
 	Disable                  types.Bool                        `tfsdk:"disable"`
 	Encapsulation            types.String                      `tfsdk:"encapsulation"`
+	ProxyMacipAdvertisement  types.Bool                        `tfsdk:"proxy_macip_advertisement"`
 	RoutingInstance          types.String                      `tfsdk:"routing_instance"`
 	SecurityInboundProtocols []types.String                    `tfsdk:"security_inbound_protocols"`
 	SecurityInboundServices  []types.String                    `tfsdk:"security_inbound_services"`
@@ -1140,6 +1148,7 @@ type interfaceLogicalConfig struct {
 	Description              types.String                            `tfsdk:"description"`
 	Disable                  types.Bool                              `tfsdk:"disable"`
 	Encapsulation            types.String                            `tfsdk:"encapsulation"`
+	ProxyMacipAdvertisement  types.Bool                              `tfsdk:"proxy_macip_advertisement"`
 	RoutingInstance          types.String                            `tfsdk:"routing_instance"`
 	SecurityInboundProtocols types.Set                               `tfsdk:"security_inbound_protocols"`
 	SecurityInboundServices  types.Set                               `tfsdk:"security_inbound_services"`
@@ -1407,6 +1416,14 @@ func (rsc *interfaceLogical) ValidateConfig(
 
 	if !config.Name.IsNull() && !config.Name.IsUnknown() &&
 		!strings.HasPrefix(config.Name.ValueString(), "irb.") {
+		if !config.ProxyMacipAdvertisement.IsNull() &&
+			!config.ProxyMacipAdvertisement.IsUnknown() {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("proxy_macip_advertisement"),
+				tfdiag.ConflictConfigErrSummary,
+				"cannot set proxy_macip_advertisement if interface name doesn't have 'irb.' prefix",
+			)
+		}
 		if !config.VirtualGatewayAcceptData.IsNull() &&
 			!config.VirtualGatewayAcceptData.IsUnknown() {
 			resp.Diagnostics.AddAttributeError(
@@ -2552,6 +2569,9 @@ func (rscData *interfaceLogicalData) set(
 	if v := rscData.Encapsulation.ValueString(); v != "" {
 		configSet = append(configSet, setPrefix+"encapsulation "+v)
 	}
+	if rscData.ProxyMacipAdvertisement.ValueBool() {
+		configSet = append(configSet, setPrefix+"proxy-macip-advertisement")
+	}
 	if rscData.VirtualGatewayAcceptData.ValueBool() {
 		configSet = append(configSet, setPrefix+"virtual-gateway-accept-data")
 	}
@@ -3246,6 +3266,8 @@ func (rscData *interfaceLogicalData) read(
 				case itemTrim == " sampling output":
 					rscData.FamilyInet.SamplingOutput = types.BoolValue(true)
 				}
+			case itemTrim == "proxy-macip-advertisement":
+				rscData.ProxyMacipAdvertisement = types.BoolValue(true)
 			case balt.CutPrefixInString(&itemTrim, "tunnel "):
 				if rscData.Tunnel == nil {
 					rscData.Tunnel = &interfaceLogicalBlockTunnel{}
@@ -3703,6 +3725,7 @@ func (rscData *interfaceLogicalData) delOpts(
 		delPrefix + "encapsulation",
 		delPrefix + "family inet",
 		delPrefix + "family inet6",
+		delPrefix + "proxy-macip-advertisement",
 		delPrefix + "tunnel",
 		delPrefix + "virtual-gateway-accept-data",
 		delPrefix + "virtual-gateway-v4-mac",

--- a/internal/provider/resource_interface_logical_test.go
+++ b/internal/provider/resource_interface_logical_test.go
@@ -230,3 +230,20 @@ func TestAccResourceInterfaceLogical_router(t *testing.T) {
 		})
 	}
 }
+
+func TestAccResourceInterfaceLogical_switch(t *testing.T) {
+	if os.Getenv("TESTACC_SWITCH") != "" {
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					ConfigDirectory: config.TestStepDirectory(),
+				},
+				{
+					ConfigDirectory: config.TestStepDirectory(),
+				},
+			},
+		})
+	}
+}

--- a/internal/provider/testdata/TestAccResourceInterfaceLogical_switch/1/main.tf
+++ b/internal/provider/testdata/TestAccResourceInterfaceLogical_switch/1/main.tf
@@ -1,0 +1,4 @@
+resource "junos_interface_logical" "testacc_interface_logical" {
+  name                      = "irb.100"
+  proxy_macip_advertisement = true
+}

--- a/internal/provider/testdata/TestAccResourceInterfaceLogical_switch/2/main.tf
+++ b/internal/provider/testdata/TestAccResourceInterfaceLogical_switch/2/main.tf
@@ -1,0 +1,3 @@
+resource "junos_interface_logical" "testacc_interface_logical" {
+  name = "irb.100"
+}


### PR DESCRIPTION
ENHANCEMENTS:

* **resource/junos_interface_logical**: add `proxy_macip_advertisement` argument (Fix #895)
* **data-source/junos_interface_logical**: add `proxy_macip_advertisement` attribute like resource