### PR TITLE
bump Go version to 1.27

### DIFF
--- a/.changes/golang-1.27.md
+++ b/.changes/golang-1.27.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable-file MD013 MD041 -->
+ENHANCEMENTS:
+
+* release now with Go 1.27

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,8 +8,8 @@ jobs:
     strategy:
       matrix:
         golang:
-          - '1.25'
           - '1.26'
+          - '1.27'
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go ${{ matrix.golang }}
@@ -33,8 +33,8 @@ jobs:
     strategy:
       matrix:
         golang:
-          - '1.25'
           - '1.26'
+          - '1.27'
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go ${{ matrix.golang }}

--- a/.github/workflows/go_analysis.yml
+++ b/.github/workflows/go_analysis.yml
@@ -16,8 +16,8 @@ jobs:
       - name: Running govulncheck
         uses: Templum/govulncheck-action@v1.0.2
         with:
-          go-version: '1.26'
-          vulncheck-version: 'v1.1.4'
+          go-version: '1.27'
+          vulncheck-version: 'v1.7.0'
           package: ./...
           fail-on-vuln: false
 

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -21,7 +21,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.12.0
+          version: v2.13.2
           args: -c .golangci.yml -v
 
   markdown-lint:

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -7,10 +7,10 @@ jobs:
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.26
+      - name: Set up Go 1.27
         uses: actions/setup-go@v7
         with:
-          go-version: '1.26'
+          go-version: '1.27'
           check-latest: true
         id: go
       - name: Disable cgo
@@ -40,10 +40,10 @@ jobs:
     name: terrafmt
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.26
+      - name: Set up Go 1.27
         uses: actions/setup-go@v7
         with:
-          go-version: '1.26'
+          go-version: '1.27'
           check-latest: true
         id: go
       - name: Show version

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -41,10 +41,10 @@ jobs:
           - goos: windows
             goarch: arm64
     steps:
-      - name: Set up Go 1.26
+      - name: Set up Go 1.27
         uses: actions/setup-go@v7
         with:
-          go-version: '1.26'
+          go-version: '1.27'
           check-latest: true
         id: go
       - name: Show version

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,17 +4,20 @@ linters:
   default: all
   disable:
     # deprecated
+    - exhaustruct
     - gomodguard
+    - wsl
     # unwanted
     - cyclop
     - depguard
     - dupl
     - err113
-    - exhaustruct
+    - exhaustruct_v5
     - forcetypeassert
     - funcorder
     - funlen
     - goconst
+    - gomodguard_v2
     - gosec
     - inamedparam
     - ireturn
@@ -27,7 +30,6 @@ linters:
     - paralleltest
     - recvcheck
     - varnamelen
-    - wsl
     - wsl_v5
   settings:
     gocognit:
@@ -106,7 +108,10 @@ formatters:
         - default
       custom-order: true
     gofumpt:
-      extra-rules: true
+      extra:
+        group-params: true
+        clothe-returns: true
+        balance-calls: true
   exclusions:
     paths:
       - third_party$

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ for provider and resources documentation.
 
 ### In addition to develop
 
-- [Go](https://go.dev/doc/install) `v1.25` or `v1.26`
+- [Go](https://go.dev/doc/install) `v1.26` or `v1.27`
 
 ## Automatic install
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jeremmfr/terraform-provider-junos
 
-go 1.25.8
+go 1.26.0
 
 require (
 	github.com/hashicorp/go-version v1.9.0

--- a/internal/provider/resource_aggregate_route.go
+++ b/internal/provider/resource_aggregate_route.go
@@ -131,9 +131,10 @@ func (rsc *aggregateRoute) Schema(
 				Optional:    true,
 				Description: "AS number to add AGGREGATOR path attribute to route.",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(
-						`^\d+(\.\d+)?$`),
-						"must be in plain number or `higher 16bits`.`lower 16 bits` (asdot notation) format"),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^\d+(\.\d+)?$`),
+						"must be in plain number or `higher 16bits`.`lower 16 bits` (asdot notation) format",
+					),
 				},
 			},
 			"as_path_atomic_aggregate": schema.BoolAttribute{

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -188,8 +188,8 @@ func (applicationAttrData) attributesSchema() map[string]schema.Attribute {
 			Optional:    true,
 			Description: "Match ether type.",
 			Validators: []validator.String{
-				stringvalidator.RegexMatches(regexp.MustCompile(
-					`^0[xX][0-9a-fA-F]{4}$`),
+				stringvalidator.RegexMatches(
+					regexp.MustCompile(`^0[xX][0-9a-fA-F]{4}$`),
 					"must be in hex (example: 0x8906)",
 				),
 			},
@@ -252,9 +252,10 @@ func (applicationAttrData) attributesSchema() map[string]schema.Attribute {
 			Optional:    true,
 			Description: "Match range of RPC program numbers.",
 			Validators: []validator.String{
-				stringvalidator.RegexMatches(regexp.MustCompile(
-					`^\d+(-\d+)?$`),
-					"must be an integer or a range of integers"),
+				stringvalidator.RegexMatches(
+					regexp.MustCompile(`^\d+(-\d+)?$`),
+					"must be an integer or a range of integers",
+				),
 			},
 		},
 		"source_port": schema.StringAttribute{
@@ -269,8 +270,8 @@ func (applicationAttrData) attributesSchema() map[string]schema.Attribute {
 			Optional:    true,
 			Description: "Match universal unique identifier for DCE RPC objects.",
 			Validators: []validator.String{
-				stringvalidator.RegexMatches(regexp.MustCompile(
-					`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`),
+				stringvalidator.RegexMatches(
+					regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`),
 					"must be of the form xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
 				),
 			},
@@ -366,9 +367,10 @@ func (applicationAttrData) blocksSchema() map[string]schema.Block {
 						Optional:    true,
 						Description: "Match range of RPC program numbers.",
 						Validators: []validator.String{
-							stringvalidator.RegexMatches(regexp.MustCompile(
-								`^\d+(-\d+)?$`),
-								"must be an integer or a range of integers"),
+							stringvalidator.RegexMatches(
+								regexp.MustCompile(`^\d+(-\d+)?$`),
+								"must be an integer or a range of integers",
+							),
 						},
 					},
 					"source_port": schema.StringAttribute{
@@ -383,8 +385,8 @@ func (applicationAttrData) blocksSchema() map[string]schema.Block {
 						Optional:    true,
 						Description: "Match universal unique identifier for DCE RPC objects.",
 						Validators: []validator.String{
-							stringvalidator.RegexMatches(regexp.MustCompile(
-								`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`),
+							stringvalidator.RegexMatches(
+								regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`),
 								"must be of the form xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
 							),
 						},

--- a/internal/provider/resource_bgp_group_test.go
+++ b/internal/provider/resource_bgp_group_test.go
@@ -216,7 +216,8 @@ func TestAccResourceBgpGroup_writeOnly(t *testing.T) {
 							"data.junos_config_raw.testacc_bgpgroup_wo",
 							tfjsonpath.New("config"),
 							knownvalue.StringRegexp(regexp.MustCompile(
-								`set protocols bgp group "?testacc_bgpgroup_wo"? authentication-key `)),
+								`set protocols bgp group "?testacc_bgpgroup_wo"? authentication-key `,
+							)),
 						),
 					},
 				},

--- a/internal/provider/resource_bgp_neighbor_test.go
+++ b/internal/provider/resource_bgp_neighbor_test.go
@@ -214,7 +214,8 @@ func TestAccResourceBgpNeighbor_writeOnly(t *testing.T) {
 							"data.junos_config_raw.testacc_bgpneighbor_wo",
 							tfjsonpath.New("config"),
 							knownvalue.StringRegexp(regexp.MustCompile(
-								`set protocols bgp group "?testacc_bgpneighbor_wo"? neighbor 192\.0\.2\.4 authentication-key `)),
+								`set protocols bgp group "?testacc_bgpneighbor_wo"? neighbor 192\.0\.2\.4 authentication-key `,
+							)),
 						),
 					},
 				},

--- a/internal/provider/resource_bridge_domain.go
+++ b/internal/provider/resource_bridge_domain.go
@@ -178,9 +178,10 @@ func (rsc *bridgeDomain) Schema(
 				Description: "Routing interface name for this bridge-domain.",
 				Validators: []validator.String{
 					tfvalidator.StringFormat(tfvalidator.InterfaceFormat),
-					stringvalidator.RegexMatches(regexp.MustCompile(
-						`^(irb|vlan)\.`),
-						"must start with 'irb.' or 'vlan.'"),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^(irb|vlan)\.`),
+						"must start with 'irb.' or 'vlan.'",
+					),
 				},
 			},
 			"service_id": schema.Int64Attribute{

--- a/internal/provider/resource_eventoptions_destination_test.go
+++ b/internal/provider/resource_eventoptions_destination_test.go
@@ -60,7 +60,8 @@ func TestAccResourceEventoptionsDestination_writeOnly(t *testing.T) {
 						"data.junos_config_raw.testacc_evtopts_dest_wo",
 						tfjsonpath.New("config"),
 						knownvalue.StringRegexp(regexp.MustCompile(
-							`destinations "?testacc_evtopts_dest_wo"? archive-sites "?https://example\.fr"? password `)),
+							`destinations "?testacc_evtopts_dest_wo"? archive-sites "?https://example\.fr"? password `,
+						)),
 					),
 				},
 			},

--- a/internal/provider/resource_eventoptions_generate_event.go
+++ b/internal/provider/resource_eventoptions_generate_event.go
@@ -110,8 +110,8 @@ func (rsc *eventoptionsGenerateEvent) Schema(
 				Optional:    true,
 				Description: "Start-time to generate event.",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(
-						`^\d{4}\-\d\d?\-\d\d?\.\d{2}:\d{2}:\d{2}$`),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^\d{4}\-\d\d?\-\d\d?\.\d{2}:\d{2}:\d{2}$`),
 						"must be in the format 'YYYY-MM-DD.HH:MM:SS'",
 					),
 				},
@@ -127,8 +127,8 @@ func (rsc *eventoptionsGenerateEvent) Schema(
 				Optional:    true,
 				Description: "Time of day at which to generate event.",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(
-						`^\d{2}:\d{2}:\d{2}$`),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^\d{2}:\d{2}:\d{2}$`),
 						"must be in the format 'HH:MM:SS'",
 					),
 				},

