### PR TITLE
r/forwardingoptions_sampling_instance, r/chassis_fpc: attach sampling instance to chassis FPC in same commit

### DIFF
--- a/.changes/issue-912.md
+++ b/.changes/issue-912.md
@@ -1,4 +1,5 @@
 <!-- markdownlint-disable-file MD013 MD041 -->
 ENHANCEMENTS:
 
+* **resource/junos_chassis_fpc**: add `configure_sampling_instance_singly` argument to configure the `sampling-instance` option in an other resource
 * **resource/junos_forwardingoptions_sampling_instance**: add `chassis_fpc_slot_numbers` argument to attach the sampling instance to chassis FPC slots with the same commit, required on some Junos systems where the sampling instance and the FPC binding cannot be committed separately (Fix [#912](https://github.com/jeremmfr/terraform-provider-junos/issues/912))

--- a/.changes/issue-912.md
+++ b/.changes/issue-912.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable-file MD013 MD041 -->
+ENHANCEMENTS:
+
+* **resource/junos_forwardingoptions_sampling_instance**: add `chassis_fpc_slot_numbers` argument to attach the sampling instance to chassis FPC slots with the same commit, required on some Junos systems where the sampling instance and the FPC binding cannot be committed separately (Fix [#912](https://github.com/jeremmfr/terraform-provider-junos/issues/912))

--- a/docs/resources/chassis_fpc.md
+++ b/docs/resources/chassis_fpc.md
@@ -20,6 +20,28 @@ resource "junos_chassis_fpc" "fpc0" {
 }
 ```
 
+```hcl
+# Configure chassis FPC slot 0 with the sampling instance attached by the sampling instance resource
+resource "junos_chassis_fpc" "fpc0" {
+  slot_number                        = 0
+  configure_sampling_instance_singly = true
+
+  error {
+    major_action    = "alarm"
+    major_threshold = 10
+  }
+}
+
+resource "junos_forwardingoptions_sampling_instance" "demo" {
+  name                     = "demo"
+  chassis_fpc_slot_numbers = [0]
+
+  input {
+    rate = 1
+  }
+}
+```
+
 ## Argument Reference
 
 -> **Note**
@@ -31,6 +53,12 @@ The following arguments are supported:
   FPC number.
 - **cfp_to_et** (Optional, Boolean)  
   Enable ET interface and remove CFP client.
+- **configure_sampling_instance_singly** (Optional, Boolean)  
+  Configure `sampling-instance` option in other resource
+  (like `junos_forwardingoptions_sampling_instance` with `chassis_fpc_slot_numbers` argument).  
+  Conflict with `sampling_instance`.  
+  Required on some Junos systems where the sampling instance and the FPC binding cannot be
+  committed separately.
 - **sampling_instance** (Optional, String)  
   Name for sampling instance.
 - **error** (Optional, Block)  

--- a/docs/resources/forwardingoptions_sampling_instance.md
+++ b/docs/resources/forwardingoptions_sampling_instance.md
@@ -36,6 +36,15 @@ The following arguments are supported:
   Routing instance if not root level.  
   Need to be `default` or name of routing instance.  
   Defaults to `default`
+- **chassis_fpc_slot_numbers** (Optional, Set of Number)  
+  Attach sampling instance to chassis FPC slots.  
+  Generate `chassis fpc <slot_number> sampling-instance <name>` lines with the same commit as the
+  sampling instance itself, which is required on some Junos systems where the sampling instance and
+  the FPC binding cannot be committed separately.  
+  Cannot be set when `routing_instance` is not `default`, a chassis FPC can only be attached to a
+  root level sampling instance.  
+  Don't manage the same FPC slot with the `sampling_instance` argument of a `junos_chassis_fpc`
+  resource, set `configure_sampling_instance_singly` on it instead.
 - **disable** (Optional, Boolean)  
   Disable sampling instance.
 - **family_inet_input** (Optional, Block)  
@@ -157,3 +166,7 @@ Junos forwarding-options sampling instance can be imported using an id made up o
 ```shell
 $ terraform import junos_forwardingoptions_sampling_instance.demo demo
 ```
+
+`chassis_fpc_slot_numbers` is never imported.  
+Add the argument in the configuration after the import to manage the FPC slots with this resource,
+the apply doesn't change the Junos configuration if the lines are already configured.

--- a/internal/provider/resource_chassis_fpc.go
+++ b/internal/provider/resource_chassis_fpc.go
@@ -107,6 +107,14 @@ func (rsc *chassisFpc) Schema(
 					tfvalidator.BoolTrue(),
 				},
 			},
+			"configure_sampling_instance_singly": schema.BoolAttribute{
+				Optional: true,
+				Description: "Configure `sampling-instance` option in other resource " +
+					"(like `junos_forwardingoptions_sampling_instance`).",
+				Validators: []validator.Bool{
+					tfvalidator.BoolTrue(),
+				},
+			},
 			"sampling_instance": schema.StringAttribute{
 				Optional:    true,
 				Description: "Name for sampling instance.",
@@ -171,12 +179,14 @@ func (rsc *chassisFpc) Schema(
 	}
 }
 
+//nolint:lll
 type chassisFpcData struct {
-	ID               types.String          `tfsdk:"id"                tfdata:"skip_isempty"`
-	SlotNumber       types.Int64           `tfsdk:"slot_number"       tfdata:"skip_isempty"`
-	CfpToEt          types.Bool            `tfsdk:"cfp_to_et"`
-	SamplingInstance types.String          `tfsdk:"sampling_instance"`
-	Error            *chassisFpcBlockError `tfsdk:"error"`
+	ID                              types.String          `tfsdk:"id"                                 tfdata:"skip_isempty"`
+	SlotNumber                      types.Int64           `tfsdk:"slot_number"                        tfdata:"skip_isempty"`
+	CfpToEt                         types.Bool            `tfsdk:"cfp_to_et"`
+	ConfigureSamplingInstanceSingly types.Bool            `tfsdk:"configure_sampling_instance_singly" tfdata:"skip_isempty"`
+	SamplingInstance                types.String          `tfsdk:"sampling_instance"`
+	Error                           *chassisFpcBlockError `tfsdk:"error"`
 }
 
 func (rscData *chassisFpcData) isEmpty() bool {
@@ -213,6 +223,15 @@ func (rsc *chassisFpc) ValidateConfig(
 		)
 	}
 
+	if config.ConfigureSamplingInstanceSingly.ValueBool() &&
+		!config.SamplingInstance.IsNull() && !config.SamplingInstance.IsUnknown() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("configure_sampling_instance_singly"),
+			tfdiag.ConflictConfigErrSummary,
+			"cannot have configure_sampling_instance_singly and want to configure sampling instance at the same time",
+		)
+	}
+
 	if config.Error != nil {
 		if config.Error.isEmpty() {
 			resp.Diagnostics.AddAttributeError(
@@ -237,7 +256,11 @@ func (rsc *chassisFpc) Create(
 		ctx,
 		rsc,
 		func(fnCtx context.Context, junSess *junos.Session) bool {
-			slotNumberExists, err := checkChassisFpcExists(fnCtx, plan.SlotNumber.ValueInt64(), junSess)
+			slotNumberExists, err := checkChassisFpcExists(fnCtx,
+				plan.SlotNumber.ValueInt64(),
+				plan.ConfigureSamplingInstanceSingly.ValueBool(),
+				junSess,
+			)
 			if err != nil {
 				resp.Diagnostics.AddError(tfdiag.PreCheckErrSummary, err.Error())
 
@@ -255,7 +278,11 @@ func (rsc *chassisFpc) Create(
 			return true
 		},
 		func(fnCtx context.Context, junSess *junos.Session) bool {
-			slotNumberExists, err := checkChassisFpcExists(fnCtx, plan.SlotNumber.ValueInt64(), junSess)
+			slotNumberExists, err := checkChassisFpcExists(fnCtx,
+				plan.SlotNumber.ValueInt64(),
+				plan.ConfigureSamplingInstanceSingly.ValueBool(),
+				junSess,
+			)
 			if err != nil {
 				resp.Diagnostics.AddError(tfdiag.PostCheckErrSummary, err.Error())
 
@@ -295,7 +322,12 @@ func (rsc *chassisFpc) Read(
 			state.SlotNumber.ValueInt64(),
 		},
 		&data,
-		nil,
+		func() {
+			data.ConfigureSamplingInstanceSingly = state.ConfigureSamplingInstanceSingly
+			if data.ConfigureSamplingInstanceSingly.ValueBool() {
+				data.SamplingInstance = types.StringNull()
+			}
+		},
 		resp,
 	)
 }
@@ -310,13 +342,90 @@ func (rsc *chassisFpc) Update(
 		return
 	}
 
-	defaultResourceUpdate(
-		ctx,
-		rsc,
-		&state,
-		&plan,
-		resp,
-	)
+	samplingInstanceSingly := plan.ConfigureSamplingInstanceSingly.ValueBool()
+	if !plan.ConfigureSamplingInstanceSingly.Equal(state.ConfigureSamplingInstanceSingly) {
+		if state.ConfigureSamplingInstanceSingly.ValueBool() {
+			samplingInstanceSingly = state.ConfigureSamplingInstanceSingly.ValueBool()
+			resp.Diagnostics.AddAttributeWarning(
+				path.Root("configure_sampling_instance_singly"),
+				"Disable configure_sampling_instance_singly on resource already created",
+				"It's doesn't delete sampling-instance line already configured. "+
+					"So remove the slot number from `chassis_fpc_slot_numbers` argument on the "+
+					"`junos_forwardingoptions_sampling_instance` resource to avoid conflict",
+			)
+		} else {
+			resp.Diagnostics.AddAttributeWarning(
+				path.Root("configure_sampling_instance_singly"),
+				"Enable configure_sampling_instance_singly on resource already created",
+				"It's doesn't delete sampling-instance line already configured. "+
+					"So add the slot number in `chassis_fpc_slot_numbers` argument on the "+
+					"`junos_forwardingoptions_sampling_instance` resource to be able to manage it",
+			)
+		}
+	}
+
+	if rsc.client.FakeUpdateAlso() {
+		junSess := rsc.client.NewSessionWithoutNetconf(ctx)
+
+		if err := state.delOpts(ctx, samplingInstanceSingly, junSess); err != nil {
+			resp.Diagnostics.AddError(tfdiag.ConfigDelErrSummary, err.Error())
+
+			return
+		}
+		if errPath, err := plan.set(ctx, junSess); err != nil {
+			if !errPath.Equal(path.Empty()) {
+				resp.Diagnostics.AddAttributeError(errPath, tfdiag.ConfigSetErrSummary, err.Error())
+			} else {
+				resp.Diagnostics.AddError(tfdiag.ConfigSetErrSummary, err.Error())
+			}
+
+			return
+		}
+
+		resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+
+		return
+	}
+
+	junSess, err := rsc.client.StartNewSession(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError(tfdiag.StartSessErrSummary, err.Error())
+
+		return
+	}
+	defer junSess.Close()
+	if err := junSess.ConfigLock(ctx); err != nil {
+		resp.Diagnostics.AddError(tfdiag.ConfigLockErrSummary, err.Error())
+
+		return
+	}
+	defer func() {
+		resp.Diagnostics.Append(tfdiag.Warns(tfdiag.ConfigUnlockWarnSummary, junSess.ConfigUnlock(ctx))...)
+	}()
+
+	if err := state.delOpts(ctx, samplingInstanceSingly, junSess); err != nil {
+		resp.Diagnostics.AddError(tfdiag.ConfigDelErrSummary, err.Error())
+
+		return
+	}
+	if errPath, err := plan.set(ctx, junSess); err != nil {
+		if !errPath.Equal(path.Empty()) {
+			resp.Diagnostics.AddAttributeError(errPath, tfdiag.ConfigSetErrSummary, err.Error())
+		} else {
+			resp.Diagnostics.AddError(tfdiag.ConfigSetErrSummary, err.Error())
+		}
+
+		return
+	}
+	warns, err := junSess.CommitConf(ctx, "update resource "+rsc.typeName())
+	resp.Diagnostics.Append(tfdiag.Warns(tfdiag.ConfigCommitWarnSummary, warns)...)
+	if err != nil {
+		resp.Diagnostics.AddError(tfdiag.ConfigCommitErrSummary, err.Error())
+
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }
 
 func (rsc *chassisFpc) Delete(
@@ -353,7 +462,7 @@ func (rsc *chassisFpc) ImportState(
 }
 
 func checkChassisFpcExists(
-	ctx context.Context, slotNumber int64, junSess *junos.Session,
+	ctx context.Context, slotNumber int64, samplingInstanceSingly bool, junSess *junos.Session,
 ) (
 	bool, error,
 ) {
@@ -377,7 +486,7 @@ func checkChassisFpcExists(
 		case strings.HasPrefix(itemTrim, "error minor "):
 			return true
 		case strings.HasPrefix(itemTrim, "sampling-instance "):
-			return true
+			return !samplingInstanceSingly
 		default:
 			return false
 		}
@@ -412,8 +521,10 @@ func (rscData *chassisFpcData) set(
 	if rscData.CfpToEt.ValueBool() {
 		configSet = append(configSet, setPrefix+"cfp-to-et")
 	}
-	if v := rscData.SamplingInstance.ValueString(); v != "" {
-		configSet = append(configSet, setPrefix+"sampling-instance \""+v+"\"")
+	if !rscData.ConfigureSamplingInstanceSingly.ValueBool() {
+		if v := rscData.SamplingInstance.ValueString(); v != "" {
+			configSet = append(configSet, setPrefix+"sampling-instance \""+v+"\"")
+		}
 	}
 
 	if rscData.Error != nil {
@@ -533,6 +644,12 @@ func (block *chassisFpcBlockError) read(itemTrim string) (err error) {
 func (rscData *chassisFpcData) del(
 	ctx context.Context, junSess *junos.Session,
 ) error {
+	return rscData.delOpts(ctx, rscData.ConfigureSamplingInstanceSingly.ValueBool(), junSess)
+}
+
+func (rscData *chassisFpcData) delOpts(
+	ctx context.Context, samplingInstanceSingly bool, junSess *junos.Session,
+) error {
 	delPrefix := junos.DeleteLS + "chassis fpc " + utils.ConvI64toa(rscData.SlotNumber.ValueInt64()) + " "
 
 	configSet := []string{
@@ -540,7 +657,10 @@ func (rscData *chassisFpcData) del(
 		delPrefix + "error fatal",
 		delPrefix + "error major",
 		delPrefix + "error minor",
-		delPrefix + "sampling-instance \"" + rscData.SamplingInstance.ValueString() + "\"",
+	}
+	if !samplingInstanceSingly {
+		configSet = append(configSet,
+			delPrefix+"sampling-instance \""+rscData.SamplingInstance.ValueString()+"\"")
 	}
 
 	return junSess.ConfigSet(ctx, configSet)

--- a/internal/provider/resource_chassis_fpc_test.go
+++ b/internal/provider/resource_chassis_fpc_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-func TestAccResourceChassisFpc_switch(t *testing.T) {
-	if os.Getenv("TESTACC_SWITCH") != "" {
+func TestAccResourceChassisFpc_basic(t *testing.T) {
+	if os.Getenv("TESTACC_ROUTER") != "" || os.Getenv("TESTACC_SWITCH") != "" {
 		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { testAccPreCheck(t) },
 			ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,

--- a/internal/provider/resource_forwardingoptions_sampling_instance.go
+++ b/internal/provider/resource_forwardingoptions_sampling_instance.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -116,6 +117,18 @@ func (rsc *forwardingoptionsSamplingInstance) Schema(
 					tfvalidator.StringFormat(tfvalidator.DefaultFormat),
 				},
 			},
+			"chassis_fpc_slot_numbers": schema.SetAttribute{
+				ElementType: types.Int64Type,
+				Optional:    true,
+				Description: "Attach sampling instance to chassis FPC slots.",
+				Validators: []validator.Set{
+					setvalidator.SizeAtLeast(1),
+					setvalidator.NoNullValues(),
+					setvalidator.ValueInt64sAre(
+						int64validator.AtLeast(0),
+					),
+				},
+			},
 			"disable": schema.BoolAttribute{
 				Optional:    true,
 				Description: "Disable sampling instance.",
@@ -182,31 +195,33 @@ func (rsc *forwardingoptionsSamplingInstance) Schema(
 }
 
 type forwardingoptionsSamplingInstanceData struct {
-	ID                types.String                                             `tfsdk:"id"`
-	Name              types.String                                             `tfsdk:"name"`
-	RoutingInstance   types.String                                             `tfsdk:"routing_instance"`
-	Disable           types.Bool                                               `tfsdk:"disable"`
-	FamilyInetInput   *forwardingoptionsSamplingInstanceBlockInput             `tfsdk:"family_inet_input"`
-	FamilyInetOutput  *forwardingoptionsSamplingInstanceBlockFamilyInetOutput  `tfsdk:"family_inet_output"`
-	FamilyInet6Input  *forwardingoptionsSamplingInstanceBlockInput             `tfsdk:"family_inet6_input"`
-	FamilyInet6Output *forwardingoptionsSamplingInstanceBlockFamilyInet6Output `tfsdk:"family_inet6_output"`
-	FamilyMplsInput   *forwardingoptionsSamplingInstanceBlockInput             `tfsdk:"family_mpls_input"`
-	FamilyMplsOutput  *forwardingoptionsSamplingInstanceBlockFamilyMplsOutput  `tfsdk:"family_mpls_output"`
-	Input             *forwardingoptionsSamplingInstanceBlockInput             `tfsdk:"input"`
+	ID                    types.String                                             `tfsdk:"id"`
+	Name                  types.String                                             `tfsdk:"name"`
+	RoutingInstance       types.String                                             `tfsdk:"routing_instance"`
+	ChassisFpcSlotNumbers []types.Int64                                            `tfsdk:"chassis_fpc_slot_numbers"`
+	Disable               types.Bool                                               `tfsdk:"disable"`
+	FamilyInetInput       *forwardingoptionsSamplingInstanceBlockInput             `tfsdk:"family_inet_input"`
+	FamilyInetOutput      *forwardingoptionsSamplingInstanceBlockFamilyInetOutput  `tfsdk:"family_inet_output"`
+	FamilyInet6Input      *forwardingoptionsSamplingInstanceBlockInput             `tfsdk:"family_inet6_input"`
+	FamilyInet6Output     *forwardingoptionsSamplingInstanceBlockFamilyInet6Output `tfsdk:"family_inet6_output"`
+	FamilyMplsInput       *forwardingoptionsSamplingInstanceBlockInput             `tfsdk:"family_mpls_input"`
+	FamilyMplsOutput      *forwardingoptionsSamplingInstanceBlockFamilyMplsOutput  `tfsdk:"family_mpls_output"`
+	Input                 *forwardingoptionsSamplingInstanceBlockInput             `tfsdk:"input"`
 }
 
 type forwardingoptionsSamplingInstanceConfig struct {
-	ID                types.String                                                  `tfsdk:"id"`
-	Name              types.String                                                  `tfsdk:"name"`
-	RoutingInstance   types.String                                                  `tfsdk:"routing_instance"`
-	Disable           types.Bool                                                    `tfsdk:"disable"`
-	FamilyInetInput   *forwardingoptionsSamplingInstanceBlockInput                  `tfsdk:"family_inet_input"`
-	FamilyInetOutput  *forwardingoptionsSamplingInstanceBlockFamilyInetOutputConfig `tfsdk:"family_inet_output"`
-	FamilyInet6Input  *forwardingoptionsSamplingInstanceBlockInput                  `tfsdk:"family_inet6_input"`
-	FamilyInet6Output *forwardingoptionsSamplingInstanceBlockFamilyInetOutputConfig `tfsdk:"family_inet6_output"`
-	FamilyMplsInput   *forwardingoptionsSamplingInstanceBlockInput                  `tfsdk:"family_mpls_input"`
-	FamilyMplsOutput  *forwardingoptionsSamplingInstanceBlockFamilyMplsOutputConfig `tfsdk:"family_mpls_output"`
-	Input             *forwardingoptionsSamplingInstanceBlockInput                  `tfsdk:"input"`
+	ID                    types.String                                                  `tfsdk:"id"`
+	Name                  types.String                                                  `tfsdk:"name"`
+	RoutingInstance       types.String                                                  `tfsdk:"routing_instance"`
+	ChassisFpcSlotNumbers types.Set                                                     `tfsdk:"chassis_fpc_slot_numbers"`
+	Disable               types.Bool                                                    `tfsdk:"disable"`
+	FamilyInetInput       *forwardingoptionsSamplingInstanceBlockInput                  `tfsdk:"family_inet_input"`
+	FamilyInetOutput      *forwardingoptionsSamplingInstanceBlockFamilyInetOutputConfig `tfsdk:"family_inet_output"`
+	FamilyInet6Input      *forwardingoptionsSamplingInstanceBlockInput                  `tfsdk:"family_inet6_input"`
+	FamilyInet6Output     *forwardingoptionsSamplingInstanceBlockFamilyInetOutputConfig `tfsdk:"family_inet6_output"`
+	FamilyMplsInput       *forwardingoptionsSamplingInstanceBlockInput                  `tfsdk:"family_mpls_input"`
+	FamilyMplsOutput      *forwardingoptionsSamplingInstanceBlockFamilyMplsOutputConfig `tfsdk:"family_mpls_output"`
+	Input                 *forwardingoptionsSamplingInstanceBlockInput                  `tfsdk:"input"`
 }
 
 type forwardingoptionsSamplingInstanceBlockInput struct {
@@ -654,6 +669,17 @@ func (rsc *forwardingoptionsSamplingInstance) ValidateConfig(
 		return
 	}
 
+	if !config.ChassisFpcSlotNumbers.IsNull() && !config.ChassisFpcSlotNumbers.IsUnknown() &&
+		!config.RoutingInstance.IsNull() && !config.RoutingInstance.IsUnknown() &&
+		config.RoutingInstance.ValueString() != junos.DefaultW {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("chassis_fpc_slot_numbers"),
+			tfdiag.ConflictConfigErrSummary,
+			"cannot set chassis_fpc_slot_numbers when routing_instance is not "+junos.DefaultW+
+				" because a chassis FPC can only be attached to a root level sampling instance",
+		)
+	}
+
 	if config.Input != nil {
 		if config.Input.isEmpty() {
 			resp.Diagnostics.AddAttributeError(
@@ -1065,18 +1091,40 @@ func (rsc *forwardingoptionsSamplingInstance) Read(
 		return
 	}
 
-	var _ resourceDataReadFrom2String = &data
-	defaultResourceRead(
-		ctx,
-		rsc,
-		[]any{
-			state.Name.ValueString(),
-			state.RoutingInstance.ValueString(),
-		},
-		&data,
-		nil,
-		resp,
-	)
+	junSess, err := rsc.client.StartNewSession(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError(tfdiag.StartSessErrSummary, err.Error())
+
+		return
+	}
+	defer junSess.Close()
+
+	junos.MutexLock()
+	if err := data.read(
+		ctx, state.Name.ValueString(), state.RoutingInstance.ValueString(), junSess,
+	); err != nil {
+		junos.MutexUnlock()
+		resp.Diagnostics.AddError(tfdiag.ConfigReadErrSummary, err.Error())
+
+		return
+	}
+	if !data.nullID() && state.ChassisFpcSlotNumbers != nil {
+		if err := data.readChassisFpcSlotNumbers(ctx, state.Name.ValueString(), junSess); err != nil {
+			junos.MutexUnlock()
+			resp.Diagnostics.AddError(tfdiag.ConfigReadErrSummary, err.Error())
+
+			return
+		}
+	}
+	junos.MutexUnlock()
+
+	if data.nullID() {
+		resp.State.RemoveResource(ctx)
+
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
 func (rsc *forwardingoptionsSamplingInstance) Update(
@@ -1199,6 +1247,17 @@ func (rscData *forwardingoptionsSamplingInstanceData) set(
 	}
 	setPrefix += "forwarding-options sampling instance \"" + rscData.Name.ValueString() + "\" "
 
+	if len(rscData.ChassisFpcSlotNumbers) > 0 {
+		if v := rscData.RoutingInstance.ValueString(); v != "" && v != junos.DefaultW {
+			return path.Root("chassis_fpc_slot_numbers"),
+				errors.New("cannot set chassis_fpc_slot_numbers when routing_instance is not " + junos.DefaultW +
+					" because a chassis FPC can only be attached to a root level sampling instance")
+		}
+		for _, v := range rscData.ChassisFpcSlotNumbers {
+			configSet = append(configSet, junos.SetLS+"chassis fpc "+utils.ConvI64toa(v.ValueInt64())+
+				" sampling-instance \""+rscData.Name.ValueString()+"\"")
+		}
+	}
 	if rscData.Disable.ValueBool() {
 		configSet = append(configSet, setPrefix+"disable")
 	}
@@ -1708,6 +1767,47 @@ func (rscData *forwardingoptionsSamplingInstanceData) read(
 	return nil
 }
 
+func (rscData *forwardingoptionsSamplingInstanceData) readChassisFpcSlotNumbers(
+	ctx context.Context, name string, junSess *junos.Session,
+) error {
+	showConfig, err := junSess.Command(ctx, junos.CmdShowConfig+
+		"chassis"+junos.PipeDisplaySetRelative)
+	if err != nil {
+		return err
+	}
+	if showConfig == junos.EmptyW {
+		return nil
+	}
+
+	for item := range strings.SplitSeq(showConfig, "\n") {
+		if strings.Contains(item, junos.XMLStartTagConfigOut) {
+			continue
+		}
+		if strings.Contains(item, junos.XMLEndTagConfigOut) {
+			break
+		}
+		itemTrim := strings.TrimPrefix(item, junos.SetLS)
+		if !balt.CutPrefixInString(&itemTrim, "fpc ") {
+			continue
+		}
+		slotNumber := tfdata.FirstElementOfJunosLine(itemTrim)
+		if !balt.CutPrefixInString(&itemTrim, slotNumber+" sampling-instance ") {
+			continue
+		}
+		if strings.Trim(itemTrim, "\"") != name {
+			continue
+		}
+
+		slotNumberValue, err := tfdata.ConvAtoi64Value(slotNumber)
+		if err != nil {
+			return err
+		}
+		rscData.ChassisFpcSlotNumbers = append(rscData.ChassisFpcSlotNumbers, slotNumberValue)
+	}
+
+	return nil
+}
+
 func (block *forwardingoptionsSamplingInstanceBlockInput) read(itemTrim string) (err error) {
 	switch {
 	case balt.CutPrefixInString(&itemTrim, "max-packets-per-second "):
@@ -2002,8 +2102,13 @@ func (rscData *forwardingoptionsSamplingInstanceData) del(
 		delPrefix += junos.RoutingInstancesWS + v + " "
 	}
 
-	configSet := []string{
-		delPrefix + "forwarding-options sampling instance \"" + rscData.Name.ValueString() + "\"",
+	configSet := make([]string, 0, 1+len(rscData.ChassisFpcSlotNumbers))
+	configSet = append(configSet,
+		delPrefix+"forwarding-options sampling instance \""+rscData.Name.ValueString()+"\"")
+	for _, v := range rscData.ChassisFpcSlotNumbers {
+		configSet = append(configSet,
+			junos.DeleteLS+"chassis fpc "+utils.ConvI64toa(v.ValueInt64())+
+				" sampling-instance \""+rscData.Name.ValueString()+"\"")
 	}
 
 	return junSess.ConfigSet(ctx, configSet)

--- a/internal/provider/testdata/TestAccResourceChassisFpc_basic/1/main.tf
+++ b/internal/provider/testdata/TestAccResourceChassisFpc_basic/1/main.tf
@@ -33,6 +33,8 @@ resource "junos_chassis_fpc" "testacc_chassis_fpc2" {
 
 resource "junos_chassis_fpc" "testacc_chassis_fpc3" {
   slot_number = 3
+
+  configure_sampling_instance_singly = true
   error {
     fatal_action    = "log"
     fatal_threshold = 100
@@ -40,5 +42,21 @@ resource "junos_chassis_fpc" "testacc_chassis_fpc3" {
     major_threshold = 70
     minor_action    = "trap"
     minor_threshold = 1
+  }
+}
+
+resource "junos_forwardingoptions_sampling_instance" "testacc_chassis_fpc3" {
+  name                     = "sampling_instance for testacc_chassis_fpc3"
+  chassis_fpc_slot_numbers = [3]
+  family_inet_input {
+    rate = 2
+  }
+  family_inet_output {
+    inline_jflow_source_address = "192.0.2.2"
+    flow_server {
+      hostname               = "192.0.2.1"
+      port                   = 3000
+      version_ipfix_template = junos_services_flowmonitoring_vipfix_template.testacc_chassis_fpc.name
+    }
   }
 }

--- a/internal/provider/testdata/TestAccResourceChassisFpc_basic/2/main.tf
+++ b/internal/provider/testdata/TestAccResourceChassisFpc_basic/2/main.tf
@@ -24,6 +24,8 @@ resource "junos_chassis_fpc" "testacc_chassis_fpc" {
 
 resource "junos_chassis_fpc" "testacc_chassis_fpc2" {
   slot_number = 2
+
+  configure_sampling_instance_singly = true
   error {
     fatal_action = "log"
   }
@@ -31,11 +33,29 @@ resource "junos_chassis_fpc" "testacc_chassis_fpc2" {
 
 resource "junos_chassis_fpc" "testacc_chassis_fpc3" {
   slot_number = 3
+
+  configure_sampling_instance_singly = true
   error {
     fatal_action    = "trap"
     fatal_threshold = 99
     major_threshold = 77
     minor_action    = "trap"
     minor_threshold = 32
+  }
+}
+
+resource "junos_forwardingoptions_sampling_instance" "testacc_chassis_fpc3" {
+  name                     = "sampling_instance for testacc_chassis_fpc3"
+  chassis_fpc_slot_numbers = [3]
+  family_inet_input {
+    rate = 3
+  }
+  family_inet_output {
+    inline_jflow_source_address = "192.0.2.2"
+    flow_server {
+      hostname               = "192.0.2.1"
+      port                   = 3000
+      version_ipfix_template = junos_services_flowmonitoring_vipfix_template.testacc_chassis_fpc.name
+    }
   }
 }

--- a/internal/provider/testdata/TestAccResourceForwardingoptionsSamplingInstance_basic/1/main.tf
+++ b/internal/provider/testdata/TestAccResourceForwardingoptionsSamplingInstance_basic/1/main.tf
@@ -95,6 +95,22 @@ resource "junos_routing_instance" "testacc_sampInstance5" {
   name = "testacc_sampInstance5"
 }
 
+resource "junos_forwardingoptions_sampling_instance" "testacc_sampInstance6" {
+  name                     = "testacc_instance@6"
+  chassis_fpc_slot_numbers = [2]
+  family_inet_input {
+    rate = 2
+  }
+  family_inet_output {
+    inline_jflow_source_address = "192.0.2.2"
+    flow_server {
+      hostname               = "192.0.2.1"
+      port                   = 3000
+      version_ipfix_template = junos_services_flowmonitoring_vipfix_template.testacc_sampInstance2.name
+    }
+  }
+}
+
 resource "junos_system_ntp_server" "testacc_sampInstance" {
   address = "192.0.2.3"
 }

--- a/internal/provider/testdata/TestAccResourceForwardingoptionsSamplingInstance_basic/2/main.tf
+++ b/internal/provider/testdata/TestAccResourceForwardingoptionsSamplingInstance_basic/2/main.tf
@@ -112,6 +112,22 @@ resource "junos_routing_instance" "testacc_sampInstance5" {
   name = "testacc_sampInstance5"
 }
 
+resource "junos_forwardingoptions_sampling_instance" "testacc_sampInstance6" {
+  name                     = "testacc_instance@6"
+  chassis_fpc_slot_numbers = [3]
+  family_inet_input {
+    rate = 3
+  }
+  family_inet_output {
+    inline_jflow_source_address = "192.0.2.2"
+    flow_server {
+      hostname               = "192.0.2.1"
+      port                   = 3000
+      version_ipfix_template = junos_services_flowmonitoring_vipfix_template.testacc_sampInstance2.name
+    }
+  }
+}
+
 resource "junos_system_ntp_server" "testacc_sampInstance" {
   address = "192.0.2.3"
 }


### PR DESCRIPTION
ENHANCEMENTS:

* **resource/junos_chassis_fpc**: add `configure_sampling_instance_singly` argument to configure the `sampling-instance` option in an other resource
* **resource/junos_forwardingoptions_sampling_instance**: add `chassis_fpc_slot_numbers` argument to attach the sampling instance to chassis FPC slots with the same commit, required on some Junos systems where the sampling instance and the FPC binding cannot be committed separately (Fix [#912](https://github.com/jeremmfr/terraform-provider-junos/issues/912))