--- a/internal/provider/resource_evpn.go
+++ b/internal/provider/resource_evpn.go
@@ -189,9 +189,10 @@ func (rsc *evpn) Schema(
 						Optional:    true,
 						Description: "Route distinguisher for this instance.",
 						Validators: []validator.String{
-							stringvalidator.RegexMatches(regexp.MustCompile(
-								`^(\d|\.)+L?:\d+$`),
-								"must have valid route distinguisher. Use format 'x:y'"),
+							stringvalidator.RegexMatches(
+								regexp.MustCompile(`^(\d|\.)+L?:\d+$`),
+								"must have valid route distinguisher. Use format 'x:y'",
+							),
 						},
 					},
 					"vrf_export": schema.ListAttribute{
@@ -224,9 +225,10 @@ func (rsc *evpn) Schema(
 						Optional:    true,
 						Description: "VRF target community configuration.",
 						Validators: []validator.String{
-							stringvalidator.RegexMatches(regexp.MustCompile(
-								`^target:(\d|\.)+L?:\d+$`),
-								"must have valid target. Use format 'target:x:y'"),
+							stringvalidator.RegexMatches(
+								regexp.MustCompile(`^target:(\d|\.)+L?:\d+$`),
+								"must have valid target. Use format 'target:x:y'",
+							),
 						},
 					},
 					"vrf_target_auto": schema.BoolAttribute{
@@ -240,18 +242,20 @@ func (rsc *evpn) Schema(
 						Optional:    true,
 						Description: "Target community to use when marking routes on export.",
 						Validators: []validator.String{
-							stringvalidator.RegexMatches(regexp.MustCompile(
-								`^target:(\d|\.)+L?:\d+$`),
-								"must have valid target. Use format 'target:x:y'"),
+							stringvalidator.RegexMatches(
+								regexp.MustCompile(`^target:(\d|\.)+L?:\d+$`),
+								"must have valid target. Use format 'target:x:y'",
+							),
 						},
 					},
 					"vrf_target_import": schema.StringAttribute{
 						Optional:    true,
 						Description: "Target community to use when filtering on import.",
 						Validators: []validator.String{
-							stringvalidator.RegexMatches(regexp.MustCompile(
-								`^target:(\d|\.)+L?:\d+$`),
-								"must have valid target. Use format 'target:x:y'"),
+							stringvalidator.RegexMatches(
+								regexp.MustCompile(`^target:(\d|\.)+L?:\d+$`),
+								"must have valid target. Use format 'target:x:y'",
+							),
 						},
 					},
 				},

--- a/internal/provider/resource_firewall_filter.go
+++ b/internal/provider/resource_firewall_filter.go
@@ -204,8 +204,8 @@ func (rsc *firewallFilter) Schema(
 										setvalidator.SizeAtLeast(1),
 										setvalidator.NoNullValues(),
 										setvalidator.ValueStringsAre(
-											stringvalidator.RegexMatches(regexp.MustCompile(
-												`^[a-f0-9]{2}(:[a-f0-9]{2}){5}\/\d+$`),
+											stringvalidator.RegexMatches(
+												regexp.MustCompile(`^[a-f0-9]{2}(:[a-f0-9]{2}){5}\/\d+$`),
 												"must be an MAC address with mask",
 											),
 										),
@@ -219,8 +219,8 @@ func (rsc *firewallFilter) Schema(
 										setvalidator.SizeAtLeast(1),
 										setvalidator.NoNullValues(),
 										setvalidator.ValueStringsAre(
-											stringvalidator.RegexMatches(regexp.MustCompile(
-												`^[a-f0-9]{2}(:[a-f0-9]{2}){5}\/\d+$`),
+											stringvalidator.RegexMatches(
+												regexp.MustCompile(`^[a-f0-9]{2}(:[a-f0-9]{2}){5}\/\d+$`),
 												"must be an MAC address with mask",
 											),
 										),
@@ -460,8 +460,8 @@ func (rsc *firewallFilter) Schema(
 										setvalidator.SizeAtLeast(1),
 										setvalidator.NoNullValues(),
 										setvalidator.ValueStringsAre(
-											stringvalidator.RegexMatches(regexp.MustCompile(
-												`^\d+(-\d+)?$`),
+											stringvalidator.RegexMatches(
+												regexp.MustCompile(`^\d+(-\d+)?$`),
 												"must be an integer or a range of integers",
 											),
 										),
@@ -475,8 +475,8 @@ func (rsc *firewallFilter) Schema(
 										setvalidator.SizeAtLeast(1),
 										setvalidator.NoNullValues(),
 										setvalidator.ValueStringsAre(
-											stringvalidator.RegexMatches(regexp.MustCompile(
-												`^\d+(-\d+)?$`),
+											stringvalidator.RegexMatches(
+												regexp.MustCompile(`^\d+(-\d+)?$`),
 												"must be an integer or a range of integers",
 											),
 										),
@@ -631,8 +631,8 @@ func (rsc *firewallFilter) Schema(
 										setvalidator.SizeAtLeast(1),
 										setvalidator.NoNullValues(),
 										setvalidator.ValueStringsAre(
-											stringvalidator.RegexMatches(regexp.MustCompile(
-												`^[a-f0-9]{2}(:[a-f0-9]{2}){5}\/\d+$`),
+											stringvalidator.RegexMatches(
+												regexp.MustCompile(`^[a-f0-9]{2}(:[a-f0-9]{2}){5}\/\d+$`),
 												"must be an MAC address with mask",
 											),
 										),
@@ -646,8 +646,8 @@ func (rsc *firewallFilter) Schema(
 										setvalidator.SizeAtLeast(1),
 										setvalidator.NoNullValues(),
 										setvalidator.ValueStringsAre(
-											stringvalidator.RegexMatches(regexp.MustCompile(
-												`^[a-f0-9]{2}(:[a-f0-9]{2}){5}\/\d+$`),
+											stringvalidator.RegexMatches(
+												regexp.MustCompile(`^[a-f0-9]{2}(:[a-f0-9]{2}){5}\/\d+$`),
 												"must be an MAC address with mask",
 											),
 										),

--- a/internal/provider/resource_firewall_policer.go
+++ b/internal/provider/resource_firewall_policer.go
@@ -185,18 +185,20 @@ func (rsc *firewallPolicer) Schema(
 						Optional:    true,
 						Description: "Burst size limit in bytes.",
 						Validators: []validator.String{
-							stringvalidator.RegexMatches(regexp.MustCompile(
-								`^(\d)+(m|k|g)?$`),
-								`must be a bandwidth ^(\d)+(m|k|g)?$`),
+							stringvalidator.RegexMatches(
+								regexp.MustCompile(`^(\d)+(m|k|g)?$`),
+								`must be a bandwidth ^(\d)+(m|k|g)?$`,
+							),
 						},
 					},
 					"bandwidth_limit": schema.StringAttribute{
 						Optional:    true,
 						Description: "Bandwidth limit in bits/second.",
 						Validators: []validator.String{
-							stringvalidator.RegexMatches(regexp.MustCompile(
-								`^(\d)+(m|k|g)?$`),
-								`must be a bandwidth ^(\d)+(m|k|g)?$`),
+							stringvalidator.RegexMatches(
+								regexp.MustCompile(`^(\d)+(m|k|g)?$`),
+								`must be a bandwidth ^(\d)+(m|k|g)?$`,
+							),
 						},
 					},
 					"bandwidth_percent": schema.Int64Attribute{
@@ -219,9 +221,10 @@ func (rsc *firewallPolicer) Schema(
 						Optional:    true,
 						Description: "PPS burst size limit.",
 						Validators: []validator.String{
-							stringvalidator.RegexMatches(regexp.MustCompile(
-								`^(\d)+(m|k|g)?$`),
-								`must be a pps ^(\d)+(m|k|g)?$`),
+							stringvalidator.RegexMatches(
+								regexp.MustCompile(`^(\d)+(m|k|g)?$`),
+								`must be a pps ^(\d)+(m|k|g)?$`,
+							),
 						},
 					},
 					"pps_limit": schema.StringAttribute{
@@ -229,9 +232,10 @@ func (rsc *firewallPolicer) Schema(
 						Optional:    true,
 						Description: "PPS limit.",
 						Validators: []validator.String{
-							stringvalidator.RegexMatches(regexp.MustCompile(
-								`^(\d)+(m|k|g)?$`),
-								`must be a pps ^(\d)+(m|k|g)?$`),
+							stringvalidator.RegexMatches(
+								regexp.MustCompile(`^(\d)+(m|k|g)?$`),
+								`must be a pps ^(\d)+(m|k|g)?$`,
+							),
 						},
 					},
 				},

--- a/internal/provider/resource_generate_route.go
+++ b/internal/provider/resource_generate_route.go
@@ -131,9 +131,10 @@ func (rsc *generateRoute) Schema(
 				Optional:    true,
 				Description: "AS number to add AGGREGATOR path attribute to route.",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(
-						`^\d+(\.\d+)?$`),
-						"must be in plain number or `higher 16bits`.`lower 16 bits` (asdot notation) format"),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^\d+(\.\d+)?$`),
+						"must be in plain number or `higher 16bits`.`lower 16 bits` (asdot notation) format",
+					),
 				},
 			},
 			"as_path_atomic_aggregate": schema.BoolAttribute{

--- a/internal/provider/resource_iccp_peer_test.go
+++ b/internal/provider/resource_iccp_peer_test.go
@@ -63,7 +63,8 @@ func TestAccResourceIccpPeer_writeOnly(t *testing.T) {
 							"data.junos_config_raw.testacc_iccp_peer_wo",
 							tfjsonpath.New("config"),
 							knownvalue.StringRegexp(regexp.MustCompile(
-								`set protocols iccp peer 192.0.2.2 authentication-key `)),
+								`set protocols iccp peer 192.0.2.2 authentication-key `,
+							)),
 						),
 					},
 				},

--- a/internal/provider/resource_iccp_test.go
+++ b/internal/provider/resource_iccp_test.go
@@ -63,7 +63,8 @@ func TestAccResourceIccp_writeOnly(t *testing.T) {
 							"data.junos_config_raw.testacc_iccp_wo",
 							tfjsonpath.New("config"),
 							knownvalue.StringRegexp(regexp.MustCompile(
-								`set protocols iccp authentication-key `)),
+								`set protocols iccp authentication-key `,
+							)),
 						),
 					},
 				},

--- a/internal/provider/resource_igmp_snooping_vlan.go
+++ b/internal/provider/resource_igmp_snooping_vlan.go
@@ -153,18 +153,20 @@ func (rsc *igmpSnoopingVlan) Schema(
 				Optional:    true,
 				Description: "When to send group query messages (seconds).",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(
-						`^\d+(\.\d+)?$`),
-						"must be a number with optional decimal"),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^\d+(\.\d+)?$`),
+						"must be a number with optional decimal",
+					),
 				},
 			},
 			"query_response_interval": schema.StringAttribute{
 				Optional:    true,
 				Description: "How long to wait for a host query response (seconds).",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(
-						`^\d+(\.\d+)?$`),
-						"must be a number with optional decimal"),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^\d+(\.\d+)?$`),
+						"must be a number with optional decimal",
+					),
 				},
 			},
 			"robust_count": schema.Int64Attribute{

--- a/internal/provider/resource_interface_logical.go
+++ b/internal/provider/resource_interface_logical.go
@@ -521,9 +521,10 @@ func (rsc *interfaceLogical) Schema(
 								Optional:    true,
 								Description: "Client identifier as a hexadecimal string.",
 								Validators: []validator.String{
-									stringvalidator.RegexMatches(regexp.MustCompile(
-										`^[0-9a-fA-F]+$`),
-										"must be hexadecimal digits (0-9, a-f, A-F)"),
+									stringvalidator.RegexMatches(
+										regexp.MustCompile(`^[0-9a-fA-F]+$`),
+										"must be hexadecimal digits (0-9, a-f, A-F)",
+									),
 								},
 							},
 							"client_identifier_prefix_hostname": schema.BoolAttribute{
@@ -559,9 +560,10 @@ func (rsc *interfaceLogical) Schema(
 								Optional:    true,
 								Description: "Add user id as a hexadecimal string to client-id option.",
 								Validators: []validator.String{
-									stringvalidator.RegexMatches(regexp.MustCompile(
-										`^[0-9a-fA-F]+$`),
-										"must be hexadecimal digits (0-9, a-f, A-F)"),
+									stringvalidator.RegexMatches(
+										regexp.MustCompile(`^[0-9a-fA-F]+$`),
+										"must be hexadecimal digits (0-9, a-f, A-F)",
+									),
 								},
 							},
 							"force_discover": schema.BoolAttribute{

--- a/internal/provider/resource_interface_logical_test.go
+++ b/internal/provider/resource_interface_logical_test.go
@@ -277,14 +277,16 @@ func TestAccResourceInterfaceLogical_writeOnly(t *testing.T) {
 							tfjsonpath.New("config"),
 							knownvalue.StringRegexp(regexp.MustCompile(
 								testaccInterface+` unit 100 family inet address 192\.0\.2\.1/25`+
-									` vrrp-group 100 authentication-key `)),
+									` vrrp-group 100 authentication-key `,
+							)),
 						),
 						statecheck.ExpectKnownValue(
 							"data.junos_config_raw.testacc_interface_logical_wo",
 							tfjsonpath.New("config"),
 							knownvalue.StringRegexp(regexp.MustCompile(
 								testaccInterface+` unit 100 family inet address 192\.0\.2\.129/25`+
-									` vrrp-group 101 authentication-key `)),
+									` vrrp-group 101 authentication-key `,
+							)),
 						),
 					},
 				},

--- a/internal/provider/resource_interface_physical.go
+++ b/internal/provider/resource_interface_physical.go
@@ -191,9 +191,10 @@ func (rsc *interfacePhysical) Schema(
 				Optional:    true,
 				Description: "Link speed.",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(
-						`^(\d+(m|g)|2\.5g|auto|auto-10m-100m)$`),
-						"must be a valid speed (10m | 100m | 1g ...)"),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^(\d+(m|g)|2\.5g|auto|auto-10m-100m)$`),
+						"must be a valid speed (10m | 100m | 1g ...)",
+					),
 				},
 			},
 			"storm_control": schema.StringAttribute{
@@ -284,9 +285,10 @@ func (rsc *interfacePhysical) Schema(
 						Optional:    true,
 						Description: "The ESI value for the interface.",
 						Validators: []validator.String{
-							stringvalidator.RegexMatches(regexp.MustCompile(
-								`^([\d\w]{2}:){9}[\d\w]{2}$`),
-								"must be ten octets integer value with colon separator"),
+							stringvalidator.RegexMatches(
+								regexp.MustCompile(`^([\d\w]{2}:){9}[\d\w]{2}$`),
+								"must be ten octets integer value with colon separator",
+							),
 						},
 					},
 					"source_bmac": schema.StringAttribute{
@@ -362,9 +364,10 @@ func (rsc *interfacePhysical) Schema(
 						Optional:    true,
 						Description: "Minimum bandwidth configured for aggregated bundle.",
 						Validators: []validator.String{
-							stringvalidator.RegexMatches(regexp.MustCompile(
-								`^[0-9]+ (k|g|m)?bps$`),
-								"must be 'N (k|g|m)?bps' format"),
+							stringvalidator.RegexMatches(
+								regexp.MustCompile(`^[0-9]+ (k|g|m)?bps$`),
+								"must be 'N (k|g|m)?bps' format",
+							),
 						},
 					},
 					"minimum_links": schema.Int64Attribute{
@@ -757,9 +760,10 @@ func (interfacePhysicalBlockEtherOpts) attributesSchema() map[string]schema.Attr
 			Optional:    true,
 			Description: "Name of an aggregated Ethernet interface to join.",
 			Validators: []validator.String{
-				stringvalidator.RegexMatches(regexp.MustCompile(
-					`^ae\d+$`),
-					"must be an ae interface"),
+				stringvalidator.RegexMatches(
+					regexp.MustCompile(`^ae\d+$`),
+					"must be an ae interface",
+				),
 			},
 		},
 		"auto_negotiation": schema.BoolAttribute{
@@ -808,9 +812,10 @@ func (interfacePhysicalBlockEtherOpts) attributesSchema() map[string]schema.Attr
 			Optional:    true,
 			Description: "Name of a redundant ethernet interface to join.",
 			Validators: []validator.String{
-				stringvalidator.RegexMatches(regexp.MustCompile(
-					`^reth\d+$`),
-					"must be a reth interface"),
+				stringvalidator.RegexMatches(
+					regexp.MustCompile(`^reth\d+$`),
+					"must be a reth interface",
+				),
 			},
 		},
 	}

--- a/internal/provider/resource_mstp.go
+++ b/internal/provider/resource_mstp.go
@@ -105,8 +105,8 @@ func (rsc *mstp) Schema(
 				Optional:    true,
 				Description: "Priority of the bridge.",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(
-						`^\d\d?k$`),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^\d\d?k$`),
 						"must be a number with increments of 4k - 4k,8k,..60k",
 					),
 				},
@@ -129,8 +129,8 @@ func (rsc *mstp) Schema(
 				Optional:    true,
 				Description: "Priority of the bridge.",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(
-						`^(0|\d\d?k)$`),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^(0|\d\d?k)$`),
 						"must be a number with increments of 4k - 0,4k,8k,..60k",
 					),
 				},

--- a/internal/provider/resource_mstp_msti.go
+++ b/internal/provider/resource_mstp_msti.go
@@ -122,10 +122,11 @@ func (rsc *mstpMsti) Schema(
 					setvalidator.SizeAtLeast(1),
 					setvalidator.NoNullValues(),
 					setvalidator.ValueStringsAre(
-						stringvalidator.RegexMatches(regexp.MustCompile(
-							`^(409[0-4]|(40[0-8]|[1-3]\d\d|[1-9]\d|[1-9])\d|[1-9])`+
+						stringvalidator.RegexMatches(
+							regexp.MustCompile(`^(409[0-4]|(40[0-8]|[1-3]\d\d|[1-9]\d|[1-9])\d|[1-9])`+
 								`(-(409[0-4]|(40[0-8]|[1-3]\d\d|[1-9]\d|[1-9])\d|[1-9]))?$`),
-							"must be a VLAN id (1..4094) or a range of VLAN id (1..4094)-(1..4094)"),
+							"must be a VLAN id (1..4094) or a range of VLAN id (1..4094)-(1..4094)",
+						),
 					),
 				},
 			},
@@ -133,8 +134,8 @@ func (rsc *mstpMsti) Schema(
 				Optional:    true,
 				Description: "Priority of the bridge.",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(
-						`^\d\d?k$`),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^\d\d?k$`),
 						"must be a number with increments of 4k - 4k,8k,..60k",
 					),
 				},
@@ -143,8 +144,8 @@ func (rsc *mstpMsti) Schema(
 				Optional:    true,
 				Description: "Priority of the bridge.",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(
-						`^(0|\d\d?k)$`),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^(0|\d\d?k)$`),
 						"must be a number with increments of 4k - 0,4k,8k,..60k",
 					),
 				},

--- a/internal/provider/resource_oam_gretunnel_interface.go
+++ b/internal/provider/resource_oam_gretunnel_interface.go
@@ -95,9 +95,10 @@ func (rsc *oamGretunnelInterface) Schema(
 				Validators: []validator.String{
 					stringvalidator.LengthAtLeast(1),
 					tfvalidator.StringFormat(tfvalidator.InterfaceFormat),
-					stringvalidator.RegexMatches(regexp.MustCompile(
-						`^gr-`),
-						"must be a gr interface"),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^gr-`),
+						"must be a gr interface",
+					),
 				},
 			},
 			"hold_time": schema.Int64Attribute{

--- a/internal/provider/resource_ospf.go
+++ b/internal/provider/resource_ospf.go
@@ -220,9 +220,10 @@ func (rsc *ospf) Schema(
 				Optional:    true,
 				Description: "Bandwidth for calculating metric defaults.",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(
-						`^(\d)+(m|k|g)?$`),
-						`must be a bandwidth ^(\d)+(m|k|g)?$`),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^(\d)+(m|k|g)?$`),
+						`must be a bandwidth ^(\d)+(m|k|g)?$`,
+					),
 				},
 			},
 			"rib_group": schema.StringAttribute{

--- a/internal/provider/resource_ospf_area.go
+++ b/internal/provider/resource_ospf_area.go
@@ -110,8 +110,8 @@ func (rsc *ospfArea) Schema(
 				Validators: []validator.String{
 					stringvalidator.Any(
 						tfvalidator.StringIPAddress().IPv4Only(),
-						stringvalidator.RegexMatches(regexp.MustCompile(
-							`^\d+$`),
+						stringvalidator.RegexMatches(
+							regexp.MustCompile(`^\d+$`),
 							"should be usually in the IP format (but a number is accepted)",
 						),
 					),
@@ -337,8 +337,8 @@ func (rsc *ospfArea) Schema(
 							Optional:    true,
 							Description: "Value for index or label to define adjacency SID is eligible for protection.",
 							Validators: []validator.String{
-								stringvalidator.RegexMatches(regexp.MustCompile(
-									`^\d+$`),
+								stringvalidator.RegexMatches(
+									regexp.MustCompile(`^\d+$`),
 									"should be a numeric value",
 								),
 							},
@@ -354,8 +354,8 @@ func (rsc *ospfArea) Schema(
 							Optional:    true,
 							Description: "Value for index or label to define adjacency SID uneligible for protection.",
 							Validators: []validator.String{
-								stringvalidator.RegexMatches(regexp.MustCompile(
-									`^\d+$`),
+								stringvalidator.RegexMatches(
+									regexp.MustCompile(`^\d+$`),
 									"should be a numeric value",
 								),
 							},
@@ -542,8 +542,8 @@ func (rsc *ospfArea) Schema(
 										Optional:    true,
 										Description: "Start time for key transmission.",
 										Validators: []validator.String{
-											stringvalidator.RegexMatches(regexp.MustCompile(
-												`^\d{4}\-\d\d?\-\d\d?\.\d{2}:\d{2}:\d{2}$`),
+											stringvalidator.RegexMatches(
+												regexp.MustCompile(`^\d{4}\-\d\d?\-\d\d?\.\d{2}:\d{2}:\d{2}$`),
 												"must be in the format 'YYYY-MM-DD.HH:MM:SS'",
 											),
 										},
@@ -559,9 +559,10 @@ func (rsc *ospfArea) Schema(
 										Required:    true,
 										Description: "Bandwidth threshold.",
 										Validators: []validator.String{
-											stringvalidator.RegexMatches(regexp.MustCompile(
-												`^(\d)+(m|k|g)?$`),
-												`must be a bandwidth ^(\d)+(m|k|g)?$`),
+											stringvalidator.RegexMatches(
+												regexp.MustCompile(`^(\d)+(m|k|g)?$`),
+												`must be a bandwidth ^(\d)+(m|k|g)?$`,
+											),
 										},
 									},
 									"metric": schema.Int64Attribute{

--- a/internal/provider/resource_ospf_area_test.go
+++ b/internal/provider/resource_ospf_area_test.go
@@ -230,19 +230,22 @@ func TestAccResourceOspfArea_writeOnly(t *testing.T) {
 							"data.junos_config_raw.testacc_ospfarea_wo",
 							tfjsonpath.New("config"),
 							knownvalue.StringRegexp(regexp.MustCompile(
-								`area 0.0.0.0 interface all authentication simple-password `)),
+								`area 0.0.0.0 interface all authentication simple-password `,
+							)),
 						),
 						statecheck.ExpectKnownValue(
 							"data.junos_config_raw.testacc_ospfarea_wo",
 							tfjsonpath.New("config"),
 							knownvalue.StringRegexp(regexp.MustCompile(
-								`interface `+testaccInterface+`\.0 authentication md5 1 key `)),
+								`interface `+testaccInterface+`\.0 authentication md5 1 key `,
+							)),
 						),
 						statecheck.ExpectKnownValue(
 							"data.junos_config_raw.testacc_ospfarea_wo",
 							tfjsonpath.New("config"),
 							knownvalue.StringRegexp(regexp.MustCompile(
-								`interface `+testaccInterface+`\.0 authentication md5 2 key `)),
+								`interface `+testaccInterface+`\.0 authentication md5 2 key `,
+							)),
 						),
 					},
 				},

--- a/internal/provider/resource_policyoptions_policy_statement.go
+++ b/internal/provider/resource_policyoptions_policy_statement.go
@@ -344,9 +344,10 @@ func (policyoptionsPolicyStatementBlockFrom) attributesSchema() map[string]schem
 				setvalidator.SizeAtLeast(1),
 				setvalidator.NoNullValues(),
 				setvalidator.ValueStringsAre(
-					stringvalidator.RegexMatches(regexp.MustCompile(
-						`^([\d\w]{2}:){9}[\d\w]{2}$`),
-						"bad format or length"),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^([\d\w]{2}:){9}[\d\w]{2}$`),
+						"bad format or length",
+					),
 				),
 			},
 		},
@@ -1818,7 +1819,8 @@ func (rsc *policyoptionsPolicyStatement) ImportState(
 	)
 
 	resp.Diagnostics.Append(resp.State.SetAttribute(
-		ctx, path.Root("add_it_to_forwarding_table_export"), types.BoolNull())...)
+		ctx, path.Root("add_it_to_forwarding_table_export"), types.BoolNull(),
+	)...)
 }
 
 func checkPolicyoptionsPolicyStatementExists(

--- a/internal/provider/resource_rib_group.go
+++ b/internal/provider/resource_rib_group.go
@@ -119,8 +119,8 @@ func (rsc *ribGroup) Schema(
 					listvalidator.NoNullValues(),
 					listvalidator.ValueStringsAre(
 						tfvalidator.StringFormat(tfvalidator.DNSNameFormat),
-						stringvalidator.RegexMatches(regexp.MustCompile(
-							`^(.+\.)?(inet6?\.0)$`),
+						stringvalidator.RegexMatches(
+							regexp.MustCompile(`^(.+\.)?(inet6?\.0)$`),
 							"must be equal to or end with `inet.0` or `inet6.0`",
 						),
 					),
@@ -131,8 +131,8 @@ func (rsc *ribGroup) Schema(
 				Description: "Export routing table.",
 				Validators: []validator.String{
 					tfvalidator.StringFormat(tfvalidator.DNSNameFormat),
-					stringvalidator.RegexMatches(regexp.MustCompile(
-						`^(.+\.)?(inet6?\.0)$`),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^(.+\.)?(inet6?\.0)$`),
 						"must be equal to or end with `inet.0` or `inet6.0`",
 					),
 				},

--- a/internal/provider/resource_rip_neighbor.go
+++ b/internal/provider/resource_rip_neighbor.go
@@ -351,8 +351,8 @@ func (rsc *ripNeighbor) Schema(
 							Optional:    true,
 							Description: "Start time for key transmission.",
 							Validators: []validator.String{
-								stringvalidator.RegexMatches(regexp.MustCompile(
-									`^\d{4}\-\d\d?\-\d\d?\.\d{2}:\d{2}:\d{2}$`),
+								stringvalidator.RegexMatches(
+									regexp.MustCompile(`^\d{4}\-\d\d?\-\d\d?\.\d{2}:\d{2}:\d{2}$`),
 									"must be in the format 'YYYY-MM-DD.HH:MM:SS'",
 								),
 							},

--- a/internal/provider/resource_rip_neighbor_test.go
+++ b/internal/provider/resource_rip_neighbor_test.go
@@ -125,19 +125,22 @@ func TestAccResourceRipNeighbor_writeOnly(t *testing.T) {
 							"data.junos_config_raw.testacc_ripneigh_wo",
 							tfjsonpath.New("config"),
 							knownvalue.StringRegexp(regexp.MustCompile(
-								`group "?test_rip_group_wo"? neighbor ae0\.0 authentication-key `)),
+								`group "?test_rip_group_wo"? neighbor ae0\.0 authentication-key `,
+							)),
 						),
 						statecheck.ExpectKnownValue(
 							"data.junos_config_raw.testacc_ripneigh_wo",
 							tfjsonpath.New("config"),
 							knownvalue.StringRegexp(regexp.MustCompile(
-								`neighbor ae1\.0 authentication-selective-md5 1 key `)),
+								`neighbor ae1\.0 authentication-selective-md5 1 key `,
+							)),
 						),
 						statecheck.ExpectKnownValue(
 							"data.junos_config_raw.testacc_ripneigh_wo",
 							tfjsonpath.New("config"),
 							knownvalue.StringRegexp(regexp.MustCompile(
-								`neighbor ae1\.0 authentication-selective-md5 2 key `)),
+								`neighbor ae1\.0 authentication-selective-md5 2 key `,
+							)),
 						),
 					},
 				},

--- a/internal/provider/resource_routing_instance.go
+++ b/internal/provider/resource_routing_instance.go
@@ -133,9 +133,10 @@ func (rsc *routingInstance) Schema(
 				Optional:    true,
 				Description: "Autonomous system number in plain number or `higher 16bits`.`lower 16 bits` (asdot notation) format.",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(
-						`^\d+(\.\d+)?$`),
-						"must be in plain number or `higher 16bits`.`lower 16 bits` (asdot notation) format"),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^\d+(\.\d+)?$`),
+						"must be in plain number or `higher 16bits`.`lower 16 bits` (asdot notation) format",
+					),
 				},
 			},
 			"description": schema.StringAttribute{
@@ -200,10 +201,11 @@ func (rsc *routingInstance) Schema(
 				Optional:    true,
 				Description: "Route distinguisher for this instance.",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(
-						`^(\d|\.)+L?:\d+$`),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^(\d|\.)+L?:\d+$`),
 						"must be use format 'x:y' where 'x' is an AS number followed by an optional 'L' (To indicate 4 byte AS), "+
-							"or an IP address and 'y' is a number. e.g. 123456L:100"),
+							"or an IP address and 'y' is a number. e.g. 123456L:100",
+					),
 				},
 			},
 			"router_id": schema.StringAttribute{
@@ -243,10 +245,11 @@ func (rsc *routingInstance) Schema(
 				Optional:    true,
 				Description: "Target community to use in import and export.",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(
-						`^target:(\d|\.)+L?:\d+$`),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^target:(\d|\.)+L?:\d+$`),
 						"must be use format 'target:x:y' where 'x' is an AS number followed by an optional 'L' (To indicate 4 byte AS), "+
-							"or an IP address and 'y' is a number. e.g. target:123456L:100"),
+							"or an IP address and 'y' is a number. e.g. target:123456L:100",
+					),
 				},
 			},
 			"vrf_target_auto": schema.BoolAttribute{
@@ -260,20 +263,22 @@ func (rsc *routingInstance) Schema(
 				Optional:    true,
 				Description: "Target community to use when marking routes on export.",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(
-						`^target:(\d|\.)+L?:\d+$`),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^target:(\d|\.)+L?:\d+$`),
 						"must be use format 'target:x:y' where 'x' is an AS number followed by an optional 'L' (To indicate 4 byte AS), "+
-							"or an IP address and 'y' is a number. e.g. target:123456L:100"),
+							"or an IP address and 'y' is a number. e.g. target:123456L:100",
+					),
 				},
 			},
 			"vrf_target_import": schema.StringAttribute{
 				Optional:    true,
 				Description: "Target community to use when filtering on import.",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(
-						`^target:(\d|\.)+L?:\d+$`),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^target:(\d|\.)+L?:\d+$`),
 						"must be use format 'target:x:y' where 'x' is an AS number followed by an optional 'L' (To indicate 4 byte AS), "+
-							"or an IP address and 'y' is a number. e.g. target:123456L:100"),
+							"or an IP address and 'y' is a number. e.g. target:123456L:100",
+					),
 				},
 			},
 			"vtep_source_interface": schema.StringAttribute{

--- a/internal/provider/resource_routing_options.go
+++ b/internal/provider/resource_routing_options.go
@@ -153,9 +153,10 @@ func (rsc *routingOptions) Schema(
 						Optional:    true,
 						Description: "Autonomous system number.",
 						Validators: []validator.String{
-							stringvalidator.RegexMatches(regexp.MustCompile(
-								`^\d+(\.\d+)?$`),
-								"must be in plain number or `higher 16bits`.`lower 16 bits` (asdot notation) format"),
+							stringvalidator.RegexMatches(
+								regexp.MustCompile(`^\d+(\.\d+)?$`),
+								"must be in plain number or `higher 16bits`.`lower 16 bits` (asdot notation) format",
+							),
 						},
 					},
 					"asdot_notation": schema.BoolAttribute{

--- a/internal/provider/resource_rstp.go
+++ b/internal/provider/resource_rstp.go
@@ -106,8 +106,8 @@ func (rsc *rstp) Schema(
 				Optional:    true,
 				Description: "Priority of the bridge.",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(
-						`^\d\d?k$`),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^\d\d?k$`),
 						"must be a number with increments of 4k - 4k,8k,..60k",
 					),
 				},
@@ -130,8 +130,8 @@ func (rsc *rstp) Schema(
 				Optional:    true,
 				Description: "Priority of the bridge.",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(
-						`^(0|\d\d?k)$`),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^(0|\d\d?k)$`),
 						"must be a number with increments of 4k - 0,4k,8k,..60k",
 					),
 				},

--- a/internal/provider/resource_security.go
+++ b/internal/provider/resource_security.go
@@ -633,8 +633,8 @@ func (rsc *security) Schema(
 						Optional:    true,
 						Description: "Automatic start time (YYYY-MM-DD.HH:MM:SS).",
 						Validators: []validator.String{
-							stringvalidator.RegexMatches(regexp.MustCompile(
-								`^\d{4}\-\d\d?\-\d\d?\.\d{2}:\d{2}:\d{2}$`),
+							stringvalidator.RegexMatches(
+								regexp.MustCompile(`^\d{4}\-\d\d?\-\d\d?\.\d{2}:\d{2}:\d{2}$`),
 								"must be in the format 'YYYY-MM-DD.HH:MM:SS'",
 							),
 						},

--- a/internal/provider/resource_security_authentication_key_chain.go
+++ b/internal/provider/resource_security_authentication_key_chain.go
@@ -179,8 +179,8 @@ func (rsc *securityAuthenticationKeyChain) Schema(
 							Required:    true,
 							Description: "Start time for key transmission (YYYY-MM-DD.HH:MM:SS).",
 							Validators: []validator.String{
-								stringvalidator.RegexMatches(regexp.MustCompile(
-									`^\d{4}\-\d\d?\-\d\d?\.\d{2}:\d{2}:\d{2}$`),
+								stringvalidator.RegexMatches(
+									regexp.MustCompile(`^\d{4}\-\d\d?\-\d\d?\.\d{2}:\d{2}:\d{2}$`),
 									"must be in the format 'YYYY-MM-DD.HH:MM:SS'",
 								),
 							},

--- a/internal/provider/resource_security_authentication_key_chain_test.go
+++ b/internal/provider/resource_security_authentication_key_chain_test.go
@@ -103,13 +103,15 @@ func TestAccResourceSecurityAuthenticationKeyChain_writeOnly(t *testing.T) {
 							"data.junos_config_raw.testacc_secauthKeyChain_wo",
 							tfjsonpath.New("config"),
 							knownvalue.StringRegexp(regexp.MustCompile(
-								`set security authentication-key-chains key-chain "?testacc_secauthKeyChainWO"? key 5 secret `)),
+								`set security authentication-key-chains key-chain "?testacc_secauthKeyChainWO"? key 5 secret `,
+							)),
 						),
 						statecheck.ExpectKnownValue(
 							"data.junos_config_raw.testacc_secauthKeyChain_wo",
 							tfjsonpath.New("config"),
 							knownvalue.StringRegexp(regexp.MustCompile(
-								`set security authentication-key-chains key-chain "?testacc_secauthKeyChainWO"? key 6 secret `)),
+								`set security authentication-key-chains key-chain "?testacc_secauthKeyChainWO"? key 6 secret `,
+							)),
 						),
 					},
 				},

--- a/internal/provider/resource_security_idp_custom_attack.go
+++ b/internal/provider/resource_security_idp_custom_attack.go
@@ -171,8 +171,8 @@ func (rsc *securityIdpCustomAttack) Schema(
 						Optional:    true,
 						Description: "Protocol binding over which attack will be detected.",
 						Validators: []validator.String{
-							stringvalidator.RegexMatches(regexp.MustCompile(
-								`^(application|icmp|ip|rpc|tcp|udp)`),
+							stringvalidator.RegexMatches(
+								regexp.MustCompile(`^(application|icmp|ip|rpc|tcp|udp)`),
 								"must have valid protocol (application|icmp|ip|rpc|tcp|udp) with optional option",
 							),
 						},
@@ -1067,8 +1067,8 @@ func (securityIdpCustomAttackBlockAttackTypeSignature) attributesSchema() map[st
 		Optional:    true,
 		Description: "Protocol binding over which attack will be detected.",
 		Validators: []validator.String{
-			stringvalidator.RegexMatches(regexp.MustCompile(
-				`^(application|icmp|ip|rpc|tcp|udp)`),
+			stringvalidator.RegexMatches(
+				regexp.MustCompile(`^(application|icmp|ip|rpc|tcp|udp)`),
 				"must have valid protocol (application|icmp|ip|rpc|tcp|udp) with optional option",
 			),
 		},

--- a/internal/provider/resource_security_ike_gateway.go
+++ b/internal/provider/resource_security_ike_gateway.go
@@ -1137,7 +1137,8 @@ func (rscData *securityIkeGatewayData) read(
 				rscData.LocalIdentity.Type = types.StringValue(itemTrimFields[0])
 				if len(itemTrimFields) > 1 {
 					rscData.LocalIdentity.Value = types.StringValue(
-						strings.Trim(strings.TrimPrefix(itemTrim, itemTrimFields[0]+" "), "\""))
+						strings.Trim(strings.TrimPrefix(itemTrim, itemTrimFields[0]+" "), "\""),
+					)
 				}
 			case itemTrim == "no-nat-traversal":
 				rscData.NoNatTraversal = types.BoolValue(true)
@@ -1151,15 +1152,18 @@ func (rscData *securityIkeGatewayData) read(
 					if rscData.RemoteIdentity.Type.ValueString() == "distinguished-name" {
 						if itemTrimFields[1] == "container" {
 							rscData.RemoteIdentity.DistinguishedNameContainer = types.StringValue(
-								strings.Trim(strings.TrimPrefix(itemTrim, itemTrimFields[0]+" "+itemTrimFields[1]+" "), "\""))
+								strings.Trim(strings.TrimPrefix(itemTrim, itemTrimFields[0]+" "+itemTrimFields[1]+" "), "\""),
+							)
 						}
 						if itemTrimFields[1] == "wildcard" {
 							rscData.RemoteIdentity.DistinguishedNameWildcard = types.StringValue(
-								strings.Trim(strings.TrimPrefix(itemTrim, itemTrimFields[0]+" "+itemTrimFields[1]+" "), "\""))
+								strings.Trim(strings.TrimPrefix(itemTrim, itemTrimFields[0]+" "+itemTrimFields[1]+" "), "\""),
+							)
 						}
 					} else {
 						rscData.RemoteIdentity.Value = types.StringValue(
-							strings.Trim(strings.TrimPrefix(itemTrim, itemTrimFields[0]+" "), "\""))
+							strings.Trim(strings.TrimPrefix(itemTrim, itemTrimFields[0]+" "), "\""),
+						)
 					}
 				}
 			case balt.CutPrefixInString(&itemTrim, "version "):

--- a/internal/provider/resource_security_ike_gateway_test.go
+++ b/internal/provider/resource_security_ike_gateway_test.go
@@ -54,7 +54,8 @@ func TestAccResourceSecurityIkeGateway_writeOnly(t *testing.T) {
 							"data.junos_config_raw.testacc_ikegw_wo",
 							tfjsonpath.New("config"),
 							knownvalue.StringRegexp(regexp.MustCompile(
-								`set security ike gateway "?testacc_ikegw_wo"? aaa client password `)),
+								`set security ike gateway "?testacc_ikegw_wo"? aaa client password `,
+							)),
 						),
 					},
 				},

--- a/internal/provider/resource_security_ike_policy_test.go
+++ b/internal/provider/resource_security_ike_policy_test.go
@@ -41,7 +41,8 @@ func TestAccResourceSecurityIkePolicy_writeOnly(t *testing.T) {
 							"data.junos_config_raw.testacc_ikepol_wo",
 							tfjsonpath.New("config"),
 							knownvalue.StringRegexp(regexp.MustCompile(
-								`set security ike policy "?testacc_ikepol_wo"? pre-shared-key ascii-text `)),
+								`set security ike policy "?testacc_ikepol_wo"? pre-shared-key ascii-text `,
+							)),
 						),
 					},
 				},

--- a/internal/provider/resource_security_ipsec_vpn.go
+++ b/internal/provider/resource_security_ipsec_vpn.go
@@ -112,9 +112,10 @@ func (rsc *securityIpsecVpn) Schema(
 				Validators: []validator.String{
 					stringvalidator.LengthAtLeast(1),
 					tfvalidator.StringFormat(tfvalidator.InterfaceFormat),
-					stringvalidator.RegexMatches(regexp.MustCompile(
-						`^st0\.`),
-						"must be a secure tunnel interface"),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^st0\.`),
+						"must be a secure tunnel interface",
+					),
 				},
 			},
 			"copy_outer_dscp": schema.BoolAttribute{

--- a/internal/provider/resource_security_ipsec_vpn_test.go
+++ b/internal/provider/resource_security_ipsec_vpn_test.go
@@ -71,12 +71,12 @@ func TestAccResourceSecurityIpsecVpn_writeOnly(t *testing.T) {
 						"interface": config.StringVariable(testaccInterface),
 					},
 					Check: testCheckIfSecurityIpsecVpnManual(
-						resource.TestMatchResourceAttr("data.junos_config_raw.testacc_ipsecvpn_wo",
-							"config", regexp.MustCompile(
-								`set security ipsec vpn "?testacc_ipsecvpn_wo"? manual authentication key ascii-text `)),
-						resource.TestMatchResourceAttr("data.junos_config_raw.testacc_ipsecvpn_wo",
-							"config", regexp.MustCompile(
-								`set security ipsec vpn "?testacc_ipsecvpn_wo"? manual encryption key ascii-text `)),
+						resource.TestMatchResourceAttr("data.junos_config_raw.testacc_ipsecvpn_wo", "config", regexp.MustCompile(
+							`set security ipsec vpn "?testacc_ipsecvpn_wo"? manual authentication key ascii-text `,
+						)),
+						resource.TestMatchResourceAttr("data.junos_config_raw.testacc_ipsecvpn_wo", "config", regexp.MustCompile(
+							`set security ipsec vpn "?testacc_ipsecvpn_wo"? manual encryption key ascii-text `,
+						)),
 					),
 				},
 				{

--- a/internal/provider/resource_security_nat_destination.go
+++ b/internal/provider/resource_security_nat_destination.go
@@ -202,8 +202,8 @@ func (rsc *securityNatDestination) Schema(
 								setvalidator.SizeAtLeast(1),
 								setvalidator.NoNullValues(),
 								setvalidator.ValueStringsAre(
-									stringvalidator.RegexMatches(regexp.MustCompile(
-										`^\d+( to \d+)?$`),
+									stringvalidator.RegexMatches(
+										regexp.MustCompile(`^\d+( to \d+)?$`),
 										"must be use format `x` or `x to y`",
 									),
 								),

--- a/internal/provider/resource_security_nat_source.go
+++ b/internal/provider/resource_security_nat_source.go
@@ -251,8 +251,8 @@ func (rsc *securityNatSource) Schema(
 										setvalidator.SizeAtLeast(1),
 										setvalidator.NoNullValues(),
 										setvalidator.ValueStringsAre(
-											stringvalidator.RegexMatches(regexp.MustCompile(
-												`^\d+( to \d+)?$`),
+											stringvalidator.RegexMatches(
+												regexp.MustCompile(`^\d+( to \d+)?$`),
 												"must be use format `x` or `x to y`",
 											),
 										),
@@ -304,8 +304,8 @@ func (rsc *securityNatSource) Schema(
 										setvalidator.SizeAtLeast(1),
 										setvalidator.NoNullValues(),
 										setvalidator.ValueStringsAre(
-											stringvalidator.RegexMatches(regexp.MustCompile(
-												`^\d+( to \d+)?$`),
+											stringvalidator.RegexMatches(
+												regexp.MustCompile(`^\d+( to \d+)?$`),
 												"must be use format `x` or `x to y`",
 											),
 										),

--- a/internal/provider/resource_security_nat_static.go
+++ b/internal/provider/resource_security_nat_static.go
@@ -236,8 +236,8 @@ func (rsc *securityNatStatic) Schema(
 								setvalidator.SizeAtLeast(1),
 								setvalidator.NoNullValues(),
 								setvalidator.ValueStringsAre(
-									stringvalidator.RegexMatches(regexp.MustCompile(
-										`^\d+( to \d+)?$`),
+									stringvalidator.RegexMatches(
+										regexp.MustCompile(`^\d+( to \d+)?$`),
 										"must be use format `x` or `x to y`",
 									),
 								),

--- a/internal/provider/resource_security_nat_static_rule.go
+++ b/internal/provider/resource_security_nat_static_rule.go
@@ -185,8 +185,8 @@ func (rsc *securityNatStaticRule) Schema(
 					setvalidator.SizeAtLeast(1),
 					setvalidator.NoNullValues(),
 					setvalidator.ValueStringsAre(
-						stringvalidator.RegexMatches(regexp.MustCompile(
-							`^\d+( to \d+)?$`),
+						stringvalidator.RegexMatches(
+							regexp.MustCompile(`^\d+( to \d+)?$`),
 							"must be use format `x` or `x to y`",
 						),
 					),

--- a/internal/provider/resource_security_utm_custom_message.go
+++ b/internal/provider/resource_security_utm_custom_message.go
@@ -115,9 +115,10 @@ func (rsc *securityUtmCustomMessage) Schema(
 				Validators: []validator.String{
 					stringvalidator.LengthBetween(1, 64),
 					tfvalidator.StringDoubleQuoteExclusion(),
-					stringvalidator.RegexMatches(regexp.MustCompile(
-						`^.+\.html$`),
-						"must be end with '.html'"),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^.+\.html$`),
+						"must be end with '.html'",
+					),
 				},
 			},
 		},

--- a/internal/provider/resource_security_utm_profile_web_filtering_websense_redirect_test.go
+++ b/internal/provider/resource_security_utm_profile_web_filtering_websense_redirect_test.go
@@ -19,19 +19,24 @@ func TestAccResourceSecurityUtmProfileWebFilteringWebsenseRedirect_basic(t *test
 					Check: resource.ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr(
 							"junos_security_utm_profile_web_filtering_websense_redirect.testacc_ProfileWebFWebS",
-							"custom_block_message", "Blocked by Juniper"),
+							"custom_block_message", "Blocked by Juniper",
+						),
 						resource.TestCheckResourceAttr(
 							"junos_security_utm_profile_web_filtering_websense_redirect.testacc_ProfileWebFWebS",
-							"fallback_settings.default", "log-and-permit"),
+							"fallback_settings.default", "log-and-permit",
+						),
 						resource.TestCheckResourceAttr(
 							"junos_security_utm_profile_web_filtering_websense_redirect.testacc_ProfileWebFWebS",
-							"fallback_settings.server_connectivity", "log-and-permit"),
+							"fallback_settings.server_connectivity", "log-and-permit",
+						),
 						resource.TestCheckResourceAttr(
 							"junos_security_utm_profile_web_filtering_websense_redirect.testacc_ProfileWebFWebS",
-							"fallback_settings.timeout", "log-and-permit"),
+							"fallback_settings.timeout", "log-and-permit",
+						),
 						resource.TestCheckResourceAttr(
 							"junos_security_utm_profile_web_filtering_websense_redirect.testacc_ProfileWebFWebS",
-							"fallback_settings.timeout", "log-and-permit"),
+							"fallback_settings.timeout", "log-and-permit",
+						),
 					),
 				},
 				{
@@ -39,19 +44,24 @@ func TestAccResourceSecurityUtmProfileWebFilteringWebsenseRedirect_basic(t *test
 					Check: resource.ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr(
 							"junos_security_utm_profile_web_filtering_websense_redirect.testacc_ProfileWebFWebS",
-							"custom_block_message", "Blocked by Juniper"),
+							"custom_block_message", "Blocked by Juniper",
+						),
 						resource.TestCheckResourceAttr(
 							"junos_security_utm_profile_web_filtering_websense_redirect.testacc_ProfileWebFWebS",
-							"timeout", "3"),
+							"timeout", "3",
+						),
 						resource.TestCheckResourceAttr(
 							"junos_security_utm_profile_web_filtering_websense_redirect.testacc_ProfileWebFWebS",
-							"server.host", "10.0.0.1"),
+							"server.host", "10.0.0.1",
+						),
 						resource.TestCheckResourceAttr(
 							"junos_security_utm_profile_web_filtering_websense_redirect.testacc_ProfileWebFWebS",
-							"server.port", "1024"),
+							"server.port", "1024",
+						),
 						resource.TestCheckResourceAttr(
 							"junos_security_utm_profile_web_filtering_websense_redirect.testacc_ProfileWebFWebS",
-							"sockets", "16"),
+							"sockets", "16",
+						),
 					),
 				},
 				{

--- a/internal/provider/resource_services.go
+++ b/internal/provider/resource_services.go
@@ -405,8 +405,10 @@ func (rsc *services) Schema(
 								Optional:    true,
 								Description: "Start time to scheduled download and update.",
 								Validators: []validator.String{
-									stringvalidator.RegexMatches(regexp.MustCompile(
-										`^([0-9]{4}-)?(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1]).(2[0-3]|[01][0-9]):[0-5][0-9](:[0-5][0-9])?$`),
+									stringvalidator.RegexMatches(
+										regexp.MustCompile(
+											`^([0-9]{4}-)?(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1]).(2[0-3]|[01][0-9]):[0-5][0-9](:[0-5][0-9])?$`,
+										),
 										"must be in the format MM-DD.hh:mm / YYYY-MM-DD.hh:mm:ss",
 									),
 								},
@@ -432,8 +434,8 @@ func (rsc *services) Schema(
 								Validators: []validator.String{
 									stringvalidator.LengthAtLeast(1),
 									tfvalidator.StringDoubleQuoteExclusion(),
-									stringvalidator.RegexMatches(regexp.MustCompile(
-										`^(?i)(https?|file):`),
+									stringvalidator.RegexMatches(
+										regexp.MustCompile(`^(?i)(https?|file):`),
 										"URL starts with http, https or file",
 									),
 								},
@@ -530,8 +532,8 @@ func (rsc *services) Schema(
 							tfplanmodifier.StringUseNullStateForUnknown(),
 						},
 						Validators: []validator.String{
-							stringvalidator.RegexMatches(regexp.MustCompile(
-								`^[a-zA-Z0-9]{32}$`),
+							stringvalidator.RegexMatches(
+								regexp.MustCompile(`^[a-zA-Z0-9]{32}$`),
 								"must be consisted of 32 alphanumeric characters",
 							),
 						},

--- a/internal/provider/resource_services_advanced_anti_malware_policy.go
+++ b/internal/provider/resource_services_advanced_anti_malware_policy.go
@@ -154,9 +154,10 @@ func (rsc *servicesAdvancedAntiMalwarePolicy) Schema(
 				Validators: []validator.String{
 					stringvalidator.LengthBetween(1, 1023),
 					tfvalidator.StringDoubleQuoteExclusion(),
-					stringvalidator.RegexMatches(regexp.MustCompile(
-						`^https?:\/\/.+$`),
-						"URL must begin with http:// or https://"),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^https?:\/\/.+$`),
+						"URL must begin with http:// or https://",
+					),
 				},
 			},
 			"http_file_verdict_unknown": schema.StringAttribute{

--- a/internal/provider/resource_services_security_intelligence_profile.go
+++ b/internal/provider/resource_services_security_intelligence_profile.go
@@ -137,9 +137,12 @@ func (rsc *servicesSecurityIntelligenceProfile) Schema(
 							Required:    true,
 							Description: "Security intelligence profile action.",
 							Validators: []validator.String{
-								stringvalidator.RegexMatches(regexp.MustCompile(
-									`^(permit|recommended|sinkhole|block (drop|close( http (file|message|redirect-url) .+)?))$`),
-									"must have valid action (permit|recommended|block...)"),
+								stringvalidator.RegexMatches(
+									regexp.MustCompile(
+										`^(permit|recommended|sinkhole|block (drop|close( http (file|message|redirect-url) .+)?))$`,
+									),
+									"must have valid action (permit|recommended|block...)",
+								),
 							},
 						},
 						"then_log": schema.BoolAttribute{
@@ -202,9 +205,12 @@ func (rsc *servicesSecurityIntelligenceProfile) Schema(
 						Optional:    true,
 						Description: "Security intelligence profile action.",
 						Validators: []validator.String{
-							stringvalidator.RegexMatches(regexp.MustCompile(
-								`^(permit|recommended|sinkhole|block (drop|close( http (file|message|redirect-url) .+)?))$`),
-								"must have valid action (permit|recommended|block...)"),
+							stringvalidator.RegexMatches(
+								regexp.MustCompile(
+									`^(permit|recommended|sinkhole|block (drop|close( http (file|message|redirect-url) .+)?))$`,
+								),
+								"must have valid action (permit|recommended|block...)",
+							),
 						},
 					},
 					"log": schema.BoolAttribute{

--- a/internal/provider/resource_services_test.go
+++ b/internal/provider/resource_services_test.go
@@ -88,19 +88,22 @@ func TestAccResourceServices_writeOnly(t *testing.T) {
 							"data.junos_config_raw.testacc_wo",
 							tfjsonpath.New("config"),
 							knownvalue.StringRegexp(regexp.MustCompile(
-								`set services security-intelligence url-parameter `)),
+								`set services security-intelligence url-parameter `,
+							)),
 						),
 						statecheck.ExpectKnownValue(
 							"data.junos_config_raw.testacc_wo",
 							tfjsonpath.New("config"),
 							knownvalue.StringRegexp(regexp.MustCompile(
-								`set services user-identification identity-management connection primary client-secret `)),
+								`set services user-identification identity-management connection primary client-secret `,
+							)),
 						),
 						statecheck.ExpectKnownValue(
 							"data.junos_config_raw.testacc_wo",
 							tfjsonpath.New("config"),
 							knownvalue.StringRegexp(regexp.MustCompile(
-								`set services user-identification identity-management connection secondary client-secret `)),
+								`set services user-identification identity-management connection secondary client-secret `,
+							)),
 						),
 					},
 				},

--- a/internal/provider/resource_services_user_identification_ad_access_domain_test.go
+++ b/internal/provider/resource_services_user_identification_ad_access_domain_test.go
@@ -82,13 +82,15 @@ func TestAccResourceServicesUserIdentificationADAccessDomain_writeOnly(t *testin
 							"data.junos_config_raw.testacc_userID_addomain_wo",
 							tfjsonpath.New("config"),
 							knownvalue.StringRegexp(regexp.MustCompile(
-								`domain "?testacc_userID_addomain_wo\.local"? user password `)),
+								`domain "?testacc_userID_addomain_wo\.local"? user password `,
+							)),
 						),
 						statecheck.ExpectKnownValue(
 							"data.junos_config_raw.testacc_userID_addomain_wo",
 							tfjsonpath.New("config"),
 							knownvalue.StringRegexp(regexp.MustCompile(
-								`user-group-mapping ldap user password `)),
+								`user-group-mapping ldap user password `,
+							)),
 						),
 					},
 				},

--- a/internal/provider/resource_snmp.go
+++ b/internal/provider/resource_snmp.go
@@ -128,8 +128,8 @@ func (rsc *snmp) Schema(
 				Optional:    true,
 				Description: "SNMPv3 engine ID.",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(
-						`^(use-default-ip-address|use-mac-address|local .+)$`),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^(use-default-ip-address|use-mac-address|local .+)$`),
 						"must have 'use-default-ip-address', 'use-mac-address' or 'local ...'",
 					),
 				},

--- a/internal/provider/resource_snmp_v3_usm_user.go
+++ b/internal/provider/resource_snmp_v3_usm_user.go
@@ -806,7 +806,8 @@ func (rsc *snmpV3UsmUser) ImportState(
 					"local"+junos.IDSeparator+"<name> or "+
 					"remote"+junos.IDSeparator+"<engine_id>"+junos.IDSeparator+"<name>)",
 				req.ID,
-			))
+			),
+		)
 
 		return
 	}

--- a/internal/provider/resource_static_route.go
+++ b/internal/provider/resource_static_route.go
@@ -131,9 +131,10 @@ func (rsc *staticRoute) Schema(
 				Optional:    true,
 				Description: "AS number to add AGGREGATOR path attribute to route.",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(
-						`^\d+(\.\d+)?$`),
-						"must be in plain number or `higher 16bits`.`lower 16 bits` (asdot notation) format"),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^\d+(\.\d+)?$`),
+						"must be in plain number or `higher 16bits`.`lower 16 bits` (asdot notation) format",
+					),
 				},
 			},
 			"as_path_atomic_aggregate": schema.BoolAttribute{

--- a/internal/provider/resource_system_login_class.go
+++ b/internal/provider/resource_system_login_class.go
@@ -104,8 +104,8 @@ func (rsc *systemLoginClass) Schema(
 				Optional:    true,
 				Description: "End time for remote access.",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(
-						`^([0-1]\d|2[0-3]):([0-5]\d):([0-5]\d)$`),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^([0-1]\d|2[0-3]):([0-5]\d):([0-5]\d)$`),
 						"must be in the format 'HH:MM:SS'",
 					),
 				},
@@ -114,8 +114,8 @@ func (rsc *systemLoginClass) Schema(
 				Optional:    true,
 				Description: "Start time for remote access.",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(
-						`^([0-1]\d|2[0-3]):([0-5]\d):([0-5]\d)$`),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^([0-1]\d|2[0-3]):([0-5]\d):([0-5]\d)$`),
 						"must be in the format 'HH:MM:SS'",
 					),
 				},

--- a/internal/provider/resource_system_login_user_test.go
+++ b/internal/provider/resource_system_login_user_test.go
@@ -122,7 +122,8 @@ func TestAccResourceSystemLoginUser_writeOnly(t *testing.T) {
 						"data.junos_config_raw.testacc_wo",
 						tfjsonpath.New("config"),
 						knownvalue.StringRegexp(regexp.MustCompile(
-							`set system login user testacc_wo authentication encrypted-password `)),
+							`set system login user testacc_wo authentication encrypted-password `,
+						)),
 					),
 				},
 			},

--- a/internal/provider/resource_system_radius_server_test.go
+++ b/internal/provider/resource_system_radius_server_test.go
@@ -114,13 +114,15 @@ func TestAccResourceSystemRadiusServer_writeOnly(t *testing.T) {
 						"data.junos_config_raw.testacc_radiusServer_wo",
 						tfjsonpath.New("config"),
 						knownvalue.StringRegexp(regexp.MustCompile(
-							`set system radius-server 192.0.2.11 secret `)),
+							`set system radius-server 192.0.2.11 secret `,
+						)),
 					),
 					statecheck.ExpectKnownValue(
 						"data.junos_config_raw.testacc_radiusServer_wo",
 						tfjsonpath.New("config"),
 						knownvalue.StringRegexp(regexp.MustCompile(
-							`set system radius-server 192.0.2.11 preauthentication-secret `)),
+							`set system radius-server 192.0.2.11 preauthentication-secret `,
+						)),
 					),
 				},
 			},

--- a/internal/provider/resource_system_root_authentication_test.go
+++ b/internal/provider/resource_system_root_authentication_test.go
@@ -112,7 +112,8 @@ func TestAccResourceSystemRootAuthentication_writeOnly(t *testing.T) {
 							"data.junos_config_raw.root_auth_wo",
 							tfjsonpath.New("config"),
 							knownvalue.StringRegexp(regexp.MustCompile(
-								`set system root-authentication encrypted-password `)),
+								`set system root-authentication encrypted-password `,
+							)),
 						),
 					},
 				},

--- a/internal/provider/resource_system_syslog_file.go
+++ b/internal/provider/resource_system_syslog_file.go
@@ -285,8 +285,8 @@ func (rsc *systemSyslogFile) Schema(
 						Optional:    true,
 						Description: "Start time for file transmission (YYYY-MM-DD.HH:MM:SS).",
 						Validators: []validator.String{
-							stringvalidator.RegexMatches(regexp.MustCompile(
-								`^\d{4}\-\d\d?\-\d\d?\.\d{2}:\d{2}:\d{2}$`),
+							stringvalidator.RegexMatches(
+								regexp.MustCompile(`^\d{4}\-\d\d?\-\d\d?\.\d{2}:\d{2}:\d{2}$`),
 								"must be in the format 'YYYY-MM-DD.HH:MM:SS'",
 							),
 						},

--- a/internal/provider/resource_system_syslog_file_test.go
+++ b/internal/provider/resource_system_syslog_file_test.go
@@ -134,7 +134,8 @@ func TestAccResourceSystemSyslogFile_writeOnly(t *testing.T) {
 						"data.junos_config_raw.testacc_syslogFile_wo",
 						tfjsonpath.New("config"),
 						knownvalue.StringRegexp(regexp.MustCompile(
-							`file "?testacc_wo"? archive archive-sites "?192\.0\.2\.2"? password `)),
+							`file "?testacc_wo"? archive archive-sites "?192\.0\.2\.2"? password `,
+						)),
 					),
 				},
 			},

--- a/internal/provider/resource_system_tacplus_server_test.go
+++ b/internal/provider/resource_system_tacplus_server_test.go
@@ -62,7 +62,8 @@ func TestAccResourceSystemTacplusServer_writeOnly(t *testing.T) {
 						"data.junos_config_raw.testacc_tacplusServer_wo",
 						tfjsonpath.New("config"),
 						knownvalue.StringRegexp(regexp.MustCompile(
-							`set system tacplus-server 192.0.2.11 secret `)),
+							`set system tacplus-server 192.0.2.11 secret `,
+						)),
 					),
 				},
 			},

--- a/internal/provider/resource_system_test.go
+++ b/internal/provider/resource_system_test.go
@@ -277,31 +277,36 @@ func TestAccResourceSystem_writeOnly(t *testing.T) {
 							"data.junos_config_raw.testacc_system_wo",
 							tfjsonpath.New("config"),
 							knownvalue.StringRegexp(regexp.MustCompile(
-								`accounting destination radius server "?192\.0\.2\.53"? secret `)),
+								`accounting destination radius server "?192\.0\.2\.53"? secret `,
+							)),
 						),
 						statecheck.ExpectKnownValue(
 							"data.junos_config_raw.testacc_system_wo",
 							tfjsonpath.New("config"),
 							knownvalue.StringRegexp(regexp.MustCompile(
-								`accounting destination radius server "?192\.0\.2\.53"? preauthentication-secret `)),
+								`accounting destination radius server "?192\.0\.2\.53"? preauthentication-secret `,
+							)),
 						),
 						statecheck.ExpectKnownValue(
 							"data.junos_config_raw.testacc_system_wo",
 							tfjsonpath.New("config"),
 							knownvalue.StringRegexp(regexp.MustCompile(
-								`accounting destination tacplus server "?192\.0\.2\.55"? secret `)),
+								`accounting destination tacplus server "?192\.0\.2\.55"? secret `,
+							)),
 						),
 						statecheck.ExpectKnownValue(
 							"data.junos_config_raw.testacc_system_wo",
 							tfjsonpath.New("config"),
 							knownvalue.StringRegexp(regexp.MustCompile(
-								`archival configuration archive-sites "?scp://juniper-configs@192\.0\.2\.30:/dir"? password `)),
+								`archival configuration archive-sites "?scp://juniper-configs@192\.0\.2\.30:/dir"? password `,
+							)),
 						),
 						statecheck.ExpectKnownValue(
 							"data.junos_config_raw.testacc_system_wo",
 							tfjsonpath.New("config"),
 							knownvalue.StringRegexp(regexp.MustCompile(
-								`license autoupdate url "?https://ae1\.juniper\.net/junos/key_retrieval"? password `)),
+								`license autoupdate url "?https://ae1\.juniper\.net/junos/key_retrieval"? password `,
+							)),
 						),
 					},
 				},

--- a/internal/provider/resource_virtual_chassis.go
+++ b/internal/provider/resource_virtual_chassis.go
@@ -116,8 +116,8 @@ func (rsc *virtualChassis) Schema(
 				Optional:    true,
 				Description: "Virtual chassis identifier, of type ISO system-id.",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(
-						`^[0-9a-f]{4}\.[0-9a-f]{4}\.[0-9a-f]{4}$`),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^[0-9a-f]{4}\.[0-9a-f]{4}\.[0-9a-f]{4}$`),
 						"must be of type ISO system-id",
 					),
 				},
@@ -126,8 +126,8 @@ func (rsc *virtualChassis) Schema(
 				Optional:    true,
 				Description: "MAC persistence time (minutes) or disable.",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(
-						`^([1-9]|[1-5][0-9]|60|disable)$`),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^([1-9]|[1-5][0-9]|60|disable)$`),
 						"must be a number between 1 to 60 or disable",
 					),
 				},

--- a/internal/provider/resource_vlan.go
+++ b/internal/provider/resource_vlan.go
@@ -189,9 +189,10 @@ func (rsc *vlan) Schema(
 				Description: "L3 interface name for this VLAN.",
 				Validators: []validator.String{
 					tfvalidator.StringFormat(tfvalidator.InterfaceFormat),
-					stringvalidator.RegexMatches(regexp.MustCompile(
-						`^(irb|vlan)\.`),
-						"must start with 'irb.' or 'vlan.'"),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^(irb|vlan)\.`),
+						"must start with 'irb.' or 'vlan.'",
+					),
 				},
 			},
 			"no_arp_suppression": schema.BoolAttribute{
@@ -219,9 +220,10 @@ func (rsc *vlan) Schema(
 				Optional:    true,
 				Description: "802.1q VLAN id or `all` or `none`.",
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(
-						`^(409[0-4]|(40[0-8]|[1-3]\d\d|[1-9]\d|[1-9])\d|[1-9]|all|none)$`),
-						"must be a VLAN id (1..4094) or all or none"),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^(409[0-4]|(40[0-8]|[1-3]\d\d|[1-9]\d|[1-9])\d|[1-9]|all|none)$`),
+						"must be a VLAN id (1..4094) or all or none",
+					),
 				},
 			},
 			"vlan_id_list": schema.SetAttribute{
@@ -232,10 +234,11 @@ func (rsc *vlan) Schema(
 					setvalidator.SizeAtLeast(1),
 					setvalidator.NoNullValues(),
 					setvalidator.ValueStringsAre(
-						stringvalidator.RegexMatches(regexp.MustCompile(
-							`^(409[0-4]|(40[0-8]|[1-3]\d\d|[1-9]\d|[1-9])\d|[1-9])`+
+						stringvalidator.RegexMatches(
+							regexp.MustCompile(`^(409[0-4]|(40[0-8]|[1-3]\d\d|[1-9]\d|[1-9])\d|[1-9])`+
 								`(-(409[0-4]|(40[0-8]|[1-3]\d\d|[1-9]\d|[1-9])\d|[1-9]))?$`),
-							"must be a VLAN id (1..4094) or a range of VLAN id (1..4094)-(1..4094)"),
+							"must be a VLAN id (1..4094) or a range of VLAN id (1..4094)-(1..4094)",
+						),
 					),
 				},
 			},

--- a/internal/provider/resource_vstp_interface.go
+++ b/internal/provider/resource_vstp_interface.go
@@ -123,9 +123,10 @@ func (rsc *vstpInterface) Schema(
 					stringplanmodifier.RequiresReplace(),
 				},
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(regexp.MustCompile(
-						`^(409[0-4]|(40[0-8]|[1-3]\d\d|[1-9]\d|[1-9])\d|[1-9]|all)$`),
-						"must be a VLAN id (1..4094) or all"),
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^(409[0-4]|(40[0-8]|[1-3]\d\d|[1-9]\d|[1-9])\d|[1-9]|all)$`),
+						"must be a VLAN id (1..4094) or all",
+					),
 				},
 			},
 			"vlan_group": schema.StringAttribute{

--- a/internal/provider/resource_vstp_vlan.go
+++ b/internal/provider/resource_vstp_vlan.go
@@ -91,9 +91,10 @@ func (rsc *vstpVlan) Schema(
 				stringplanmodifier.RequiresReplace(),
 			},
 			Validators: []validator.String{
-				stringvalidator.RegexMatches(regexp.MustCompile(
-					`^(409[0-4]|(40[0-8]|[1-3]\d\d|[1-9]\d|[1-9])\d|[1-9]|all)$`),
-					"must be a VLAN id (1..4094) or all"),
+				stringvalidator.RegexMatches(
+					regexp.MustCompile(`^(409[0-4]|(40[0-8]|[1-3]\d\d|[1-9]\d|[1-9])\d|[1-9]|all)$`),
+					"must be a VLAN id (1..4094) or all",
+				),
 			},
 		},
 		"routing_instance": schema.StringAttribute{

--- a/internal/provider/resource_vstp_vlan_group.go
+++ b/internal/provider/resource_vstp_vlan_group.go
@@ -118,10 +118,11 @@ func (rsc *vstpVlanGroup) Schema(
 				setvalidator.SizeAtLeast(1),
 				setvalidator.NoNullValues(),
 				setvalidator.ValueStringsAre(
-					stringvalidator.RegexMatches(regexp.MustCompile(
-						`^(409[0-4]|(40[0-8]|[1-3]\d\d|[1-9]\d|[1-9])\d|[1-9])`+
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^(409[0-4]|(40[0-8]|[1-3]\d\d|[1-9]\d|[1-9])\d|[1-9])`+
 							`(-(409[0-4]|(40[0-8]|[1-3]\d\d|[1-9]\d|[1-9])\d|[1-9]))?$`),
-						"must be a VLAN id (1..4094) or a range of VLAN id (1..4094)-(1..4094)"),
+						"must be a VLAN id (1..4094) or a range of VLAN id (1..4094)-(1..4094)",
+					),
 				),
 			},
 		},

--- a/internal/provider/resourceattr_bgp.go
+++ b/internal/provider/resourceattr_bgp.go
@@ -256,9 +256,10 @@ func (bgpAttrData) attributesSchema() map[string]schema.Attribute {
 			Optional:    true,
 			Description: "Local autonomous system number.",
 			Validators: []validator.String{
-				stringvalidator.RegexMatches(regexp.MustCompile(
-					`^\d+(\.\d+)?$`),
-					"must be in plain number or `higher 16bits`.`lower 16 bits` (asdot notation) format"),
+				stringvalidator.RegexMatches(
+					regexp.MustCompile(`^\d+(\.\d+)?$`),
+					"must be in plain number or `higher 16bits`.`lower 16 bits` (asdot notation) format",
+				),
 			},
 		},
 		"local_as_alias": schema.BoolAttribute{
@@ -395,9 +396,10 @@ func (bgpAttrData) attributesSchema() map[string]schema.Attribute {
 			Optional:    true,
 			Description: "Autonomous system number.",
 			Validators: []validator.String{
-				stringvalidator.RegexMatches(regexp.MustCompile(
-					`^\d+(\.\d+)?$`),
-					"must be in plain number or `higher 16bits`.`lower 16 bits` (asdot notation) format"),
+				stringvalidator.RegexMatches(
+					regexp.MustCompile(`^\d+(\.\d+)?$`),
+					"must be in plain number or `higher 16bits`.`lower 16 bits` (asdot notation) format",
+				),
 			},
 		},
 		"preference": schema.Int64Attribute{

--- a/internal/provider/resourceattr_vstp_vlan.go
+++ b/internal/provider/resourceattr_vstp_vlan.go
@@ -35,8 +35,8 @@ func (vstpVlanAttrData) attributesSchema() map[string]schema.Attribute {
 			Optional:    true,
 			Description: "Priority of the bridge.",
 			Validators: []validator.String{
-				stringvalidator.RegexMatches(regexp.MustCompile(
-					`^\d\d?k$`),
+				stringvalidator.RegexMatches(
+					regexp.MustCompile(`^\d\d?k$`),
 					"must be a number with increments of 4k - 4k,8k,..60k",
 				),
 			},
@@ -45,8 +45,8 @@ func (vstpVlanAttrData) attributesSchema() map[string]schema.Attribute {
 			Optional:    true,
 			Description: "Priority of the bridge.",
 			Validators: []validator.String{
-				stringvalidator.RegexMatches(regexp.MustCompile(
-					`^(0|\d\d?k)$`),
+				stringvalidator.RegexMatches(
+					regexp.MustCompile(`^(0|\d\d?k)$`),
 					"must be a number with increments of 4k - 0,4k,8k,..60k",
 				),
 			},

--- a/internal/tfdata/alter_asblock_slice.go
+++ b/internal/tfdata/alter_asblock_slice.go
@@ -59,7 +59,10 @@ loopBlocks:
 
 		// check if match with the arguments
 		for iIdent, fieldValue := range blockIdentifierValues {
-			attrValue := fieldValue.Interface().(attr.Value)
+			attrValue, ok := reflect.TypeAssert[attr.Value](fieldValue)
+			if !ok {
+				panic("tfdata identifier tag on a field which is not an attr.Value")
+			}
 			if !attrValue.Equal(identifierValues[iIdent]) {
 				continue loopBlocks
 			}
@@ -124,7 +127,10 @@ func AppendPotentialNewBlock[B any](
 
 		// check if match with the arguments
 		for iIdent, fieldValue := range blockIdentifierValues {
-			attrValue := fieldValue.Interface().(attr.Value)
+			attrValue, ok := reflect.TypeAssert[attr.Value](fieldValue)
+			if !ok {
+				panic("tfdata identifier tag on a field which is not an attr.Value")
+			}
 			if !attrValue.Equal(identifierValues[iIdent]) {
 				lastestOK = false
 

--- a/internal/tfdata/check_asblock.go
+++ b/internal/tfdata/check_asblock.go
@@ -46,7 +46,7 @@ func checkBlockValueIsEmpty(blockValue reflect.Value) bool {
 			continue
 		}
 
-		if attrValue, ok := fieldValue.Interface().(attr.Value); ok {
+		if attrValue, ok := reflect.TypeAssert[attr.Value](fieldValue); ok {
 			if !attrValue.IsNull() {
 				return false
 			}
@@ -107,7 +107,7 @@ func checkBlockValueHasKnownValue(blockValue reflect.Value, excludeFields ...str
 			continue
 		}
 
-		if attrValue, ok := fieldValue.Interface().(attr.Value); ok {
+		if attrValue, ok := reflect.TypeAssert[attr.Value](fieldValue); ok {
 			if !attrValue.IsNull() && !attrValue.IsUnknown() {
 				return true
 			}


### PR DESCRIPTION
- deps: bump Go version to 1.27
  - min version to v1.26
  - release with v1.27
  - workflows: go tests with both versions
  - tfdata: use reflect.TypeAssert instead of Value.Interface() type assertion
- deps: bump golangci-lint to v2.13.2
  - disable exhaustruct_v5 and gomodguard_v2
  - move newly deprecated exhaustruct and wsl to the deprecated list
  - gofumpt: replace extra-rules by the named extra options
  - reformat with the new gofumpt extra rules